### PR TITLE
Implement flattening of row major matrix indexing

### DIFF
--- a/reference/shaders/flatten/matrixindex.flatten.vert
+++ b/reference/shaders/flatten/matrixindex.flatten.vert
@@ -14,6 +14,6 @@ void main()
     oB = vec4(UBO[4].y, UBO[5].y, UBO[6].y, UBO[7].y);
     oC = UBO[9];
     oD = vec4(UBO[10].x, UBO[11].x, UBO[12].x, UBO[13].x);
-    oE = vec4(UBO[1].z, float(UBO[6].y), UBO[9].z, float(UBO[12].y));
+    oE = vec4(UBO[1].z, UBO[6].y, UBO[9].z, UBO[12].y);
 }
 

--- a/reference/shaders/flatten/matrixindex.flatten.vert
+++ b/reference/shaders/flatten/matrixindex.flatten.vert
@@ -1,0 +1,19 @@
+#version 310 es
+
+uniform vec4 UBO[14];
+out vec4 oA;
+out vec4 oB;
+out vec4 oC;
+out vec4 oD;
+out vec4 oE;
+
+void main()
+{
+    gl_Position = vec4(0.0);
+    oA = UBO[1];
+    oB = vec4(UBO[4].y, UBO[5].y, UBO[6].y, UBO[7].y);
+    oC = UBO[9];
+    oD = vec4(UBO[10].x, UBO[11].x, UBO[12].x, UBO[13].x);
+    oE = vec4(UBO[1].z, float(UBO[6].y), UBO[9].z, float(UBO[12].y));
+}
+

--- a/shaders/flatten/matrixindex.flatten.vert
+++ b/shaders/flatten/matrixindex.flatten.vert
@@ -1,0 +1,25 @@
+#version 310 es
+
+layout(std140) uniform UBO
+{
+    layout(column_major) mat4 M1C;
+    layout(row_major) mat4 M1R;
+    layout(column_major) mat2x4 M2C;
+    layout(row_major) mat2x4 M2R;
+};
+
+out vec4 oA;
+out vec4 oB;
+out vec4 oC;
+out vec4 oD;
+out vec4 oE;
+
+void main()
+{
+	gl_Position = vec4(0.0);
+	oA = M1C[1];
+	oB = M1R[1];
+	oC = M2C[1];
+	oD = M2R[0];
+	oE = vec4(M1C[1][2], M1R[1][2], M2C[1][2], M2R[1][2]);
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -3418,8 +3418,11 @@ std::string CompilerGLSL::flattened_access_chain_vector(uint32_t base, const uin
 	{
 		std::string expr;
 
-		expr += type_to_glsl_constructor(target_type);
-		expr += "(";
+		if (target_type.vecsize > 1)
+		{
+			expr += type_to_glsl_constructor(target_type);
+			expr += "(";
+		}
 
 		for (uint32_t i = 0; i < target_type.vecsize; ++i)
 		{
@@ -3440,7 +3443,10 @@ std::string CompilerGLSL::flattened_access_chain_vector(uint32_t base, const uin
 			expr += vector_swizzle(1, index % 4);
 		}
 
-		expr += ")";
+		if (target_type.vecsize > 1)
+		{
+			expr += ")";
+		}
 
 		return expr;
 	}

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -320,15 +320,16 @@ protected:
 	                         bool *need_transpose = nullptr);
 
 	std::string flattened_access_chain(uint32_t base, const uint32_t *indices, uint32_t count,
-	                                   const SPIRType &target_type, uint32_t offset, uint32_t matrix_stride = 0,
-	                                   bool need_transpose = false);
+	                                   const SPIRType &target_type, uint32_t offset, uint32_t matrix_stride,
+	                                   bool need_transpose);
 	std::string flattened_access_chain_struct(uint32_t base, const uint32_t *indices, uint32_t count,
 	                                          const SPIRType &target_type, uint32_t offset);
 	std::string flattened_access_chain_matrix(uint32_t base, const uint32_t *indices, uint32_t count,
 	                                          const SPIRType &target_type, uint32_t offset, uint32_t matrix_stride,
 	                                          bool need_transpose);
-	std::string flattened_access_chain_vector_scalar(uint32_t base, const uint32_t *indices, uint32_t count,
-	                                                 const SPIRType &target_type, uint32_t offset);
+	std::string flattened_access_chain_vector(uint32_t base, const uint32_t *indices, uint32_t count,
+	                                          const SPIRType &target_type, uint32_t offset, uint32_t matrix_stride,
+	                                          bool need_transpose);
 	std::pair<std::string, uint32_t> flattened_access_chain_offset(uint32_t base, const uint32_t *indices,
 	                                                               uint32_t count, uint32_t offset,
 	                                                               bool *need_transpose = nullptr,


### PR DESCRIPTION
To extract a column from row-major matrix, we need to do a strided load one
component at a time. In this case flattened_access_chain_offset still returns
the offset to the first element, but the stride is equal to matrix stride
instead of vector stride.

For this to work, we need to pass matrix stride (and transpose flag) through,
similar to how matrix flattening works.

Additionally slightly clean up recursive flattened_access_chain structure -
specifically, instead of deciding mid-traversal that we need matrix stride
information, we can just pass the matrix stride through - for access chains
that end in matrix/vector this gets us what we need, and for access chains
that end in structs the flattened_access_chain_struct code will recompute
correct stride/transposition data to pass through further.