### PR TITLE
Use the classic locale when converting floats to string

### DIFF
--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -20,6 +20,7 @@
 #include <cstdio>
 #include <cstring>
 #include <functional>
+#include <locale>
 #include <sstream>
 
 namespace spirv_cross
@@ -905,6 +906,22 @@ struct Meta
 // name_of_type is the textual name of the type which will be used in the code unless written to by the callback.
 using VariableTypeRemapCallback =
     std::function<void(const SPIRType &type, const std::string &var_name, std::string &name_of_type)>;
+
+class ClassicLocale
+{
+public:
+	ClassicLocale()
+	{
+		old = std::locale::global(std::locale::classic());
+	}
+	~ClassicLocale()
+	{
+		std::locale::global(old);
+	}
+
+private:
+	std::locale old;
+};
 }
 
 #endif

--- a/spirv_cpp.cpp
+++ b/spirv_cpp.cpp
@@ -279,6 +279,9 @@ void CompilerCPP::emit_resources()
 
 string CompilerCPP::compile()
 {
+	// Force a classic "C" locale, reverts when function returns
+	ClassicLocale classic_locale;
+
 	// Do not deal with ES-isms like precision, older extensions and such.
 	options.es = false;
 	options.version = 450;

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -52,6 +52,8 @@ Compiler::Compiler(vector<uint32_t> ir)
 
 string Compiler::compile()
 {
+	// Force a classic "C" locale, reverts when function returns
+	ClassicLocale classic_locale;
 	return "";
 }
 

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -264,6 +264,9 @@ void CompilerGLSL::find_static_extensions()
 
 string CompilerGLSL::compile()
 {
+	// Force a classic "C" locale, reverts when function returns
+	ClassicLocale classic_locale;
+
 	// Scan the SPIR-V to find trivial uses of extensions.
 	find_static_extensions();
 	fixup_image_load_store_access();

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -41,6 +41,9 @@ void CompilerMSL::populate_func_name_overrides()
 string CompilerMSL::compile(MSLConfiguration &msl_cfg, vector<MSLVertexAttr> *p_vtx_attrs,
                             std::vector<MSLResourceBinding> *p_res_bindings)
 {
+	// Force a classic "C" locale, reverts when function returns
+	ClassicLocale classic_locale;
+
 	// Remember the input parameters
 	msl_config = msl_cfg;
 


### PR DESCRIPTION
When used in a locale-sensitive setting, eg. GUI application, the float to string conversions will necessarily use the current locale. This may result in floating point numbers with eg. commas as a decimal mark.

This patch attempts to avoid these locale specific conversions by temporarily overriding the current locale with a classic locale (C locale).

I am not sure if this is the best way.