### PR TITLE
For loop evaluation order fix.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -15,8 +15,8 @@
  */
 
 #include "spirv_cpp.hpp"
-#include "spirv_msl.hpp"
 #include "spirv_hlsl.hpp"
+#include "spirv_msl.hpp"
 #include <algorithm>
 #include <cstdio>
 #include <cstring>

--- a/reference/shaders-msl/frag/for-loop-init.frag
+++ b/reference/shaders-msl/frag/for-loop-init.frag
@@ -1,0 +1,58 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    int FragColor [[color(0)]];
+};
+
+fragment main0_out main0()
+{
+    main0_out out = {};
+    out.FragColor = 16;
+    for (int i = 0; i < 25; i++)
+    {
+        out.FragColor += 10;
+    }
+    for (int i_1 = 1, j = 4; i_1 < 30; i_1++, j += 4)
+    {
+        out.FragColor += 11;
+    }
+    int k = 0;
+    for (; k < 20; k++)
+    {
+        out.FragColor += 12;
+    }
+    k += 3;
+    out.FragColor += k;
+    int l;
+    if (k == 40)
+    {
+        l = 0;
+        for (; l < 40; l++)
+        {
+            out.FragColor += 13;
+        }
+        return out;
+    }
+    else
+    {
+        l = k;
+        out.FragColor += l;
+    }
+    int2 i_2 = int2(0);
+    for (; i_2.x < 10; i_2.x += 4)
+    {
+        out.FragColor += i_2.y;
+    }
+    int o = k;
+    for (int m = k; m < 40; m++)
+    {
+        out.FragColor += m;
+    }
+    out.FragColor += o;
+    return out;
+}
+

--- a/reference/shaders-msl/vert/copy.flatten.vert
+++ b/reference/shaders-msl/vert/copy.flatten.vert
@@ -1,0 +1,48 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Light
+{
+    float3 Position;
+    float Radius;
+    float4 Color;
+};
+
+struct UBO
+{
+    float4x4 uMVP;
+    Light lights[4];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
+};
+
+struct main0_out
+{
+    float4 vColor [[user(locn0)]];
+    float4 gl_Position [[position]];
+    float gl_PointSize;
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _21 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = _21.uMVP * in.aVertex;
+    out.vColor = float4(0.0);
+    for (int i = 0; i < 4; i++)
+    {
+        Light light;
+        light.Position = _21.lights[i].Position;
+        light.Radius = _21.lights[i].Radius;
+        light.Color = _21.lights[i].Color;
+        float3 L = in.aVertex.xyz - light.Position;
+        out.vColor += ((_21.lights[i].Color * clamp(1.0 - (length(L) / light.Radius), 0.0, 1.0)) * dot(in.aNormal, normalize(L)));
+    }
+    return out;
+}
+

--- a/reference/shaders-msl/vert/dynamic.flatten.vert
+++ b/reference/shaders-msl/vert/dynamic.flatten.vert
@@ -1,0 +1,44 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Light
+{
+    float3 Position;
+    float Radius;
+    float4 Color;
+};
+
+struct UBO
+{
+    float4x4 uMVP;
+    Light lights[4];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
+};
+
+struct main0_out
+{
+    float4 vColor [[user(locn0)]];
+    float4 gl_Position [[position]];
+    float gl_PointSize;
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _21 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = _21.uMVP * in.aVertex;
+    out.vColor = float4(0.0);
+    for (int i = 0; i < 4; i++)
+    {
+        float3 L = in.aVertex.xyz - _21.lights[i].Position;
+        out.vColor += ((_21.lights[i].Color * clamp(1.0 - (length(L) / _21.lights[i].Radius), 0.0, 1.0)) * dot(in.aNormal, normalize(L)));
+    }
+    return out;
+}
+

--- a/shaders-msl/frag/for-loop-init.frag
+++ b/shaders-msl/frag/for-loop-init.frag
@@ -1,0 +1,52 @@
+#version 310 es
+precision mediump float;
+layout(location = 0) out int FragColor;
+
+void main()
+{
+   FragColor = 16;
+
+   // Basic loop variable.
+   for (int i = 0; i < 25; i++)
+      FragColor += 10;
+
+   // Multiple loop variables.
+   for (int i = 1, j = 4; i < 30; i++, j += 4)
+      FragColor += 11;
+
+   // A potential loop variables, but we access it outside the loop,
+   // so cannot be one.
+   int k = 0;
+   for (; k < 20; k++)
+      FragColor += 12;
+   k += 3;
+   FragColor += k;
+
+   // Potential loop variables, but the dominator is not trivial.
+   int l;
+   if (k == 40)
+   {
+      for (l = 0; l < 40; l++)
+         FragColor += 13;
+      return;
+   }
+   else
+   {
+      l = k;
+      FragColor += l;
+   }
+
+   // Vectors cannot be loop variables
+   for (ivec2 i = ivec2(0); i.x < 10; i.x += 4)
+   {
+      FragColor += i.y;
+   }
+
+   // Check that static expressions can be used before the loop header.
+   int m = 0;
+   m = k;
+   int o = m;
+   for (; m < 40; m++)
+      FragColor += m;
+   FragColor += o;
+}

--- a/shaders-msl/vert/copy.flatten.vert
+++ b/shaders-msl/vert/copy.flatten.vert
@@ -1,0 +1,34 @@
+#version 310 es
+
+struct Light
+{
+    vec3 Position;
+    float Radius;
+
+    vec4 Color;
+};
+
+layout(std140) uniform UBO
+{
+    mat4 uMVP;
+
+    Light lights[4];
+};
+
+in vec4 aVertex;
+in vec3 aNormal;
+out vec4 vColor;
+
+void main()
+{
+    gl_Position = uMVP * aVertex;
+
+    vColor = vec4(0.0);
+
+    for (int i = 0; i < 4; ++i)
+    {
+        Light light = lights[i];
+        vec3 L = aVertex.xyz - light.Position;
+        vColor += dot(aNormal, normalize(L)) * (clamp(1.0 - length(L) / light.Radius, 0.0, 1.0) * lights[i].Color);
+    }
+}

--- a/shaders-msl/vert/dynamic.flatten.vert
+++ b/shaders-msl/vert/dynamic.flatten.vert
@@ -1,0 +1,33 @@
+#version 310 es
+
+struct Light
+{
+    vec3 Position;
+    float Radius;
+
+    vec4 Color;
+};
+
+layout(std140) uniform UBO
+{
+    mat4 uMVP;
+
+    Light lights[4];
+};
+
+in vec4 aVertex;
+in vec3 aNormal;
+out vec4 vColor;
+
+void main()
+{
+    gl_Position = uMVP * aVertex;
+
+    vColor = vec4(0.0);
+
+    for (int i = 0; i < 4; ++i)
+    {
+        vec3 L = aVertex.xyz - lights[i].Position;
+        vColor += dot(aNormal, normalize(L)) * (clamp(1.0 - length(L) / lights[i].Radius, 0.0, 1.0) * lights[i].Color);
+    }
+}

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -2404,8 +2404,7 @@ bool Compiler::interface_variable_exists_in_entry_point(uint32_t id) const
 	auto &var = get<SPIRVariable>(id);
 	if (var.storage != StorageClassInput && var.storage != StorageClassOutput &&
 	    var.storage != StorageClassUniformConstant)
-		SPIRV_CROSS_THROW(
-		    "Only Input, Output variables and Uniform constants are part of a shader linking interface.");
+		SPIRV_CROSS_THROW("Only Input, Output variables and Uniform constants are part of a shader linking interface.");
 
 	// This is to avoid potential problems with very old glslang versions which did
 	// not emit input/output interfaces properly.

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -6227,9 +6227,15 @@ bool CompilerGLSL::attempt_emit_loop_header(SPIRBlock &block, SPIRBlock::Method 
 			switch (continue_type)
 			{
 			case SPIRBlock::ForLoop:
-				statement("for (", emit_for_loop_initializers(block), "; ", to_expression(block.condition), "; ",
-				          emit_continue_block(block.continue_block), ")");
+			{
+				// Important that we do this in this order because
+				// emitting the continue block can invalidate the condition expression.
+				auto initializer = emit_for_loop_initializers(block);
+				auto condition = to_expression(block.condition);
+				auto continue_block = emit_continue_block(block.continue_block);
+				statement("for (", initializer, "; ", condition, "; ", continue_block, ")");
 				break;
+			}
 
 			case SPIRBlock::WhileLoop:
 				statement("while (", to_expression(block.condition), ")");
@@ -6274,9 +6280,15 @@ bool CompilerGLSL::attempt_emit_loop_header(SPIRBlock &block, SPIRBlock::Method 
 			switch (continue_type)
 			{
 			case SPIRBlock::ForLoop:
-				statement("for (", emit_for_loop_initializers(block), "; ", to_expression(child.condition), "; ",
-				          emit_continue_block(block.continue_block), ")");
+			{
+				// Important that we do this in this order because
+				// emitting the continue block can invalidate the condition expression.
+				auto initializer = emit_for_loop_initializers(block);
+				auto condition = to_expression(child.condition);
+				auto continue_block = emit_continue_block(block.continue_block);
+				statement("for (", initializer, "; ", condition, "; ", continue_block, ")");
 				break;
+			}
 
 			case SPIRBlock::WhileLoop:
 				statement("while (", to_expression(child.condition), ")");

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -10,6 +10,7 @@ import itertools
 import hashlib
 import shutil
 import argparse
+import codecs
 
 METALC = '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/usr/bin/metal'
 
@@ -145,10 +146,15 @@ def cross_compile(shader, vulkan, spirv, invalid_spirv, eliminate, is_legacy, fl
 
     return (spirv_path, glsl_path, vulkan_glsl_path if vulkan else None)
 
+def make_unix_newline(buf):
+    decoded = codecs.decode(buf, 'utf-8')
+    decoded = decoded.replace('\r', '')
+    return codecs.encode(decoded, 'utf-8')
+
 def md5_for_file(path):
     md5 = hashlib.md5()
     with open(path, 'rb') as f:
-        for chunk in iter(lambda: f.read(8192), b''):
+        for chunk in iter(lambda: make_unix_newline(f.read(8192)), b''):
             md5.update(chunk)
     return md5.digest()
 


### PR DESCRIPTION
Addresses https://github.com/KhronosGroup/SPIRV-Cross/issues/112.
Problem was that the statement which emits a function was evaluated out-of-order (which is legal for compiler to do) and the condition statement was wrongly invalidated.