### PR TITLE
Refactor emit_texture_op() function.

### DIFF
--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -893,7 +893,6 @@ struct Meta
 		uint32_t input_attachment = 0;
 		uint32_t spec_id = 0;
 		bool builtin = false;
-		bool per_instance = false;
 	};
 
 	Decoration decoration;

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -2710,6 +2710,15 @@ string CompilerGLSL::to_function_args(uint32_t img, const SPIRType &, bool, bool
 	return farg_str;
 }
 
+// Some languages may have additional standard library functions whose names conflict
+// with a function defined in the body of the shader. Subclasses can override to rename
+// the function name defined in the shader to avoid conflict with the language standard
+// functions (eg. MSL includes saturate()).
+string CompilerGLSL::clean_func_name(string func_name)
+{
+    return func_name;
+}
+
 void CompilerGLSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop, const uint32_t *args, uint32_t)
 {
 	GLSLstd450 op = static_cast<GLSLstd450>(eop);
@@ -3638,7 +3647,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 
 		string funexpr;
 		vector<string> arglist;
-		funexpr += to_name(func) + "(";
+		funexpr += clean_func_name(to_name(func)) + "(";
 		for (uint32_t i = 0; i < length; i++)
 		{
 			// Do not pass in separate images or samplers if we're remapping
@@ -5359,11 +5368,11 @@ void CompilerGLSL::emit_function_prototype(SPIRFunction &func, uint64_t return_f
 
 	if (func.self == entry_point)
 	{
-		decl += "main";
+		decl += clean_func_name("main");
 		processing_entry_point = true;
 	}
 	else
-		decl += to_name(func.self);
+		decl += clean_func_name(to_name(func.self));
 
 	decl += "(";
 	vector<string> arglist;

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -2558,9 +2558,9 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 
 // Returns the function name for a texture sampling function for the specified image and sampling characteristics.
 // For some subclasses, the function is a method on the specified image.
-string CompilerGLSL::to_function_name(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather,
+string CompilerGLSL::to_function_name(uint32_t, const SPIRType &imgtype, bool is_fetch, bool is_gather,
                                       bool is_proj, bool has_array_offsets, bool has_offset, bool has_grad,
-                                      bool has_lod, bool has_dref)
+                                      bool has_lod, bool)
 {
 	string fname;
 
@@ -2589,8 +2589,8 @@ string CompilerGLSL::to_function_name(uint32_t img, const SPIRType &imgtype, boo
 }
 
 // Returns the function args for a texture sampling function for the specified image and sampling characteristics.
-string CompilerGLSL::to_function_args(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather,
-                                      bool is_proj, uint32_t coord, uint32_t coord_components, uint32_t dref,
+string CompilerGLSL::to_function_args(uint32_t img, const SPIRType &, bool, bool,
+                                      bool, uint32_t coord, uint32_t coord_components, uint32_t dref,
                                       uint32_t grad_x, uint32_t grad_y, uint32_t lod, uint32_t coffset, uint32_t offset,
                                       uint32_t bias, uint32_t comp, uint32_t sample, bool *p_forward)
 {

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -2404,6 +2404,7 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 	uint32_t comp = 0;
 	bool gather = false;
 	bool proj = false;
+	bool fetch = false;
 	const uint32_t *opt = nullptr;
 
 	switch (op)
@@ -2418,23 +2419,29 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 	case OpImageSampleProjDrefImplicitLod:
 	case OpImageSampleProjDrefExplicitLod:
 		dref = ops[4];
-		proj = true;
 		opt = &ops[5];
 		length -= 5;
+		proj = true;
 		break;
 
 	case OpImageDrefGather:
 		dref = ops[4];
 		opt = &ops[5];
-		gather = true;
 		length -= 5;
+		gather = true;
 		break;
 
 	case OpImageGather:
 		comp = ops[4];
 		opt = &ops[5];
-		gather = true;
 		length -= 5;
+		gather = true;
+		break;
+
+	case OpImageFetch:
+		opt = &ops[4];
+		length -= 4;
+		fetch = true;
 		break;
 
 	case OpImageSampleProjImplicitLod:
@@ -2491,8 +2498,7 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 
 	if (length)
 	{
-		flags = opt[0];
-		opt++;
+		flags = *opt++;
 		length--;
 	}
 
@@ -2514,35 +2520,56 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 	test(sample, ImageOperandsSampleMask);
 
 	string expr;
-	string texop;
+	bool forward = false;
+	expr += to_function_name(img, imgtype, fetch, gather, proj, coffsets, (coffset || offset), (grad_x || grad_y), lod,
+	                         dref);
+	expr += "(";
+	expr += to_function_args(img, imgtype, fetch, gather, proj, coord, coord_components, dref, grad_x, grad_y, lod,
+	                         coffset, offset, bias, comp, sample, &forward);
+	expr += ")";
 
-	if (op == OpImageFetch)
-		texop += "texelFetch";
+	emit_op(result_type, id, expr, forward);
+}
+
+// Returns the function name for a texture sampling function for the specified image and sampling characteristics.
+// For some subclasses, the function is a method on the specified image.
+string CompilerGLSL::to_function_name(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather,
+                                      bool is_proj, bool has_array_offsets, bool has_offset, bool has_grad,
+                                      bool has_lod, bool has_dref)
+{
+	string fname;
+
+	if (is_fetch)
+		fname += "texelFetch";
 	else
 	{
-		texop += "texture";
+		fname += "texture";
 
-		if (gather)
-			texop += "Gather";
-		if (coffsets)
-			texop += "Offsets";
-		if (proj)
-			texop += "Proj";
-		if (grad_x || grad_y)
-			texop += "Grad";
-		if (lod)
-			texop += "Lod";
+		if (is_gather)
+			fname += "Gather";
+		if (has_array_offsets)
+			fname += "Offsets";
+		if (is_proj)
+			fname += "Proj";
+		if (has_grad)
+			fname += "Grad";
+		if (has_lod)
+			fname += "Lod";
 	}
 
-	if (coffset || offset)
-		texop += "Offset";
+	if (has_offset)
+		fname += "Offset";
 
-	if (is_legacy())
-		texop = legacy_tex_op(texop, imgtype);
+	return is_legacy() ? legacy_tex_op(fname, imgtype) : fname;
+}
 
-	expr += texop;
-	expr += "(";
-	expr += to_expression(img);
+// Returns the function args for a texture sampling function for the specified image and sampling characteristics.
+string CompilerGLSL::to_function_args(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather,
+                                      bool is_proj, uint32_t coord, uint32_t coord_components, uint32_t dref,
+                                      uint32_t grad_x, uint32_t grad_y, uint32_t lod, uint32_t coffset, uint32_t offset,
+                                      uint32_t bias, uint32_t comp, uint32_t sample, bool *p_forward)
+{
+	string farg_str = to_expression(img);
 
 	bool swizz_func = backend.swizzle_is_function;
 	auto swizzle = [swizz_func](uint32_t comps, uint32_t in_comps) -> const char * {
@@ -2578,84 +2605,84 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 		// SPIR-V splits dref and coordinate.
 		if (coord_components == 4) // GLSL also splits the arguments in two.
 		{
-			expr += ", ";
-			expr += to_expression(coord);
-			expr += ", ";
-			expr += to_expression(dref);
+			farg_str += ", ";
+			farg_str += to_expression(coord);
+			farg_str += ", ";
+			farg_str += to_expression(dref);
 		}
 		else
 		{
 			// Create a composite which merges coord/dref into a single vector.
 			auto type = expression_type(coord);
 			type.vecsize = coord_components + 1;
-			expr += ", ";
-			expr += type_to_glsl_constructor(type);
-			expr += "(";
-			expr += coord_expr;
-			expr += ", ";
-			expr += to_expression(dref);
-			expr += ")";
+			farg_str += ", ";
+			farg_str += type_to_glsl_constructor(type);
+			farg_str += "(";
+			farg_str += coord_expr;
+			farg_str += ", ";
+			farg_str += to_expression(dref);
+			farg_str += ")";
 		}
 	}
 	else
 	{
-		expr += ", ";
-		expr += coord_expr;
+		farg_str += ", ";
+		farg_str += coord_expr;
 	}
 
 	if (grad_x || grad_y)
 	{
 		forward = forward && should_forward(grad_x);
 		forward = forward && should_forward(grad_y);
-		expr += ", ";
-		expr += to_expression(grad_x);
-		expr += ", ";
-		expr += to_expression(grad_y);
+		farg_str += ", ";
+		farg_str += to_expression(grad_x);
+		farg_str += ", ";
+		farg_str += to_expression(grad_y);
 	}
 
 	if (lod)
 	{
 		forward = forward && should_forward(lod);
-		expr += ", ";
-		expr += to_expression(lod);
+		farg_str += ", ";
+		farg_str += to_expression(lod);
 	}
 
 	if (coffset)
 	{
 		forward = forward && should_forward(coffset);
-		expr += ", ";
-		expr += to_expression(coffset);
+		farg_str += ", ";
+		farg_str += to_expression(coffset);
 	}
 	else if (offset)
 	{
 		forward = forward && should_forward(offset);
-		expr += ", ";
-		expr += to_expression(offset);
+		farg_str += ", ";
+		farg_str += to_expression(offset);
 	}
 
 	if (bias)
 	{
 		forward = forward && should_forward(bias);
-		expr += ", ";
-		expr += to_expression(bias);
+		farg_str += ", ";
+		farg_str += to_expression(bias);
 	}
 
 	if (comp)
 	{
 		forward = forward && should_forward(comp);
-		expr += ", ";
-		expr += to_expression(comp);
+		farg_str += ", ";
+		farg_str += to_expression(comp);
 	}
 
 	if (sample)
 	{
-		expr += ", ";
-		expr += to_expression(sample);
+		farg_str += ", ";
+		farg_str += to_expression(sample);
 	}
 
-	expr += ")";
+	*p_forward = forward;
 
-	emit_op(result_type, id, expr, forward);
+	return farg_str;
 }
 
 void CompilerGLSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop, const uint32_t *args, uint32_t)

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -2558,9 +2558,8 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 
 // Returns the function name for a texture sampling function for the specified image and sampling characteristics.
 // For some subclasses, the function is a method on the specified image.
-string CompilerGLSL::to_function_name(uint32_t, const SPIRType &imgtype, bool is_fetch, bool is_gather,
-                                      bool is_proj, bool has_array_offsets, bool has_offset, bool has_grad,
-                                      bool has_lod, bool)
+string CompilerGLSL::to_function_name(uint32_t, const SPIRType &imgtype, bool is_fetch, bool is_gather, bool is_proj,
+                                      bool has_array_offsets, bool has_offset, bool has_grad, bool has_lod, bool)
 {
 	string fname;
 
@@ -2589,10 +2588,10 @@ string CompilerGLSL::to_function_name(uint32_t, const SPIRType &imgtype, bool is
 }
 
 // Returns the function args for a texture sampling function for the specified image and sampling characteristics.
-string CompilerGLSL::to_function_args(uint32_t img, const SPIRType &, bool, bool,
-                                      bool, uint32_t coord, uint32_t coord_components, uint32_t dref,
-                                      uint32_t grad_x, uint32_t grad_y, uint32_t lod, uint32_t coffset, uint32_t offset,
-                                      uint32_t bias, uint32_t comp, uint32_t sample, bool *p_forward)
+string CompilerGLSL::to_function_args(uint32_t img, const SPIRType &, bool, bool, bool, uint32_t coord,
+                                      uint32_t coord_components, uint32_t dref, uint32_t grad_x, uint32_t grad_y,
+                                      uint32_t lod, uint32_t coffset, uint32_t offset, uint32_t bias, uint32_t comp,
+                                      uint32_t sample, bool *p_forward)
 {
 	string farg_str = to_expression(img);
 
@@ -2716,7 +2715,7 @@ string CompilerGLSL::to_function_args(uint32_t img, const SPIRType &, bool, bool
 // functions (eg. MSL includes saturate()).
 string CompilerGLSL::clean_func_name(string func_name)
 {
-    return func_name;
+	return func_name;
 }
 
 void CompilerGLSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop, const uint32_t *args, uint32_t)

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -160,6 +160,14 @@ protected:
 	virtual void emit_fixup();
 	virtual std::string variable_decl(const SPIRType &type, const std::string &name);
 	virtual std::string to_func_call_arg(uint32_t id);
+	virtual std::string to_function_name(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather,
+	                                     bool is_proj, bool has_array_offsets, bool has_offset, bool has_grad,
+	                                     bool has_lod, bool has_dref);
+	virtual std::string to_function_args(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather,
+	                                     bool is_proj, uint32_t coord, uint32_t coord_components, uint32_t dref,
+	                                     uint32_t grad_x, uint32_t grad_y, uint32_t lod, uint32_t coffset,
+	                                     uint32_t offset, uint32_t bias, uint32_t comp, uint32_t sample,
+	                                     bool *p_forward);
 
 	std::unique_ptr<std::ostringstream> buffer;
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -168,7 +168,7 @@ protected:
 	                                     uint32_t grad_x, uint32_t grad_y, uint32_t lod, uint32_t coffset,
 	                                     uint32_t offset, uint32_t bias, uint32_t comp, uint32_t sample,
 	                                     bool *p_forward);
-    virtual std::string clean_func_name(std::string func_name);
+	virtual std::string clean_func_name(std::string func_name);
 
 	std::unique_ptr<std::ostringstream> buffer;
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -168,6 +168,7 @@ protected:
 	                                     uint32_t grad_x, uint32_t grad_y, uint32_t lod, uint32_t coffset,
 	                                     uint32_t offset, uint32_t bias, uint32_t comp, uint32_t sample,
 	                                     bool *p_forward);
+    virtual std::string clean_func_name(std::string func_name);
 
 	std::unique_ptr<std::ostringstream> buffer;
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -699,9 +699,8 @@ void CompilerMSL::emit_function_prototype(SPIRFunction &func, bool is_decl)
 }
 
 // Returns the texture sampling function string for the specified image and sampling characteristics.
-string CompilerMSL::to_function_name(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather, bool is_proj,
-                                     bool has_array_offsets, bool has_offset, bool has_grad, bool has_lod,
-                                     bool has_dref)
+string CompilerMSL::to_function_name(uint32_t img, const SPIRType &, bool is_fetch, bool is_gather,
+                                     bool, bool, bool, bool, bool, bool has_dref)
 {
 	// Texture reference
 	string fname = to_expression(img) + ".";
@@ -721,10 +720,10 @@ string CompilerMSL::to_function_name(uint32_t img, const SPIRType &imgtype, bool
 }
 
 // Returns the function args for a texture sampling function for the specified image and sampling characteristics.
-string CompilerMSL::to_function_args(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather, bool is_proj,
-                                     uint32_t coord, uint32_t coord_components, uint32_t dref, uint32_t grad_x,
-                                     uint32_t grad_y, uint32_t lod, uint32_t coffset, uint32_t offset, uint32_t bias,
-                                     uint32_t comp, uint32_t sample, bool *p_forward)
+string CompilerMSL::to_function_args(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool, bool is_proj,
+                                     uint32_t coord, uint32_t, uint32_t dref, uint32_t grad_x, uint32_t grad_y,
+                                     uint32_t lod, uint32_t coffset, uint32_t offset, uint32_t bias, uint32_t comp,
+                                     uint32_t, bool *p_forward)
 {
 	string farg_str = to_sampler_expression(img);
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -27,6 +27,15 @@ CompilerMSL::CompilerMSL(vector<uint32_t> spirv_)
     : CompilerGLSL(move(spirv_))
 {
 	options.vertex.fixup_clipspace = false;
+
+    populate_func_name_overrides();
+}
+
+// Populate the collection of function names that need to be overridden
+void CompilerMSL::populate_func_name_overrides()
+{
+    func_name_overrides["main"] = "main0";
+    func_name_overrides["saturate"] = "saturate0";
 }
 
 string CompilerMSL::compile(MSLConfiguration &msl_cfg, vector<MSLVertexAttr> *p_vtx_attrs,
@@ -1203,8 +1212,8 @@ string CompilerMSL::func_type_decl(SPIRType &type)
 // Ensures the function name is not "main", which is illegal in MSL
 string CompilerMSL::clean_func_name(string func_name)
 {
-	static std::string _clean_msl_main_func_name = "mmain";
-	return (func_name == "main") ? _clean_msl_main_func_name : func_name;
+    auto iter = func_name_overrides.find(func_name);
+    return (iter != func_name_overrides.end()) ? iter->second : func_name;
 }
 
 // Returns a string containing a comma-delimited list of args for the entry point function

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -32,8 +32,7 @@ CompilerMSL::CompilerMSL(vector<uint32_t> spirv_)
 string CompilerMSL::compile(MSLConfiguration &msl_cfg, vector<MSLVertexAttr> *p_vtx_attrs,
                             std::vector<MSLResourceBinding> *p_res_bindings)
 {
-	pad_type_ids_by_pad_len.clear();
-
+	// Remember the input parameters
 	msl_config = msl_cfg;
 
 	vtx_attrs_by_location.clear();
@@ -43,21 +42,23 @@ string CompilerMSL::compile(MSLConfiguration &msl_cfg, vector<MSLVertexAttr> *p_
 
 	resource_bindings.clear();
 	if (p_res_bindings)
-	{
-		resource_bindings.reserve(p_res_bindings->size());
 		for (auto &rb : *p_res_bindings)
 			resource_bindings.push_back(&rb);
-	}
 
+	// Establish the need to output any custom functions
 	set_enabled_interface_variables(get_active_interface_variables());
-
 	register_custom_functions();
-	extract_builtins();
+
+	// Create structs to hold input and output variables
+	qual_pos_var_name = "";
+	stage_in_var_id = add_interface_block(StorageClassInput);
+	stage_out_var_id = add_interface_block(StorageClassOutput);
+
+	// Convert the use of global variables to recursively-passed function parameters
 	localize_global_variables();
-	add_interface_structs();
 	extract_global_variables_from_functions();
 
-	// Do not deal with ES-isms like precision, older extensions and such.
+	// Do not deal with GLES-isms like precision, older extensions and such.
 	options.es = false;
 	options.version = 120;
 	backend.float_literal_suffix = false;
@@ -108,53 +109,6 @@ void CompilerMSL::register_custom_functions()
 	traverse_all_reachable_opcodes(get<SPIRFunction>(entry_point), handler);
 }
 
-// Adds any builtins used by this shader to the builtin_vars collection
-void CompilerMSL::extract_builtins()
-{
-	builtin_vars.clear();
-
-	for (auto &id : ids)
-	{
-		if (id.get_type() == TypeVariable)
-		{
-			auto &var = id.get<SPIRVariable>();
-			auto &dec = meta[var.self].decoration;
-
-			if (dec.builtin)
-				builtin_vars[dec.builtin_type] = var.self;
-		}
-	}
-
-	auto &execution = get_entry_point();
-	if (execution.model == ExecutionModelVertex)
-	{
-		if (!(builtin_vars[BuiltInVertexIndex] || builtin_vars[BuiltInVertexId]))
-			add_builtin(BuiltInVertexIndex);
-
-		if (!(builtin_vars[BuiltInInstanceIndex] || builtin_vars[BuiltInInstanceId]))
-			add_builtin(BuiltInInstanceIndex);
-	}
-}
-
-// Adds an appropriate built-in variable for the specified builtin type.
-void CompilerMSL::add_builtin(BuiltIn builtin_type)
-{
-
-	// Add a new typed variable for this interface structure.
-	uint32_t next_id = increase_bound_by(2);
-	uint32_t ib_type_id = next_id++;
-	auto &ib_type = set<SPIRType>(ib_type_id);
-	ib_type.basetype = SPIRType::UInt;
-	ib_type.storage = StorageClassInput;
-
-	uint32_t ib_var_id = next_id++;
-	set<SPIRVariable>(ib_var_id, ib_type_id, StorageClassInput, 0);
-	set_decoration(ib_var_id, DecorationBuiltIn, builtin_type);
-	set_name(ib_var_id, builtin_to_glsl(builtin_type));
-
-	builtin_vars[builtin_type] = ib_var_id;
-}
-
 // Move the Private global variables to the entry function.
 // Non-constant variables cannot have global scope in Metal.
 void CompilerMSL::localize_global_variables()
@@ -171,9 +125,7 @@ void CompilerMSL::localize_global_variables()
 			iter = global_variables.erase(iter);
 		}
 		else
-		{
 			iter++;
-		}
 	}
 }
 
@@ -271,96 +223,31 @@ void CompilerMSL::extract_global_variables_from_function(uint32_t func_id, std::
 	}
 }
 
-// Adds any interface structure variables needed by this shader
-void CompilerMSL::add_interface_structs()
+// If a vertex attribute exists at the location, it is marked as being used by this shader
+void CompilerMSL::mark_location_as_used_by_shader(uint32_t location, StorageClass storage)
 {
+	MSLVertexAttr *p_va;
 	auto &execution = get_entry_point();
-
-	stage_in_var_ids.clear();
-	qual_pos_var_name = "";
-
-	uint32_t var_id;
-	if (execution.model == ExecutionModelVertex && !vtx_attrs_by_location.empty())
-	{
-		std::unordered_set<uint32_t> vtx_bindings;
-		bind_vertex_attributes(vtx_bindings);
-		for (uint32_t vb : vtx_bindings)
-		{
-			var_id = add_interface_struct(StorageClassInput, vb);
-			if (var_id)
-				stage_in_var_ids.push_back(var_id);
-		}
-	}
-	else
-	{
-		var_id = add_interface_struct(StorageClassInput);
-		if (var_id)
-			stage_in_var_ids.push_back(var_id);
-	}
-
-	stage_out_var_id = add_interface_struct(StorageClassOutput);
+	if ((execution.model == ExecutionModelVertex) && (storage == StorageClassInput) &&
+	    (p_va = vtx_attrs_by_location[location]))
+		p_va->used_by_shader = true;
 }
 
-// Iterate through the variables and populates each input vertex attribute variable
-// from the binding info provided during compiler construction, matching by location.
-void CompilerMSL::bind_vertex_attributes(std::unordered_set<uint32_t> &bindings)
-{
-	auto &execution = get_entry_point();
-
-	if (execution.model == ExecutionModelVertex)
-	{
-		for (auto &id : ids)
-		{
-			if (id.get_type() == TypeVariable)
-			{
-				auto &var = id.get<SPIRVariable>();
-				auto &type = get<SPIRType>(var.basetype);
-
-				if (var.storage == StorageClassInput && interface_variable_exists_in_entry_point(var.self) &&
-				    !is_hidden_variable(var) && type.pointer)
-				{
-					auto &dec = meta[var.self].decoration;
-					MSLVertexAttr *p_va = vtx_attrs_by_location[dec.location];
-					if (p_va)
-					{
-						dec.binding = p_va->msl_buffer;
-						dec.offset = p_va->msl_offset;
-						dec.array_stride = p_va->msl_stride;
-						dec.per_instance = p_va->per_instance;
-
-						// Mark the vertex attributes that were used.
-						p_va->used_by_shader = true;
-						bindings.insert(p_va->msl_buffer);
-					}
-				}
-			}
-		}
-	}
-}
-
-// Add an interface structure for the type of storage. For vertex inputs, each
-// binding must have its own structure, and a structure is created for vtx_binding.
-// For non-vertex input, and all outputs, the vtx_binding argument is ignored.
+// Add an interface structure for the type of storage, which is either StorageClassInput or StorageClassOutput.
 // Returns the ID of the newly added variable, or zero if no variable was added.
-uint32_t CompilerMSL::add_interface_struct(StorageClass storage, uint32_t vtx_binding)
+uint32_t CompilerMSL::add_interface_block(StorageClass storage)
 {
-	auto &execution = get_entry_point();
-	bool incl_builtins = (storage == StorageClassOutput);
-	bool match_binding = (execution.model == ExecutionModelVertex) && (storage == StorageClassInput);
-
 	// Accumulate the variables that should appear in the interface struct
 	vector<SPIRVariable *> vars;
+	bool incl_builtins = (storage == StorageClassOutput);
 	for (auto &id : ids)
 	{
 		if (id.get_type() == TypeVariable)
 		{
 			auto &var = id.get<SPIRVariable>();
 			auto &type = get<SPIRType>(var.basetype);
-			auto &dec = meta[var.self].decoration;
-
 			if (var.storage == storage && interface_variable_exists_in_entry_point(var.self) &&
-			    !is_hidden_variable(var, incl_builtins) && (!match_binding || (vtx_binding == dec.binding)) &&
-			    type.pointer)
+			    !is_hidden_variable(var, incl_builtins) && type.pointer)
 			{
 				vars.push_back(&var);
 			}
@@ -385,26 +272,14 @@ uint32_t CompilerMSL::add_interface_struct(StorageClass storage, uint32_t vtx_bi
 	auto &var = set<SPIRVariable>(ib_var_id, ib_type_id, storage, 0);
 	var.initializer = next_id++;
 
-	// Set the binding of the variable and mark if packed (used only with vertex inputs)
-	auto &var_dec = meta[ib_var_id].decoration;
-	var_dec.binding = vtx_binding;
-
-	// Track whether this is vertex input that is indexed, as opposed to stage_in
-	bool is_indxd_vtx_input = (execution.model == ExecutionModelVertex && storage == StorageClassInput &&
-	                           var_dec.binding != msl_config.vtx_attr_stage_in_binding);
-
 	string ib_var_ref;
-
-	if (storage == StorageClassInput)
+	switch (storage)
 	{
+	case StorageClassInput:
 		ib_var_ref = stage_in_var_name;
+		break;
 
-		// Multiple vertex input bindings are available, so qualify each with the Metal buffer index
-		if (execution.model == ExecutionModelVertex)
-			ib_var_ref += convert_to_string(vtx_binding);
-	}
-
-	if (storage == StorageClassOutput)
+	case StorageClassOutput:
 	{
 		ib_var_ref = stage_out_var_name;
 
@@ -419,92 +294,64 @@ uint32_t CompilerMSL::add_interface_struct(StorageClass storage, uint32_t vtx_bi
 			if (blk.terminator == SPIRBlock::Return)
 				blk.return_value = ib_var_id;
 		}
+		break;
+	}
+
+	default:
+		break;
 	}
 
 	set_name(ib_type_id, get_entry_point_name() + "_" + ib_var_ref);
 	set_name(ib_var_id, ib_var_ref);
 
-	size_t struct_size = 0;
-	bool first_elem = true;
 	for (auto p_var : vars)
 	{
-		// For index-accessed vertex attributes, copy the attribute characteristics to the parent
-		// structure (all components have same vertex attribute characteristics except offset),
-		// and add a reference to the vertex index builtin to the parent struct variable name.
-		if (is_indxd_vtx_input && first_elem)
-		{
-			auto &elem_dec = meta[p_var->self].decoration;
-			var_dec.binding = elem_dec.binding;
-			var_dec.array_stride = elem_dec.array_stride;
-			var_dec.per_instance = elem_dec.per_instance;
-			ib_var_ref += "[" + get_vtx_idx_var_name(var_dec.per_instance) + "]";
-			first_elem = false;
-		}
-
 		uint32_t type_id = p_var->basetype;
 		auto &type = get<SPIRType>(type_id);
 		if (type.basetype == SPIRType::Struct)
 		{
 			// Flatten the struct members into the interface struct
-			uint32_t i = 0;
+			uint32_t mbr_idx = 0;
 			for (auto &member : type.member_types)
 			{
-				// If needed, add a padding member to the struct to align to the next member's offset.
-				uint32_t mbr_offset = get_member_decoration(type_id, i, DecorationOffset);
-				struct_size =
-				    pad_to_offset(ib_type, is_indxd_vtx_input, (var_dec.offset + mbr_offset), uint32_t(struct_size));
-
 				// Add a reference to the member to the interface struct.
 				uint32_t ib_mbr_idx = uint32_t(ib_type.member_types.size());
 				ib_type.member_types.push_back(member); // membertype.self is different for array types
 
-				// Give the member a name, and assign it an offset within the struct.
-				string mbr_name = ensure_valid_name(to_qualified_member_name(type, i), "m");
+				// Give the member a name
+				string mbr_name = ensure_valid_name(to_qualified_member_name(type, mbr_idx), "m");
 				set_member_name(ib_type_id, ib_mbr_idx, mbr_name);
-				set_member_decoration(ib_type_id, ib_mbr_idx, DecorationOffset, uint32_t(struct_size));
-				struct_size = get_declared_struct_size(ib_type);
 
 				// Update the original variable reference to include the structure reference
 				string qual_var_name = ib_var_ref + "." + mbr_name;
-				set_member_qualified_name(type_id, i, qual_var_name);
+				set_member_qualified_name(type_id, mbr_idx, qual_var_name);
 
 				// Copy the variable location from the original variable to the member
-				uint32_t locn = get_member_decoration(type_id, i, DecorationLocation);
+				uint32_t locn = get_member_decoration(type_id, mbr_idx, DecorationLocation);
 				set_member_decoration(ib_type_id, ib_mbr_idx, DecorationLocation, locn);
-
-				// Set vertex binding offsets
-				if (execution.model == ExecutionModelVertex && storage == StorageClassInput)
-				{
-					uint32_t offset = get_member_decoration(type_id, i, DecorationOffset);
-					set_member_decoration(ib_type_id, ib_mbr_idx, DecorationOffset, offset);
-				}
+				mark_location_as_used_by_shader(locn, storage);
 
 				// Mark the member as builtin if needed
 				BuiltIn builtin;
-				if (is_member_builtin(type, i, &builtin))
+				if (is_member_builtin(type, mbr_idx, &builtin))
 				{
 					set_member_decoration(ib_type_id, ib_mbr_idx, DecorationBuiltIn, builtin);
 					if (builtin == BuiltInPosition)
 						qual_pos_var_name = qual_var_name;
 				}
 
-				i++;
+				mbr_idx++;
 			}
 		}
 		else
 		{
-			// If needed, add a padding member to the struct to align to the next member's offset.
-			struct_size = pad_to_offset(ib_type, is_indxd_vtx_input, var_dec.offset, uint32_t(struct_size));
-
 			// Add a reference to the variable type to the interface struct.
 			uint32_t ib_mbr_idx = uint32_t(ib_type.member_types.size());
 			ib_type.member_types.push_back(type_id);
 
-			// Give the member a name, and assign it an offset within the struct.
+			// Give the member a name
 			string mbr_name = ensure_valid_name(to_expression(p_var->self), "m");
 			set_member_name(ib_type_id, ib_mbr_idx, mbr_name);
-			set_member_decoration(ib_type_id, ib_mbr_idx, DecorationOffset, uint32_t(struct_size));
-			struct_size = get_declared_struct_size(ib_type);
 
 			// Update the original variable reference to include the structure reference
 			string qual_var_name = ib_var_ref + "." + mbr_name;
@@ -512,11 +359,9 @@ uint32_t CompilerMSL::add_interface_struct(StorageClass storage, uint32_t vtx_bi
 
 			// Copy the variable location from the original variable to the member
 			auto &dec = meta[p_var->self].decoration;
-			set_member_decoration(ib_type_id, ib_mbr_idx, DecorationLocation, dec.location);
-
-			// Set vertex binding offsets
-			if (execution.model == ExecutionModelVertex && storage == StorageClassInput)
-				set_member_decoration(ib_type_id, ib_mbr_idx, DecorationOffset, dec.offset);
+			uint32_t locn = dec.location;
+			set_member_decoration(ib_type_id, ib_mbr_idx, DecorationLocation, locn);
+			mark_location_as_used_by_shader(locn, storage);
 
 			// Mark the member as builtin if needed
 			if (is_builtin_variable(*p_var))
@@ -616,12 +461,8 @@ void CompilerMSL::emit_resources()
 	}
 
 	// Output interface blocks.
-	for (uint32_t var_id : stage_in_var_ids)
-		emit_interface_block(var_id);
-
+	emit_interface_block(stage_in_var_id);
 	emit_interface_block(stage_out_var_id);
-
-	// TODO: Consolidate and output loose uniforms into an input struct
 }
 
 // Override for MSL-specific syntax instructions
@@ -1370,26 +1211,18 @@ string CompilerMSL::clean_func_name(string func_name)
 // Returns a string containing a comma-delimited list of args for the entry point function
 string CompilerMSL::entry_point_args(bool append_comma)
 {
-	auto &execution = get_entry_point();
 	string ep_args;
 
-	// Stage-in structures
-	for (uint32_t var_id : stage_in_var_ids)
+	// Stage-in structure
+	if (stage_in_var_id)
 	{
-		auto &var = get<SPIRVariable>(var_id);
+		auto &var = get<SPIRVariable>(stage_in_var_id);
 		auto &type = get<SPIRType>(var.basetype);
-		auto &dec = meta[var.self].decoration;
-
-		bool use_stage_in =
-		    (execution.model != ExecutionModelVertex || dec.binding == msl_config.vtx_attr_stage_in_binding);
 
 		if (!ep_args.empty())
 			ep_args += ", ";
-		if (use_stage_in)
-			ep_args += type_to_glsl(type) + " " + to_name(var.self) + " [[stage_in]]";
-		else
-			ep_args += "device " + type_to_glsl(type) + "* " + to_name(var.self) + " [[buffer(" +
-			           convert_to_string(dec.binding) + ")]]";
+
+		ep_args += type_to_glsl(type) + " " + to_name(var.self) + " [[stage_in]]";
 	}
 
 	// Uniforms
@@ -1506,65 +1339,6 @@ uint32_t CompilerMSL::get_metal_resource_index(SPIRVariable &var, SPIRType::Base
 string CompilerMSL::get_entry_point_name()
 {
 	return clean_func_name(to_name(entry_point));
-}
-
-// Returns the name of either the vertex index or instance index builtin
-string CompilerMSL::get_vtx_idx_var_name(bool per_instance)
-{
-	BuiltIn builtin;
-	uint32_t var_id;
-
-	// Try modern builtin name first
-	builtin = per_instance ? BuiltInInstanceIndex : BuiltInVertexIndex;
-	var_id = builtin_vars[builtin];
-	if (var_id)
-		return to_expression(var_id);
-
-	// Try legacy builtin name second
-	builtin = per_instance ? BuiltInInstanceId : BuiltInVertexId;
-	var_id = builtin_vars[builtin];
-	if (var_id)
-		return to_expression(var_id);
-
-	return "missing_vtx_idx_var";
-}
-
-// If the struct contains indexed vertex input, and the offset is greater than the current
-// size of the struct, appends a padding member to the struct, and returns the offset to
-// use for the next member, which is the offset provided. Otherwise, no padding is added,
-// and the struct size is returned.
-uint32_t CompilerMSL::pad_to_offset(SPIRType &struct_type, bool is_indxd_vtx_input, uint32_t offset,
-                                    uint32_t struct_size)
-{
-	if (!(is_indxd_vtx_input && offset > struct_size))
-		return struct_size;
-
-	auto &pad_type = get_pad_type(offset - struct_size);
-	uint32_t mbr_idx = uint32_t(struct_type.member_types.size());
-	struct_type.member_types.push_back(pad_type.self);
-	set_member_name(struct_type.self, mbr_idx, ("pad" + convert_to_string(mbr_idx)));
-	set_member_decoration(struct_type.self, mbr_idx, DecorationOffset, struct_size);
-	return offset;
-}
-
-// Returns a char array type suitable for use as a padding member in a packed struct
-SPIRType &CompilerMSL::get_pad_type(uint32_t pad_len)
-{
-	uint32_t pad_type_id = pad_type_ids_by_pad_len[pad_len];
-	if (pad_type_id != 0)
-		return get<SPIRType>(pad_type_id);
-
-	pad_type_id = increase_bound_by(1);
-	auto &ib_type = set<SPIRType>(pad_type_id);
-	ib_type.storage = StorageClassGeneric;
-	ib_type.basetype = SPIRType::Char;
-	ib_type.width = 8;
-	ib_type.array.push_back(pad_len);
-	ib_type.array_size_literal.push_back(true);
-	set_decoration(ib_type.self, DecorationArrayStride, pad_len);
-
-	pad_type_ids_by_pad_len[pad_len] = pad_type_id;
-	return ib_type;
 }
 
 string CompilerMSL::argument_decl(const SPIRFunction::Parameter &arg)

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -28,14 +28,14 @@ CompilerMSL::CompilerMSL(vector<uint32_t> spirv_)
 {
 	options.vertex.fixup_clipspace = false;
 
-    populate_func_name_overrides();
+	populate_func_name_overrides();
 }
 
 // Populate the collection of function names that need to be overridden
 void CompilerMSL::populate_func_name_overrides()
 {
-    func_name_overrides["main"] = "main0";
-    func_name_overrides["saturate"] = "saturate0";
+	func_name_overrides["main"] = "main0";
+	func_name_overrides["saturate"] = "saturate0";
 }
 
 string CompilerMSL::compile(MSLConfiguration &msl_cfg, vector<MSLVertexAttr> *p_vtx_attrs,
@@ -708,8 +708,8 @@ void CompilerMSL::emit_function_prototype(SPIRFunction &func, bool is_decl)
 }
 
 // Returns the texture sampling function string for the specified image and sampling characteristics.
-string CompilerMSL::to_function_name(uint32_t img, const SPIRType &, bool is_fetch, bool is_gather,
-                                     bool, bool, bool, bool, bool, bool has_dref)
+string CompilerMSL::to_function_name(uint32_t img, const SPIRType &, bool is_fetch, bool is_gather, bool, bool, bool,
+                                     bool, bool, bool has_dref)
 {
 	// Texture reference
 	string fname = to_expression(img) + ".";
@@ -1212,8 +1212,8 @@ string CompilerMSL::func_type_decl(SPIRType &type)
 // Ensures the function name is not "main", which is illegal in MSL
 string CompilerMSL::clean_func_name(string func_name)
 {
-    auto iter = func_name_overrides.find(func_name);
-    return (iter != func_name_overrides.end()) ? iter->second : func_name;
+	auto iter = func_name_overrides.find(func_name);
+	return (iter != func_name_overrides.end()) ? iter->second : func_name;
 }
 
 // Returns a string containing a comma-delimited list of args for the entry point function

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -104,7 +104,6 @@ protected:
 	void emit_header() override;
 	void emit_function_prototype(SPIRFunction &func, uint64_t return_flags) override;
 	void emit_sampled_image_op(uint32_t result_type, uint32_t result_id, uint32_t image_id, uint32_t samp_id) override;
-	void emit_texture_op(const Instruction &i) override;
 	void emit_fixup() override;
 	std::string type_to_glsl(const SPIRType &type) override;
 	std::string image_type_glsl(const SPIRType &type) override;
@@ -114,6 +113,13 @@ protected:
 	size_t get_declared_struct_member_size(const SPIRType &struct_type, uint32_t index) const override;
 	std::string to_func_call_arg(uint32_t id) override;
 	std::string to_name(uint32_t id, bool allow_alias = true) override;
+	std::string to_function_name(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather, bool is_proj,
+	                             bool has_array_offsets, bool has_offset, bool has_grad, bool has_lod,
+	                             bool has_dref) override;
+	std::string to_function_args(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather, bool is_proj,
+	                             uint32_t coord, uint32_t coord_components, uint32_t dref, uint32_t grad_x,
+	                             uint32_t grad_y, uint32_t lod, uint32_t coffset, uint32_t offset, uint32_t bias,
+	                             uint32_t comp, uint32_t sample, bool *p_forward) override;
 
 	void register_custom_functions();
 	void emit_custom_functions();
@@ -150,6 +156,7 @@ protected:
 	SPIRType &get_pad_type(uint32_t pad_len);
 	size_t get_declared_type_size(uint32_t type_id) const;
 	size_t get_declared_type_size(uint32_t type_id, uint64_t dec_mask) const;
+	std::string to_component_argument(uint32_t id);
 
 	MSLConfiguration msl_config;
 	std::set<uint32_t> custom_function_ops;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -115,6 +115,7 @@ protected:
 	                             uint32_t coord, uint32_t coord_components, uint32_t dref, uint32_t grad_x,
 	                             uint32_t grad_y, uint32_t lod, uint32_t coffset, uint32_t offset, uint32_t bias,
 	                             uint32_t comp, uint32_t sample, bool *p_forward) override;
+    std::string clean_func_name(std::string func_name) override;
 
 	void register_custom_functions();
 	void emit_custom_functions();
@@ -129,9 +130,9 @@ protected:
 	void emit_interface_block(uint32_t ib_var_id);
 	void emit_function_prototype(SPIRFunction &func, bool is_decl);
 	void emit_function_declarations();
+    void populate_func_name_overrides();
 
 	std::string func_type_decl(SPIRType &type);
-	std::string clean_func_name(std::string func_name);
 	std::string entry_point_args(bool append_comma);
 	std::string get_entry_point_name();
 	std::string to_qualified_member_name(const SPIRType &type, uint32_t index);
@@ -148,6 +149,7 @@ protected:
 	std::string to_component_argument(uint32_t id);
 
 	MSLConfiguration msl_config;
+    std::unordered_map<std::string,std::string> func_name_overrides;
 	std::set<uint32_t> custom_function_ops;
 	std::unordered_map<uint32_t, MSLVertexAttr *> vtx_attrs_by_location;
 	std::vector<MSLResourceBinding *> resource_bindings;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -115,7 +115,7 @@ protected:
 	                             uint32_t coord, uint32_t coord_components, uint32_t dref, uint32_t grad_x,
 	                             uint32_t grad_y, uint32_t lod, uint32_t coffset, uint32_t offset, uint32_t bias,
 	                             uint32_t comp, uint32_t sample, bool *p_forward) override;
-    std::string clean_func_name(std::string func_name) override;
+	std::string clean_func_name(std::string func_name) override;
 
 	void register_custom_functions();
 	void emit_custom_functions();
@@ -130,7 +130,7 @@ protected:
 	void emit_interface_block(uint32_t ib_var_id);
 	void emit_function_prototype(SPIRFunction &func, bool is_decl);
 	void emit_function_declarations();
-    void populate_func_name_overrides();
+	void populate_func_name_overrides();
 
 	std::string func_type_decl(SPIRType &type);
 	std::string entry_point_args(bool append_comma);
@@ -149,7 +149,7 @@ protected:
 	std::string to_component_argument(uint32_t id);
 
 	MSLConfiguration msl_config;
-    std::unordered_map<std::string,std::string> func_name_overrides;
+	std::unordered_map<std::string, std::string> func_name_overrides;
 	std::set<uint32_t> custom_function_ops;
 	std::unordered_map<uint32_t, MSLVertexAttr *> vtx_attrs_by_location;
 	std::vector<MSLResourceBinding *> resource_bindings;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -29,7 +29,6 @@ namespace spirv_cross
 // Options for compiling to Metal Shading Language
 struct MSLConfiguration
 {
-	uint32_t vtx_attr_stage_in_binding = 0;
 	bool flip_vert_y = true;
 	bool flip_frag_y = true;
 	bool is_rendering_points = false;
@@ -41,10 +40,6 @@ struct MSLConfiguration
 struct MSLVertexAttr
 {
 	uint32_t location = 0;
-	uint32_t msl_buffer = 0;
-	uint32_t msl_offset = 0;
-	uint32_t msl_stride = 0;
-	bool per_instance = false;
 	bool used_by_shader = false;
 };
 
@@ -123,16 +118,13 @@ protected:
 
 	void register_custom_functions();
 	void emit_custom_functions();
-	void extract_builtins();
-	void add_builtin(spv::BuiltIn builtin_type);
 	void localize_global_variables();
 	void extract_global_variables_from_functions();
 	void extract_global_variables_from_function(uint32_t func_id, std::unordered_set<uint32_t> &added_arg_ids,
 	                                            std::unordered_set<uint32_t> &global_var_ids,
 	                                            std::unordered_set<uint32_t> &processed_func_ids);
-	void add_interface_structs();
-	void bind_vertex_attributes(std::unordered_set<uint32_t> &bindings);
-	uint32_t add_interface_struct(spv::StorageClass storage, uint32_t vtx_binding = 0);
+	uint32_t add_interface_block(spv::StorageClass storage);
+	void mark_location_as_used_by_shader(uint32_t location, spv::StorageClass storage);
 	void emit_resources();
 	void emit_interface_block(uint32_t ib_var_id);
 	void emit_function_prototype(SPIRFunction &func, bool is_decl);
@@ -149,11 +141,8 @@ protected:
 	std::string builtin_type_decl(spv::BuiltIn builtin);
 	std::string member_attribute_qualifier(const SPIRType &type, uint32_t index);
 	std::string argument_decl(const SPIRFunction::Parameter &arg);
-	std::string get_vtx_idx_var_name(bool per_instance);
 	uint32_t get_metal_resource_index(SPIRVariable &var, SPIRType::BaseType basetype);
 	uint32_t get_ordered_member_location(uint32_t type_id, uint32_t index);
-	uint32_t pad_to_offset(SPIRType &struct_type, bool is_indxd_vtx_input, uint32_t offset, uint32_t struct_size);
-	SPIRType &get_pad_type(uint32_t pad_len);
 	size_t get_declared_type_size(uint32_t type_id) const;
 	size_t get_declared_type_size(uint32_t type_id, uint64_t dec_mask) const;
 	std::string to_component_argument(uint32_t id);
@@ -162,10 +151,8 @@ protected:
 	std::set<uint32_t> custom_function_ops;
 	std::unordered_map<uint32_t, MSLVertexAttr *> vtx_attrs_by_location;
 	std::vector<MSLResourceBinding *> resource_bindings;
-	std::unordered_map<uint32_t, uint32_t> builtin_vars;
 	MSLResourceBinding next_metal_resource_index;
-	std::unordered_map<uint32_t, uint32_t> pad_type_ids_by_pad_len;
-	std::vector<uint32_t> stage_in_var_ids;
+	uint32_t stage_in_var_id = 0;
 	uint32_t stage_out_var_id = 0;
 	std::string qual_pos_var_name;
 	std::string stage_in_var_name = "in";


### PR DESCRIPTION
Refactor emit_texture_op() function to simplify subclass overrides.
CompilerMSL refactored to simplify handling of vertex attributes.