### PR TITLE
Fix build when SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS=On.

### DIFF
--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -2404,7 +2404,7 @@ bool Compiler::interface_variable_exists_in_entry_point(uint32_t id) const
 	auto &var = get<SPIRVariable>(id);
 	if (var.storage != StorageClassInput && var.storage != StorageClassOutput &&
 	    var.storage != StorageClassUniformConstant)
-		throw CompilerError(
+		SPIRV_CROSS_THROW(
 		    "Only Input, Output variables and Uniform constants are part of a shader linking interface.");
 
 	// This is to avoid potential problems with very old glslang versions which did

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -632,7 +632,7 @@ void CompilerHLSL::emit_texture_op(const Instruction &i)
 	uint32_t length = i.length;
 
 	if (i.offset + length > spirv.size())
-		throw CompilerError("Compiler::parse() opcode out of range.");
+		SPIRV_CROSS_THROW("Compiler::parse() opcode out of range.");
 
 	uint32_t result_type = ops[0];
 	uint32_t id = ops[1];
@@ -999,7 +999,7 @@ string CompilerHLSL::compile()
 	do
 	{
 		if (pass_count >= 3)
-			throw CompilerError("Over 3 compilation loops detected. Must be a bug!");
+			SPIRV_CROSS_THROW("Over 3 compilation loops detected. Must be a bug!");
 
 		reset();
 


### PR DESCRIPTION
There is still some `throw` syntax, thus failed to compile when `SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS=On`.

This simple patch fixes it.