### PR TITLE
Add more complete specialization constant support

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -347,6 +347,16 @@ static void print_push_constant_resources(const Compiler &compiler, const vector
 	}
 }
 
+static void print_spec_constants(const Compiler &compiler)
+{
+	auto spec_constants = compiler.get_specialization_constants();
+	fprintf(stderr, "Specialization constants\n");
+	fprintf(stderr, "==================\n\n");
+	for (auto &c : spec_constants)
+		fprintf(stderr, "ID: %u, Spec ID: %u\n", c.id, c.constant_id);
+	fprintf(stderr, "==================\n\n");
+}
+
 struct PLSArg
 {
 	PlsFormat format;
@@ -650,6 +660,7 @@ int main(int argc, char *argv[])
 	{
 		print_resources(*compiler, res);
 		print_push_constant_resources(*compiler, res.push_constant_buffers);
+		print_spec_constants(*compiler);
 	}
 
 	if (combined_image_samplers)

--- a/reference/shaders/vulkan/frag/spec-constant.vk.frag
+++ b/reference/shaders/vulkan/frag/spec-constant.vk.frag
@@ -2,6 +2,11 @@
 precision mediump float;
 precision highp int;
 
+struct Foo
+{
+    float elems[(4 + 2)];
+};
+
 layout(location = 0) out vec4 FragColor;
 
 void main()
@@ -46,6 +51,9 @@ void main()
     mediump int c35 = int(false);
     mediump uint c36 = uint(false);
     float c37 = float(false);
-    FragColor = vec4((t0 + t1));
+    float vec0[4][(3 + 3)];
+    float vec1[(3 + 2)][(4 + 5)];
+    Foo foo;
+    FragColor = (((vec4((t0 + t1)) + vec4(vec0[0][0])) + vec4(vec1[0][0])) + vec4(foo.elems[3]));
 }
 

--- a/reference/shaders/vulkan/frag/spec-constant.vk.frag
+++ b/reference/shaders/vulkan/frag/spec-constant.vk.frag
@@ -1,0 +1,51 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    float t0 = 1.0;
+    float t1 = 2.0;
+    mediump uint c0 = (uint(3) + 0u);
+    mediump int c1 = (-3);
+    mediump int c2 = (~3);
+    mediump int c3 = (3 + 4);
+    mediump int c4 = (3 - 4);
+    mediump int c5 = (3 * 4);
+    mediump int c6 = (3 / 4);
+    mediump uint c7 = (5u / 6u);
+    mediump int c8 = (3 % 4);
+    mediump uint c9 = (5u % 6u);
+    mediump int c10 = (3 >> 4);
+    mediump uint c11 = (5u >> 6u);
+    mediump int c12 = (3 << 4);
+    mediump int c13 = (3 | 4);
+    mediump int c14 = (3 ^ 4);
+    mediump int c15 = (3 & 4);
+    bool c16 = (false || true);
+    bool c17 = (false && true);
+    bool c18 = (!false);
+    bool c19 = (false == true);
+    bool c20 = (false != true);
+    bool c21 = (3 == 4);
+    bool c22 = (3 != 4);
+    bool c23 = (3 < 4);
+    bool c24 = (5u < 6u);
+    bool c25 = (3 > 4);
+    bool c26 = (5u > 6u);
+    bool c27 = (3 <= 4);
+    bool c28 = (5u <= 6u);
+    bool c29 = (3 >= 4);
+    bool c30 = (5u >= 6u);
+    mediump int c31 = (c8 + c3);
+    mediump int c32 = int(5u + 0u);
+    bool c33 = (3 != int(0u));
+    bool c34 = (5u != 0u);
+    mediump int c35 = int(false);
+    mediump uint c36 = uint(false);
+    float c37 = float(false);
+    FragColor = vec4((t0 + t1));
+}
+

--- a/reference/shaders/vulkan/frag/spec-constant.vk.frag.vk
+++ b/reference/shaders/vulkan/frag/spec-constant.vk.frag.vk
@@ -2,7 +2,6 @@
 precision mediump float;
 precision highp int;
 
-layout(location = 0) out vec4 FragColor;
 layout(constant_id = 1) const float _9 = 1.0;
 layout(constant_id = 2) const float _11 = 2.0;
 layout(constant_id = 3) const int _16 = 3;
@@ -11,6 +10,13 @@ layout(constant_id = 5) const uint _34 = 5u;
 layout(constant_id = 6) const uint _35 = 6u;
 layout(constant_id = 7) const bool _56 = false;
 layout(constant_id = 8) const bool _57 = true;
+
+struct Foo
+{
+    float elems[(_25 + 2)];
+};
+
+layout(location = 0) out vec4 FragColor;
 
 void main()
 {
@@ -54,6 +60,9 @@ void main()
     mediump int c35 = int(_56);
     mediump uint c36 = uint(_56);
     float c37 = float(_56);
-    FragColor = vec4((t0 + t1));
+    float vec0[_25][(_16 + 3)];
+    float vec1[(_16 + 2)][(_25 + 5)];
+    Foo foo;
+    FragColor = (((vec4((t0 + t1)) + vec4(vec0[0][0])) + vec4(vec1[0][0])) + vec4(foo.elems[_16]));
 }
 

--- a/reference/shaders/vulkan/frag/spec-constant.vk.frag.vk
+++ b/reference/shaders/vulkan/frag/spec-constant.vk.frag.vk
@@ -1,0 +1,59 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+layout(location = 0) out vec4 FragColor;
+layout(constant_id = 1) const float _9 = 1.0;
+layout(constant_id = 2) const float _11 = 2.0;
+layout(constant_id = 3) const int _16 = 3;
+layout(constant_id = 4) const int _25 = 4;
+layout(constant_id = 5) const uint _34 = 5u;
+layout(constant_id = 6) const uint _35 = 6u;
+layout(constant_id = 7) const bool _56 = false;
+layout(constant_id = 8) const bool _57 = true;
+
+void main()
+{
+    float t0 = _9;
+    float t1 = _11;
+    mediump uint c0 = (uint(_16) + 0u);
+    mediump int c1 = (-_16);
+    mediump int c2 = (~_16);
+    mediump int c3 = (_16 + _25);
+    mediump int c4 = (_16 - _25);
+    mediump int c5 = (_16 * _25);
+    mediump int c6 = (_16 / _25);
+    mediump uint c7 = (_34 / _35);
+    mediump int c8 = (_16 % _25);
+    mediump uint c9 = (_34 % _35);
+    mediump int c10 = (_16 >> _25);
+    mediump uint c11 = (_34 >> _35);
+    mediump int c12 = (_16 << _25);
+    mediump int c13 = (_16 | _25);
+    mediump int c14 = (_16 ^ _25);
+    mediump int c15 = (_16 & _25);
+    bool c16 = (_56 || _57);
+    bool c17 = (_56 && _57);
+    bool c18 = (!_56);
+    bool c19 = (_56 == _57);
+    bool c20 = (_56 != _57);
+    bool c21 = (_16 == _25);
+    bool c22 = (_16 != _25);
+    bool c23 = (_16 < _25);
+    bool c24 = (_34 < _35);
+    bool c25 = (_16 > _25);
+    bool c26 = (_34 > _35);
+    bool c27 = (_16 <= _25);
+    bool c28 = (_34 <= _35);
+    bool c29 = (_16 >= _25);
+    bool c30 = (_34 >= _35);
+    mediump int c31 = (c8 + c3);
+    mediump int c32 = int(_34 + 0u);
+    bool c33 = (_16 != int(0u));
+    bool c34 = (_34 != 0u);
+    mediump int c35 = int(_56);
+    mediump uint c36 = uint(_56);
+    float c37 = float(_56);
+    FragColor = vec4((t0 + t1));
+}
+

--- a/shaders/vulkan/frag/spec-constant.vk.frag
+++ b/shaders/vulkan/frag/spec-constant.vk.frag
@@ -1,0 +1,67 @@
+#version 310 es
+precision mediump float;
+
+layout(location = 0) out vec4 FragColor;
+layout(constant_id = 1) const float a = 1.0;
+layout(constant_id = 2) const float b = 2.0;
+layout(constant_id = 3) const int c = 3;
+layout(constant_id = 4) const int d = 4;
+layout(constant_id = 5) const uint e = 5u;
+layout(constant_id = 6) const uint f = 6u;
+layout(constant_id = 7) const bool g = false;
+layout(constant_id = 8) const bool h = true;
+// glslang doesn't seem to support partial spec constants or composites yet, so only test the basics.
+
+void main()
+{
+	float t0 = a;
+	float t1 = b;
+
+	uint c0 = uint(c); // OpIAdd with different types.
+	// FConvert, float-to-double.
+	int c1 = -c; // SNegate
+	int c2 = ~c; // OpNot
+	int c3 = c + d; // OpIAdd
+	int c4 = c - d; // OpISub
+	int c5 = c * d; // OpIMul
+	int c6 = c / d; // OpSDiv
+	uint c7 = e / f; // OpUDiv
+	int c8 = c % d; // OpSMod
+	uint c9 = e % f; // OpUMod
+	// TODO: OpSRem, any way to access this in GLSL?
+	int c10 = c >> d; // OpShiftRightArithmetic
+	uint c11 = e >> f; // OpShiftRightLogical
+	int c12 = c << d; // OpShiftLeftLogical
+	int c13 = c | d; // OpBitwiseOr
+	int c14 = c ^ d; // OpBitwiseXor
+	int c15 = c & d; // OpBitwiseAnd
+	// VectorShuffle, CompositeExtract, CompositeInsert, not testable atm.
+	bool c16 = g || h; // OpLogicalOr
+	bool c17 = g && h; // OpLogicalAnd
+	bool c18 = !g; // OpLogicalNot
+	bool c19 = g == h; // OpLogicalEqual
+	bool c20 = g != h; // OpLogicalNotEqual
+	// OpSelect not testable atm.
+	bool c21 = c == d; // OpIEqual
+	bool c22 = c != d; // OpINotEqual
+	bool c23 = c < d; // OpSLessThan
+	bool c24 = e < f; // OpULessThan
+	bool c25 = c > d; // OpSGreaterThan
+	bool c26 = e > f; // OpUGreaterThan
+	bool c27 = c <= d; // OpSLessThanEqual
+	bool c28 = e <= f; // OpULessThanEqual
+	bool c29 = c >= d; // OpSGreaterThanEqual
+	bool c30 = e >= f; // OpUGreaterThanEqual
+	// OpQuantizeToF16 not testable atm.
+
+	int c31 = c8 + c3;
+
+	int c32 = int(e); // OpIAdd with different types.
+	bool c33 = bool(c); // int -> bool
+	bool c34 = bool(e); // uint -> bool
+	int c35 = int(g); // bool -> int
+	uint c36 = uint(g); // bool -> uint
+	float c37 = float(g); // bool -> float
+
+	FragColor = vec4(t0 + t1);
+}

--- a/shaders/vulkan/frag/spec-constant.vk.frag
+++ b/shaders/vulkan/frag/spec-constant.vk.frag
@@ -12,6 +12,11 @@ layout(constant_id = 7) const bool g = false;
 layout(constant_id = 8) const bool h = true;
 // glslang doesn't seem to support partial spec constants or composites yet, so only test the basics.
 
+struct Foo
+{
+	float elems[d + 2];
+};
+
 void main()
 {
 	float t0 = a;
@@ -63,5 +68,10 @@ void main()
 	uint c36 = uint(g); // bool -> uint
 	float c37 = float(g); // bool -> float
 
-	FragColor = vec4(t0 + t1);
+	// Flexible sized arrays with spec constants and spec constant ops.
+	float vec0[d][c + 3];
+	float vec1[c + 2][d + 5];
+
+	Foo foo;
+	FragColor = vec4(t0 + t1) + vec0[0][0] + vec1[0][0] + foo.elems[c];
 }

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -202,8 +202,15 @@ struct SPIRType : IVariant
 	uint32_t vecsize = 1;
 	uint32_t columns = 1;
 
-	// Arrays, suport array of arrays by having a vector of array sizes.
+	// Arrays, support array of arrays by having a vector of array sizes.
 	std::vector<uint32_t> array;
+
+	// Array elements can be either specialization constants or specialization ops.
+	// This array determines how to interpret the array size.
+	// If an element is true, the element is a literal,
+	// otherwise, it's an expression, which must be resolved on demand.
+	// The actual size is not really known until runtime.
+	std::vector<bool> array_size_literal;
 
 	// Pointers
 	bool pointer = false;

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -826,6 +826,7 @@ struct Meta
 		uint32_t offset = 0;
 		uint32_t array_stride = 0;
 		uint32_t input_attachment = 0;
+		uint32_t spec_id = 0;
 		bool builtin = false;
 		bool per_instance = false;
 	};

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -134,6 +134,7 @@ enum Types
 	TypeBlock,
 	TypeExtension,
 	TypeExpression,
+	TypeConstantOp,
 	TypeUndef
 };
 
@@ -147,6 +148,25 @@ struct SPIRUndef : IVariant
 	    : basetype(basetype_)
 	{
 	}
+	uint32_t basetype;
+};
+
+struct SPIRConstantOp : IVariant
+{
+	enum
+	{
+		type = TypeConstantOp
+	};
+
+	SPIRConstantOp(uint32_t result_type, spv::Op op, const uint32_t *args, uint32_t length)
+	    : opcode(op)
+	    , arguments(args, args + length)
+	    , basetype(result_type)
+	{
+	}
+
+	spv::Op opcode;
+	std::vector<uint32_t> arguments;
 	uint32_t basetype;
 };
 

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -814,6 +814,10 @@ void Compiler::set_member_decoration(uint32_t id, uint32_t index, Decoration dec
 		dec.offset = argument;
 		break;
 
+	case DecorationSpecId:
+		dec.spec_id = argument;
+		break;
+
 	default:
 		break;
 	}
@@ -855,6 +859,8 @@ uint32_t Compiler::get_member_decoration(uint32_t id, uint32_t index, Decoration
 		return dec.location;
 	case DecorationOffset:
 		return dec.offset;
+	case DecorationSpecId:
+		return dec.spec_id;
 	default:
 		return 0;
 	}
@@ -890,6 +896,10 @@ void Compiler::unset_member_decoration(uint32_t id, uint32_t index, Decoration d
 
 	case DecorationOffset:
 		dec.offset = 0;
+		break;
+
+	case DecorationSpecId:
+		dec.spec_id = 0;
 		break;
 
 	default:
@@ -933,6 +943,10 @@ void Compiler::set_decoration(uint32_t id, Decoration decoration, uint32_t argum
 		dec.input_attachment = argument;
 		break;
 
+	case DecorationSpecId:
+		dec.spec_id = argument;
+		break;
+
 	default:
 		break;
 	}
@@ -974,6 +988,8 @@ uint32_t Compiler::get_decoration(uint32_t id, Decoration decoration) const
 		return dec.set;
 	case DecorationInputAttachmentIndex:
 		return dec.input_attachment;
+	case DecorationSpecId:
+		return dec.spec_id;
 	default:
 		return 0;
 	}
@@ -1003,6 +1019,14 @@ void Compiler::unset_decoration(uint32_t id, Decoration decoration)
 
 	case DecorationDescriptorSet:
 		dec.set = 0;
+		break;
+
+	case DecorationInputAttachmentIndex:
+		dec.input_attachment = 0;
+		break;
+
+	case DecorationSpecId:
+		dec.spec_id = 0;
 		break;
 
 	default:
@@ -2615,4 +2639,31 @@ void Compiler::build_combined_image_samplers()
 	combined_image_samplers.clear();
 	CombinedImageSamplerHandler handler(*this);
 	traverse_all_reachable_opcodes(get<SPIRFunction>(entry_point), handler);
+}
+
+vector<SpecializationConstant> Compiler::get_specialization_constants() const
+{
+	vector<SpecializationConstant> spec_consts;
+	for (auto &id : ids)
+	{
+		if (id.get_type() == TypeConstant)
+		{
+			auto &c = id.get<SPIRConstant>();
+			if (c.specialization)
+			{
+				spec_consts.push_back({ c.self, get_decoration(c.self, DecorationSpecId) });
+			}
+		}
+	}
+	return spec_consts;
+}
+
+SPIRConstant &Compiler::get_constant(uint32_t id)
+{
+	return get<SPIRConstant>(id);
+}
+
+const SPIRConstant &Compiler::get_constant(uint32_t id) const
+{
+	return get<SPIRConstant>(id);
 }

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -1265,7 +1265,12 @@ void Compiler::parse(const Instruction &instruction)
 		auto &arraybase = set<SPIRType>(id);
 
 		arraybase = base;
-		arraybase.array.push_back(get<SPIRConstant>(ops[2]).scalar());
+
+		auto *c = maybe_get<SPIRConstant>(ops[2]);
+		bool literal = c && !c->specialization;
+
+		arraybase.array_size_literal.push_back(literal);
+		arraybase.array.push_back(literal ? c->scalar() : ops[2]);
 		// Do NOT set arraybase.self!
 		break;
 	}
@@ -1279,6 +1284,7 @@ void Compiler::parse(const Instruction &instruction)
 
 		arraybase = base;
 		arraybase.array.push_back(0);
+		arraybase.array_size_literal.push_back(true);
 		// Do NOT set arraybase.self!
 		break;
 	}

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -91,6 +91,14 @@ struct CombinedImageSampler
 	uint32_t sampler_id;
 };
 
+struct SpecializationConstant
+{
+	// The ID of the specialization constant.
+	uint32_t id;
+	// The constant ID of the constant, used in Vulkan during pipeline creation.
+	uint32_t constant_id;
+};
+
 struct BufferRange
 {
 	unsigned index;
@@ -287,6 +295,16 @@ public:
 	{
 		variable_remap_callback = std::move(cb);
 	}
+
+	// API for querying which specialization constants exist.
+	// To modify a specialization constant before compile(), use get_constant(constant.id),
+	// then update constants directly in the SPIRConstant data structure.
+	// For composite types, the subconstants can be iterated over and modified.
+	// constant_type is the SPIRType for the specialization constant,
+	// which can be queried to determine which fields in the unions should be poked at.
+	std::vector<SpecializationConstant> get_specialization_constants() const;
+	SPIRConstant &get_constant(uint32_t id);
+	const SPIRConstant &get_constant(uint32_t id) const;
 
 protected:
 	const uint32_t *stream(const Instruction &instr) const

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1467,11 +1467,6 @@ string CompilerGLSL::constant_op_expression(const SPIRConstantOp &cop)
 	string op;
 
 	// TODO: Find a clean way to reuse emit_instruction.
-	//
-	// FIXME: This doesn't take into account the possibility
-	// of type mismatches like emit_instruction does yet, but
-	// for spec op purposes, this seems extremely unlikely to
-	// hit in practice.
 	switch (cop.opcode)
 	{
 	case OpSConvert:

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -240,6 +240,7 @@ protected:
 	void emit_push_constant_block_glsl(const SPIRVariable &var);
 	void emit_interface_block(const SPIRVariable &type);
 	void emit_block_chain(SPIRBlock &block);
+	void emit_specialization_constant(const SPIRConstant &constant);
 	std::string emit_continue_block(uint32_t continue_block);
 	bool attempt_emit_loop_header(SPIRBlock &block, SPIRBlock::Method method);
 	void emit_uniform(const SPIRVariable &var);

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -144,6 +144,7 @@ protected:
 	virtual std::string member_decl(const SPIRType &type, const SPIRType &member_type, uint32_t member);
 	virtual std::string image_type_glsl(const SPIRType &type);
 	virtual std::string constant_expression(const SPIRConstant &c);
+	std::string constant_op_expression(const SPIRConstantOp &cop);
 	virtual std::string constant_expression_vector(const SPIRConstant &c, uint32_t vector);
 	virtual void emit_fixup();
 	virtual std::string variable_decl(const SPIRType &type, const std::string &name);
@@ -255,6 +256,7 @@ protected:
 
 	bool should_forward(uint32_t id);
 	void emit_mix_op(uint32_t result_type, uint32_t id, uint32_t left, uint32_t right, uint32_t lerp);
+	bool to_trivial_mix_op(const SPIRType &type, std::string &op, uint32_t left, uint32_t right, uint32_t lerp);
 	void emit_glsl_op(uint32_t result_type, uint32_t result_id, uint32_t op, const uint32_t *args, uint32_t count);
 	void emit_quaternary_func_op(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, uint32_t op2,
 	                             uint32_t op3, const char *op);

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -204,6 +204,8 @@ protected:
 	Options options;
 
 	std::string type_to_array_glsl(const SPIRType &type);
+	std::string to_array_size(const SPIRType &type, uint32_t index);
+	uint32_t to_array_size_literal(const SPIRType &type, uint32_t index) const;
 	std::string variable_decl(const SPIRVariable &variable);
 
 	void add_local_variable_name(uint32_t id);

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1260,6 +1260,7 @@ SPIRType &CompilerMSL::get_pad_type(uint32_t pad_len)
 	ib_type.basetype = SPIRType::Char;
 	ib_type.width = 8;
 	ib_type.array.push_back(pad_len);
+	ib_type.array_size_literal.push_back(true);
 	set_decoration(ib_type.self, DecorationArrayStride, pad_len);
 
 	pad_type_ids_by_pad_len[pad_len] = pad_type_id;
@@ -1616,7 +1617,7 @@ size_t CompilerMSL::get_declared_type_size(const SPIRType &type, uint64_t dec_ma
 			// ArrayStride is part of the array type not OpMemberDecorate.
 			auto &dec = meta[type.self].decoration;
 			if (dec.decoration_flags & (1ull << DecorationArrayStride))
-				return dec.array_stride * type.array.back();
+				return dec.array_stride * to_array_size_literal(type, type.array.size() - 1);
 			else
 				throw CompilerError("Type does not have ArrayStride set.");
 		}


### PR DESCRIPTION
This PR adds "full" support for specialization constants.

- Basic reflection API
- Vulkan GLSL backend emits spec constants and not plain constants
- OpSpecConstantOp implemented for every known testable opcode 
- Arrays can have spec constant size