### PR TITLE
Fix get_declared_struct_size for nested arrays of structs.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -198,6 +198,10 @@ static void print_resources(const Compiler &compiler, const char *tag, const vec
 		                 ((1ull << DecorationBlock) | (1ull << DecorationBufferBlock))) != 0;
 		uint32_t fallback_id = !is_push_constant && is_block ? res.base_type_id : res.id;
 
+		uint32_t block_size = 0;
+		if (is_block)
+			block_size = compiler.get_declared_struct_size(compiler.get_type(res.base_type_id));
+
 		string array;
 		for (auto arr : type.array)
 			array = join("[", arr ? convert_to_string(arr) : "", "]") + array;
@@ -213,6 +217,8 @@ static void print_resources(const Compiler &compiler, const char *tag, const vec
 			fprintf(stderr, " (Binding : %u)", compiler.get_decoration(res.id, DecorationBinding));
 		if (mask & (1ull << DecorationInputAttachmentIndex))
 			fprintf(stderr, " (Attachment : %u)", compiler.get_decoration(res.id, DecorationInputAttachmentIndex));
+		if (is_block)
+			fprintf(stderr, " (BlockSize : %u bytes)", block_size);
 		fprintf(stderr, "\n");
 	}
 	fprintf(stderr, "=============\n\n");

--- a/reference/shaders/comp/struct-packing.comp
+++ b/reference/shaders/comp/struct-packing.comp
@@ -25,6 +25,11 @@ struct S3
     float b;
 };
 
+struct S4
+{
+    vec2 c;
+};
+
 struct Content
 {
     S0 m0s[1];
@@ -35,6 +40,7 @@ struct Content
     S2 m2;
     S3 m3;
     float m4;
+    S4 m3s[8];
 };
 
 layout(binding = 1, std430) buffer SSBO1
@@ -78,5 +84,13 @@ void main()
     ssbo_430.content.m3.a = ssbo_140.content.m3.a;
     ssbo_430.content.m3.b = ssbo_140.content.m3.b;
     ssbo_430.content.m4 = ssbo_140.content.m4;
+    ssbo_430.content.m3s[0].c = ssbo_140.content.m3s[0].c;
+    ssbo_430.content.m3s[1].c = ssbo_140.content.m3s[1].c;
+    ssbo_430.content.m3s[2].c = ssbo_140.content.m3s[2].c;
+    ssbo_430.content.m3s[3].c = ssbo_140.content.m3s[3].c;
+    ssbo_430.content.m3s[4].c = ssbo_140.content.m3s[4].c;
+    ssbo_430.content.m3s[5].c = ssbo_140.content.m3s[5].c;
+    ssbo_430.content.m3s[6].c = ssbo_140.content.m3s[6].c;
+    ssbo_430.content.m3s[7].c = ssbo_140.content.m3s[7].c;
 }
 

--- a/shaders/comp/struct-packing.comp
+++ b/shaders/comp/struct-packing.comp
@@ -25,6 +25,11 @@ struct S3
     float b;
 };
 
+struct S4
+{
+	vec2 c;
+};
+
 struct Content
 {
     S0 m0s[1];
@@ -35,6 +40,8 @@ struct Content
     S2 m2;
     S3 m3;
     float m4;
+
+	S4 m3s[8];
 };
 
 layout(binding = 1, std430) buffer SSBO1

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -2115,7 +2115,14 @@ size_t Compiler::get_declared_struct_member_size(const SPIRType &struct_type, ui
 		// Recurse.
 		uint32_t last = uint32_t(struct_type.member_types.size() - 1);
 		uint32_t offset = type_struct_member_offset(struct_type, last);
-		size_t size = get_declared_struct_size(get<SPIRType>(struct_type.member_types.back()));
+		size_t size;
+
+		// If we have an array of structs inside our struct, handle that with array strides instead.
+		auto &last_type = get<SPIRType>(struct_type.member_types.back());
+		if (last_type.array.empty())
+			size = get_declared_struct_size(last_type);
+		else
+			size = type_struct_member_array_stride(struct_type, last) * last_type.array.back();
 		return offset + size;
 	}
 }


### PR DESCRIPTION
The array size was dropped from consideration during recursion.