### PR TITLE
Fix gl_FragData transformation

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -2496,7 +2496,19 @@ string CompilerGLSL::access_chain(uint32_t base, const uint32_t *indices, uint32
 {
 	string expr;
 	if (!chain_only)
+	{
 		expr = to_expression(base);
+		
+		// Avoid replace_fragment_output scrambling array access
+		if (expr.substr(0, 11) == "gl_FragData")
+		{
+			size_t bracket_pos = expr.find_last_of('[');
+			if (bracket_pos != string::npos)
+			{
+				expr = expr.substr(0, bracket_pos);
+			}
+		}
+	}
 
 	const auto *type = &expression_type(base);
 


### PR DESCRIPTION
When reading legacy GLSL and writing legacy GLSL
gl_FragData[0] was transformed to gl_FragData[0][0].

This pull request feels like a hack on top of a hack and
there might be edge cases where it fails so I'd be happy
to find a better solution. It fixes an assumably very
common situation though.