### PR TITLE
Fix compilation on some old C++11 standard libraries.

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1569,7 +1569,7 @@ void CompilerGLSL::strip_enclosed_expression(string &expr)
 				return;
 		}
 	}
-	expr.pop_back();
+	expr.erase(expr.size() - 1, 1);
 	expr.erase(begin(expr));
 }
 


### PR DESCRIPTION
Hey all, this is another fix for compiling spirv_cross with the old C++11 stdlib used by Chrome.