### PR TITLE
Legacy GL_ARB_shader_texture_lod support.

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -2128,8 +2128,13 @@ string CompilerGLSL::legacy_tex_op(const std::string &op, const SPIRType &imgtyp
 		break;
 	}
 
-	if (is_legacy_es() && (op == "textureLod" || op == "textureProjLod"))
-		require_extension("GL_EXT_shader_texture_lod");
+	if (op == "textureLod" || op == "textureProjLod") 
+	{
+		if (is_legacy_es())
+			require_extension("GL_EXT_shader_texture_lod");
+		else if (is_legacy())
+			require_extension("GL_ARB_shader_texture_lod");
+	}
 
 	if (op == "texture")
 		return join("texture", type);


### PR DESCRIPTION
Enables [GL_ARB_shader_texture_lod](https://cvs.khronos.org/svn/repos/ogl/trunk/doc/registry/public/specs/ARB/shader_texture_lod.txt) extension if textureLod() is used on version < 130.