### PR TITLE
Validate Metal shaders on OSX with Metal compiler

### DIFF
--- a/reference/shaders-msl/vert/basic.vert
+++ b/reference/shaders-msl/vert/basic.vert
@@ -10,8 +10,8 @@ struct UBO
 
 struct main0_in
 {
+    float3 aNormal [[attribute(1)]];
     float4 aVertex [[attribute(0)]];
-    float3 aNormal [[attribute(0)]];
 };
 
 struct main0_out

--- a/shaders-msl/vert/basic.vert
+++ b/shaders-msl/vert/basic.vert
@@ -4,8 +4,10 @@ layout(std140) uniform UBO
 {
     uniform mat4 uMVP;
 };
-in vec4 aVertex;
-in vec3 aNormal;
+
+layout(location = 0) in vec4 aVertex;
+layout(location = 1) in vec3 aNormal;
+
 out vec3 vNormal;
 
 void main()


### PR DESCRIPTION
If we run on a system with Xcode installed to a default path, run Xcode
Metal shader compiler to validate the generated MSL shader.

This uncovers an issue in the existing MSL test - MSL backend currently
does not auto-assign attribute locations, which means that translating
GLSL shader without location layout produces an invalid MSL which
generates "error: 'attribute' index '0' is used more than once".