### PR TITLE
Fix for loops for legacy ESSL.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -162,3 +162,6 @@ TabWidth: 4
 
 # The way to use tab characters in the resulting file. Possible values: Never, ForIndentation, Always.
 UseTab: ForIndentation
+
+# Do not reflow comments
+ReflowComments: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ script:
   - cd glslang && cmake . && make -j2 && cd ..
   - cd SPIRV-Tools && cmake . && make -j2 && cd ..
   - make -j2
-  - PATH=$PATH:./glslang/StandAlone:./SPIRV-Tools/tools
+  - PATH=./glslang/StandAlone:./SPIRV-Tools/tools:$PATH
   - ./test_shaders.py shaders

--- a/reference/shaders/comp/cfg.comp
+++ b/reference/shaders/comp/cfg.comp
@@ -63,9 +63,8 @@ void test()
             break;
         }
     }
-    int i = 0;
     float h;
-    for (; i < 20; i = i + 1, h = h + 10.0)
+    for (int i = 0; i < 20; i = i + 1, h = h + 10.0)
     {
     }
     _11.data = h;

--- a/reference/shaders/comp/cfg.comp
+++ b/reference/shaders/comp/cfg.comp
@@ -64,7 +64,7 @@ void test()
         }
     }
     float h;
-    for (int i = 0; i < 20; i += 1, h += 10.0)
+    for (int i = 0; i < 20; i++, h += 10.0)
     {
     }
     _11.data = h;

--- a/reference/shaders/comp/cfg.comp
+++ b/reference/shaders/comp/cfg.comp
@@ -64,7 +64,7 @@ void test()
         }
     }
     float h;
-    for (int i = 0; i < 20; i = i + 1, h = h + 10.0)
+    for (int i = 0; i < 20; i += 1, h += 10.0)
     {
     }
     _11.data = h;

--- a/reference/shaders/comp/dowhile.comp
+++ b/reference/shaders/comp/dowhile.comp
@@ -22,7 +22,7 @@ void main()
     do
     {
         idat = _28.mvp * idat;
-        i = i + 1;
+        i += 1;
     } while (i < 16);
     _52.out_data[ident] = idat;
 }

--- a/reference/shaders/comp/dowhile.comp
+++ b/reference/shaders/comp/dowhile.comp
@@ -22,7 +22,7 @@ void main()
     do
     {
         idat = _28.mvp * idat;
-        i += 1;
+        i++;
     } while (i < 16);
     _52.out_data[ident] = idat;
 }

--- a/reference/shaders/comp/inout-struct.invalid.comp
+++ b/reference/shaders/comp/inout-struct.invalid.comp
@@ -35,10 +35,10 @@ void baz(out Foo foo)
 
 void meow(inout Foo foo)
 {
-    foo.a = foo.a + vec4(10.0);
-    foo.b = foo.b + vec4(20.0);
-    foo.c = foo.c + vec4(30.0);
-    foo.d = foo.d + vec4(40.0);
+    foo.a += vec4(10.0);
+    foo.b += vec4(20.0);
+    foo.c += vec4(30.0);
+    foo.d += vec4(40.0);
 }
 
 vec4 bar(Foo foo)

--- a/reference/shaders/comp/loop.comp
+++ b/reference/shaders/comp/loop.comp
@@ -23,7 +23,7 @@ void main()
         do
         {
             k *= 2;
-            i += uint(1);
+            i++;
         } while (i < ident);
     }
     switch (k)
@@ -32,7 +32,7 @@ void main()
         {
             for (;;)
             {
-                i += uint(1);
+                i++;
                 if (i > 10u)
                 {
                     break;
@@ -58,11 +58,11 @@ void main()
     while (k < 10)
     {
         idat *= 2.0;
-        k += 1;
+        k++;
     }
-    for (uint i_1 = 0u; i_1 < 16u; i_1 += uint(1), k += 1)
+    for (uint i_1 = 0u; i_1 < 16u; i_1++, k++)
     {
-        for (uint j = 0u; j < 30u; j += uint(1))
+        for (uint j = 0u; j < 30u; j++)
         {
             idat = _24.mvp * idat;
         }
@@ -70,7 +70,7 @@ void main()
     k = 0;
     for (;;)
     {
-        k += 1;
+        k++;
         if (k > 10)
         {
             k += 2;
@@ -86,18 +86,18 @@ void main()
     k = 0;
     do
     {
-        k += 1;
+        k++;
     } while (k > 10);
     int l = 0;
     for (;;)
     {
         if (l == 5)
         {
-            l += 1;
+            l++;
             continue;
         }
         idat += vec4(1.0);
-        l += 1;
+        l++;
         continue;
     }
     _177.out_data[ident] = idat;

--- a/reference/shaders/comp/loop.comp
+++ b/reference/shaders/comp/loop.comp
@@ -22,8 +22,8 @@ void main()
     {
         do
         {
-            k = k * 2;
-            i = i + uint(1);
+            k *= 2;
+            i += uint(1);
         } while (i < ident);
     }
     switch (k)
@@ -32,7 +32,7 @@ void main()
         {
             for (;;)
             {
-                i = i + uint(1);
+                i += uint(1);
                 if (i > 10u)
                 {
                     break;
@@ -45,7 +45,7 @@ void main()
         {
             for (;;)
             {
-                i = i + 2u;
+                i += 2u;
                 if (i > 20u)
                 {
                     break;
@@ -57,12 +57,12 @@ void main()
     }
     while (k < 10)
     {
-        idat = idat * 2.0;
-        k = k + 1;
+        idat *= 2.0;
+        k += 1;
     }
-    for (uint i_1 = 0u; i_1 < 16u; i_1 = i_1 + uint(1), k = k + 1)
+    for (uint i_1 = 0u; i_1 < 16u; i_1 += uint(1), k += 1)
     {
-        for (uint j = 0u; j < 30u; j = j + uint(1))
+        for (uint j = 0u; j < 30u; j += uint(1))
         {
             idat = _24.mvp * idat;
         }
@@ -70,34 +70,34 @@ void main()
     k = 0;
     for (;;)
     {
-        k = k + 1;
+        k += 1;
         if (k > 10)
         {
-            k = k + 2;
+            k += 2;
         }
         else
         {
-            k = k + 3;
+            k += 3;
             continue;
         }
-        k = k + 10;
+        k += 10;
         continue;
     }
     k = 0;
     do
     {
-        k = k + 1;
+        k += 1;
     } while (k > 10);
     int l = 0;
     for (;;)
     {
         if (l == 5)
         {
-            l = l + 1;
+            l += 1;
             continue;
         }
-        idat = idat + vec4(1.0);
-        l = l + 1;
+        idat += vec4(1.0);
+        l += 1;
         continue;
     }
     _177.out_data[ident] = idat;

--- a/reference/shaders/comp/loop.comp
+++ b/reference/shaders/comp/loop.comp
@@ -60,11 +60,9 @@ void main()
         idat = idat * 2.0;
         k = k + 1;
     }
-    uint i_1 = 0u;
-    for (; i_1 < 16u; i_1 = i_1 + uint(1), k = k + 1)
+    for (uint i_1 = 0u; i_1 < 16u; i_1 = i_1 + uint(1), k = k + 1)
     {
-        uint j = 0u;
-        for (; j < 30u; j = j + uint(1))
+        for (uint j = 0u; j < 30u; j = j + uint(1))
         {
             idat = _24.mvp * idat;
         }

--- a/reference/shaders/comp/return.comp
+++ b/reference/shaders/comp/return.comp
@@ -21,7 +21,7 @@ void main()
             return;
         }
     }
-    for (int i = 0; i < 20; i = i + 1)
+    for (int i = 0; i < 20; i += 1)
     {
         if (i == 10)
         {

--- a/reference/shaders/comp/return.comp
+++ b/reference/shaders/comp/return.comp
@@ -21,7 +21,7 @@ void main()
             return;
         }
     }
-    for (int i = 0; i < 20; i += 1)
+    for (int i = 0; i < 20; i++)
     {
         if (i == 10)
         {

--- a/reference/shaders/comp/return.comp
+++ b/reference/shaders/comp/return.comp
@@ -21,8 +21,7 @@ void main()
             return;
         }
     }
-    int i = 0;
-    for (; i < 20; i = i + 1)
+    for (int i = 0; i < 20; i = i + 1)
     {
         if (i == 10)
         {

--- a/reference/shaders/comp/torture-loop.comp
+++ b/reference/shaders/comp/torture-loop.comp
@@ -24,8 +24,8 @@ void main()
         k = _40;
         if (_40 < 10)
         {
-            idat = idat * 2.0;
-            k = k + 1;
+            idat *= 2.0;
+            k += 1;
             continue;
         }
         else
@@ -33,16 +33,16 @@ void main()
             break;
         }
     }
-    for (uint i = 0u; i < 16u; i = i + uint(1), k = k + 1)
+    for (uint i = 0u; i < 16u; i += uint(1), k += 1)
     {
-        for (uint j = 0u; j < 30u; j = j + uint(1))
+        for (uint j = 0u; j < 30u; j += uint(1))
         {
             idat = _24.mvp * idat;
         }
     }
     do
     {
-        k = k + 1;
+        k += 1;
     } while (k > 10);
     _89.out_data[ident] = idat;
 }

--- a/reference/shaders/comp/torture-loop.comp
+++ b/reference/shaders/comp/torture-loop.comp
@@ -25,7 +25,7 @@ void main()
         if (_40 < 10)
         {
             idat *= 2.0;
-            k += 1;
+            k++;
             continue;
         }
         else
@@ -33,16 +33,16 @@ void main()
             break;
         }
     }
-    for (uint i = 0u; i < 16u; i += uint(1), k += 1)
+    for (uint i = 0u; i < 16u; i++, k++)
     {
-        for (uint j = 0u; j < 30u; j += uint(1))
+        for (uint j = 0u; j < 30u; j++)
         {
             idat = _24.mvp * idat;
         }
     }
     do
     {
-        k += 1;
+        k++;
     } while (k > 10);
     _89.out_data[ident] = idat;
 }

--- a/reference/shaders/comp/torture-loop.comp
+++ b/reference/shaders/comp/torture-loop.comp
@@ -33,11 +33,9 @@ void main()
             break;
         }
     }
-    uint i = 0u;
-    for (; i < 16u; i = i + uint(1), k = k + 1)
+    for (uint i = 0u; i < 16u; i = i + uint(1), k = k + 1)
     {
-        uint j = 0u;
-        for (; j < 30u; j = j + uint(1))
+        for (uint j = 0u; j < 30u; j = j + uint(1))
         {
             idat = _24.mvp * idat;
         }

--- a/reference/shaders/desktop-only/comp/fp64.desktop.comp
+++ b/reference/shaders/desktop-only/comp/fp64.desktop.comp
@@ -37,8 +37,8 @@ layout(binding = 3, std140) buffer SSBO3
 
 void main()
 {
-    ssbo_0.a = ssbo_0.a + dvec4(10.0lf, 20.0lf, 30.0lf, 40.0lf);
-    ssbo_0.a = ssbo_0.a + dvec4(20.0lf);
+    ssbo_0.a += dvec4(10.0lf, 20.0lf, 30.0lf, 40.0lf);
+    ssbo_0.a += dvec4(20.0lf);
     dvec4 a = ssbo_0.a;
     dmat4 amat = ssbo_0.b;
     ssbo_0.a = abs(a);
@@ -77,8 +77,8 @@ void main()
     k = lessThanEqual(a, a);
     k = greaterThan(a, a);
     k = greaterThanEqual(a, a);
-    ssbo_1.b.x = ssbo_1.b.x + 1.0lf;
-    ssbo_2.b[0].x = ssbo_2.b[0].x + 1.0lf;
-    ssbo_3.b[0].x = ssbo_3.b[0].x + 1.0lf;
+    ssbo_1.b.x += 1.0lf;
+    ssbo_2.b[0].x += 1.0lf;
+    ssbo_3.b[0].x += 1.0lf;
 }
 

--- a/reference/shaders/desktop-only/comp/int64.desktop.comp
+++ b/reference/shaders/desktop-only/comp/int64.desktop.comp
@@ -36,17 +36,17 @@ layout(binding = 3, std140) buffer SSBO3
 
 void main()
 {
-    ssbo_0.a = ssbo_0.a + i64vec4(10l, 20l, 30l, 40l);
-    ssbo_1.b = ssbo_1.b + u64vec4(999999999999999999ul, 8888888888888888ul, 77777777777777777ul, 6666666666666666ul);
-    ssbo_0.a = ssbo_0.a + i64vec4(20l);
+    ssbo_0.a += i64vec4(10l, 20l, 30l, 40l);
+    ssbo_1.b += u64vec4(999999999999999999ul, 8888888888888888ul, 77777777777777777ul, 6666666666666666ul);
+    ssbo_0.a += i64vec4(20l);
     ssbo_0.a = abs(ssbo_0.a + i64vec4(ssbo_1.b));
-    ssbo_0.a = ssbo_0.a + i64vec4(1l);
-    ssbo_1.b = ssbo_1.b + u64vec4(i64vec4(1l));
-    ssbo_0.a = ssbo_0.a - i64vec4(1l);
-    ssbo_1.b = ssbo_1.b - u64vec4(i64vec4(1l));
+    ssbo_0.a += i64vec4(1l);
+    ssbo_1.b += u64vec4(i64vec4(1l));
+    ssbo_0.a -= i64vec4(1l);
+    ssbo_1.b -= u64vec4(i64vec4(1l));
     ssbo_1.b = doubleBitsToUint64(int64BitsToDouble(ssbo_0.a));
     ssbo_0.a = doubleBitsToInt64(uint64BitsToDouble(ssbo_1.b));
-    ssbo_2.a[0] = ssbo_2.a[0] + 1l;
-    ssbo_3.a[0] = ssbo_3.a[0] + 2l;
+    ssbo_2.a[0] += 1l;
+    ssbo_3.a[0] += 2l;
 }
 

--- a/reference/shaders/frag/for-loop-init.frag
+++ b/reference/shaders/frag/for-loop-init.frag
@@ -7,46 +7,46 @@ layout(location = 0) out mediump int FragColor;
 void main()
 {
     FragColor = 15;
-    for (mediump int i = 0; i < 25; i = i + 1)
+    for (mediump int i = 0; i < 25; i += 1)
     {
-        FragColor = FragColor + 10;
+        FragColor += 10;
     }
-    for (mediump int j = 4, i_1 = 1; i_1 < 30; i_1 = i_1 + 1, j = j + 4)
+    for (mediump int j = 4, i_1 = 1; i_1 < 30; i_1 += 1, j += 4)
     {
-        FragColor = FragColor + 11;
+        FragColor += 11;
     }
     mediump int k = 0;
-    for (; k < 20; k = k + 1)
+    for (; k < 20; k += 1)
     {
-        FragColor = FragColor + 12;
+        FragColor += 12;
     }
-    k = k + 3;
-    FragColor = FragColor + k;
+    k += 3;
+    FragColor += k;
     mediump int l;
     if (k == 40)
     {
         l = 0;
-        for (; l < 40; l = l + 1)
+        for (; l < 40; l += 1)
         {
-            FragColor = FragColor + 13;
+            FragColor += 13;
         }
         return;
     }
     else
     {
         l = k;
-        FragColor = FragColor + l;
+        FragColor += l;
     }
     mediump ivec2 i_2 = ivec2(0);
-    for (; i_2.x < 10; i_2.x = i_2.x + 1)
+    for (; i_2.x < 10; i_2.x += 1)
     {
-        FragColor = FragColor + i_2.y;
+        FragColor += i_2.y;
     }
     mediump int o = k;
-    for (mediump int m = k; m < 40; m = m + 1)
+    for (mediump int m = k; m < 40; m += 1)
     {
-        FragColor = FragColor + m;
+        FragColor += m;
     }
-    FragColor = FragColor + o;
+    FragColor += o;
 }
 

--- a/reference/shaders/frag/for-loop-init.frag
+++ b/reference/shaders/frag/for-loop-init.frag
@@ -1,0 +1,52 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+layout(location = 0) out mediump int FragColor;
+
+void main()
+{
+    FragColor = 15;
+    for (mediump int i = 0; i < 25; i = i + 1)
+    {
+        FragColor = FragColor + 10;
+    }
+    for (mediump int j = 4, i_1 = 1; i_1 < 30; i_1 = i_1 + 1, j = j + 4)
+    {
+        FragColor = FragColor + 11;
+    }
+    mediump int k = 0;
+    for (; k < 20; k = k + 1)
+    {
+        FragColor = FragColor + 12;
+    }
+    k = k + 3;
+    FragColor = FragColor + k;
+    mediump int l;
+    if (k == 40)
+    {
+        l = 0;
+        for (; l < 40; l = l + 1)
+        {
+            FragColor = FragColor + 13;
+        }
+        return;
+    }
+    else
+    {
+        l = k;
+        FragColor = FragColor + l;
+    }
+    mediump ivec2 i_2 = ivec2(0);
+    for (; i_2.x < 10; i_2.x = i_2.x + 1)
+    {
+        FragColor = FragColor + i_2.y;
+    }
+    mediump int o = k;
+    for (mediump int m = k; m < 40; m = m + 1)
+    {
+        FragColor = FragColor + m;
+    }
+    FragColor = FragColor + o;
+}
+

--- a/reference/shaders/frag/for-loop-init.frag
+++ b/reference/shaders/frag/for-loop-init.frag
@@ -6,7 +6,7 @@ layout(location = 0) out mediump int FragColor;
 
 void main()
 {
-    FragColor = 15;
+    FragColor = 16;
     for (mediump int i = 0; i < 25; i++)
     {
         FragColor += 10;

--- a/reference/shaders/frag/for-loop-init.frag
+++ b/reference/shaders/frag/for-loop-init.frag
@@ -11,7 +11,7 @@ void main()
     {
         FragColor += 10;
     }
-    for (mediump int j = 4, i_1 = 1; i_1 < 30; i_1++, j += 4)
+    for (mediump int i_1 = 1, j = 4; i_1 < 30; i_1++, j += 4)
     {
         FragColor += 11;
     }

--- a/reference/shaders/frag/for-loop-init.frag
+++ b/reference/shaders/frag/for-loop-init.frag
@@ -7,16 +7,16 @@ layout(location = 0) out mediump int FragColor;
 void main()
 {
     FragColor = 15;
-    for (mediump int i = 0; i < 25; i += 1)
+    for (mediump int i = 0; i < 25; i++)
     {
         FragColor += 10;
     }
-    for (mediump int j = 4, i_1 = 1; i_1 < 30; i_1 += 1, j += 4)
+    for (mediump int j = 4, i_1 = 1; i_1 < 30; i_1++, j += 4)
     {
         FragColor += 11;
     }
     mediump int k = 0;
-    for (; k < 20; k += 1)
+    for (; k < 20; k++)
     {
         FragColor += 12;
     }
@@ -26,7 +26,7 @@ void main()
     if (k == 40)
     {
         l = 0;
-        for (; l < 40; l += 1)
+        for (; l < 40; l++)
         {
             FragColor += 13;
         }
@@ -38,12 +38,12 @@ void main()
         FragColor += l;
     }
     mediump ivec2 i_2 = ivec2(0);
-    for (; i_2.x < 10; i_2.x += 1)
+    for (; i_2.x < 10; i_2.x += 4)
     {
         FragColor += i_2.y;
     }
     mediump int o = k;
-    for (mediump int m = k; m < 40; m += 1)
+    for (mediump int m = k; m < 40; m++)
     {
         FragColor += m;
     }

--- a/reference/shaders/frag/ground.frag
+++ b/reference/shaders/frag/ground.frag
@@ -51,7 +51,7 @@ void main()
     vec3 base = mix(grass, snow, vec3(grass_snow));
     float edge = smoothstep(0.699999988079071044921875, 0.75, Normal.y);
     Color = mix(dirt, base, vec3(edge));
-    Color = Color * Color;
+    Color *= Color;
     float Roughness = 1.0 - (edge * grass_snow);
     highp vec3 param_1 = Color;
     highp vec3 param_2 = Normal;

--- a/reference/shaders/tese/water_tess.tese
+++ b/reference/shaders/tese/water_tess.tese
@@ -46,7 +46,7 @@ void main()
     vec2 param_1 = tess_coord;
     mediump vec2 lod = lod_factor(param_1);
     vec2 tex = pos * _31.uInvHeightmapSize;
-    pos = pos * _31.uScale.xy;
+    pos *= _31.uScale.xy;
     mediump float delta_mod = exp2(lod.x);
     vec2 off = _31.uInvHeightmapSize * delta_mod;
     vGradNormalTex = vec4(tex + (_31.uInvHeightmapSize * 0.5), tex * _31.uScale.zw);
@@ -54,7 +54,7 @@ void main()
     vec2 param_3 = off;
     vec2 param_4 = lod;
     vec3 height_displacement = sample_height_displacement(param_2, param_3, param_4);
-    pos = pos + height_displacement.yz;
+    pos += height_displacement.yz;
     vWorld = vec3(pos.x, height_displacement.x, pos.y);
     gl_Position = _31.uMVP * vec4(vWorld, 1.0);
 }

--- a/reference/shaders/vert/ground.vert
+++ b/reference/shaders/vert/ground.vert
@@ -101,8 +101,8 @@ void main()
     vec2 Offset = _381.InvGroundSize_PatchScale.xy * exp2(lod.x);
     float Elevation = mix(textureLod(TexHeightmap, NormalizedPos + (Offset * 0.5), lod.x).x, textureLod(TexHeightmap, NormalizedPos + (Offset * 1.0), lod.x + 1.0).x, lod.y);
     vec3 WorldPos = vec3(NormalizedPos.x, Elevation, NormalizedPos.y);
-    WorldPos = WorldPos * _381.GroundScale.xyz;
-    WorldPos = WorldPos + _381.GroundPosition.xyz;
+    WorldPos *= _381.GroundScale.xyz;
+    WorldPos += _381.GroundPosition.xyz;
     EyeVec = WorldPos - _58.g_CamPos.xyz;
     TexCoord = NormalizedPos + (_381.InvGroundSize_PatchScale.xy * 0.5);
     gl_Position = (((_58.g_ViewProj_Row0 * WorldPos.x) + (_58.g_ViewProj_Row1 * WorldPos.y)) + (_58.g_ViewProj_Row2 * WorldPos.z)) + _58.g_ViewProj_Row3;

--- a/reference/shaders/vert/ocean.vert
+++ b/reference/shaders/vert/ocean.vert
@@ -124,8 +124,8 @@ void main()
     vec2 Offset = (_405.InvOceanSize_PatchScale.xy * exp2(lod.x)) * _405.NormalTexCoordScale.zw;
     vec3 Displacement = mix(textureLod(TexDisplacement, NormalizedTex + (Offset * 0.5), lod.x).yxz, textureLod(TexDisplacement, NormalizedTex + (Offset * 1.0), lod.x + 1.0).yxz, vec3(lod.y));
     vec3 WorldPos = vec3(NormalizedPos.x, 0.0, NormalizedPos.y) + Displacement;
-    WorldPos = WorldPos * _405.OceanScale.xyz;
-    WorldPos = WorldPos + _405.OceanPosition.xyz;
+    WorldPos *= _405.OceanScale.xyz;
+    WorldPos += _405.OceanPosition.xyz;
     EyeVec = WorldPos - _58.g_CamPos.xyz;
     TexCoord = vec4(NormalizedTex, NormalizedTex * _405.NormalTexCoordScale.xy) + ((_405.InvOceanSize_PatchScale.xyxy * 0.5) * _405.NormalTexCoordScale.zwzw);
     gl_Position = (((_58.g_ViewProj_Row0 * WorldPos.x) + (_58.g_ViewProj_Row1 * WorldPos.y)) + (_58.g_ViewProj_Row2 * WorldPos.z)) + _58.g_ViewProj_Row3;

--- a/shaders/frag/for-loop-init.frag
+++ b/shaders/frag/for-loop-init.frag
@@ -1,0 +1,52 @@
+#version 310 es
+precision mediump float;
+layout(location = 0) out int FragColor;
+
+void main()
+{
+   FragColor = 15;
+
+   // Basic loop variable.
+   for (int i = 0; i < 25; i++)
+      FragColor += 10;
+
+   // Multiple loop variables.
+   for (int i = 1, j = 4; i < 30; i++, j += 4)
+      FragColor += 11;
+
+   // A potential loop variables, but we access it outside the loop,
+   // so cannot be one.
+   int k = 0;
+   for (; k < 20; k++)
+      FragColor += 12;
+   k += 3;
+   FragColor += k;
+
+   // Potential loop variables, but the dominator is not trivial.
+   int l;
+   if (k == 40)
+   {
+      for (l = 0; l < 40; l++)
+         FragColor += 13;
+      return;
+   }
+   else
+   {
+      l = k;
+      FragColor += l;
+   }
+
+   // Vectors cannot be loop variables
+   for (ivec2 i = ivec2(0); i.x < 10; i.x++)
+   {
+      FragColor += i.y;
+   }
+
+   // Check that static expressions can be used before the loop header.
+   int m = 0;
+   m = k;
+   int o = m;
+   for (; m < 40; m++)
+      FragColor += m;
+   FragColor += o;
+}

--- a/shaders/frag/for-loop-init.frag
+++ b/shaders/frag/for-loop-init.frag
@@ -4,7 +4,7 @@ layout(location = 0) out int FragColor;
 
 void main()
 {
-   FragColor = 15;
+   FragColor = 16;
 
    // Basic loop variable.
    for (int i = 0; i < 25; i++)

--- a/shaders/frag/for-loop-init.frag
+++ b/shaders/frag/for-loop-init.frag
@@ -37,7 +37,7 @@ void main()
    }
 
    // Vectors cannot be loop variables
-   for (ivec2 i = ivec2(0); i.x < 10; i.x++)
+   for (ivec2 i = ivec2(0); i.x < 10; i.x += 4)
    {
       FragColor += i.y;
    }

--- a/spirv_cfg.hpp
+++ b/spirv_cfg.hpp
@@ -56,6 +56,24 @@ public:
 
 	uint32_t find_common_dominator(uint32_t a, uint32_t b) const;
 
+	const std::vector<uint32_t> &get_preceding_edges(uint32_t block) const
+	{
+		return preceding_edges[block];
+	}
+
+	const std::vector<uint32_t> &get_succeeding_edges(uint32_t block) const
+	{
+		return succeeding_edges[block];
+	}
+
+	template <typename Op>
+	void walk_from(uint32_t block, const Op &op) const
+	{
+		op(block);
+		for (auto b : succeeding_edges[block])
+			walk_from(b, op);
+	}
+
 private:
 	Compiler &compiler;
 	const SPIRFunction &func;

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -445,6 +445,11 @@ struct SPIRBlock : IVariant
 	// All access to these variables are dominated by this block,
 	// so before branching anywhere we need to make sure that we declare these variables.
 	std::vector<uint32_t> dominated_variables;
+
+	// These are variables which should be declared in a for loop header, if we
+	// fail to use a classic for-loop,
+	// we remove these variables, and fall back to regular variables outside the loop.
+	std::vector<uint32_t> loop_variables;
 };
 
 struct SPIRFunction : IVariant
@@ -552,6 +557,15 @@ struct SPIRVariable : IVariant
 	bool phi_variable = false;
 	bool remapped_variable = false;
 	uint32_t remapped_components = 0;
+
+	// The block which dominates all access to this variable.
+	uint32_t dominator = 0;
+	// If true, this variable is a loop variable, when accessing the variable
+	// outside a loop,
+	// we should statically forward it.
+	bool loop_variable = false;
+	// Set to true while we're inside the for loop.
+	bool loop_variable_enable = false;
 
 	SPIRFunction::Parameter *parameter = nullptr;
 };

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -3025,6 +3025,9 @@ void Compiler::analyze_variable_scope(SPIRFunction &entry)
 
 		// We have a loop variable.
 		header_block.loop_variables.push_back(loop_variable.first);
+		// Need to sort here as variables come from an unordered container, and pushing stuff in wrong order
+		// will break reproducability in regression runs.
+		sort(begin(header_block.loop_variables), end(header_block.loop_variables));
 		get<SPIRVariable>(loop_variable.first).loop_variable = true;
 	}
 }

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -2916,13 +2916,14 @@ void Compiler::analyze_variable_scope(SPIRFunction &entry)
 	{
 		DominatorBuilder builder(cfg);
 		auto &blocks = var.second;
+		auto &type = expression_type(var.first);
 
 		// Figure out which block is dominating all accesses of those variables.
 		for (auto &block : blocks)
 		{
-			// If we're accessing a variable inside a continue block, this variable
-			// might be a loop variable.
-			if (is_continue(block))
+			// If we're accessing a variable inside a continue block, this variable might be a loop variable.
+			// We can only use loop variables with scalars, as we cannot track static expressions for vectors.
+			if (is_continue(block) && type.vecsize == 1 && type.columns == 1)
 			{
 				// The variable is used in multiple continue blocks, this is not a loop
 				// candidate, signal that by setting block to -1u.

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -2909,6 +2909,8 @@ void Compiler::analyze_variable_scope(SPIRFunction &entry)
 	// Compute the control flow graph for this function.
 	CFG cfg(*this, entry);
 
+	unordered_map<uint32_t, uint32_t> potential_loop_variables;
+
 	// For each variable which is statically accessed.
 	for (auto &var : handler.accessed_variables_to_block)
 	{
@@ -2917,7 +2919,22 @@ void Compiler::analyze_variable_scope(SPIRFunction &entry)
 
 		// Figure out which block is dominating all accesses of those variables.
 		for (auto &block : blocks)
+		{
+			// If we're accessing a variable inside a continue block, this variable
+			// might be a loop variable.
+			if (is_continue(block))
+			{
+				// The variable is used in multiple continue blocks, this is not a loop
+				// candidate, signal that by setting block to -1u.
+				auto &potential = potential_loop_variables[var.first];
+
+				if (potential == 0)
+					potential = block;
+				else
+					potential = -1u;
+			}
 			builder.add_block(block);
+		}
 
 		builder.lift_continue_block_dominator();
 
@@ -2929,6 +2946,84 @@ void Compiler::analyze_variable_scope(SPIRFunction &entry)
 		{
 			auto &block = this->get<SPIRBlock>(dominating_block);
 			block.dominated_variables.push_back(var.first);
+			get<SPIRVariable>(var.first).dominator = dominating_block;
 		}
+	}
+
+	// Now, try to analyze whether or not these variables are actually loop variables.
+	for (auto &loop_variable : potential_loop_variables)
+	{
+		auto &var = get<SPIRVariable>(loop_variable.first);
+		auto dominator = var.dominator;
+		auto block = loop_variable.second;
+
+		// The variable was accessed in multiple continue blocks, ignore.
+		if (block == -1u || block == 0)
+			continue;
+
+		// Dead code.
+		if (dominator == 0)
+			continue;
+
+		uint32_t header = 0;
+
+		// Find the loop header for this block.
+		for (auto b : loop_blocks)
+		{
+			auto &potential_header = get<SPIRBlock>(b);
+			if (potential_header.continue_block == block)
+			{
+				header = b;
+				break;
+			}
+		}
+
+		assert(header);
+		auto &header_block = get<SPIRBlock>(header);
+
+		// Now, there are two conditions we need to meet for the variable to be a loop variable.
+		// 1. The dominating block must have a branch-free path to the loop header,
+		// this way we statically know which expression should be part of the loop variable initializer.
+
+		// Walk from the dominator, if there is one straight edge connecting
+		// dominator and loop header, we statically know the loop initializer.
+		bool static_loop_init = true;
+		while (dominator != header)
+		{
+			auto &succ = cfg.get_succeeding_edges(dominator);
+			if (succ.size() != 1)
+			{
+				static_loop_init = false;
+				break;
+			}
+
+			auto &pred = cfg.get_preceding_edges(succ.front());
+			if (pred.size() != 1 || pred.front() != dominator)
+			{
+				static_loop_init = false;
+				break;
+			}
+
+			dominator = succ.front();
+		}
+
+		if (!static_loop_init)
+			continue;
+
+		// The second condition we need to meet is that no access after the loop
+		// merge can occur. Walk the CFG to see if we find anything.
+		auto &blocks = handler.accessed_variables_to_block[loop_variable.first];
+		cfg.walk_from(header_block.merge_block, [&](uint32_t walk_block) {
+			// We found a block which accesses the variable outside the loop.
+			if (blocks.find(walk_block) != end(blocks))
+				static_loop_init = false;
+		});
+
+		if (!static_loop_init)
+			continue;
+
+		// We have a loop variable.
+		header_block.loop_variables.push_back(loop_variable.first);
+		get<SPIRVariable>(loop_variable.first).loop_variable = true;
 	}
 }

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -390,6 +390,8 @@ protected:
 	void find_static_extensions();
 
 	std::string emit_for_loop_initializers(const SPIRBlock &block);
+
+	bool optimize_read_modify_write(const std::string &lhs, const std::string &rhs);
 };
 }
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -388,6 +388,8 @@ protected:
 	void check_function_call_constraints(const uint32_t *args, uint32_t length);
 	void handle_invalid_expression(uint32_t id);
 	void find_static_extensions();
+
+	std::string emit_for_loop_initializers(const SPIRBlock &block);
 };
 }
 

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -137,6 +137,14 @@ def regression_check(shader, glsl, update, keep):
                 shutil.move(glsl, reference)
             else:
                 print('Generated GLSL in {} does not match reference {}!'.format(glsl, reference))
+                with open(glsl, 'r') as f:
+                    print('')
+                    print('Generated:')
+                    print('======================')
+                    print(f.read())
+                    print('======================')
+                    print('')
+
                 # Otherwise, fail the test. Keep the shader file around so we can inspect.
                 if not keep:
                     os.remove(glsl)


### PR DESCRIPTION
This is one of the most complicated fixes in SPIRV-Cross so far, but fixes a long-standing bug with for loops in ESSL, which have a very particular restriction. https://github.com/KhronosGroup/SPIRV-Cross/issues/55

```
for (int i = 0; i < 4; i++)
```

via SPIR-V and back again generated this kind of code

```
int i = 0;
for (; i < 4; i = i + 1)
```

While this is perfectly legal GLSL it looks ugly, and also breaks a GLES 2.0 restriction saying that for loops must have a strict form of
```
for (int i = initializer; condition only using i; i++, i-- or i += const-expr)
```

In order to acheive this, we need a control flow graph implementation which analyzes the scope of variables. With the CFG, we can move the initializer into the for loop header if we can prove that the loop header is directly connected with the initializer and that the variable is not accessed after the loop merge target.

The side-effect of the CFG is that variable declaration is now placed in the appropriate scope which was commited earlier.

The secondary fix is to optimize `i = i + 1` into `i += 1`, or even better, `i++`. This is done with string manipulation as the pattern is trivial and handling this in SPIRExpressions would be far more complex than it needs to be.