### PR TITLE
Added all glsl reserved keywords to replace_illegal_names

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -18,7 +18,6 @@
 #include "GLSL.std.450.h"
 #include <algorithm>
 #include <assert.h>
-#include <array>
 
 using namespace spv;
 using namespace spirv_cross;
@@ -1110,7 +1109,28 @@ void CompilerGLSL::emit_specialization_constant(const SPIRConstant &constant)
 
 void CompilerGLSL::replace_illegal_names()
 {
-  std::array<const char*, 201> keywords = {"active","asm","atomic_uint","attribute","bool","break","bvec2","bvec3","bvec4","case","cast","centroid","class","coherent","common","const","continue","default","discard","dmat2","dmat2x2","dmat2x3","dmat2x4","dmat3","dmat3x2","dmat3x3","dmat3x4","dmat4","dmat4x2","dmat4x3","dmat4x4","do","double","dvec2","dvec3","dvec4","else","enum","extern","external","false","filter","fixed","flat","float","for","fvec2","fvec3","fvec4","goto","half","highp","hvec2","hvec3","hvec4","if","iimage1D","iimage1DArray","iimage2D","iimage2DArray","iimage2DMS","iimage2DMSArray","iimage2DRect","iimage3D","iimageBuffer","iimageCube","iimageCubeArray","image1D","image1DArray","image2D","image2DArray","image2DMS","image2DMSArray","image2DRect","image3D","imageBuffer","imageCube","imageCubeArray","in","inline","inout","input","int","interface","invariant","isampler1D","isampler1DArray","isampler2D","isampler2DArray","isampler2DMS","isampler2DMSArray","isampler2DRect","isampler3D","isamplerBuffer","isamplerCube","isamplerCubeArray","ivec2","ivec3","ivec4","layout","long","lowp","mat2","mat2x2","mat2x3","mat2x4","mat3","mat3x2","mat3x3","mat3x4","mat4","mat4x2","mat4x3","mat4x4","mediump","namespace","noinline","noperspective","out","output","packed","partition","patch","precision","public","readonly","resource","restrict","return","row_major","sample","sampler1D","sampler1DArray","sampler1DArrayShadow","sampler1DShadow","sampler2D","sampler2DArray","sampler2DArrayShadow","sampler2DMS","sampler2DMSArray","sampler2DRect","sampler2DRectShadow","sampler2DShadow","sampler3D","sampler3DRect","samplerBuffer","samplerCube","samplerCubeArray","samplerCubeArrayShadow","samplerCubeShadow","short","sizeof","smooth","static","struct","subroutine","superp","switch","template","this","true","typedef","uimage1D","uimage1DArray","uimage2D","uimage2DArray","uimage2DMS","uimage2DMSArray","uimage2DRect","uimage3D","uimageBuffer","uimageCube","uimageCubeArray","uint","uniform","union","unsigned","usampler1D","usampler1DArray","usampler2D","usampler2DArray","usampler2DMS","usampler2DMSArray","usampler2DRect","usampler3D","usamplerBuffer","usamplerCube","usamplerCubeArray","using","uvec2","uvec3","uvec4","varying","vec2","vec3","vec4","void","volatile","volatile","while","writeonly"};
+  static const std::unordered_set<std::string> keywords = {"active","asm","atomic_uint","attribute","bool","break",
+    "bvec2","bvec3","bvec4","case","cast","centroid","class","coherent","common","const","continue","default","discard",
+    "dmat2","dmat2x2","dmat2x3","dmat2x4","dmat3","dmat3x2","dmat3x3","dmat3x4","dmat4","dmat4x2","dmat4x3","dmat4x4",
+    "do","double","dvec2","dvec3","dvec4","else","enum","extern","external","false","filter","fixed","flat","float",
+    "for","fvec2","fvec3","fvec4","goto","half","highp","hvec2","hvec3","hvec4","if","iimage1D","iimage1DArray",
+    "iimage2D","iimage2DArray","iimage2DMS","iimage2DMSArray","iimage2DRect","iimage3D","iimageBuffer","iimageCube",
+    "iimageCubeArray","image1D","image1DArray","image2D","image2DArray","image2DMS","image2DMSArray","image2DRect",
+    "image3D","imageBuffer","imageCube","imageCubeArray","in","inline","inout","input","int","interface","invariant",
+    "isampler1D","isampler1DArray","isampler2D","isampler2DArray","isampler2DMS","isampler2DMSArray","isampler2DRect",
+    "isampler3D","isamplerBuffer","isamplerCube","isamplerCubeArray","ivec2","ivec3","ivec4","layout","long","lowp",
+    "mat2","mat2x2","mat2x3","mat2x4","mat3","mat3x2","mat3x3","mat3x4","mat4","mat4x2","mat4x3","mat4x4","mediump",
+    "namespace","noinline","noperspective","out","output","packed","partition","patch","precision","public","readonly",
+    "resource","restrict","return","row_major","sample","sampler1D","sampler1DArray","sampler1DArrayShadow",
+    "sampler1DShadow","sampler2D","sampler2DArray","sampler2DArrayShadow","sampler2DMS","sampler2DMSArray",
+    "sampler2DRect","sampler2DRectShadow","sampler2DShadow","sampler3D","sampler3DRect","samplerBuffer",
+    "samplerCube","samplerCubeArray","samplerCubeArrayShadow","samplerCubeShadow","short","sizeof","smooth","static",
+    "struct","subroutine","superp","switch","template","this","true","typedef","uimage1D","uimage1DArray","uimage2D",
+    "uimage2DArray","uimage2DMS","uimage2DMSArray","uimage2DRect","uimage3D","uimageBuffer","uimageCube",
+    "uimageCubeArray","uint","uniform","union","unsigned","usampler1D","usampler1DArray","usampler2D","usampler2DArray",
+    "usampler2DMS","usampler2DMSArray","usampler2DRect","usampler3D","usamplerBuffer","usamplerCube",
+    "usamplerCubeArray","using","uvec2","uvec3","uvec4","varying","vec2","vec3","vec4","void","volatile","volatile",
+    "while","writeonly"};
 
 	for (auto &id : ids)
 	{
@@ -1121,7 +1141,7 @@ void CompilerGLSL::replace_illegal_names()
 			{
 				auto &m = meta[var.self].decoration;
 				if (m.alias.compare(0, 3, "gl_") == 0 ||
-            std::find(keywords.begin(), keywords.end(), m.alias) != keywords.end())
+            keywords.find(m.alias) != keywords.end())
 					m.alias = join("_", m.alias);
 			}
 		}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -18,6 +18,7 @@
 #include "GLSL.std.450.h"
 #include <algorithm>
 #include <assert.h>
+#include <array>
 
 using namespace spv;
 using namespace spirv_cross;
@@ -1109,6 +1110,8 @@ void CompilerGLSL::emit_specialization_constant(const SPIRConstant &constant)
 
 void CompilerGLSL::replace_illegal_names()
 {
+  std::array<const char*, 201> keywords = {"active","asm","atomic_uint","attribute","bool","break","bvec2","bvec3","bvec4","case","cast","centroid","class","coherent","common","const","continue","default","discard","dmat2","dmat2x2","dmat2x3","dmat2x4","dmat3","dmat3x2","dmat3x3","dmat3x4","dmat4","dmat4x2","dmat4x3","dmat4x4","do","double","dvec2","dvec3","dvec4","else","enum","extern","external","false","filter","fixed","flat","float","for","fvec2","fvec3","fvec4","goto","half","highp","hvec2","hvec3","hvec4","if","iimage1D","iimage1DArray","iimage2D","iimage2DArray","iimage2DMS","iimage2DMSArray","iimage2DRect","iimage3D","iimageBuffer","iimageCube","iimageCubeArray","image1D","image1DArray","image2D","image2DArray","image2DMS","image2DMSArray","image2DRect","image3D","imageBuffer","imageCube","imageCubeArray","in","inline","inout","input","int","interface","invariant","isampler1D","isampler1DArray","isampler2D","isampler2DArray","isampler2DMS","isampler2DMSArray","isampler2DRect","isampler3D","isamplerBuffer","isamplerCube","isamplerCubeArray","ivec2","ivec3","ivec4","layout","long","lowp","mat2","mat2x2","mat2x3","mat2x4","mat3","mat3x2","mat3x3","mat3x4","mat4","mat4x2","mat4x3","mat4x4","mediump","namespace","noinline","noperspective","out","output","packed","partition","patch","precision","public","readonly","resource","restrict","return","row_major","sample","sampler1D","sampler1DArray","sampler1DArrayShadow","sampler1DShadow","sampler2D","sampler2DArray","sampler2DArrayShadow","sampler2DMS","sampler2DMSArray","sampler2DRect","sampler2DRectShadow","sampler2DShadow","sampler3D","sampler3DRect","samplerBuffer","samplerCube","samplerCubeArray","samplerCubeArrayShadow","samplerCubeShadow","short","sizeof","smooth","static","struct","subroutine","superp","switch","template","this","true","typedef","uimage1D","uimage1DArray","uimage2D","uimage2DArray","uimage2DMS","uimage2DMSArray","uimage2DRect","uimage3D","uimageBuffer","uimageCube","uimageCubeArray","uint","uniform","union","unsigned","usampler1D","usampler1DArray","usampler2D","usampler2DArray","usampler2DMS","usampler2DMSArray","usampler2DRect","usampler3D","usamplerBuffer","usamplerCube","usamplerCubeArray","using","uvec2","uvec3","uvec4","varying","vec2","vec3","vec4","void","volatile","volatile","while","writeonly"};
+
 	for (auto &id : ids)
 	{
 		if (id.get_type() == TypeVariable)
@@ -1117,7 +1120,8 @@ void CompilerGLSL::replace_illegal_names()
 			if (!is_hidden_variable(var))
 			{
 				auto &m = meta[var.self].decoration;
-				if (m.alias.compare(0, 3, "gl_") == 0)
+				if (m.alias.compare(0, 3, "gl_") == 0 ||
+            std::find(keywords.begin(), keywords.end(), m.alias) != keywords.end())
 					m.alias = join("_", m.alias);
 			}
 		}


### PR DESCRIPTION
I am converting HLSL shaders to spirv with gslang and converting spirv to GLSL with SPIRV-Cross. I'm running into an issue where I have shaders which define variables named `input` or `output` which are reserved keywords in GLSL (as defined in https://www.opengl.org/registry/doc/GLSLangSpec.4.20.6.pdf under 3.6: Keywords). SPIRV-Cross does modify names starting with `gl_` but not any other keywords.

SPIRV-Cross outputs `input` & `output` (as defined in HLSL) as valid variable names however the driver rejects this code. I modified the function `CompilerGLSL::replace_illegal_names` to check that either `m.alias` starts with `gl_` or equals one of the reserved keywords.

The list of keywords is quite large (201 elements), but it also contains a lot of keywords that are not very likely to ever exist in shaders (like `isampler2DMSArray` or `mat2x3`) I left these in for consistency sake because I don't think there are restrictions on vulkan variable names(?). It should be quite trivial to remove them though.