### PR TITLE
spirv_msl: Add support for gl_GlobalInvocationId

### DIFF
--- a/reference/shaders-msl/comp/global-invocation-id-writable-ssbo-in-function.comp
+++ b/reference/shaders-msl/comp/global-invocation-id-writable-ssbo-in-function.comp
@@ -1,0 +1,31 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct myBlock
+{
+    int a;
+    float b[1];
+};
+
+// Support GLSL mod(), which is slightly different than Metal fmod()
+template<typename Tx, typename Ty>
+Tx mod(Tx x, Ty y)
+{
+    return x - y * floor(x / y);
+}
+
+float getB(device const myBlock& myStorage, thread const uint3& gl_GlobalInvocationID)
+{
+    return myStorage.b[gl_GlobalInvocationID.x];
+}
+
+kernel void main0(device myBlock& myStorage [[buffer(0)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+{
+    myStorage.a = (myStorage.a + 1) % 256;
+    myStorage.b[gl_GlobalInvocationID.x] = mod(getB(myStorage, gl_GlobalInvocationID) + 0.0199999995529651641845703125, 1.0);
+}
+

--- a/reference/shaders-msl/comp/global-invocation-id.comp
+++ b/reference/shaders-msl/comp/global-invocation-id.comp
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct myBlock
+{
+    int a;
+    float b[1];
+};
+
+// Support GLSL mod(), which is slightly different than Metal fmod()
+template<typename Tx, typename Ty>
+Tx mod(Tx x, Ty y)
+{
+    return x - y * floor(x / y);
+}
+
+kernel void main0(device myBlock& myStorage [[buffer(0)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+{
+    myStorage.a = (myStorage.a + 1) % 256;
+    myStorage.b[gl_GlobalInvocationID.x] = mod(myStorage.b[gl_GlobalInvocationID.x] + 0.0199999995529651641845703125, 1.0);
+}
+

--- a/reference/shaders-msl/comp/local-invocation-id.comp
+++ b/reference/shaders-msl/comp/local-invocation-id.comp
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct myBlock
+{
+    int a;
+    float b[1];
+};
+
+// Support GLSL mod(), which is slightly different than Metal fmod()
+template<typename Tx, typename Ty>
+Tx mod(Tx x, Ty y)
+{
+    return x - y * floor(x / y);
+}
+
+kernel void main0(device myBlock& myStorage [[buffer(0)]], uint3 gl_LocalInvocationID [[thread_position_in_threadgroup]])
+{
+    myStorage.a = (myStorage.a + 1) % 256;
+    myStorage.b[gl_LocalInvocationID.x] = mod(myStorage.b[gl_LocalInvocationID.x] + 0.0199999995529651641845703125, 1.0);
+}
+

--- a/reference/shaders-msl/comp/local-invocation-index.comp
+++ b/reference/shaders-msl/comp/local-invocation-index.comp
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct myBlock
+{
+    int a;
+    float b[1];
+};
+
+// Support GLSL mod(), which is slightly different than Metal fmod()
+template<typename Tx, typename Ty>
+Tx mod(Tx x, Ty y)
+{
+    return x - y * floor(x / y);
+}
+
+kernel void main0(device myBlock& myStorage [[buffer(0)]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]])
+{
+    myStorage.a = (myStorage.a + 1) % 256;
+    myStorage.b[gl_LocalInvocationIndex] = mod(myStorage.b[gl_LocalInvocationIndex] + 0.0199999995529651641845703125, 1.0);
+}
+

--- a/reference/shaders-msl/comp/writable-ssbo.comp
+++ b/reference/shaders-msl/comp/writable-ssbo.comp
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct myBlock
+{
+    int a;
+    float b;
+};
+
+// Support GLSL mod(), which is slightly different than Metal fmod()
+template<typename Tx, typename Ty>
+Tx mod(Tx x, Ty y)
+{
+    return x - y * floor(x / y);
+}
+
+kernel void main0(device myBlock& myStorage [[buffer(0)]])
+{
+    myStorage.a = (myStorage.a + 1) % 256;
+    myStorage.b = mod(myStorage.b + 0.0199999995529651641845703125, 1.0);
+}
+

--- a/shaders-msl/comp/global-invocation-id-writable-ssbo-in-function.comp
+++ b/shaders-msl/comp/global-invocation-id-writable-ssbo-in-function.comp
@@ -1,0 +1,12 @@
+#version 450
+layout(set = 0, binding = 0) buffer myBlock {
+    int a;
+    float b[1];
+} myStorage;
+float getB() {
+    return myStorage.b[gl_GlobalInvocationID.x];
+}
+void main() {
+    myStorage.a = (myStorage.a + 1) % 256;
+    myStorage.b[gl_GlobalInvocationID.x] = mod((getB() + 0.02), 1.0);
+}

--- a/shaders-msl/comp/global-invocation-id.comp
+++ b/shaders-msl/comp/global-invocation-id.comp
@@ -1,0 +1,9 @@
+#version 450
+layout(set = 0, binding = 0) buffer myBlock {
+    int a;
+    float b[1];
+} myStorage;
+void main() {
+    myStorage.a = (myStorage.a + 1) % 256;
+    myStorage.b[gl_GlobalInvocationID.x] = mod((myStorage.b[gl_GlobalInvocationID.x] + 0.02), 1.0);
+}

--- a/shaders-msl/comp/local-invocation-id.comp
+++ b/shaders-msl/comp/local-invocation-id.comp
@@ -1,0 +1,9 @@
+#version 450
+layout(set = 0, binding = 0) buffer myBlock {
+    int a;
+    float b[1];
+} myStorage;
+void main() {
+    myStorage.a = (myStorage.a + 1) % 256;
+    myStorage.b[gl_LocalInvocationID.x] = mod((myStorage.b[gl_LocalInvocationID.x] + 0.02), 1.0);
+}

--- a/shaders-msl/comp/local-invocation-index.comp
+++ b/shaders-msl/comp/local-invocation-index.comp
@@ -1,0 +1,9 @@
+#version 450
+layout(set = 0, binding = 0) buffer myBlock {
+    int a;
+    float b[1];
+} myStorage;
+void main() {
+    myStorage.a = (myStorage.a + 1) % 256;
+    myStorage.b[gl_LocalInvocationIndex.x] = mod((myStorage.b[gl_LocalInvocationIndex.x] + 0.02), 1.0);
+}

--- a/shaders-msl/comp/writable-ssbo.comp
+++ b/shaders-msl/comp/writable-ssbo.comp
@@ -1,0 +1,9 @@
+#version 450
+layout(set = 0, binding = 0) buffer myBlock {
+    int a;
+    float b;
+} myStorage;
+void main() {
+    myStorage.a = (myStorage.a + 1) % 256;
+    myStorage.b = mod((myStorage.b + 0.02), 1.0);
+}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1104,6 +1104,22 @@ string CompilerMSL::member_attribute_qualifier(const SPIRType &type, uint32_t in
 		return string(" [[color(") + convert_to_string(locn) + ")]]";
 	}
 
+	// Compute function inputs
+	if (execution.model == ExecutionModelGLCompute && type.storage == StorageClassInput)
+	{
+		if (is_builtin)
+		{
+			switch (builtin)
+			{
+			case BuiltInGlobalInvocationId:
+				return string(" [[") + builtin_qualifier(builtin) + "]]";
+
+			default:
+				return "";
+			}
+		}
+	}
+
 	return "";
 }
 
@@ -1610,6 +1626,10 @@ string CompilerMSL::builtin_qualifier(BuiltIn builtin)
 			return "depth(any)";
 	}
 
+    // Fragment function in
+	case BuiltInGlobalInvocationId:
+		return "thread_position_in_grid";
+
 	default:
 		return "unsupported-built-in";
 	}
@@ -1649,6 +1669,10 @@ string CompilerMSL::builtin_type_decl(BuiltIn builtin)
 		return "uint";
 	case BuiltInSampleMask:
 		return "uint";
+
+	// Compute function in
+	case BuiltInGlobalInvocationId:
+		return "uint3";
 
 	default:
 		return "unsupported-built-in-type";

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1108,6 +1108,8 @@ string CompilerMSL::member_attribute_qualifier(const SPIRType &type, uint32_t in
 			switch (builtin)
 			{
 			case BuiltInGlobalInvocationId:
+			case BuiltInLocalInvocationId:
+			case BuiltInLocalInvocationIndex:
 				return string(" [[") + builtin_qualifier(builtin) + "]]";
 
 			default:
@@ -1640,6 +1642,12 @@ string CompilerMSL::builtin_qualifier(BuiltIn builtin)
 	case BuiltInGlobalInvocationId:
 		return "thread_position_in_grid";
 
+	case BuiltInLocalInvocationId:
+		return "thread_position_in_threadgroup";
+
+	case BuiltInLocalInvocationIndex:
+		return "thread_index_in_threadgroup";
+
 	default:
 		return "unsupported-built-in";
 	}
@@ -1683,6 +1691,10 @@ string CompilerMSL::builtin_type_decl(BuiltIn builtin)
 	// Compute function in
 	case BuiltInGlobalInvocationId:
 		return "uint3";
+	case BuiltInLocalInvocationId:
+		return "uint3";
+	case BuiltInLocalInvocationIndex:
+		return "uint";
 
 	default:
 		return "unsupported-built-in-type";

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -116,6 +116,7 @@ protected:
 	                             uint32_t grad_y, uint32_t lod, uint32_t coffset, uint32_t offset, uint32_t bias,
 	                             uint32_t comp, uint32_t sample, bool *p_forward) override;
 	std::string clean_func_name(std::string func_name) override;
+	std::string get_argument_address_space(const SPIRVariable &argument);
 
 	void preprocess_op_codes();
 	void emit_custom_functions();


### PR DESCRIPTION
Hey all,
As the name implies this adds support for gl_GlobalInvocationID to the MSL output so that non-trivial compute shaders work. Unfortunately this commit is in the MSL backend that doesn't have tests but locally we have verified this works correctly and using gl_GlobalInvocationID works as expected.