### PR TITLE
Add Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: cpp
+os:
+  - linux
+  - osx
+
+# Use Ubuntu 14.04 LTS (Trusty) as the Linux testing environment.
+sudo: required
+dist: trusty
+
+before_script:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
+  - git clone https://github.com/KhronosGroup/glslang.git glslang
+  - git clone https://github.com/KhronosGroup/SPIRV-Tools SPIRV-Tools
+  - git clone https://github.com/KhronosGroup/SPIRV-Headers.git SPIRV-Tools/external/spirv-headers
+
+script:
+  - cd glslang && cmake . && make -j2 && cd ..
+  - cd SPIRV-Tools && cmake . && make -j2 && cd ..
+  - make -j2
+  - PATH=$PATH:./glslang/StandAlone:./SPIRV-Tools/tools
+  - ./test_shaders.py shaders

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ os:
 sudo: required
 dist: trusty
 
+# We check out glslang at a specific revision to avoid test output mismatches
+env:
+  - GLSLANG_REV=b56f4ac72c57f5c50f14ddb0bf1f78eaaef21c2b
+
 before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
   - git clone https://github.com/KhronosGroup/glslang.git glslang
@@ -14,6 +18,7 @@ before_script:
   - git clone https://github.com/KhronosGroup/SPIRV-Headers.git SPIRV-Tools/external/spirv-headers
 
 script:
+  - git -C glslang checkout $GLSLANG_REV
   - cd glslang && cmake . && make -j2 && cd ..
   - cd SPIRV-Tools && cmake . && make -j2 && cd ..
   - make -j2


### PR DESCRIPTION
Builds on both Linux and OSX and tests all shaders for regressions. The
shader set currently does not include any Metal shaders but once it does
we should be able to also validate the resulting MSL using Xcode metal
compiler.

Also fix reference shader.comp and use Python 2 in the regression
testing script because Python 3 does not seem to be readily available on
Travis CI.