### PR TITLE
spirv_msl: Put writable SSBOs in the 'device' address space

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1253,7 +1253,16 @@ string CompilerMSL::entry_point_args(bool append_comma)
 				case SPIRType::Struct:
 					if (!ep_args.empty())
 						ep_args += ", ";
-					ep_args += "constant " + type_to_glsl(type) + "& " + to_name(var.self);
+					if ((meta[type.self].decoration.decoration_flags & (1ull << DecorationBufferBlock)) != 0 &&
+					    (meta[type.self].decoration.decoration_flags & (1ull << DecorationNonWritable)) == 0)
+					{
+						ep_args += "device ";
+					}
+					else
+					{
+						ep_args += "constant ";
+					}
+					ep_args += type_to_glsl(type) + "& " + to_name(var.self);
 					ep_args += " [[buffer(" + convert_to_string(get_metal_resource_index(var, type.basetype)) + ")]]";
 					break;
 				case SPIRType::Sampler:


### PR DESCRIPTION
Hey all, this fixes writable SSBOs being put in the "constant" address spaces causing compile errors when their are written to. This is a quick-fix and I would understand it if more work is required. If that's the case please kindly provide guidance on what should be done.