### PR TITLE
Change variable names beginning with gl_ in GLSL

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1026,7 +1026,7 @@ void CompilerGLSL::replace_illegal_names()
 			auto &var = id.get<SPIRVariable>();
 			auto &type = get<SPIRType>(var.basetype);
 
-			if (!is_builtin_variable(var))
+			if (!is_builtin_variable(var) && !var.remapped_variable)
 			{
 				auto &m = meta[var.self].decoration;
 				if (m.alias.compare(0, 3, "gl_") == 0)

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1024,7 +1024,6 @@ void CompilerGLSL::replace_illegal_names()
 		if (id.get_type() == TypeVariable)
 		{
 			auto &var = id.get<SPIRVariable>();
-			auto &type = get<SPIRType>(var.basetype);
 
 			if (!is_builtin_variable(var) && !var.remapped_variable)
 			{

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1017,6 +1017,27 @@ void CompilerGLSL::emit_uniform(const SPIRVariable &var)
 	statement(layout_for_variable(var), "uniform ", variable_decl(var), ";");
 }
 
+void CompilerGLSL::replace_illegal_names()
+{
+	for (auto &id : ids)
+	{
+		if (id.get_type() == TypeVariable)
+		{
+			auto &var = id.get<SPIRVariable>();
+			auto &type = get<SPIRType>(var.basetype);
+
+			if (!is_builtin_variable(var))
+			{
+				auto &m = meta[var.self].decoration;
+				if (m.alias.compare(0, 3, "gl_") == 0)
+				{
+					m.alias = join("_", m.alias);
+				}
+			}
+		}
+	}
+}
+
 void CompilerGLSL::replace_fragment_output(SPIRVariable &var)
 {
 	auto &m = meta[var.self].decoration;
@@ -1100,6 +1121,8 @@ void CompilerGLSL::emit_pls()
 void CompilerGLSL::emit_resources()
 {
 	auto &execution = get_entry_point();
+
+	replace_illegal_names();
 
 	// Legacy GL uses gl_FragData[], redeclare all fragment outputs
 	// with builtins.

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -308,6 +308,8 @@ protected:
 	// and force recompile.
 	bool check_atomic_image(uint32_t id);
 
+	void replace_illegal_names();
+
 	void replace_fragment_output(SPIRVariable &var);
 	void replace_fragment_outputs();
 	std::string legacy_tex_op(const std::string &op, const SPIRType &imgtype);


### PR DESCRIPTION
Using old-school GLSL as input containing code ala
"gl_FragColor = whatever" resulted in illegal
declarations ala "out vec4 gl_FragColor;".