### PR TITLE
CompilerCPP now properly initializes arrays with constant expressions

### DIFF
--- a/spirv_cpp.cpp
+++ b/spirv_cpp.cpp
@@ -319,6 +319,39 @@ void CompilerCPP::emit_c_linkage()
 	end_scope();
 }
 
+string CompilerCPP::constant_expression(const SPIRConstant &c)
+{
+	if (!c.subconstants.empty())
+	{
+		// Handles Arrays and structures.
+		string res = "{";
+		for (auto &elem : c.subconstants)
+		{
+			res += constant_expression(get<SPIRConstant>(elem));
+			if (&elem != &c.subconstants.back())
+				res += ", ";
+		}
+		res += "}";
+		return res;
+	}
+	else if (c.columns() == 1)
+	{
+		return constant_expression_vector(c, 0);
+	}
+	else
+	{
+		string res = "{";
+		for (uint32_t col = 0; col < c.columns(); col++)
+		{
+			res += constant_expression_vector(c, col);
+			if (col + 1 < c.columns())
+				res += ", ";
+		}
+		res += "}";
+		return res;
+	}
+}
+
 void CompilerCPP::emit_function_prototype(SPIRFunction &func, uint64_t)
 {
 	local_variables.clear();

--- a/spirv_cpp.hpp
+++ b/spirv_cpp.hpp
@@ -44,6 +44,7 @@ private:
 	void emit_uniform(const SPIRVariable &var);
 	void emit_shared(const SPIRVariable &var);
 
+	std::string constant_expression(const SPIRConstant &c) override;
 	std::string argument_decl(const SPIRFunction::Parameter &arg);
 
 	std::vector<std::string> resource_registrations;


### PR DESCRIPTION
Concerning #9 