### PR TITLE
Implement buffer block flattening

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -672,7 +672,7 @@ int main(int argc, char *argv[])
 
 	if (args.flatten_ubo)
 		for (auto &ubo : res.uniform_buffers)
-			compiler->flatten_interface_block(ubo.id);
+			compiler->flatten_buffer_block(ubo.id);
 
 	auto pls_inputs = remap_pls(args.pls_in, res.stage_inputs, &res.subpass_inputs);
 	auto pls_outputs = remap_pls(args.pls_out, res.stage_outputs, nullptr);

--- a/reference/shaders/flatten/array.flatten.vert
+++ b/reference/shaders/flatten/array.flatten.vert
@@ -5,6 +5,6 @@ in vec4 aVertex;
 
 void main()
 {
-    gl_Position = (mat4(UBO[0],UBO[1],UBO[2],UBO[3]) * aVertex) + UBO[13];
+    gl_Position = (mat4(UBO[0], UBO[1], UBO[2], UBO[3]) * aVertex) + UBO[13];
 }
 

--- a/reference/shaders/flatten/array.flatten.vert
+++ b/reference/shaders/flatten/array.flatten.vert
@@ -1,0 +1,10 @@
+#version 310 es
+
+uniform vec4 UBO[14];
+in vec4 aVertex;
+
+void main()
+{
+    gl_Position = (mat4(UBO[0],UBO[1],UBO[2],UBO[3]) * aVertex) + UBO[13];
+}
+

--- a/reference/shaders/flatten/basic.flatten.vert
+++ b/reference/shaders/flatten/basic.flatten.vert
@@ -1,0 +1,13 @@
+#version 310 es
+
+uniform vec4 UBO[4];
+in vec4 aVertex;
+out vec3 vNormal;
+in vec3 aNormal;
+
+void main()
+{
+    gl_Position = mat4(UBO[0],UBO[1],UBO[2],UBO[3]) * aVertex;
+    vNormal = aNormal;
+}
+

--- a/reference/shaders/flatten/basic.flatten.vert
+++ b/reference/shaders/flatten/basic.flatten.vert
@@ -7,7 +7,7 @@ in vec3 aNormal;
 
 void main()
 {
-    gl_Position = mat4(UBO[0],UBO[1],UBO[2],UBO[3]) * aVertex;
+    gl_Position = mat4(UBO[0], UBO[1], UBO[2], UBO[3]) * aVertex;
     vNormal = aNormal;
 }
 

--- a/reference/shaders/flatten/copy.flatten.vert
+++ b/reference/shaders/flatten/copy.flatten.vert
@@ -14,16 +14,16 @@ in vec3 aNormal;
 
 void main()
 {
-    gl_Position = mat4(UBO[0],UBO[1],UBO[2],UBO[3]) * aVertex;
+    gl_Position = mat4(UBO[0], UBO[1], UBO[2], UBO[3]) * aVertex;
     vColor = vec4(0.0);
     for (int i = 0; i < 4; i++)
     {
         Light light;
-        light.Position = Light(UBO[i*2+4].xyz,UBO[i*2+4].w,UBO[i*2+5]).Position;
-        light.Radius = Light(UBO[i*2+4].xyz,UBO[i*2+4].w,UBO[i*2+5]).Radius;
-        light.Color = Light(UBO[i*2+4].xyz,UBO[i*2+4].w,UBO[i*2+5]).Color;
+        light.Position = Light(UBO[i * 2 + 4].xyz, UBO[i * 2 + 4].w, UBO[i * 2 + 5]).Position;
+        light.Radius = Light(UBO[i * 2 + 4].xyz, UBO[i * 2 + 4].w, UBO[i * 2 + 5]).Radius;
+        light.Color = Light(UBO[i * 2 + 4].xyz, UBO[i * 2 + 4].w, UBO[i * 2 + 5]).Color;
         vec3 L = aVertex.xyz - light.Position;
-        vColor += ((UBO[i*2+5] * clamp(1.0 - (length(L) / light.Radius), 0.0, 1.0)) * dot(aNormal, normalize(L)));
+        vColor += (((UBO[i * 2 + 5]) * clamp(1.0 - (length(L) / light.Radius), 0.0, 1.0)) * dot(aNormal, normalize(L)));
     }
 }
 

--- a/reference/shaders/flatten/copy.flatten.vert
+++ b/reference/shaders/flatten/copy.flatten.vert
@@ -1,0 +1,29 @@
+#version 310 es
+
+struct Light
+{
+    vec3 Position;
+    float Radius;
+    vec4 Color;
+};
+
+uniform vec4 UBO[12];
+in vec4 aVertex;
+out vec4 vColor;
+in vec3 aNormal;
+
+void main()
+{
+    gl_Position = mat4(UBO[0],UBO[1],UBO[2],UBO[3]) * aVertex;
+    vColor = vec4(0.0);
+    for (int i = 0; i < 4; i++)
+    {
+        Light light;
+        light.Position = Light(UBO[i*2+4].xyz,UBO[i*2+4].w,UBO[i*2+5]).Position;
+        light.Radius = Light(UBO[i*2+4].xyz,UBO[i*2+4].w,UBO[i*2+5]).Radius;
+        light.Color = Light(UBO[i*2+4].xyz,UBO[i*2+4].w,UBO[i*2+5]).Color;
+        vec3 L = aVertex.xyz - light.Position;
+        vColor += ((UBO[i*2+5] * clamp(1.0 - (length(L) / light.Radius), 0.0, 1.0)) * dot(aNormal, normalize(L)));
+    }
+}
+

--- a/reference/shaders/flatten/dynamic.flatten.vert
+++ b/reference/shaders/flatten/dynamic.flatten.vert
@@ -14,12 +14,12 @@ in vec3 aNormal;
 
 void main()
 {
-    gl_Position = mat4(UBO[0],UBO[1],UBO[2],UBO[3]) * aVertex;
+    gl_Position = mat4(UBO[0], UBO[1], UBO[2], UBO[3]) * aVertex;
     vColor = vec4(0.0);
     for (int i = 0; i < 4; i++)
     {
-        vec3 L = aVertex.xyz - UBO[i*2+4].xyz;
-        vColor += ((UBO[i*2+5] * clamp(1.0 - (length(L) / UBO[i*2+4].w), 0.0, 1.0)) * dot(aNormal, normalize(L)));
+        vec3 L = aVertex.xyz - (UBO[i * 2 + 4].xyz);
+        vColor += (((UBO[i * 2 + 5]) * clamp(1.0 - (length(L) / (UBO[i * 2 + 4].w)), 0.0, 1.0)) * dot(aNormal, normalize(L)));
     }
 }
 

--- a/reference/shaders/flatten/dynamic.flatten.vert
+++ b/reference/shaders/flatten/dynamic.flatten.vert
@@ -1,0 +1,25 @@
+#version 310 es
+
+struct Light
+{
+    vec3 Position;
+    float Radius;
+    vec4 Color;
+};
+
+uniform vec4 UBO[12];
+in vec4 aVertex;
+out vec4 vColor;
+in vec3 aNormal;
+
+void main()
+{
+    gl_Position = mat4(UBO[0],UBO[1],UBO[2],UBO[3]) * aVertex;
+    vColor = vec4(0.0);
+    for (int i = 0; i < 4; i++)
+    {
+        vec3 L = aVertex.xyz - UBO[i*2+4].xyz;
+        vColor += ((UBO[i*2+5] * clamp(1.0 - (length(L) / UBO[i*2+4].w), 0.0, 1.0)) * dot(aNormal, normalize(L)));
+    }
+}
+

--- a/reference/shaders/flatten/multiindex.flatten.vert
+++ b/reference/shaders/flatten/multiindex.flatten.vert
@@ -1,0 +1,10 @@
+#version 310 es
+
+uniform vec4 UBO[15];
+in ivec2 aIndex;
+
+void main()
+{
+    gl_Position = UBO[aIndex.x*5+aIndex.y*1+0];
+}
+

--- a/reference/shaders/flatten/multiindex.flatten.vert
+++ b/reference/shaders/flatten/multiindex.flatten.vert
@@ -5,6 +5,6 @@ in ivec2 aIndex;
 
 void main()
 {
-    gl_Position = UBO[aIndex.x*5+aIndex.y*1+0];
+    gl_Position = UBO[aIndex.x * 5 + aIndex.y * 1 + 0];
 }
 

--- a/reference/shaders/flatten/rowmajor.flatten.vert
+++ b/reference/shaders/flatten/rowmajor.flatten.vert
@@ -1,0 +1,10 @@
+#version 310 es
+
+uniform vec4 UBO[8];
+in vec4 aVertex;
+
+void main()
+{
+    gl_Position = (mat4(UBO[0], UBO[1], UBO[2], UBO[3]) * aVertex) + (aVertex * mat4(UBO[4], UBO[5], UBO[6], UBO[7]));
+}
+

--- a/reference/shaders/flatten/struct.flatten.vert
+++ b/reference/shaders/flatten/struct.flatten.vert
@@ -14,7 +14,7 @@ in vec3 aNormal;
 
 void main()
 {
-    gl_Position = mat4(UBO[0],UBO[1],UBO[2],UBO[3]) * aVertex;
+    gl_Position = mat4(UBO[0], UBO[1], UBO[2], UBO[3]) * aVertex;
     vColor = vec4(0.0);
     vec3 L = aVertex.xyz - UBO[4].xyz;
     vColor += ((UBO[5] * clamp(1.0 - (length(L) / UBO[4].w), 0.0, 1.0)) * dot(aNormal, normalize(L)));

--- a/reference/shaders/flatten/struct.flatten.vert
+++ b/reference/shaders/flatten/struct.flatten.vert
@@ -1,0 +1,22 @@
+#version 310 es
+
+struct Light
+{
+    vec3 Position;
+    float Radius;
+    vec4 Color;
+};
+
+uniform vec4 UBO[6];
+in vec4 aVertex;
+out vec4 vColor;
+in vec3 aNormal;
+
+void main()
+{
+    gl_Position = mat4(UBO[0],UBO[1],UBO[2],UBO[3]) * aVertex;
+    vColor = vec4(0.0);
+    vec3 L = aVertex.xyz - UBO[4].xyz;
+    vColor += ((UBO[5] * clamp(1.0 - (length(L) / UBO[4].w), 0.0, 1.0)) * dot(aNormal, normalize(L)));
+}
+

--- a/reference/shaders/flatten/swizzle.flatten.vert
+++ b/reference/shaders/flatten/swizzle.flatten.vert
@@ -1,0 +1,21 @@
+#version 310 es
+
+uniform vec4 UBO[8];
+out vec4 oA;
+out vec4 oB;
+out vec4 oC;
+out vec4 oD;
+out vec4 oE;
+out vec4 oF;
+
+void main()
+{
+    gl_Position = vec4(0.0);
+    oA = UBO[0];
+    oB = vec4(UBO[1].xy, UBO[1].zw);
+    oC = vec4(UBO[2].x, UBO[3].xyz);
+    oD = vec4(UBO[4].xyz, UBO[4].w);
+    oE = vec4(UBO[5].x, UBO[5].y, UBO[5].z, UBO[5].w);
+    oF = vec4(UBO[6].x, UBO[6].zw, UBO[7].x);
+}
+

--- a/shaders/flatten/array.flatten.vert
+++ b/shaders/flatten/array.flatten.vert
@@ -1,0 +1,16 @@
+#version 310 es
+
+layout(std140) uniform UBO
+{
+    uniform mat4 uMVP;
+    vec4 A1[2];
+    vec4 A2[2][2];
+    float A3[3];
+    vec4 Offset;
+};
+in vec4 aVertex;
+
+void main()
+{
+    gl_Position = uMVP * aVertex + Offset;
+}

--- a/shaders/flatten/basic.flatten.vert
+++ b/shaders/flatten/basic.flatten.vert
@@ -1,0 +1,15 @@
+#version 310 es
+
+layout(std140) uniform UBO
+{
+    uniform mat4 uMVP;
+};
+in vec4 aVertex;
+in vec3 aNormal;
+out vec3 vNormal;
+
+void main()
+{
+    gl_Position = uMVP * aVertex;
+    vNormal = aNormal;
+}

--- a/shaders/flatten/copy.flatten.vert
+++ b/shaders/flatten/copy.flatten.vert
@@ -1,0 +1,34 @@
+#version 310 es
+
+struct Light
+{
+    vec3 Position;
+    float Radius;
+
+    vec4 Color;
+};
+
+layout(std140) uniform UBO
+{
+    mat4 uMVP;
+
+    Light lights[4];
+};
+
+in vec4 aVertex;
+in vec3 aNormal;
+out vec4 vColor;
+
+void main()
+{
+    gl_Position = uMVP * aVertex;
+
+    vColor = vec4(0.0);
+
+    for (int i = 0; i < 4; ++i)
+    {
+        Light light = lights[i];
+        vec3 L = aVertex.xyz - light.Position;
+        vColor += dot(aNormal, normalize(L)) * (clamp(1.0 - length(L) / light.Radius, 0.0, 1.0) * lights[i].Color);
+    }
+}

--- a/shaders/flatten/dynamic.flatten.vert
+++ b/shaders/flatten/dynamic.flatten.vert
@@ -1,0 +1,33 @@
+#version 310 es
+
+struct Light
+{
+    vec3 Position;
+    float Radius;
+
+    vec4 Color;
+};
+
+layout(std140) uniform UBO
+{
+    mat4 uMVP;
+
+    Light lights[4];
+};
+
+in vec4 aVertex;
+in vec3 aNormal;
+out vec4 vColor;
+
+void main()
+{
+    gl_Position = uMVP * aVertex;
+
+    vColor = vec4(0.0);
+
+    for (int i = 0; i < 4; ++i)
+    {
+        vec3 L = aVertex.xyz - lights[i].Position;
+        vColor += dot(aNormal, normalize(L)) * (clamp(1.0 - length(L) / lights[i].Radius, 0.0, 1.0) * lights[i].Color);
+    }
+}

--- a/shaders/flatten/multiindex.flatten.vert
+++ b/shaders/flatten/multiindex.flatten.vert
@@ -1,0 +1,13 @@
+#version 310 es
+
+layout(std140) uniform UBO
+{
+    vec4 Data[3][5];
+};
+
+in ivec2 aIndex;
+
+void main()
+{
+    gl_Position = Data[aIndex.x][aIndex.y];
+}

--- a/shaders/flatten/rowmajor.flatten.vert
+++ b/shaders/flatten/rowmajor.flatten.vert
@@ -1,0 +1,14 @@
+#version 310 es
+
+layout(std140) uniform UBO
+{
+    layout(column_major) mat4 uMVPR;
+    layout(row_major) mat4 uMVPC;
+};
+
+in vec4 aVertex;
+
+void main()
+{
+	gl_Position = uMVPR * aVertex + uMVPC * aVertex;
+}

--- a/shaders/flatten/struct.flatten.vert
+++ b/shaders/flatten/struct.flatten.vert
@@ -1,0 +1,30 @@
+#version 310 es
+
+struct Light
+{
+    vec3 Position;
+    float Radius;
+
+    vec4 Color;
+};
+
+layout(std140) uniform UBO
+{
+    mat4 uMVP;
+
+    Light light;
+};
+
+in vec4 aVertex;
+in vec3 aNormal;
+out vec4 vColor;
+
+void main()
+{
+    gl_Position = uMVP * aVertex;
+
+    vColor = vec4(0.0);
+
+    vec3 L = aVertex.xyz - light.Position;
+    vColor += dot(aNormal, normalize(L)) * (clamp(1.0 - length(L) / light.Radius, 0.0, 1.0) * light.Color);
+}

--- a/shaders/flatten/swizzle.flatten.vert
+++ b/shaders/flatten/swizzle.flatten.vert
@@ -1,0 +1,42 @@
+#version 310 es
+
+// comments note the 16b alignment boundaries (see GL spec 7.6.2.2 Standard Uniform Block Layout)
+layout(std140) uniform UBO
+{
+    // 16b boundary
+    uniform vec4 A;
+    // 16b boundary
+    uniform vec2 B0;
+    uniform vec2 B1;
+    // 16b boundary
+    uniform float C0;
+    // 16b boundary (vec3 is aligned to 16b)
+    uniform vec3 C1;
+    // 16b boundary
+    uniform vec3 D0;
+    uniform float D1;
+    // 16b boundary
+    uniform float E0;
+    uniform float E1;
+    uniform float E2;
+    uniform float E3;
+    // 16b boundary
+    uniform float F0;
+    uniform vec2 F1;
+    // 16b boundary (vec2 before us is aligned to 8b)
+    uniform float F2;
+};
+
+out vec4 oA, oB, oC, oD, oE, oF;
+
+void main()
+{
+    gl_Position = vec4(0.0);
+
+    oA = A;
+    oB = vec4(B0, B1);
+    oC = vec4(C0, C1);
+    oD = vec4(D0, D1);
+    oE = vec4(E0, E1, E2, E3);
+    oF = vec4(F0, F1, F2);
+}

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -201,11 +201,7 @@ public:
 	// Returns the effective size of a buffer block struct member.
 	virtual size_t get_declared_struct_member_size(const SPIRType &struct_type, uint32_t index) const;
 
-	// Legacy GLSL compatibility method.
-	// Takes a variable with a block interface and flattens it into a T array[N]; array instead.
-	// For this to work, all types in the block must not themselves be composites
-	// (except vectors and matrices), and all types must be the same.
-	// The name of the uniform will be the same as the interface block name.
+	// Legacy GLSL compatibility method. Deprecated in favor of CompilerGLSL::flatten_buffer_block
 	void flatten_interface_block(uint32_t id);
 
 	// Returns a set of all global variables which are statically accessed

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -3316,7 +3316,7 @@ void CompilerGLSL::flattened_access_chain_struct(std::string &expr, uint32_t bas
 	for (size_t i = 0; i < target_type.member_types.size(); ++i)
 	{
 		if (i != 0)
-			expr += ",";
+			expr += ", ";
 
 		const SPIRType &member_type = get<SPIRType>(target_type.member_types[i]);
 		uint32_t member_offset = type_struct_member_offset(target_type, uint32_t(i));
@@ -3335,7 +3335,7 @@ void CompilerGLSL::flattened_access_chain_matrix(std::string &expr, uint32_t bas
 	for (uint32_t i = 0; i < target_type.columns; ++i)
 	{
 		if (i != 0)
-			expr += ",";
+			expr += ", ";
 
 		flattened_access_chain_vector_scalar(expr, base, indices, count, target_type, offset + i * 16);
 	}
@@ -3405,9 +3405,9 @@ uint32_t CompilerGLSL::flattened_access_chain_offset(std::string &expr, uint32_t
 			assert(array_stride % 16 == 0);
 
 			expr += to_expression(index);
-			expr += "*";
+			expr += " * ";
 			expr += convert_to_string(array_stride / 16);
-			expr += "+";
+			expr += " + ";
 
 			type_size = array_stride;
 		}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -3272,17 +3272,13 @@ string CompilerGLSL::access_chain(uint32_t base, const uint32_t *indices, uint32
 
 string CompilerGLSL::access_chain(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, bool* need_transpose)
 {
-	if (flattened_buffer_blocks.find(base) != flattened_buffer_blocks.end())
+	if (flattened_buffer_blocks.count(base))
 	{
 		std::string expr;
 		flattened_access_chain(expr, base, indices, count, target_type, 0);
 
 		if (need_transpose)
 			*need_transpose = false;
-
-		expr += "/*";
-		expr += access_chain(base, indices, count, false);
-		expr += "*/";
 
 		return expr;
 	}

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -317,11 +317,11 @@ protected:
 	                         bool chain_only = false, bool *need_transpose = nullptr);
 	std::string access_chain(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, bool *need_transpose);
 
-	void flattened_access_chain(std::string &expr, uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, uint32_t offset);
-	void flattened_access_chain_struct(std::string &expr, uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, uint32_t offset);
-	void flattened_access_chain_matrix(std::string &expr, uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, uint32_t offset);
-	void flattened_access_chain_vector_scalar(std::string &expr, uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, uint32_t offset);
-	uint32_t flattened_access_chain_offset(std::string &expr, uint32_t base, const uint32_t *indices, uint32_t count, uint32_t offset);
+	std::string flattened_access_chain(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, uint32_t offset);
+	std::string flattened_access_chain_struct(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, uint32_t offset);
+	std::string flattened_access_chain_matrix(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, uint32_t offset);
+	std::string flattened_access_chain_vector_scalar(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, uint32_t offset);
+	std::pair<std::string, uint32_t> flattened_access_chain_offset(uint32_t base, const uint32_t *indices, uint32_t count, uint32_t offset);
 
 	const char *index_to_swizzle(uint32_t index);
 	std::string remap_swizzle(uint32_t result_type, uint32_t input_components, uint32_t expr);

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -270,8 +270,9 @@ protected:
 	void emit_struct(SPIRType &type);
 	void emit_resources();
 	void emit_buffer_block(const SPIRVariable &type);
+	void emit_buffer_block_native(const SPIRVariable &var);
 	void emit_buffer_block_legacy(const SPIRVariable &var);
-	void emit_flattened_buffer_block(const SPIRVariable &type);
+	void emit_buffer_block_flattened(const SPIRVariable &type);
 	void emit_push_constant_block(const SPIRVariable &var);
 	void emit_push_constant_block_vulkan(const SPIRVariable &var);
 	void emit_push_constant_block_glsl(const SPIRVariable &var);

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -315,13 +315,13 @@ protected:
 	                        bool suppress_usage_tracking = false);
 	std::string access_chain(uint32_t base, const uint32_t *indices, uint32_t count, bool index_is_literal,
 	                         bool chain_only = false, bool *need_transpose = nullptr);
-	std::string access_chain(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, bool *need_transpose);
+	std::string access_chain(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, bool *need_transpose = nullptr);
 
 	std::string flattened_access_chain(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, uint32_t offset);
 	std::string flattened_access_chain_struct(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, uint32_t offset);
 	std::string flattened_access_chain_matrix(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, uint32_t offset);
 	std::string flattened_access_chain_vector_scalar(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, uint32_t offset);
-	std::pair<std::string, uint32_t> flattened_access_chain_offset(uint32_t base, const uint32_t *indices, uint32_t count, uint32_t offset);
+	std::pair<std::string, uint32_t> flattened_access_chain_offset(uint32_t base, const uint32_t *indices, uint32_t count, uint32_t offset, bool *need_transpose = nullptr);
 
 	const char *index_to_swizzle(uint32_t index);
 	std::string remap_swizzle(uint32_t result_type, uint32_t input_components, uint32_t expr);


### PR DESCRIPTION
Legacy GLSL targets do not support uniform buffers, and as such require
some sort of emulation. There are two alternatives - one is to represent
a uniform buffer as a uniform struct, and another one is to flatten it
into an array of primitive vector types (vec4).

Uniform struct have two disadvantages that make using them prohibitive
in some applications:

- The location assignment for struct members is arbitrary which means
the application has to set each struct member one by one
- Some Android drivers fail to link shader programs if both vertex and
fragment shader use the same uniform struct

Because of this, we need to support flattening uniform buffers into an
array. This is not just important for legacy GLSL but also is sometimes
useful for ESSL 3.0 where some Android drivers do not have stable UBO
support.

The way flattening works is the entire buffer is represented as a vec4
array; each access chain is rewritten into a combination of array
accesses, swizzles and data type constructors. Specifically:

- Extracting a vector or a scalar requires indexing into the array with
an optional swizzle, for example CB0[13].yz for reading vec2
- Extracting a matrix or a struct requires extracting each individual
vector or struct member and then combining them into the resulting
object
- Extracting arrays is not supported, mostly because the resulting
construct is very inefficient and ESSL 1.0 does not support array
constructors.

Additionally, while we try to constant-fold each individual indexing
operation, there are cases where we have to use dynamic index
computation (specifically for indexing arrays with non-constants); so
the general form of the primitive array extraction expression is:

    buffer[stride0*index0+...+strideN*indexN+offset]

Where stride/offset are integer literals and index represents variables.