### PR TITLE
Correct vector's size begin checked

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -48,7 +48,7 @@ string CompilerMSL::compile(MSLConfiguration &msl_cfg, vector<MSLVertexAttr> *p_
 	resource_bindings.clear();
 	if (p_res_bindings)
 	{
-		resource_bindings.reserve(p_vtx_attrs->size());
+		resource_bindings.reserve(p_res_bindings->size());
 		for (auto &rb : *p_res_bindings)
 		{
 			rb.used_by_shader = false;


### PR DESCRIPTION
This caused a null pointer being used when called with p_vtx_attrs = nullptr and p_res_bindings != nullptr