### PR TITLE
Updated Android build

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -4,7 +4,7 @@ include $(CLEAR_VARS)
 
 LOCAL_CFLAGS += -std=c++11 -Wall -Wextra
 LOCAL_MODULE := spirv-cross
-LOCAL_SRC_FILES := ../spirv_cross.cpp ../spirv_glsl.cpp ../spirv_cpp.cpp
+LOCAL_SRC_FILES := ../spirv_cfg.cpp ../spirv_cross.cpp ../spirv_glsl.cpp ../spirv_msl.cpp ../spirv_cpp.cpp
 LOCAL_CPP_FEATURES := exceptions
 LOCAL_ARM_MODE := arm
 

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -21,6 +21,10 @@
 #include <set>
 #include <vector>
 
+#ifndef UINT32_MAX
+#define UINT32_MAX ((uint32_t)-1)
+#endif
+
 namespace spirv_cross
 {
 


### PR DESCRIPTION
Added spirv_cfg.cpp and spirv_msl.cpp to makefile

UINT32_MAX was giving me a compile error being undefined, neither including `<cstdint>` nor `<stdint.h>` fixed that. It could be done with `<limits>` and `std::numeric_limits<T>::max()`, but as this is a `const static` I fear there could be a problem because of static initialization order, so this seems to be the safest way to me.