### PR TITLE
Legacy UBO flattening improvements

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -671,8 +671,12 @@ int main(int argc, char *argv[])
 		res = compiler->get_shader_resources();
 
 	if (args.flatten_ubo)
+	{
 		for (auto &ubo : res.uniform_buffers)
 			compiler->flatten_buffer_block(ubo.id);
+		for (auto &ubo : res.push_constant_buffers)
+			compiler->flatten_buffer_block(ubo.id);
+	}
 
 	auto pls_inputs = remap_pls(args.pls_in, res.stage_inputs, &res.subpass_inputs);
 	auto pls_outputs = remap_pls(args.pls_out, res.stage_outputs, nullptr);

--- a/reference/shaders/comp/basic.comp
+++ b/reference/shaders/comp/basic.comp
@@ -1,12 +1,12 @@
 #version 310 es
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
-layout(binding = 0, std430) buffer SSBO
+layout(binding = 0, std430) readonly buffer SSBO
 {
     vec4 in_data[];
 } _23;
 
-layout(binding = 1, std430) buffer SSBO2
+layout(binding = 1, std430) writeonly buffer SSBO2
 {
     vec4 out_data[];
 } _45;

--- a/reference/shaders/comp/culling.comp
+++ b/reference/shaders/comp/culling.comp
@@ -1,12 +1,12 @@
 #version 310 es
 layout(local_size_x = 4, local_size_y = 1, local_size_z = 1) in;
 
-layout(binding = 0, std430) buffer SSBO
+layout(binding = 0, std430) readonly buffer SSBO
 {
     float in_data[];
 } _22;
 
-layout(binding = 1, std430) buffer SSBO2
+layout(binding = 1, std430) writeonly buffer SSBO2
 {
     float out_data[];
 } _38;

--- a/reference/shaders/comp/dowhile.comp
+++ b/reference/shaders/comp/dowhile.comp
@@ -1,13 +1,13 @@
 #version 310 es
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
-layout(binding = 0, std430) buffer SSBO
+layout(binding = 0, std430) readonly buffer SSBO
 {
     mat4 mvp;
     vec4 in_data[];
 } _28;
 
-layout(binding = 1, std430) buffer SSBO2
+layout(binding = 1, std430) writeonly buffer SSBO2
 {
     vec4 out_data[];
 } _52;

--- a/reference/shaders/comp/generate_height.comp
+++ b/reference/shaders/comp/generate_height.comp
@@ -1,7 +1,7 @@
 #version 310 es
 layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
-layout(binding = 0, std430) buffer Distribution
+layout(binding = 0, std430) readonly buffer Distribution
 {
     vec2 distribution[];
 } _190;
@@ -11,7 +11,7 @@ layout(binding = 2, std140) uniform UBO
     vec4 uModTime;
 } _218;
 
-layout(binding = 1, std430) buffer HeightmapFFT
+layout(binding = 1, std430) writeonly buffer HeightmapFFT
 {
     uint heights[];
 } _276;

--- a/reference/shaders/comp/inout-struct.invalid.comp
+++ b/reference/shaders/comp/inout-struct.invalid.comp
@@ -9,17 +9,17 @@ struct Foo
     vec4 d;
 };
 
-layout(binding = 1, std430) buffer SSBO2
+layout(binding = 1, std430) readonly buffer SSBO2
 {
     vec4 data[];
 } indata;
 
-layout(binding = 0, std430) buffer SSBO
+layout(binding = 0, std430) writeonly buffer SSBO
 {
     vec4 data[];
 } outdata;
 
-layout(binding = 2, std430) buffer SSBO3
+layout(binding = 2, std430) readonly buffer SSBO3
 {
     Foo foos[];
 } foobar;

--- a/reference/shaders/comp/insert.comp
+++ b/reference/shaders/comp/insert.comp
@@ -1,7 +1,7 @@
 #version 310 es
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
-layout(binding = 0, std430) buffer SSBO
+layout(binding = 0, std430) writeonly buffer SSBO
 {
     vec4 out_data[];
 } _27;

--- a/reference/shaders/comp/loop.comp
+++ b/reference/shaders/comp/loop.comp
@@ -1,13 +1,13 @@
 #version 310 es
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
-layout(binding = 0, std430) buffer SSBO
+layout(binding = 0, std430) readonly buffer SSBO
 {
     mat4 mvp;
     vec4 in_data[];
 } _24;
 
-layout(binding = 1, std430) buffer SSBO2
+layout(binding = 1, std430) writeonly buffer SSBO2
 {
     vec4 out_data[];
 } _177;

--- a/reference/shaders/comp/mat3.comp
+++ b/reference/shaders/comp/mat3.comp
@@ -1,7 +1,7 @@
 #version 310 es
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
-layout(binding = 1, std430) buffer SSBO2
+layout(binding = 1, std430) writeonly buffer SSBO2
 {
     mat3 out_data[];
 } _22;

--- a/reference/shaders/comp/mod.comp
+++ b/reference/shaders/comp/mod.comp
@@ -1,12 +1,12 @@
 #version 310 es
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
-layout(binding = 0, std430) buffer SSBO
+layout(binding = 0, std430) readonly buffer SSBO
 {
     vec4 in_data[];
 } _23;
 
-layout(binding = 1, std430) buffer SSBO2
+layout(binding = 1, std430) writeonly buffer SSBO2
 {
     vec4 out_data[];
 } _33;

--- a/reference/shaders/comp/modf.comp
+++ b/reference/shaders/comp/modf.comp
@@ -1,12 +1,12 @@
 #version 310 es
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
-layout(binding = 0, std430) buffer SSBO
+layout(binding = 0, std430) readonly buffer SSBO
 {
     vec4 in_data[];
 } _23;
 
-layout(binding = 1, std430) buffer SSBO2
+layout(binding = 1, std430) writeonly buffer SSBO2
 {
     vec4 out_data[];
 } _35;

--- a/reference/shaders/comp/read-write-only.comp
+++ b/reference/shaders/comp/read-write-only.comp
@@ -1,0 +1,27 @@
+#version 310 es
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 2, std430) restrict writeonly buffer SSBO2
+{
+    vec4 data4;
+    vec4 data5;
+} _10;
+
+layout(binding = 0, std430) readonly buffer SSBO0
+{
+    vec4 data0;
+    vec4 data1;
+} _15;
+
+layout(binding = 1, std430) restrict buffer SSBO1
+{
+    vec4 data2;
+    vec4 data3;
+} _21;
+
+void main()
+{
+    _10.data4 = _15.data0 + _21.data2;
+    _10.data5 = _15.data1 + _21.data3;
+}
+

--- a/reference/shaders/comp/return.comp
+++ b/reference/shaders/comp/return.comp
@@ -1,7 +1,7 @@
 #version 310 es
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
-layout(binding = 1, std430) buffer SSBO2
+layout(binding = 1, std430) writeonly buffer SSBO2
 {
     vec4 out_data[];
 } _27;

--- a/reference/shaders/comp/shared.comp
+++ b/reference/shaders/comp/shared.comp
@@ -1,15 +1,15 @@
 #version 310 es
 layout(local_size_x = 4, local_size_y = 1, local_size_z = 1) in;
 
-layout(binding = 0, std430) buffer SSBO
+layout(binding = 0, std430) readonly buffer SSBO
 {
     float in_data[];
 } _22;
 
-layout(binding = 1, std430) buffer SSBO2
+layout(binding = 1, std430) writeonly buffer SSBO2
 {
     float out_data[];
-} _44;
+} _43;
 
 shared float sShared[4];
 
@@ -20,6 +20,6 @@ void main()
     sShared[gl_LocalInvocationIndex] = idata;
     memoryBarrierShared();
     barrier();
-    _44.out_data[ident] = sShared[(4u - gl_LocalInvocationIndex) - 1u];
+    _43.out_data[ident] = sShared[(4u - gl_LocalInvocationIndex) - 1u];
 }
 

--- a/reference/shaders/comp/shared.comp
+++ b/reference/shaders/comp/shared.comp
@@ -9,7 +9,7 @@ layout(binding = 0, std430) readonly buffer SSBO
 layout(binding = 1, std430) writeonly buffer SSBO2
 {
     float out_data[];
-} _43;
+} _44;
 
 shared float sShared[4];
 
@@ -20,6 +20,6 @@ void main()
     sShared[gl_LocalInvocationIndex] = idata;
     memoryBarrierShared();
     barrier();
-    _43.out_data[ident] = sShared[(4u - gl_LocalInvocationIndex) - 1u];
+    _44.out_data[ident] = sShared[(4u - gl_LocalInvocationIndex) - 1u];
 }
 

--- a/reference/shaders/comp/struct-layout.comp
+++ b/reference/shaders/comp/struct-layout.comp
@@ -6,12 +6,12 @@ struct Foo
     mat4 m;
 };
 
-layout(binding = 1, std430) buffer SSBO2
+layout(binding = 1, std430) writeonly buffer SSBO2
 {
     Foo out_data[];
 } _23;
 
-layout(binding = 0, std430) buffer SSBO
+layout(binding = 0, std430) readonly buffer SSBO
 {
     Foo in_data[];
 } _30;

--- a/reference/shaders/comp/torture-loop.comp
+++ b/reference/shaders/comp/torture-loop.comp
@@ -1,13 +1,13 @@
 #version 310 es
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
-layout(binding = 0, std430) buffer SSBO
+layout(binding = 0, std430) readonly buffer SSBO
 {
     mat4 mvp;
     vec4 in_data[];
 } _24;
 
-layout(binding = 1, std430) buffer SSBO2
+layout(binding = 1, std430) writeonly buffer SSBO2
 {
     vec4 out_data[];
 } _89;

--- a/reference/shaders/flatten/array.flatten.vert
+++ b/reference/shaders/flatten/array.flatten.vert
@@ -1,11 +1,12 @@
 #version 310 es
 
-uniform vec4 UBO[16];
+uniform vec4 UBO[56];
 in vec4 aVertex;
 
 void main()
 {
-    vec4 offset = (UBO[10] + UBO[5]) + vec4(UBO[14].x);
-    gl_Position = ((mat4(UBO[0], UBO[1], UBO[2], UBO[3]) * aVertex) + UBO[15]) + offset;
+    vec4 a4 = UBO[23];
+    vec4 offset = (UBO[50] + UBO[45]) + vec4(UBO[54].x);
+    gl_Position = ((mat4(UBO[40], UBO[41], UBO[42], UBO[43]) * aVertex) + UBO[55]) + offset;
 }
 

--- a/reference/shaders/flatten/array.flatten.vert
+++ b/reference/shaders/flatten/array.flatten.vert
@@ -1,10 +1,11 @@
 #version 310 es
 
-uniform vec4 UBO[14];
+uniform vec4 UBO[16];
 in vec4 aVertex;
 
 void main()
 {
-    gl_Position = (mat4(UBO[0], UBO[1], UBO[2], UBO[3]) * aVertex) + UBO[13];
+    vec4 offset = (UBO[10] + UBO[5]) + vec4(UBO[14].x);
+    gl_Position = ((mat4(UBO[0], UBO[1], UBO[2], UBO[3]) * aVertex) + UBO[15]) + offset;
 }
 

--- a/reference/shaders/flatten/push-constant.flatten.vert
+++ b/reference/shaders/flatten/push-constant.flatten.vert
@@ -1,0 +1,13 @@
+#version 310 es
+
+uniform vec4 PushMe[5];
+layout(location = 1) in vec4 Pos;
+layout(location = 0) out vec2 vRot;
+layout(location = 0) in vec2 Rot;
+
+void main()
+{
+    gl_Position = mat4(PushMe[0], PushMe[1], PushMe[2], PushMe[3]) * Pos;
+    vRot = mat2(PushMe[4].xy, PushMe[4].zw) * Rot;
+}
+

--- a/reference/shaders/flatten/push-constant.flatten.vert
+++ b/reference/shaders/flatten/push-constant.flatten.vert
@@ -1,6 +1,6 @@
 #version 310 es
 
-uniform vec4 PushMe[5];
+uniform vec4 PushMe[6];
 layout(location = 1) in vec4 Pos;
 layout(location = 0) out vec2 vRot;
 layout(location = 0) in vec2 Rot;
@@ -8,6 +8,6 @@ layout(location = 0) in vec2 Rot;
 void main()
 {
     gl_Position = mat4(PushMe[0], PushMe[1], PushMe[2], PushMe[3]) * Pos;
-    vRot = mat2(PushMe[4].xy, PushMe[4].zw) * Rot;
+    vRot = (mat2(PushMe[4].xy, PushMe[4].zw) * Rot) + vec2(PushMe[5].z);
 }
 

--- a/reference/shaders/flatten/rowmajor.flatten.vert
+++ b/reference/shaders/flatten/rowmajor.flatten.vert
@@ -1,10 +1,11 @@
 #version 310 es
 
-uniform vec4 UBO[8];
+uniform vec4 UBO[12];
 in vec4 aVertex;
 
 void main()
 {
+    vec2 v = mat4x2(UBO[8].xy, UBO[9].xy, UBO[10].xy, UBO[11].xy) * aVertex;
     gl_Position = (mat4(UBO[0], UBO[1], UBO[2], UBO[3]) * aVertex) + (aVertex * mat4(UBO[4], UBO[5], UBO[6], UBO[7]));
 }
 

--- a/reference/shaders/flatten/struct.rowmajor.flatten.vert
+++ b/reference/shaders/flatten/struct.rowmajor.flatten.vert
@@ -1,0 +1,25 @@
+#version 310 es
+
+struct Foo
+{
+    mat3x4 MVP0;
+    mat3x4 MVP1;
+};
+
+uniform vec4 UBO[8];
+layout(location = 0) in vec4 v0;
+layout(location = 1) in vec4 v1;
+layout(location = 0) out vec3 V0;
+layout(location = 1) out vec3 V1;
+
+void main()
+{
+    Foo f;
+    f.MVP0 = Foo(transpose(mat4x3(UBO[0].xyz, UBO[1].xyz, UBO[2].xyz, UBO[3].xyz)), transpose(mat4x3(UBO[4].xyz, UBO[5].xyz, UBO[6].xyz, UBO[7].xyz))).MVP0;
+    f.MVP1 = Foo(transpose(mat4x3(UBO[0].xyz, UBO[1].xyz, UBO[2].xyz, UBO[3].xyz)), transpose(mat4x3(UBO[4].xyz, UBO[5].xyz, UBO[6].xyz, UBO[7].xyz))).MVP1;
+    vec3 a = v0 * f.MVP0;
+    vec3 b = v1 * f.MVP1;
+    V0 = a;
+    V1 = b;
+}
+

--- a/reference/shaders/flatten/types.flatten.frag
+++ b/reference/shaders/flatten/types.flatten.frag
@@ -1,0 +1,14 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+uniform mediump ivec4 UBO1[2];
+uniform mediump uvec4 UBO2[2];
+uniform vec4 UBO0[2];
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    FragColor = ((((vec4(UBO1[0]) + vec4(UBO1[1])) + vec4(UBO2[0])) + vec4(UBO2[1])) + UBO0[0]) + UBO0[1];
+}
+

--- a/shaders/comp/read-write-only.comp
+++ b/shaders/comp/read-write-only.comp
@@ -1,0 +1,26 @@
+#version 310 es
+layout(local_size_x = 1) in;
+
+layout(binding = 0, std430) readonly buffer SSBO0
+{
+   vec4 data0;
+   vec4 data1;
+};
+
+layout(binding = 1, std430) restrict buffer SSBO1
+{
+   vec4 data2;
+   vec4 data3;
+};
+
+layout(binding = 2, std430) restrict writeonly buffer SSBO2
+{
+   vec4 data4;
+   vec4 data5;
+};
+
+void main()
+{
+   data4 = data0 + data2;
+   data5 = data1 + data3;
+}

--- a/shaders/flatten/array.flatten.vert
+++ b/shaders/flatten/array.flatten.vert
@@ -2,6 +2,7 @@
 
 layout(std140) uniform UBO
 {
+    vec4 A4[5][4][2];
     mat4 uMVP;
     vec4 A1[2];
     vec4 A2[2][3];
@@ -12,6 +13,7 @@ in vec4 aVertex;
 
 void main()
 {
+    vec4 a4 = A4[2][3][1]; // 2 * (4 * 2) + 3 * 2 + 1 = 16 + 6 + 1 = 23.
     vec4 offset = A2[1][1] + A1[1] + A3[2];
     gl_Position = uMVP * aVertex + Offset + offset;
 }

--- a/shaders/flatten/array.flatten.vert
+++ b/shaders/flatten/array.flatten.vert
@@ -2,7 +2,7 @@
 
 layout(std140) uniform UBO
 {
-    uniform mat4 uMVP;
+    mat4 uMVP;
     vec4 A1[2];
     vec4 A2[2][3];
     float A3[3];

--- a/shaders/flatten/array.flatten.vert
+++ b/shaders/flatten/array.flatten.vert
@@ -4,7 +4,7 @@ layout(std140) uniform UBO
 {
     uniform mat4 uMVP;
     vec4 A1[2];
-    vec4 A2[2][2];
+    vec4 A2[2][3];
     float A3[3];
     vec4 Offset;
 };
@@ -12,5 +12,6 @@ in vec4 aVertex;
 
 void main()
 {
-    gl_Position = uMVP * aVertex + Offset;
+    vec4 offset = A2[1][1] + A1[1] + A3[2];
+    gl_Position = uMVP * aVertex + Offset + offset;
 }

--- a/shaders/flatten/basic.flatten.vert
+++ b/shaders/flatten/basic.flatten.vert
@@ -2,7 +2,7 @@
 
 layout(std140) uniform UBO
 {
-    uniform mat4 uMVP;
+    mat4 uMVP;
 };
 in vec4 aVertex;
 in vec3 aNormal;

--- a/shaders/flatten/push-constant.flatten.vert
+++ b/shaders/flatten/push-constant.flatten.vert
@@ -1,0 +1,16 @@
+#version 310 es
+
+layout(push_constant, std430) uniform PushMe
+{
+   mat4 MVP;
+   mat2 Rot; // The MatrixStride will be 8 here.
+} registers;
+
+layout(location = 0) in vec2 Rot;
+layout(location = 1) in vec4 Pos;
+layout(location = 0) out vec2 vRot;
+void main()
+{
+   gl_Position = registers.MVP * Pos;
+   vRot = registers.Rot * Rot;
+}

--- a/shaders/flatten/push-constant.flatten.vert
+++ b/shaders/flatten/push-constant.flatten.vert
@@ -4,6 +4,7 @@ layout(push_constant, std430) uniform PushMe
 {
    mat4 MVP;
    mat2 Rot; // The MatrixStride will be 8 here.
+   float Arr[4];
 } registers;
 
 layout(location = 0) in vec2 Rot;
@@ -12,5 +13,5 @@ layout(location = 0) out vec2 vRot;
 void main()
 {
    gl_Position = registers.MVP * Pos;
-   vRot = registers.Rot * Rot;
+   vRot = registers.Rot * Rot + registers.Arr[2]; // Constant access should work even if array stride is just 4 here.
 }

--- a/shaders/flatten/rowmajor.flatten.vert
+++ b/shaders/flatten/rowmajor.flatten.vert
@@ -4,11 +4,13 @@ layout(std140) uniform UBO
 {
     layout(column_major) mat4 uMVPR;
     layout(row_major) mat4 uMVPC;
+    layout(row_major) mat2x4 uMVP;
 };
 
 in vec4 aVertex;
 
 void main()
 {
+	vec2 v = aVertex * uMVP;
 	gl_Position = uMVPR * aVertex + uMVPC * aVertex;
 }

--- a/shaders/flatten/struct.rowmajor.flatten.vert
+++ b/shaders/flatten/struct.rowmajor.flatten.vert
@@ -1,0 +1,26 @@
+#version 310 es
+
+struct Foo
+{
+   mat3x4 MVP0;
+   mat3x4 MVP1;
+};
+
+layout(std140, binding = 0) uniform UBO
+{
+   layout(row_major) Foo foo;
+};
+
+layout(location = 0) in vec4 v0;
+layout(location = 1) in vec4 v1;
+layout(location = 0) out vec3 V0;
+layout(location = 1) out vec3 V1;
+
+void main()
+{
+   Foo f = foo;
+   vec3 a = v0 * f.MVP0;
+   vec3 b = v1 * f.MVP1;
+   V0 = a;
+   V1 = b;
+}

--- a/shaders/flatten/swizzle.flatten.vert
+++ b/shaders/flatten/swizzle.flatten.vert
@@ -4,27 +4,27 @@
 layout(std140) uniform UBO
 {
     // 16b boundary
-    uniform vec4 A;
+    vec4 A;
     // 16b boundary
-    uniform vec2 B0;
-    uniform vec2 B1;
+    vec2 B0;
+    vec2 B1;
     // 16b boundary
-    uniform float C0;
+    float C0;
     // 16b boundary (vec3 is aligned to 16b)
-    uniform vec3 C1;
+    vec3 C1;
     // 16b boundary
-    uniform vec3 D0;
-    uniform float D1;
+    vec3 D0;
+    float D1;
     // 16b boundary
-    uniform float E0;
-    uniform float E1;
-    uniform float E2;
-    uniform float E3;
+    float E0;
+    float E1;
+    float E2;
+    float E3;
     // 16b boundary
-    uniform float F0;
-    uniform vec2 F1;
+    float F0;
+    vec2 F1;
     // 16b boundary (vec2 before us is aligned to 8b)
-    uniform float F2;
+    float F2;
 };
 
 out vec4 oA, oB, oC, oD, oE, oF;

--- a/shaders/flatten/types.flatten.frag
+++ b/shaders/flatten/types.flatten.frag
@@ -1,0 +1,27 @@
+#version 310 es
+precision mediump float;
+
+layout(std140, binding = 0) uniform UBO0
+{
+   vec4 a;
+   vec4 b;
+};
+
+layout(std140, binding = 0) uniform UBO1
+{
+   ivec4 c;
+   ivec4 d;
+};
+
+layout(std140, binding = 0) uniform UBO2
+{
+   uvec4 e;
+   uvec4 f;
+};
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+   FragColor = vec4(c) + vec4(d) + vec4(e) + vec4(f) + a + b; 
+}

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -265,6 +265,10 @@ struct SPIRType : IVariant
 	// Since we cannot rely on OpName to be equal, we need to figure out aliases.
 	uint32_t type_alias = 0;
 
+	// Denotes the type which this type is based on.
+	// Allows the backend to traverse how a complex type is built up during access chains.
+	uint32_t parent_type = 0;
+
 	// Used in backends to avoid emitting members with conflicting names.
 	std::unordered_set<std::string> member_name_cache;
 };
@@ -904,6 +908,7 @@ struct Meta
 		uint32_t binding = 0;
 		uint32_t offset = 0;
 		uint32_t array_stride = 0;
+		uint32_t matrix_stride = 0;
 		uint32_t input_attachment = 0;
 		uint32_t spec_id = 0;
 		bool builtin = false;

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -3056,3 +3056,28 @@ uint64_t Compiler::get_buffer_block_flags(const SPIRVariable &var)
 
 	return base_flags | (~all_members_flag_mask);
 }
+
+bool Compiler::get_common_basic_type(const SPIRType &type, SPIRType::BaseType &base_type)
+{
+	if (type.basetype == SPIRType::Struct)
+	{
+		base_type = SPIRType::Unknown;
+		for (auto &member_type : type.member_types)
+		{
+			SPIRType::BaseType member_base;
+			if (!get_common_basic_type(get<SPIRType>(member_type), member_base))
+				return false;
+
+			if (base_type == SPIRType::Unknown)
+				base_type = member_base;
+			else if (base_type != member_base)
+				return false;
+		}
+		return true;
+	}
+	else
+	{
+		base_type = type.basetype;
+		return true;
+	}
+}

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -3008,3 +3008,18 @@ void Compiler::analyze_variable_scope(SPIRFunction &entry)
 		this->get<SPIRVariable>(loop_variable.first).loop_variable = true;
 	}
 }
+
+uint64_t Compiler::get_buffer_block_flags(const SPIRVariable &var)
+{
+	auto &type = get<SPIRType>(var.basetype);
+
+	// Some flags like non-writable, non-readable are actually found
+	// as member decorations. If all members have a decoration set, propagate
+	// the decoration up as a regular variable decoration.
+	uint64_t base_flags = meta[var.self].decoration.decoration_flags;
+	uint64_t all_members_flag_mask = 0;
+	for (uint32_t i = 0; i < uint32_t(type.member_types.size()); i++)
+		all_members_flag_mask |= ~get_member_decoration_mask(type.self, i);
+
+	return base_flags | (~all_members_flag_mask);
+}

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -459,6 +459,7 @@ protected:
 
 	uint32_t type_struct_member_offset(const SPIRType &type, uint32_t index) const;
 	uint32_t type_struct_member_array_stride(const SPIRType &type, uint32_t index) const;
+	uint32_t type_struct_member_matrix_stride(const SPIRType &type, uint32_t index) const;
 
 	bool block_is_loop_candidate(const SPIRBlock &block, SPIRBlock::Method method) const;
 

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -579,6 +579,7 @@ protected:
 	VariableTypeRemapCallback variable_remap_callback;
 
 	uint64_t get_buffer_block_flags(const SPIRVariable &var);
+	bool get_common_basic_type(const SPIRType &type, SPIRType::BaseType &base_type);
 };
 }
 

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -576,6 +576,8 @@ protected:
 	ShaderResources get_shader_resources(const std::unordered_set<uint32_t> *active_variables) const;
 
 	VariableTypeRemapCallback variable_remap_callback;
+
+	uint64_t get_buffer_block_flags(const SPIRVariable &var);
 };
 }
 

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1117,7 +1117,8 @@ void CompilerGLSL::emit_buffer_block_flattened(const SPIRVariable &var)
 		}
 
 		auto flags = get_buffer_block_flags(var);
-		statement("uniform ", flags_to_precision_qualifiers_glsl(tmp, flags), flat_type, buffer_name, "[", buffer_size, "];");
+		statement("uniform ", flags_to_precision_qualifiers_glsl(tmp, flags), flat_type, buffer_name, "[", buffer_size,
+		          "];");
 	}
 	else
 		SPIRV_CROSS_THROW("All basic types in a flattened block must be the same.");
@@ -3416,7 +3417,8 @@ std::string CompilerGLSL::flattened_access_chain_vector_scalar(uint32_t base, co
 
 std::pair<std::string, uint32_t> CompilerGLSL::flattened_access_chain_offset(uint32_t base, const uint32_t *indices,
                                                                              uint32_t count, uint32_t offset,
-                                                                             bool *need_transpose, uint32_t *out_matrix_stride)
+                                                                             bool *need_transpose,
+                                                                             uint32_t *out_matrix_stride)
 {
 	const auto *type = &expression_type(base);
 	uint32_t current_type = type->self;
@@ -3449,8 +3451,10 @@ std::pair<std::string, uint32_t> CompilerGLSL::flattened_access_chain_offset(uin
 				const uint32_t word_stride = 16;
 				if (array_stride % word_stride)
 				{
-					SPIRV_CROSS_THROW("Array stride for dynamic indexing must be divisible by the size of a 4-component vector. "
-						                  "Likely culprit here is a float or vec2 array inside a push constant block. This cannot be flattened.");
+					SPIRV_CROSS_THROW(
+					    "Array stride for dynamic indexing must be divisible by the size of a 4-component vector. "
+					    "Likely culprit here is a float or vec2 array inside a push constant block. This cannot be "
+					    "flattened.");
 				}
 
 				expr += to_expression(index);

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1100,25 +1100,12 @@ void CompilerGLSL::emit_buffer_block_flattened(const SPIRVariable &var)
 	{
 		SPIRType tmp;
 		tmp.basetype = basic_type;
-
-		const char *flat_type = nullptr;
-		switch (basic_type)
-		{
-		case SPIRType::Float:
-			flat_type = "vec4 ";
-			break;
-		case SPIRType::Int:
-			flat_type = "ivec4 ";
-			break;
-		case SPIRType::UInt:
-			flat_type = "uvec4 ";
-			break;
-		default:
+		tmp.vecsize = 4;
+		if (basic_type != SPIRType::Float && basic_type != SPIRType::Int && basic_type != SPIRType::UInt)
 			SPIRV_CROSS_THROW("Basic types in a flattened UBO must be float, int or uint.");
-		}
 
 		auto flags = get_buffer_block_flags(var);
-		statement("uniform ", flags_to_precision_qualifiers_glsl(tmp, flags), flat_type, buffer_name, "[", buffer_size,
+		statement("uniform ", flags_to_precision_qualifiers_glsl(tmp, flags), type_to_glsl(tmp), " ", buffer_name, "[", buffer_size,
 		          "];");
 	}
 	else

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -320,11 +320,13 @@ protected:
 	                         bool *need_transpose = nullptr);
 
 	std::string flattened_access_chain(uint32_t base, const uint32_t *indices, uint32_t count,
-	                                   const SPIRType &target_type, uint32_t offset);
+	                                   const SPIRType &target_type, uint32_t offset, uint32_t matrix_stride = 0,
+	                                   bool need_transpose = false);
 	std::string flattened_access_chain_struct(uint32_t base, const uint32_t *indices, uint32_t count,
 	                                          const SPIRType &target_type, uint32_t offset);
 	std::string flattened_access_chain_matrix(uint32_t base, const uint32_t *indices, uint32_t count,
-	                                          const SPIRType &target_type, uint32_t offset);
+	                                          const SPIRType &target_type, uint32_t offset, uint32_t matrix_stride,
+	                                          bool need_transpose);
 	std::string flattened_access_chain_vector_scalar(uint32_t base, const uint32_t *indices, uint32_t count,
 	                                                 const SPIRType &target_type, uint32_t offset);
 	std::pair<std::string, uint32_t> flattened_access_chain_offset(uint32_t base, const uint32_t *indices,

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -329,7 +329,8 @@ protected:
 	                                                 const SPIRType &target_type, uint32_t offset);
 	std::pair<std::string, uint32_t> flattened_access_chain_offset(uint32_t base, const uint32_t *indices,
 	                                                               uint32_t count, uint32_t offset,
-	                                                               bool *need_transpose = nullptr, uint32_t *matrix_stride = nullptr);
+	                                                               bool *need_transpose = nullptr,
+	                                                               uint32_t *matrix_stride = nullptr);
 
 	const char *index_to_swizzle(uint32_t index);
 	std::string remap_swizzle(uint32_t result_type, uint32_t input_components, uint32_t expr);

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -139,8 +139,9 @@ public:
 	void require_extension(const std::string &ext);
 
 	// Legacy GLSL compatibility method.
-	// Takes a uniform or storage buffer variable and flattens it into a vec4 array[N]; array instead.
-	// For this to work, all types in the block must not be integers or vector of integers.
+	// Takes a uniform or push constant variable and flattens it into a (i|u)vec4 array[N]; array instead.
+	// For this to work, all types in the block must be the same basic type, e.g. mixing vec2 and vec4 is fine, but
+	// mixing int and float is not.
 	// The name of the uniform array will be the same as the interface block name.
 	void flatten_buffer_block(uint32_t id);
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -329,7 +329,7 @@ protected:
 	                                                 const SPIRType &target_type, uint32_t offset);
 	std::pair<std::string, uint32_t> flattened_access_chain_offset(uint32_t base, const uint32_t *indices,
 	                                                               uint32_t count, uint32_t offset,
-	                                                               bool *need_transpose = nullptr);
+	                                                               bool *need_transpose = nullptr, uint32_t *matrix_stride = nullptr);
 
 	const char *index_to_swizzle(uint32_t index);
 	std::string remap_swizzle(uint32_t result_type, uint32_t input_components, uint32_t expr);


### PR DESCRIPTION
- Can flatten push constant blocks as well (they're technically UBOs too).
- Can flatten int/uint blocks.
- Precision qualifiers for flattened blocks is emitted.
- Propagate type hierarchy to not "guess" array strides and matrix strides.
- Can load row-major matrices from flattened UBOs with non-square matrices.
- Array indexing with constant index is folded into the overall constant offset.