### PR TITLE
Add basic setup for regression testing Metal output.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,4 @@ script:
   - make -j2
   - PATH=./glslang/StandAlone:./SPIRV-Tools/tools:$PATH
   - ./test_shaders.py shaders
+  - ./test_shaders.py --metal shaders-msl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,9 @@ if (${PYTHONINTERP_FOUND})
 	add_test(NAME spirv-cross-test
 		COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py
 			${CMAKE_CURRENT_SOURCE_DIR}/shaders)
+	add_test(NAME spirv-cross-test-metal
+		COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --metal
+			${CMAKE_CURRENT_SOURCE_DIR}/shaders-msl)
   endif()
 else()
   message(WARNING "Testing disabled. Could not find python3. If you have python3 installed try running "

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ In these cases, run `./test_shaders.py shaders --update` to update the reference
 Always make sure you are running up to date glslangValidator as well as SPIRV-Tools when updating reference files.
 
 In short, the master branch should always be able to run `./test_shaders.py shaders` without failure.
+SPIRV-Cross uses Travis CI to test all pull requests, so it is not strictly needed to perform testing yourself if you have problems running it locally.
+A pull request which does not pass testing on Travis will not be accepted however.
 
 When adding support for new features to SPIRV-Cross, a new shader and reference file should be added which covers usage of the new shader features in question.
 
@@ -204,6 +206,10 @@ The current reference output is contained in reference/.
 `./test_shaders.py shaders` can be run to perform regression testing.
 
 See `./test_shaders.py --help` for more.
+
+### Metal backend
+
+To test the roundtrip path GLSL -> SPIR-V -> MSL, `--metal` can be added, e.g. `./test_shaders.py --metal shaders-msl`.
 
 ### Updating regression tests
 

--- a/reference/shaders-msl/vert/basic.vert
+++ b/reference/shaders-msl/vert/basic.vert
@@ -1,0 +1,32 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBO
+{
+    float4x4 uMVP;
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(0)]];
+};
+
+struct main0_out
+{
+    float3 vNormal [[user(locn0)]];
+    float4 gl_Position [[position]];
+    float gl_PointSize;
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _16 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = _16.uMVP * in.aVertex;
+    out.vNormal = in.aNormal;
+    out.gl_Position.y = -(out.gl_Position.y);    // Invert Y-axis for Metal
+    return out;
+}
+

--- a/shaders-msl/vert/basic.vert
+++ b/shaders-msl/vert/basic.vert
@@ -1,0 +1,15 @@
+#version 310 es
+
+layout(std140) uniform UBO
+{
+    uniform mat4 uMVP;
+};
+in vec4 aVertex;
+in vec3 aNormal;
+out vec3 vNormal;
+
+void main()
+{
+    gl_Position = uMVP * aVertex;
+    vNormal = aNormal;
+}


### PR DESCRIPTION
This PR sets up the basic system for how we can have regression tests for Metal as well.
While shaders we test specifically are found in shaders-msl, we would ideally reuse the same shaders to test Metal as well.