### PR TITLE
Fix handling of NoWrite/NoRead decoration for images.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -234,6 +234,10 @@ static void print_resources(const Compiler &compiler, const char *tag, const vec
 			fprintf(stderr, " (Binding : %u)", compiler.get_decoration(res.id, DecorationBinding));
 		if (mask & (1ull << DecorationInputAttachmentIndex))
 			fprintf(stderr, " (Attachment : %u)", compiler.get_decoration(res.id, DecorationInputAttachmentIndex));
+		if (mask & (1ull << DecorationNonReadable))
+			fprintf(stderr, " writeonly");
+		if (mask & (1ull << DecorationNonWritable))
+			fprintf(stderr, " readonly");
 		if (is_sized_block)
 			fprintf(stderr, " (BlockSize : %u bytes)", block_size);
 		fprintf(stderr, "\n");

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -1438,17 +1438,6 @@ void Compiler::parse(const Instruction &instruction)
 		if (variable_storage_is_aliased(var))
 			aliased_variables.push_back(var.self);
 
-		// glslangValidator does not emit required qualifiers here.
-		// Solve this by making the image access as restricted as possible
-		// and loosen up if we need to.
-		auto &vartype = expression_type(id);
-		if (vartype.basetype == SPIRType::Image)
-		{
-			auto &flags = meta.at(id).decoration.decoration_flags;
-			flags |= 1ull << DecorationNonWritable;
-			flags |= 1ull << DecorationNonReadable;
-		}
-
 		break;
 	}
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -390,8 +390,8 @@ protected:
 	void find_static_extensions();
 
 	std::string emit_for_loop_initializers(const SPIRBlock &block);
-
 	bool optimize_read_modify_write(const std::string &lhs, const std::string &rhs);
+	void fixup_image_load_store_access();
 };
 }
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1995,7 +1995,7 @@ size_t CompilerMSL::get_declared_type_size(uint32_t type_id, uint64_t dec_mask) 
 }
 
 // If the opcode requires a bespoke custom function be output, remember it.
-bool CompilerMSL::CustomFunctionHandler::handle(Op opcode, const uint32_t *args, uint32_t length)
+bool CompilerMSL::CustomFunctionHandler::handle(Op opcode, const uint32_t * /*args*/, uint32_t /*length*/)
 {
 	switch (opcode)
 	{


### PR DESCRIPTION
glslang now handles NoWrite/NoRead correctly for images so the ugly workaround for ESSL 3.10 is no longer needed. Do not modify decoration flags until compile time to avoid breaking reflection.