### PR TITLE
Support MSL-specific functions

### DIFF
--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -136,6 +136,8 @@ protected:
 
 	// Virtualize methods which need to be overridden by subclass targets like C++ and such.
 	virtual void emit_function_prototype(SPIRFunction &func, uint64_t return_flags);
+	virtual void emit_instruction(const Instruction &instr);
+	virtual void emit_glsl_op(uint32_t result_type, uint32_t result_id, uint32_t op, const uint32_t *args, uint32_t count);
 	virtual void emit_header();
 	virtual void emit_sampled_image_op(uint32_t result_type, uint32_t result_id, uint32_t image_id, uint32_t samp_id);
 	virtual void emit_texture_op(const Instruction &i);
@@ -236,8 +238,6 @@ protected:
 	} backend;
 
 	void emit_struct(SPIRType &type);
-	void emit_instruction(const Instruction &instr);
-
 	void emit_resources();
 	void emit_buffer_block(const SPIRVariable &type);
 	void emit_push_constant_block(const SPIRVariable &var);
@@ -261,7 +261,6 @@ protected:
 	bool should_forward(uint32_t id);
 	void emit_mix_op(uint32_t result_type, uint32_t id, uint32_t left, uint32_t right, uint32_t lerp);
 	bool to_trivial_mix_op(const SPIRType &type, std::string &op, uint32_t left, uint32_t right, uint32_t lerp);
-	void emit_glsl_op(uint32_t result_type, uint32_t result_id, uint32_t op, const uint32_t *args, uint32_t count);
 	void emit_quaternary_func_op(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, uint32_t op2,
 	                             uint32_t op3, const char *op);
 	void emit_trinary_func_op(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, uint32_t op2,

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -96,6 +96,8 @@ public:
 	std::string compile() override;
 
 protected:
+	void emit_instruction(const Instruction &instr) override;
+	void emit_glsl_op(uint32_t result_type, uint32_t result_id, uint32_t op, const uint32_t *args, uint32_t count) override;
 	void emit_header() override;
 	void emit_function_prototype(SPIRFunction &func, uint64_t return_flags) override;
 	void emit_sampled_image_op(uint32_t result_type, uint32_t result_id, uint32_t image_id, uint32_t samp_id) override;
@@ -124,7 +126,6 @@ protected:
 	void emit_interface_block(uint32_t ib_var_id);
 	void emit_function_prototype(SPIRFunction &func, bool is_decl);
 	void emit_function_declarations();
-	void emit_msl_defines();
 
 	std::string func_type_decl(SPIRType &type);
 	std::string clean_func_name(std::string func_name);


### PR DESCRIPTION
Updated approach to MSL-specific functions to override emit_instruction() and emit_glsl_op() functions with MSL-specific behaviour. Removed emit_msl_defines() function.