### PR TITLE
WIP: Add control flow graph analysis for variable scoping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,23 +23,25 @@ if(${CMAKE_GENERATOR} MATCHES "Makefile")
 endif()
 
 add_library(spirv-cross-core STATIC
-	${CMAKE_CURRENT_SOURCE_DIR}/GLSL.std.450.h
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_common.hpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv.hpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross.hpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross.cpp)
+		${CMAKE_CURRENT_SOURCE_DIR}/GLSL.std.450.h
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_common.hpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv.hpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross.hpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cfg.hpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cfg.cpp)
 
 add_library(spirv-cross-glsl STATIC
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_glsl.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_glsl.hpp)
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_glsl.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_glsl.hpp)
 
 add_library(spirv-cross-cpp STATIC
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_cpp.hpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_cpp.cpp)
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cpp.hpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cpp.cpp)
 
 add_library(spirv-cross-msl STATIC
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_msl.hpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_msl.cpp)
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_msl.hpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_msl.cpp)
 
 add_executable(spirv-cross main.cpp)
 target_link_libraries(spirv-cross spirv-cross-glsl spirv-cross-cpp spirv-cross-msl spirv-cross-core)

--- a/main.cpp
+++ b/main.cpp
@@ -401,11 +401,13 @@ struct CLIArguments
 	bool metal = false;
 	bool vulkan_semantics = false;
 	bool remove_unused = false;
+	bool cfg_analysis = true;
 };
 
 static void print_help()
 {
-	fprintf(stderr, "Usage: spirv-cross [--output <output path>] [SPIR-V file] [--es] [--no-es] [--version <GLSL "
+	fprintf(stderr, "Usage: spirv-cross [--output <output path>] [SPIR-V file] [--es] [--no-es] [--no-cfg-analysis] "
+	                "[--version <GLSL "
 	                "version>] [--dump-resources] [--help] [--force-temporary] [--cpp] [--cpp-interface-name <name>] "
 	                "[--metal] [--vulkan-semantics] [--flatten-ubo] [--fixup-clipspace] [--iterations iter] [--pls-in "
 	                "format input-name] [--pls-out format output-name] [--remap source_name target_name components] "
@@ -519,6 +521,7 @@ int main(int argc, char *argv[])
 		args.version = parser.next_uint();
 		args.set_version = true;
 	});
+	cbs.add("--no-cfg-analysis", [&args](CLIParser &) { args.cfg_analysis = false; });
 	cbs.add("--dump-resources", [&args](CLIParser &) { args.dump_resources = true; });
 	cbs.add("--force-temporary", [&args](CLIParser &) { args.force_temporary = true; });
 	cbs.add("--flatten-ubo", [&args](CLIParser &) { args.flatten_ubo = true; });
@@ -623,6 +626,7 @@ int main(int argc, char *argv[])
 	opts.force_temporary = args.force_temporary;
 	opts.vulkan_semantics = args.vulkan_semantics;
 	opts.vertex.fixup_clipspace = args.fixup;
+	opts.cfg_analysis = args.cfg_analysis;
 	compiler->set_options(opts);
 
 	ShaderResources res;

--- a/msvc/SPIRV-Cross.vcxproj
+++ b/msvc/SPIRV-Cross.vcxproj
@@ -128,6 +128,7 @@
     <ClCompile Include="..\spirv_cross.cpp" />
     <ClCompile Include="..\spirv_glsl.cpp" />
     <ClCompile Include="..\spirv_msl.cpp" />
+    <ClCompile Include="..\spirv_cfg.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\GLSL.std.450.h" />
@@ -137,6 +138,7 @@
     <ClInclude Include="..\spirv_glsl.hpp" />
     <ClInclude Include="..\spirv.hpp" />
     <ClInclude Include="..\spirv_msl.hpp" />
+    <ClInclude Include="..\spirv_cfg.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/msvc/SPIRV-Cross.vcxproj.filters
+++ b/msvc/SPIRV-Cross.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="..\spirv_msl.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\spirv_cfg.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\GLSL.std.450.h">
@@ -51,6 +54,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\spirv_msl.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\spirv_cfg.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/reference/shaders/comp/cfg.comp
+++ b/reference/shaders/comp/cfg.comp
@@ -1,0 +1,82 @@
+#version 310 es
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0, std430) buffer SSBO
+{
+    float data;
+} _11;
+
+void test()
+{
+    float m;
+    if ((_11.data != 0.0))
+    {
+        float tmp = 10.0;
+        _11.data = tmp;
+    }
+    else
+    {
+        float tmp_1 = 15.0;
+        _11.data = tmp_1;
+    }
+    if ((_11.data != 0.0))
+    {
+        float e;
+        if ((_11.data != 5.0))
+        {
+            if ((_11.data != 6.0))
+            {
+                e = 10.0;
+            }
+        }
+        else
+        {
+            e = 20.0;
+        }
+    }
+    switch (int(_11.data))
+    {
+        case 0:
+        {
+            float tmp_2 = 20.0;
+            _11.data = tmp_2;
+            break;
+        }
+        case 1:
+        {
+            float tmp_3 = 30.0;
+            _11.data = tmp_3;
+            break;
+        }
+    }
+    float f;
+    switch (int(_11.data))
+    {
+        case 0:
+        {
+            f = 30.0;
+            break;
+        }
+        case 1:
+        {
+            f = 40.0;
+            break;
+        }
+    }
+    int i = 0;
+    float h;
+    for (; (i < 20); i = (i + 1), h = (h + 10.0))
+    {
+    }
+    _11.data = h;
+    do
+    {
+    } while ((m != 20.0));
+    _11.data = m;
+}
+
+void main()
+{
+    test();
+}
+

--- a/reference/shaders/comp/generate_height.comp
+++ b/reference/shaders/comp/generate_height.comp
@@ -19,7 +19,6 @@ layout(binding = 1, std430) buffer HeightmapFFT
 uvec2 workaround_mix(uvec2 a, uvec2 b, bvec2 sel)
 {
     uint _137;
-    uint _148;
     if (sel.x)
     {
         _137 = b.x;
@@ -29,6 +28,7 @@ uvec2 workaround_mix(uvec2 a, uvec2 b, bvec2 sel)
         _137 = a.x;
     }
     uint _147 = _137;
+    uint _148;
     if (sel.y)
     {
         _148 = b.y;

--- a/reference/shaders/comp/loop.comp
+++ b/reference/shaders/comp/loop.comp
@@ -18,9 +18,6 @@ void main()
     vec4 idat = _24.in_data[ident];
     int k = 0;
     uint i = 0u;
-    uint i_1;
-    uint j;
-    int l;
     if ((idat.y == 20.0))
     {
         do
@@ -63,10 +60,10 @@ void main()
         idat = (idat * 2.0);
         k = (k + 1);
     }
-    i_1 = 0u;
+    uint i_1 = 0u;
     for (; (i_1 < 16u); i_1 = (i_1 + uint(1)), k = (k + 1))
     {
-        j = 0u;
+        uint j = 0u;
         for (; (j < 30u); j = (j + uint(1)))
         {
             idat = (_24.mvp * idat);
@@ -93,7 +90,7 @@ void main()
     {
         k = (k + 1);
     } while ((k > 10));
-    l = 0;
+    int l = 0;
     for (;;)
     {
         if ((l == 5))

--- a/reference/shaders/comp/return.comp
+++ b/reference/shaders/comp/return.comp
@@ -9,7 +9,6 @@ layout(binding = 1, std430) buffer SSBO2
 void main()
 {
     uint ident = gl_GlobalInvocationID.x;
-    int i;
     if ((ident == 2u))
     {
         _27.out_data[ident] = vec4(20.0);
@@ -22,7 +21,7 @@ void main()
             return;
         }
     }
-    i = 0;
+    int i = 0;
     for (; (i < 20); i = (i + 1))
     {
         if ((i == 10))

--- a/reference/shaders/comp/torture-loop.comp
+++ b/reference/shaders/comp/torture-loop.comp
@@ -17,8 +17,6 @@ void main()
     uint ident = gl_GlobalInvocationID.x;
     vec4 idat = _24.in_data[ident];
     int k = 0;
-    uint i;
-    uint j;
     for (;;)
     {
         int _39 = k;
@@ -35,10 +33,10 @@ void main()
             break;
         }
     }
-    i = 0u;
+    uint i = 0u;
     for (; (i < 16u); i = (i + uint(1)), k = (k + 1))
     {
-        j = 0u;
+        uint j = 0u;
         for (; (j < 30u); j = (j + uint(1)))
         {
             idat = (_24.mvp * idat);

--- a/reference/shaders/frag/mix.frag
+++ b/reference/shaders/frag/mix.frag
@@ -15,7 +15,6 @@ void main()
     bool f = true;
     FragColor = vec4(mix(vIn2, vIn3, f));
     highp vec4 _35;
-    highp float _44;
     if (f)
     {
         _35 = vIn0;
@@ -25,6 +24,7 @@ void main()
         _35 = vIn1;
     }
     FragColor = _35;
+    highp float _44;
     if (f)
     {
         _44 = vIn2;

--- a/reference/shaders/tesc/water_tess.tesc
+++ b/reference/shaders/tesc/water_tess.tesc
@@ -99,7 +99,6 @@ void main()
 {
     vec2 p0 = vPatchPosBase[0];
     vec2 param = p0;
-    vec2 param_1;
     if ((!frustum_cull(param)))
     {
         gl_TessLevelOuter[0] = -1.0;
@@ -111,7 +110,7 @@ void main()
     }
     else
     {
-        param_1 = p0;
+        vec2 param_1 = p0;
         compute_tess_levels(param_1);
     }
 }

--- a/reference/shaders/vert/ground.vert
+++ b/reference/shaders/vert/ground.vert
@@ -58,10 +58,7 @@ vec2 warp_position()
     uint ufloor_lod = uint(floor_lod);
     uvec2 uPosition = uvec2(Position);
     uvec2 mask = ((uvec2(1u) << uvec2(ufloor_lod, (ufloor_lod + 1u))) - uvec2(1u));
-    uvec2 rounding;
     uint _332;
-    uint _343;
-    vec4 lower_upper_snapped;
     if ((uPosition.x < 32u))
     {
         _332 = mask.x;
@@ -71,6 +68,7 @@ vec2 warp_position()
         _332 = 0u;
     }
     uint _342 = _332;
+    uint _343;
     if ((uPosition.y < 32u))
     {
         _343 = mask.y;
@@ -79,8 +77,8 @@ vec2 warp_position()
     {
         _343 = 0u;
     }
-    rounding = uvec2(_342, _343);
-    lower_upper_snapped = vec4(((uPosition + rounding).xyxy & (~mask).xxyy));
+    uvec2 rounding = uvec2(_342, _343);
+    vec4 lower_upper_snapped = vec4(((uPosition + rounding).xyxy & (~mask).xxyy));
     return mix(lower_upper_snapped.xy, lower_upper_snapped.zw, vec2(fract_lod));
 }
 

--- a/reference/shaders/vert/ocean.vert
+++ b/reference/shaders/vert/ocean.vert
@@ -59,12 +59,7 @@ vec2 warp_position()
     uint ufloor_lod = uint(floor_lod);
     uvec4 uPosition = uvec4(Position);
     uvec2 mask = ((uvec2(1u) << uvec2(ufloor_lod, (ufloor_lod + 1u))) - uvec2(1u));
-    uvec4 rounding;
     uint _333;
-    uint _345;
-    uint _356;
-    uint _368;
-    vec4 lower_upper_snapped;
     if ((uPosition.x < 32u))
     {
         _333 = mask.x;
@@ -73,7 +68,9 @@ vec2 warp_position()
     {
         _333 = 0u;
     }
+    uvec4 rounding;
     rounding.x = _333;
+    uint _345;
     if ((uPosition.y < 32u))
     {
         _345 = mask.x;
@@ -83,6 +80,7 @@ vec2 warp_position()
         _345 = 0u;
     }
     rounding.y = _345;
+    uint _356;
     if ((uPosition.x < 32u))
     {
         _356 = mask.y;
@@ -92,6 +90,7 @@ vec2 warp_position()
         _356 = 0u;
     }
     rounding.z = _356;
+    uint _368;
     if ((uPosition.y < 32u))
     {
         _368 = mask.y;
@@ -101,7 +100,7 @@ vec2 warp_position()
         _368 = 0u;
     }
     rounding.w = _368;
-    lower_upper_snapped = vec4(((uPosition.xyxy + rounding) & (~mask).xxyy));
+    vec4 lower_upper_snapped = vec4(((uPosition.xyxy + rounding) & (~mask).xxyy));
     return mix(lower_upper_snapped.xy, lower_upper_snapped.zw, vec2(fract_lod));
 }
 

--- a/shaders/comp/cfg.comp
+++ b/shaders/comp/cfg.comp
@@ -1,0 +1,91 @@
+#version 310 es
+layout(local_size_x = 1) in;
+
+layout(std430, binding = 0) buffer SSBO
+{
+	float data;
+};
+
+void test()
+{
+	// Test that variables local to a scope stay local.
+	if (data != 0.0)
+	{
+		float tmp = 10.0;
+		data = tmp;
+	}
+	else
+	{
+		float tmp = 15.0;
+		data = tmp;
+	}
+
+	// Test that variable access propagates up to dominator
+	if (data != 0.0)
+	{
+		float e;
+		if (data != 5.0)
+		{
+			if (data != 6.0)
+				e = 10.0;
+		}
+		else
+			e = 20.0;
+	}
+
+	// Test that variables local to a switch block stay local.
+	switch (int(data))
+	{
+		case 0:
+		{
+			float tmp = 20.0;
+			data = tmp;
+			break;
+		}
+
+		case 1:
+		{
+			float tmp = 30.0;
+			data = tmp;
+			break;
+		}
+	}
+
+	// Check that multibranches propagate up to dominator.
+	float f;
+	switch (int(data))
+	{
+		case 0:
+		{
+			f = 30.0;
+			break;
+		}
+
+		case 1:
+		{
+			f = 40.0;
+			break;
+		}
+	}
+
+	// Check that loops work.
+	// Interesting case here is propagating variable access from the continue block.
+	float h;
+	for (int i = 0; i < 20; i++, h += 10.0)
+		;
+	data = h;
+
+	// Do the same with do-while, gotta test all the hard cases.
+	float m;
+	do
+	{
+	} while (m != 20.0);
+	data = m;
+}
+
+void main()
+{
+	// Test that we do the CFG analysis for all functions.
+	test();
+}
+

--- a/spirv_cfg.cpp
+++ b/spirv_cfg.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2016 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "spirv_cfg.hpp"
+#include <algorithm>
+
+using namespace std;
+
+namespace spirv_cross
+{
+CFG::CFG(Compiler &compiler_, const SPIRFunction &func_)
+    : compiler(compiler_), func(func_)
+{
+	preceding_edges.resize(compiler.get_current_id_bound());
+	succeeding_edges.resize(compiler.get_current_id_bound());
+	visit_order.resize(compiler.get_current_id_bound());
+	immediate_dominators.resize(compiler.get_current_id_bound());
+
+	// Set up all edges between blocks.
+	for (auto block_id : func.blocks)
+	{
+		auto &block = compiler.get<SPIRBlock>(block_id);
+
+		switch (block.terminator)
+		{
+		case SPIRBlock::Direct:
+			add_branch(block.self, block.next_block);
+			break;
+
+		case SPIRBlock::Select:
+			add_branch(block.self, block.true_block);
+			add_branch(block.self, block.false_block);
+			break;
+
+		case SPIRBlock::MultiSelect:
+			for (auto &target : block.cases)
+				add_branch(block.self, target.block);
+			if (block.default_block)
+				add_branch(block.self, block.default_block);
+			break;
+
+		default:
+			break;
+		}
+	}
+
+	build_post_order_visit_order();
+	build_immediate_dominators();
+}
+
+uint32_t CFG::find_common_dominator(uint32_t a, uint32_t b) const
+{
+	while (a != b)
+	{
+		if (visit_order[a] < visit_order[b])
+			a = immediate_dominators[a];
+		else
+			b = immediate_dominators[b];
+	}
+	return a;
+}
+
+uint32_t CFG::update_common_dominator(uint32_t a, uint32_t b)
+{
+	auto dominator = find_common_dominator(immediate_dominators[a], immediate_dominators[b]);
+	immediate_dominators[a] = dominator;
+	immediate_dominators[b] = dominator;
+	return dominator;
+}
+
+void CFG::build_immediate_dominators()
+{
+	// Traverse the post-order in reverse and build up the immediate dominator tree.
+	fill(begin(immediate_dominators), end(immediate_dominators), 0);
+	immediate_dominators[func.entry_block] = func.entry_block;
+
+	for (auto i = post_order.size(); i; i--)
+	{
+		uint32_t block = post_order[i - 1];
+		auto &pred = preceding_edges[block];
+		if (pred.empty()) // This is for the entry block, but we've already set up the dominators.
+			continue;
+
+		for (auto &edge : pred)
+		{
+			if (!immediate_dominators[block])
+				immediate_dominators[block] = edge;
+			else if (immediate_dominators[block] && immediate_dominators[edge])
+				immediate_dominators[block] = update_common_dominator(block, edge);
+		}
+	}
+}
+
+void CFG::post_order_visit(uint32_t block)
+{
+	// If we have already branched to this block (back edge), stop recursion.
+	if (visit_order[block] >= 0)
+		return;
+
+	// Block back-edges from recursively revisiting ourselves.
+	visit_order[block] = 0;
+
+	// First visit our branch targets.
+	auto &succeeding = succeeding_edges[block];
+	for (auto &id : succeeding)
+		post_order_visit(id);
+	// Then visit ourselves.
+	visit_order[block] = visit_count++;
+	post_order.push_back(block);
+}
+
+void CFG::build_post_order_visit_order()
+{
+	uint32_t block = func.entry_block;
+	visit_count = 0;
+	fill(begin(visit_order), end(visit_order), -1);
+	post_order.clear();
+	post_order_visit(block);
+}
+
+void CFG::add_branch(uint32_t from, uint32_t to)
+{
+	const auto add_unique = [](vector<uint32_t> &l, uint32_t value) {
+		auto itr = find(begin(l), end(l), value);
+		if (itr == end(l))
+			l.push_back(value);
+	};
+	add_unique(preceding_edges[to], from);
+	add_unique(succeeding_edges[from], to);
+}
+
+DominatorBuilder::DominatorBuilder(const CFG &cfg_)
+	: cfg(cfg_)
+{
+}
+
+void DominatorBuilder::add_block(uint32_t block)
+{
+	if (!dominator)
+	{
+		dominator = block;
+		return;
+	}
+
+	if (block != dominator)
+		dominator = cfg.find_common_dominator(block, dominator);
+}
+}

--- a/spirv_cfg.hpp
+++ b/spirv_cfg.hpp
@@ -55,7 +55,7 @@ private:
 	void add_branch(uint32_t from, uint32_t to);
 	void build_post_order_visit_order();
 	void build_immediate_dominators();
-	void post_order_visit(uint32_t block);
+	bool post_order_visit(uint32_t block);
 	uint32_t visit_count = 0;
 
 	uint32_t update_common_dominator(uint32_t a, uint32_t b);

--- a/spirv_cfg.hpp
+++ b/spirv_cfg.hpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SPIRV_CROSS_CFG_HPP
+#define SPIRV_CROSS_CFG_HPP
+
+#include "spirv_cross.hpp"
+
+namespace spirv_cross
+{
+class CFG
+{
+public:
+	CFG(Compiler &compiler, const SPIRFunction &function);
+
+	Compiler &get_compiler()
+	{
+		return compiler;
+	}
+
+	uint32_t get_immediate_dominator(uint32_t block) const
+	{
+		return immediate_dominators[block];
+	}
+
+	uint32_t get_post_order(uint32_t block) const
+	{
+		return post_order[block];
+	}
+
+	uint32_t find_common_dominator(uint32_t a, uint32_t b) const;
+
+private:
+	Compiler &compiler;
+	const SPIRFunction &func;
+	std::vector<std::vector<uint32_t>> preceding_edges;
+	std::vector<std::vector<uint32_t>> succeeding_edges;
+	std::vector<uint32_t> immediate_dominators;
+	std::vector<int> visit_order;
+	std::vector<uint32_t> post_order;
+
+	void add_branch(uint32_t from, uint32_t to);
+	void build_post_order_visit_order();
+	void build_immediate_dominators();
+	void post_order_visit(uint32_t block);
+	uint32_t visit_count = 0;
+
+	uint32_t update_common_dominator(uint32_t a, uint32_t b);
+};
+
+class DominatorBuilder
+{
+public:
+	DominatorBuilder(const CFG &cfg);
+
+	void add_block(uint32_t block);
+	uint32_t get_dominator() const
+	{
+		return dominator;
+	}
+
+private:
+	const CFG &cfg;
+	uint32_t dominator = 0;
+};
+}
+
+#endif

--- a/spirv_cfg.hpp
+++ b/spirv_cfg.hpp
@@ -59,6 +59,7 @@ private:
 	uint32_t visit_count = 0;
 
 	uint32_t update_common_dominator(uint32_t a, uint32_t b);
+	bool is_back_edge(uint32_t to) const;
 };
 
 class DominatorBuilder

--- a/spirv_cfg.hpp
+++ b/spirv_cfg.hpp
@@ -18,6 +18,7 @@
 #define SPIRV_CROSS_CFG_HPP
 
 #include "spirv_cross.hpp"
+#include <assert.h>
 
 namespace spirv_cross
 {
@@ -31,14 +32,26 @@ public:
 		return compiler;
 	}
 
+	const Compiler &get_compiler() const
+	{
+		return compiler;
+	}
+
+	const SPIRFunction &get_function() const
+	{
+		return func;
+	}
+
 	uint32_t get_immediate_dominator(uint32_t block) const
 	{
 		return immediate_dominators[block];
 	}
 
-	uint32_t get_post_order(uint32_t block) const
+	uint32_t get_visit_order(uint32_t block) const
 	{
-		return post_order[block];
+		int v = visit_order[block];
+		assert(v > 0);
+		return uint32_t(v);
 	}
 
 	uint32_t find_common_dominator(uint32_t a, uint32_t b) const;
@@ -72,6 +85,8 @@ public:
 	{
 		return dominator;
 	}
+
+	void lift_continue_block_dominator();
 
 private:
 	const CFG &cfg;

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SPIRV_COMMON_HPP
-#define SPIRV_COMMON_HPP
+#ifndef SPIRV_CROSS_COMMON_HPP
+#define SPIRV_CROSS_COMMON_HPP
 
 #include <functional>
 #include <sstream>
@@ -356,7 +356,6 @@ struct SPIRBlock : IVariant
 
 		Select, // Block ends with an if/else block.
 		MultiSelect, // Block ends with switch statement.
-		Loop, // Block ends with a loop.
 
 		Return, // Block ends with return.
 		Unreachable, // Noop
@@ -444,6 +443,10 @@ struct SPIRBlock : IVariant
 	// The dominating block which this block might be within.
 	// Used in continue; blocks to determine if we really need to write continue.
 	uint32_t loop_dominator = 0;
+
+	// All access to these variables are dominated by this block,
+	// so before branching anywhere we need to make sure that we declare these variables.
+	std::vector<uint32_t> dominated_variables;
 };
 
 struct SPIRFunction : IVariant

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -513,6 +513,7 @@ struct SPIRFunction : IVariant
 	bool active = false;
 	bool flush_undeclared = true;
 	bool do_combined_parameters = true;
+	bool analyzed_variable_scope = false;
 };
 
 struct SPIRVariable : IVariant

--- a/spirv_cpp.hpp
+++ b/spirv_cpp.hpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SPIRV_CPP_HPP
-#define SPIRV_CPP_HPP
+#ifndef SPIRV_CROSS_CPP_HPP
+#define SPIRV_CROSS_CPP_HPP
 
 #include "spirv_glsl.hpp"
 #include <utility>

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -2912,6 +2912,8 @@ void Compiler::analyze_variable_scope(SPIRFunction &entry)
 		for (auto &block : blocks)
 			builder.add_block(block);
 
+		builder.lift_continue_block_dominator();
+
 		// Add it to a per-block list of variables.
 		uint32_t dominating_block = builder.get_dominator();
 		// If all blocks here are dead code, this will be 0, so the variable in question

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -578,10 +578,6 @@ private:
 	ShaderResources get_shader_resources(const std::unordered_set<uint32_t> *active_variables) const;
 
 	VariableTypeRemapCallback variable_remap_callback;
-
-	SPIRBlock &find_common_dominator(
-	    const SPIRBlock &entry, uint32_t variable,
-	    const std::unordered_map<uint32_t, std::unordered_set<uint32_t>> &block_to_variable_map);
 };
 }
 

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -110,6 +110,7 @@ class Compiler
 {
 public:
 	friend class CFG;
+	friend class DominatorBuilder;
 
 	// The constructor takes a buffer of SPIR-V words and parses it.
 	Compiler(std::vector<uint32_t> ir);

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -109,6 +109,8 @@ struct BufferRange
 class Compiler
 {
 public:
+	friend class CFG;
+
 	// The constructor takes a buffer of SPIR-V words and parses it.
 	Compiler(std::vector<uint32_t> ir);
 
@@ -309,6 +311,11 @@ public:
 	SPIRConstant &get_constant(uint32_t id);
 	const SPIRConstant &get_constant(uint32_t id) const;
 
+	uint32_t get_current_id_bound() const
+	{
+		return uint32_t(ids.size());
+	}
+
 protected:
 	const uint32_t *stream(const Instruction &instr) const
 	{
@@ -473,6 +480,8 @@ protected:
 			variable_remap_callback(type, var_name, type_name);
 	}
 
+	void analyze_variable_scope(SPIRFunction &function);
+
 private:
 	void parse();
 	void parse(const Instruction &i);
@@ -485,6 +494,15 @@ private:
 		// Return true if traversal should continue.
 		// If false, traversal will end immediately.
 		virtual bool handle(spv::Op opcode, const uint32_t *args, uint32_t length) = 0;
+
+		virtual bool follow_function_call(const SPIRFunction &)
+		{
+			return true;
+		}
+
+		virtual void set_current_block(const SPIRBlock &)
+		{
+		}
 
 		virtual bool begin_function_scope(const uint32_t *, uint32_t)
 		{
@@ -559,6 +577,10 @@ private:
 	ShaderResources get_shader_resources(const std::unordered_set<uint32_t> *active_variables) const;
 
 	VariableTypeRemapCallback variable_remap_callback;
+
+	SPIRBlock &find_common_dominator(
+	    const SPIRBlock &entry, uint32_t variable,
+	    const std::unordered_map<uint32_t, std::unordered_set<uint32_t>> &block_to_variable_map);
 };
 }
 

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -5232,9 +5232,17 @@ void CompilerGLSL::emit_function(SPIRFunction &func, uint64_t return_flags)
 		}
 	}
 
-	analyze_variable_scope(func);
-
 	auto &entry_block = get<SPIRBlock>(func.entry_block);
+
+	if (!func.analyzed_variable_scope)
+	{
+		if (options.cfg_analysis)
+			analyze_variable_scope(func);
+		else
+			entry_block.dominated_variables = func.local_variables;
+		func.analyzed_variable_scope = true;
+	}
+
 	entry_block.loop_dominator = SPIRBlock::NoDominator;
 	emit_block_chain(entry_block);
 

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -5508,8 +5508,12 @@ bool CompilerGLSL::attempt_emit_loop_header(SPIRBlock &block, SPIRBlock::Method 
 	}
 	else if (method == SPIRBlock::MergeToDirectForLoop)
 	{
-		uint32_t current_count = statement_count;
 		auto &child = get<SPIRBlock>(block.next_block);
+
+		// This block may be a dominating block, so make sure we flush undeclared variables before building the for loop header.
+		flush_undeclared_variables(child);
+
+		uint32_t current_count = statement_count;
 
 		// If we're trying to create a true for loop,
 		// we need to make sure that all opcodes before branch statement do not actually emit any code.

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -60,6 +60,9 @@ public:
 		bool es = false;
 		bool force_temporary = false;
 
+		// If true, variables will be moved to their appropriate scope through CFG analysis.
+		bool cfg_analysis = true;
+
 		// If true, Vulkan GLSL features are used instead of GL-compatible features.
 		// Mostly useful for debugging SPIR-V files.
 		bool vulkan_semantics = false;

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SPIRV_GLSL_HPP
-#define SPIRV_GLSL_HPP
+#ifndef SPIRV_CROSS_GLSL_HPP
+#define SPIRV_CROSS_GLSL_HPP
 
 #include "spirv_cross.hpp"
 #include <sstream>
@@ -257,7 +257,7 @@ protected:
 	void flush_phi(uint32_t from, uint32_t to);
 	bool flush_phi_required(uint32_t from, uint32_t to);
 	void flush_variable_declaration(uint32_t id);
-	void flush_undeclared_variables();
+	void flush_undeclared_variables(SPIRBlock &block);
 
 	bool should_forward(uint32_t id);
 	void emit_mix_op(uint32_t result_type, uint32_t id, uint32_t left, uint32_t right, uint32_t lerp);

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SPIRV_MSL_HPP
-#define SPIRV_MSL_HPP
+#ifndef SPIRV_CROSS_MSL_HPP
+#define SPIRV_CROSS_MSL_HPP
 
 #include "spirv_glsl.hpp"
 #include <set>


### PR DESCRIPTION
A currently uglyness in SPIRV-Cross output is that variables are always declared in the entry block if they aren't accessed there to avoid problems where multiple scopes potentially access a variable. This PR implement CFG traversal and dominance analysis to figure out where to optimally place variable declarations to improve readability of generated code.

This is also the first step to properly fix https://github.com/KhronosGroup/SPIRV-Cross/issues/55