### PR TITLE
Support row-major matrices in access chain when not natively supporte…

### DIFF
--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -223,6 +223,11 @@ protected:
 	void add_local_variable_name(uint32_t id);
 	void add_resource_name(uint32_t id);
 	void add_member_name(SPIRType &type, uint32_t name);
+
+	bool matrix_needs_transposition(uint32_t id);
+	bool member_matrix_needs_transposition(const SPIRType &type, uint32_t index);
+	virtual std::string transpose(std::string exp_str);
+
 	std::unordered_set<std::string> local_variable_names;
 	std::unordered_set<std::string> resource_names;
 
@@ -244,6 +249,7 @@ protected:
 		bool flexible_member_array_supported = true;
 		bool explicit_struct_type = false;
 		bool use_initializer_list = false;
+		bool transpose_row_major_matrices = false;
 	} backend;
 
 	void emit_struct(SPIRType &type);

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -224,9 +224,9 @@ protected:
 	void add_resource_name(uint32_t id);
 	void add_member_name(SPIRType &type, uint32_t name);
 
-	bool matrix_needs_transposition(uint32_t id);
-	bool member_matrix_needs_transposition(const SPIRType &type, uint32_t index);
-	virtual std::string transpose(std::string exp_str);
+	bool is_non_native_row_major_matrix(uint32_t id);
+	bool member_is_non_native_row_major_matrix(const SPIRType &type, uint32_t index);
+	virtual std::string convert_row_major_matrix(std::string exp_str);
 
 	std::unordered_set<std::string> local_variable_names;
 	std::unordered_set<std::string> resource_names;
@@ -249,7 +249,7 @@ protected:
 		bool flexible_member_array_supported = true;
 		bool explicit_struct_type = false;
 		bool use_initializer_list = false;
-		bool transpose_row_major_matrices = false;
+		bool native_row_major_matrix = true;
 	} backend;
 
 	void emit_struct(SPIRType &type);

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -64,7 +64,7 @@ string CompilerMSL::compile(MSLConfiguration &msl_cfg, vector<MSLVertexAttr> *p_
 	backend.discard_literal = "discard_fragment()";
 	backend.swizzle_is_function = false;
 	backend.shared_is_implied = false;
-	backend.transpose_row_major_matrices = true;
+	backend.native_row_major_matrix = false;
 
 	uint32_t pass_count = 0;
 	do

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -64,6 +64,7 @@ string CompilerMSL::compile(MSLConfiguration &msl_cfg, vector<MSLVertexAttr> *p_
 	backend.discard_literal = "discard_fragment()";
 	backend.swizzle_is_function = false;
 	backend.shared_is_implied = false;
+	backend.transpose_row_major_matrices = true;
 
 	uint32_t pass_count = 0;
 	do


### PR DESCRIPTION
…d by backend (MSL).

This has only been applied to OpAccessChain so far, which should cover most cases of incoming row-major matrices. However, I'm not clear if this will cover all requirements to transpose, or whether we will need to transpose during other types of matrix access operations.