### PR TITLE
Legacy GLSL improvements

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -27,7 +27,7 @@
 #include <unordered_set>
 
 #ifdef _MSC_VER
-#pragma warning(disable: 4996)
+#pragma warning(disable : 4996)
 #endif
 
 using namespace spv;

--- a/reference/shaders/legacy/vert/transpose.legacy.vert
+++ b/reference/shaders/legacy/vert/transpose.legacy.vert
@@ -1,0 +1,22 @@
+#version 100
+
+struct Buffer
+{
+    mat4 MVPRowMajor;
+    mat4 MVPColMajor;
+    mat4 M;
+};
+
+uniform Buffer _13;
+
+attribute vec4 Position;
+
+void main()
+{
+    vec4 c0 = _13.M * (Position * _13.MVPRowMajor);
+    vec4 c1 = _13.M * (_13.MVPColMajor * Position);
+    vec4 c2 = _13.M * (_13.MVPRowMajor * Position);
+    vec4 c3 = _13.M * (Position * _13.MVPColMajor);
+    gl_Position = ((c0 + c1) + c2) + c3;
+}
+

--- a/shaders/legacy/vert/transpose.legacy.vert
+++ b/shaders/legacy/vert/transpose.legacy.vert
@@ -1,0 +1,20 @@
+#version 310 es
+
+uniform Buffer
+{
+	layout(row_major) mat4 MVPRowMajor;
+	layout(column_major) mat4 MVPColMajor;
+	mat4 M;
+};
+
+layout(location = 0) in vec4 Position;
+
+void main()
+{
+	vec4 c0 = M * (MVPRowMajor * Position);
+	vec4 c1 = M * (MVPColMajor * Position);
+	vec4 c2 = M * (Position * MVPRowMajor);
+	vec4 c3 = M * (Position * MVPColMajor);
+	gl_Position = c0 + c1 + c2 + c3;
+}
+

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -105,7 +105,7 @@ inline std::string convert_to_string(T &&t)
 
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable: 4996)
+#pragma warning(disable : 4996)
 #endif
 
 inline std::string convert_to_string(float t)

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -351,6 +351,10 @@ struct SPIRExpression : IVariant
 	// If this expression has been used while invalidated.
 	bool used_while_invalidated = false;
 
+	// Before use, this expression must be transposed.
+	// This is needed for targets which don't support row_major layouts.
+	bool need_transpose = false;
+
 	// A list of expressions which this expression depends on.
 	std::vector<uint32_t> expression_dependencies;
 };

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1042,7 +1042,6 @@ void CompilerGLSL::emit_buffer_block(const SPIRVariable &var)
 	else
 		resource_names.insert(buffer_name);
 
-
 	statement(layout_for_variable(var), is_restrict ? "restrict " : "", ssbo ? "buffer " : "uniform ", buffer_name);
 	begin_scope();
 
@@ -2579,8 +2578,8 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 
 	string expr;
 	bool forward = false;
-	expr += to_function_name(img, imgtype, !!fetch, !!gather, !!proj, !!coffsets, (!!coffset || !!offset), (!!grad_x || !!grad_y), !!lod,
-	                         !!dref);
+	expr += to_function_name(img, imgtype, !!fetch, !!gather, !!proj, !!coffsets, (!!coffset || !!offset),
+	                         (!!grad_x || !!grad_y), !!lod, !!dref);
 	expr += "(";
 	expr += to_function_args(img, imgtype, fetch, gather, proj, coord, coord_components, dref, grad_x, grad_y, lod,
 	                         coffset, offset, bias, comp, sample, &forward);

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1000,11 +1000,35 @@ void CompilerGLSL::emit_push_constant_block_glsl(const SPIRVariable &var)
 	statement("");
 }
 
+void CompilerGLSL::emit_buffer_block_legacy(const SPIRVariable &var)
+{
+	auto &type = get<SPIRType>(var.basetype);
+
+	// We're emitting the push constant block as a regular struct, so disable the block qualifier temporarily.
+	// Otherwise, we will end up emitting layout() qualifiers on naked structs which is not allowed.
+	auto &block_flags = meta[type.self].decoration.decoration_flags;
+	uint64_t block_flag = block_flags & (1ull << DecorationBlock);
+	block_flags &= ~block_flag;
+	emit_struct(type);
+	block_flags |= block_flag;
+	emit_uniform(var);
+	statement("");
+}
+
 void CompilerGLSL::emit_buffer_block(const SPIRVariable &var)
 {
 	auto &type = get<SPIRType>(var.basetype);
 	bool ssbo = (meta[type.self].decoration.decoration_flags & (1ull << DecorationBufferBlock)) != 0;
 	bool is_restrict = (meta[var.self].decoration.decoration_flags & (1ull << DecorationRestrict)) != 0;
+
+	// By default, for legacy targets, fall back to declaring a uniform struct.
+	if (is_legacy())
+	{
+		if (ssbo)
+			SPIRV_CROSS_THROW("SSBOs not supported in legacy targets.");
+		emit_buffer_block_legacy(var);
+		return;
+	}
 
 	add_resource_name(var.self);
 
@@ -1017,6 +1041,7 @@ void CompilerGLSL::emit_buffer_block(const SPIRVariable &var)
 		buffer_name = get_fallback_name(type.self);
 	else
 		resource_names.insert(buffer_name);
+
 
 	statement(layout_for_variable(var), is_restrict ? "restrict " : "", ssbo ? "buffer " : "uniform ", buffer_name);
 	begin_scope();
@@ -1055,6 +1080,9 @@ void CompilerGLSL::emit_interface_block(const SPIRVariable &var)
 
 	if (block)
 	{
+		if (is_legacy())
+			SPIRV_CROSS_THROW("IO blocks are not supported in legacy targets.");
+
 		add_resource_name(var.self);
 
 		// Block names should never alias.
@@ -1574,6 +1602,8 @@ string CompilerGLSL::to_expression(uint32_t id)
 		auto &e = get<SPIRExpression>(id);
 		if (e.base_expression)
 			return to_enclosed_expression(e.base_expression) + e.expression;
+		else if (e.need_transpose)
+			return convert_row_major_matrix(e.expression);
 		else
 			return e.expression;
 	}
@@ -3097,7 +3127,7 @@ const char *CompilerGLSL::index_to_swizzle(uint32_t index)
 }
 
 string CompilerGLSL::access_chain(uint32_t base, const uint32_t *indices, uint32_t count, bool index_is_literal,
-                                  bool chain_only)
+                                  bool chain_only, bool *need_transpose)
 {
 	string expr;
 	if (!chain_only)
@@ -3218,6 +3248,8 @@ string CompilerGLSL::access_chain(uint32_t base, const uint32_t *indices, uint32
 			SPIRV_CROSS_THROW("Cannot subdivide a scalar value!");
 	}
 
+	if (need_transpose)
+		*need_transpose = row_major_matrix_needs_conversion;
 	return expr;
 }
 
@@ -3554,13 +3586,28 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		// If an expression is mutable and forwardable, we speculate that it is immutable.
 		bool forward = should_forward(ptr) && forced_temporaries.find(id) == end(forced_temporaries);
 
-		// If loading a non-native row-major matrix, convert it to column-major
+		// If loading a non-native row-major matrix, mark the expression as need_transpose.
+		bool need_transpose = false;
+		bool old_need_transpose = false;
+
+		auto *ptr_expression = maybe_get<SPIRExpression>(ptr);
+		if (ptr_expression && ptr_expression->need_transpose)
+		{
+			old_need_transpose = true;
+			ptr_expression->need_transpose = false;
+			need_transpose = true;
+		}
+		else if (is_non_native_row_major_matrix(ptr))
+			need_transpose = true;
+
 		auto expr = to_expression(ptr);
-		if (is_non_native_row_major_matrix(ptr))
-			expr = convert_row_major_matrix(expr);
+
+		if (ptr_expression)
+			ptr_expression->need_transpose = old_need_transpose;
 
 		// Suppress usage tracking since using same expression multiple times does not imply any extra work.
-		emit_op(result_type, id, expr, forward, true);
+		auto &e = emit_op(result_type, id, expr, forward, true);
+		e.need_transpose = need_transpose;
 		register_read(id, ptr, forward);
 		break;
 	}
@@ -3574,9 +3621,11 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 
 		// If the base is immutable, the access chain pointer must also be.
 		// If an expression is mutable and forwardable, we speculate that it is immutable.
-		auto e = access_chain(ops[2], &ops[3], length - 3, false);
+		bool need_transpose;
+		auto e = access_chain(ops[2], &ops[3], length - 3, false, false, &need_transpose);
 		auto &expr = set<SPIRExpression>(ops[1], move(e), ops[0], should_forward(ops[2]));
 		expr.loaded_from = ops[2];
+		expr.need_transpose = need_transpose;
 		break;
 	}
 
@@ -4012,11 +4061,25 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		break;
 	}
 
-	case OpFMul:
+	case OpVectorTimesMatrix:
 	case OpMatrixTimesVector:
+	{
+		// If the matrix needs transpose, just flip the multiply order.
+		auto *e = maybe_get<SPIRExpression>(ops[opcode == OpMatrixTimesVector ? 2 : 3]);
+		if (e && e->need_transpose)
+		{
+			e->need_transpose = false;
+			emit_binary_op(ops[0], ops[1], ops[3], ops[2], "*");
+			e->need_transpose = true;
+		}
+		else
+			BOP(*);
+		break;
+	}
+
+	case OpFMul:
 	case OpMatrixTimesScalar:
 	case OpVectorTimesScalar:
-	case OpVectorTimesMatrix:
 	case OpMatrixTimesMatrix:
 		BOP(*);
 		break;
@@ -4855,7 +4918,8 @@ void CompilerGLSL::add_member_name(SPIRType &type, uint32_t index)
 bool CompilerGLSL::is_non_native_row_major_matrix(uint32_t id)
 {
 	// Natively supported row-major matrices do not need to be converted.
-	if (backend.native_row_major_matrix)
+	// Legacy targets do not support row major.
+	if (backend.native_row_major_matrix && !is_legacy())
 		return false;
 
 	// Non-matrix or column-major matrix types do not need to be converted.
@@ -4876,7 +4940,7 @@ bool CompilerGLSL::is_non_native_row_major_matrix(uint32_t id)
 bool CompilerGLSL::member_is_non_native_row_major_matrix(const SPIRType &type, uint32_t index)
 {
 	// Natively supported row-major matrices do not need to be converted.
-	if (backend.native_row_major_matrix)
+	if (backend.native_row_major_matrix && !is_legacy())
 		return false;
 
 	// Non-matrix or column-major matrix types do not need to be converted.

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -264,6 +264,7 @@ protected:
 	void emit_struct(SPIRType &type);
 	void emit_resources();
 	void emit_buffer_block(const SPIRVariable &type);
+	void emit_buffer_block_legacy(const SPIRVariable &var);
 	void emit_push_constant_block(const SPIRVariable &var);
 	void emit_push_constant_block_vulkan(const SPIRVariable &var);
 	void emit_push_constant_block_glsl(const SPIRVariable &var);
@@ -304,8 +305,9 @@ protected:
 	bool expression_is_forwarded(uint32_t id);
 	SPIRExpression &emit_op(uint32_t result_type, uint32_t result_id, const std::string &rhs, bool forward_rhs,
 	                        bool suppress_usage_tracking = false);
-	std::string access_chain(uint32_t base, const uint32_t *indices, uint32_t count, bool index_is_literal,
-	                         bool chain_only = false);
+	std::string access_chain(uint32_t base, const uint32_t *indices, uint32_t count,
+	                         bool index_is_literal,
+	                         bool chain_only = false, bool *need_transpose = nullptr);
 
 	const char *index_to_swizzle(uint32_t index);
 	std::string remap_swizzle(uint32_t result_type, uint32_t input_components, uint32_t expr);

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -305,8 +305,7 @@ protected:
 	bool expression_is_forwarded(uint32_t id);
 	SPIRExpression &emit_op(uint32_t result_type, uint32_t result_id, const std::string &rhs, bool forward_rhs,
 	                        bool suppress_usage_tracking = false);
-	std::string access_chain(uint32_t base, const uint32_t *indices, uint32_t count,
-	                         bool index_is_literal,
+	std::string access_chain(uint32_t base, const uint32_t *indices, uint32_t count, bool index_is_literal,
 	                         bool chain_only = false, bool *need_transpose = nullptr);
 
 	const char *index_to_swizzle(uint32_t index);


### PR DESCRIPTION
This improves handling of transpose in targets which do not support row_major layouts natively. The common use-case of row_major_matrix * vector will now be written as vector * matrix instead to avoid the transpose().

UBOs are now emitted as uniform structs by default.