### PR TITLE
Do not try to pump OpLine instructions into a block

### DIFF
--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -873,6 +873,7 @@ void Compiler::parse(const Instruction &instruction)
 	case OpMemoryModel:
 	case OpSourceExtension:
 	case OpNop:
+	case OpLine:
 		break;
 
 	case OpSource:


### PR DESCRIPTION
When the SPIR-V includes metadata for debugging
(aka OpLine instructions) the CompilerError at
line 1588 was eventually triggered.