### PR TITLE
Remove emission of function prototypes in MSL.

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -129,14 +129,10 @@ static uint32_t pls_format_to_components(PlsFormat format)
 	}
 }
 
-static const char* vector_swizzle(int vecsize, int index)
+static const char *vector_swizzle(int vecsize, int index)
 {
-	static const char* swizzle[4][4] =
-	{
-		{ ".x", ".y", ".z", ".w" },
-		{ ".xy", ".yz", ".zw" },
-		{ ".xyz", ".yzw" },
-		{ "" }
+	static const char *swizzle[4][4] = {
+		{ ".x", ".y", ".z", ".w" }, { ".xy", ".yz", ".zw" }, { ".xyz", ".yzw" }, { "" }
 	};
 
 	assert(vecsize >= 1 && vecsize <= 4);
@@ -3290,7 +3286,8 @@ string CompilerGLSL::access_chain(uint32_t base, const uint32_t *indices, uint32
 	return expr;
 }
 
-string CompilerGLSL::access_chain(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, bool* need_transpose)
+string CompilerGLSL::access_chain(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type,
+                                  bool *need_transpose)
 {
 	if (flattened_buffer_blocks.count(base))
 	{
@@ -3305,7 +3302,8 @@ string CompilerGLSL::access_chain(uint32_t base, const uint32_t *indices, uint32
 	}
 }
 
-std::string CompilerGLSL::flattened_access_chain(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, uint32_t offset)
+std::string CompilerGLSL::flattened_access_chain(uint32_t base, const uint32_t *indices, uint32_t count,
+                                                 const SPIRType &target_type, uint32_t offset)
 {
 	if (!target_type.array.empty())
 	{
@@ -3325,7 +3323,8 @@ std::string CompilerGLSL::flattened_access_chain(uint32_t base, const uint32_t *
 	}
 }
 
-std::string CompilerGLSL::flattened_access_chain_struct(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, uint32_t offset)
+std::string CompilerGLSL::flattened_access_chain_struct(uint32_t base, const uint32_t *indices, uint32_t count,
+                                                        const SPIRType &target_type, uint32_t offset)
 {
 	std::string expr;
 
@@ -3348,7 +3347,8 @@ std::string CompilerGLSL::flattened_access_chain_struct(uint32_t base, const uin
 	return expr;
 }
 
-std::string CompilerGLSL::flattened_access_chain_matrix(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, uint32_t offset)
+std::string CompilerGLSL::flattened_access_chain_matrix(uint32_t base, const uint32_t *indices, uint32_t count,
+                                                        const SPIRType &target_type, uint32_t offset)
 {
 	std::string expr;
 
@@ -3368,7 +3368,8 @@ std::string CompilerGLSL::flattened_access_chain_matrix(uint32_t base, const uin
 	return expr;
 }
 
-std::string CompilerGLSL::flattened_access_chain_vector_scalar(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, uint32_t offset)
+std::string CompilerGLSL::flattened_access_chain_vector_scalar(uint32_t base, const uint32_t *indices, uint32_t count,
+                                                               const SPIRType &target_type, uint32_t offset)
 {
 	if (target_type.basetype != SPIRType::Float)
 		SPIRV_CROSS_THROW("Access chains that use non-floating-point base types can not be flattened");
@@ -3393,7 +3394,9 @@ std::string CompilerGLSL::flattened_access_chain_vector_scalar(uint32_t base, co
 	return expr;
 }
 
-std::pair<std::string, uint32_t> CompilerGLSL::flattened_access_chain_offset(uint32_t base, const uint32_t *indices, uint32_t count, uint32_t offset, bool *need_transpose)
+std::pair<std::string, uint32_t> CompilerGLSL::flattened_access_chain_offset(uint32_t base, const uint32_t *indices,
+                                                                             uint32_t count, uint32_t offset,
+                                                                             bool *need_transpose)
 {
 	const auto *type = &expression_type(base);
 	uint32_t type_size = 0;
@@ -3444,7 +3447,8 @@ std::pair<std::string, uint32_t> CompilerGLSL::flattened_access_chain_offset(uin
 			offset += type_struct_member_offset(*type, index);
 
 			type_size = uint32_t(get_declared_struct_member_size(*type, index));
-			row_major_matrix_needs_conversion = (combined_decoration_for_member(*type, index) & (1ull << DecorationRowMajor)) != 0;
+			row_major_matrix_needs_conversion =
+			    (combined_decoration_for_member(*type, index) & (1ull << DecorationRowMajor)) != 0;
 			type = &get<SPIRType>(type->member_types[index]);
 		}
 		// Matrix -> Vector

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -315,13 +315,20 @@ protected:
 	                        bool suppress_usage_tracking = false);
 	std::string access_chain(uint32_t base, const uint32_t *indices, uint32_t count, bool index_is_literal,
 	                         bool chain_only = false, bool *need_transpose = nullptr);
-	std::string access_chain(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, bool *need_transpose = nullptr);
+	std::string access_chain(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type,
+	                         bool *need_transpose = nullptr);
 
-	std::string flattened_access_chain(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, uint32_t offset);
-	std::string flattened_access_chain_struct(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, uint32_t offset);
-	std::string flattened_access_chain_matrix(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, uint32_t offset);
-	std::string flattened_access_chain_vector_scalar(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type, uint32_t offset);
-	std::pair<std::string, uint32_t> flattened_access_chain_offset(uint32_t base, const uint32_t *indices, uint32_t count, uint32_t offset, bool *need_transpose = nullptr);
+	std::string flattened_access_chain(uint32_t base, const uint32_t *indices, uint32_t count,
+	                                   const SPIRType &target_type, uint32_t offset);
+	std::string flattened_access_chain_struct(uint32_t base, const uint32_t *indices, uint32_t count,
+	                                          const SPIRType &target_type, uint32_t offset);
+	std::string flattened_access_chain_matrix(uint32_t base, const uint32_t *indices, uint32_t count,
+	                                          const SPIRType &target_type, uint32_t offset);
+	std::string flattened_access_chain_vector_scalar(uint32_t base, const uint32_t *indices, uint32_t count,
+	                                                 const SPIRType &target_type, uint32_t offset);
+	std::pair<std::string, uint32_t> flattened_access_chain_offset(uint32_t base, const uint32_t *indices,
+	                                                               uint32_t count, uint32_t offset,
+	                                                               bool *need_transpose = nullptr);
 
 	const char *index_to_swizzle(uint32_t index);
 	std::string remap_swizzle(uint32_t result_type, uint32_t input_components, uint32_t expr);

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -117,11 +117,11 @@ void CompilerMSL::preprocess_op_codes()
 {
 	custom_function_ops.clear();
 
-    OpCodePreprocessor preproc(*this);
+	OpCodePreprocessor preproc(*this);
 	traverse_all_reachable_opcodes(get<SPIRFunction>(entry_point), preproc);
 
-    if (preproc.suppress_missing_prototypes)
-        add_header_line("#pragma clang diagnostic ignored \"-Wmissing-prototypes\"");
+	if (preproc.suppress_missing_prototypes)
+		add_header_line("#pragma clang diagnostic ignored \"-Wmissing-prototypes\"");
 }
 
 // Move the Private global variables to the entry function.
@@ -402,12 +402,13 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage)
 // Emits the file header info
 void CompilerMSL::emit_header()
 {
-    if ( !header_lines.empty() ) {
-        for (auto &header : header_lines)
-            statement(header);
+	if (!header_lines.empty())
+	{
+		for (auto &header : header_lines)
+			statement(header);
 
-        statement("");
-    }
+		statement("");
+	}
 
 	statement("#include <metal_stdlib>");
 	statement("#include <simd/simd.h>");
@@ -693,7 +694,7 @@ void CompilerMSL::emit_function_prototype(SPIRFunction &func, uint64_t)
 	}
 
 	decl += ")";
-    statement(decl);
+	statement(decl);
 }
 
 // Returns the texture sampling function string for the specified image and sampling characteristics.
@@ -1720,24 +1721,24 @@ size_t CompilerMSL::get_declared_type_size(uint32_t type_id, uint64_t dec_mask) 
 
 bool CompilerMSL::OpCodePreprocessor::handle(Op opcode, const uint32_t * /*args*/, uint32_t /*length*/)
 {
-    switch (opcode)
-    {
-        // If an opcode requires a bespoke custom function be output, remember it.
-        case OpFMod:
-            compiler.custom_function_ops.insert(uint32_t(opcode));
-            break;
+	switch (opcode)
+	{
+	// If an opcode requires a bespoke custom function be output, remember it.
+	case OpFMod:
+		compiler.custom_function_ops.insert(uint32_t(opcode));
+		break;
 
-        // Since MSL exists in a single execution scope, function prototype declarations are not
-        // needed, and clutter the output. If secondary functions are output (as indicated by the
-        // presence of OpFunctionCall, then suppress compiler warnings of missing function prototypes.
-        case OpFunctionCall:
-            suppress_missing_prototypes = true;
-            break;
+	// Since MSL exists in a single execution scope, function prototype declarations are not
+	// needed, and clutter the output. If secondary functions are output (as indicated by the
+	// presence of OpFunctionCall, then suppress compiler warnings of missing function prototypes.
+	case OpFunctionCall:
+		suppress_missing_prototypes = true;
+		break;
 
-        default:
-            break;
-    }
-    return true;
+	default:
+		break;
+	}
+	return true;
 }
 
 // Sort both type and meta member content based on builtin status (put builtins at end),

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -160,17 +160,18 @@ protected:
 	std::string sampler_name_suffix = "Smplr";
 
 	// OpcodeHandler that handles several MSL preprocessing operations.
-    struct OpCodePreprocessor : OpcodeHandler
-    {
-        OpCodePreprocessor(CompilerMSL &compiler_) : compiler(compiler_)
-        {
-        }
+	struct OpCodePreprocessor : OpcodeHandler
+	{
+		OpCodePreprocessor(CompilerMSL &compiler_)
+		    : compiler(compiler_)
+		{
+		}
 
-        bool handle(spv::Op opcode, const uint32_t *args, uint32_t length) override;
+		bool handle(spv::Op opcode, const uint32_t *args, uint32_t length) override;
 
-        CompilerMSL &compiler;
-        bool suppress_missing_prototypes = false;
-    };
+		CompilerMSL &compiler;
+		bool suppress_missing_prototypes = false;
+	};
 
 	// Sorts the members of a SPIRType and associated Meta info based on a settable sorting
 	// aspect, which defines which aspect of the struct members will be used to sort them.

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -117,7 +117,7 @@ protected:
 	                             uint32_t comp, uint32_t sample, bool *p_forward) override;
 	std::string clean_func_name(std::string func_name) override;
 
-	void register_custom_functions();
+	void preprocess_op_codes();
 	void emit_custom_functions();
 	void localize_global_variables();
 	void extract_global_variables_from_functions();
@@ -128,8 +128,6 @@ protected:
 	void mark_location_as_used_by_shader(uint32_t location, spv::StorageClass storage);
 	void emit_resources();
 	void emit_interface_block(uint32_t ib_var_id);
-	void emit_function_prototype(SPIRFunction &func, bool is_decl);
-	void emit_function_declarations();
 	void populate_func_name_overrides();
 
 	std::string func_type_decl(SPIRType &type);
@@ -161,21 +159,18 @@ protected:
 	std::string stage_out_var_name = "out";
 	std::string sampler_name_suffix = "Smplr";
 
-	// Extracts a set of opcodes that should be implemented as a bespoke custom function
-	// whose full source code is output as part of the shader source code.
-	struct CustomFunctionHandler : OpcodeHandler
-	{
-		CustomFunctionHandler(const CompilerMSL &compiler_, std::set<uint32_t> &custom_function_ops_)
-		    : compiler(compiler_)
-		    , custom_function_ops(custom_function_ops_)
-		{
-		}
+	// OpcodeHandler that handles several MSL preprocessing operations.
+    struct OpCodePreprocessor : OpcodeHandler
+    {
+        OpCodePreprocessor(CompilerMSL &compiler_) : compiler(compiler_)
+        {
+        }
 
-		bool handle(spv::Op opcode, const uint32_t *args, uint32_t length) override;
+        bool handle(spv::Op opcode, const uint32_t *args, uint32_t length) override;
 
-		const CompilerMSL &compiler;
-		std::set<uint32_t> &custom_function_ops;
-	};
+        CompilerMSL &compiler;
+        bool suppress_missing_prototypes = false;
+    };
 
 	// Sorts the members of a SPIRType and associated Meta info based on a settable sorting
 	// aspect, which defines which aspect of the struct members will be used to sort them.


### PR DESCRIPTION
This PR really only affects spirv_msl. Changes to spirv_glsl are a side effect of running the style formatter (on source code from a previous commit).