### PR TITLE
Suppress clang warnings

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -32,8 +32,8 @@
 #endif
 
 #ifdef __clang__
-#pragma clang diagnostic ignored "-Wcovered-switch-default"
 #pragma clang diagnostic ignored "-Wswitch-enum"
+#pragma clang diagnostic ignored "-Wpadded"
 #endif
 
 using namespace spv;
@@ -59,7 +59,6 @@ struct CLICallbacks
 		callbacks[cli] = func;
 	}
 	unordered_map<string, function<void(CLIParser &)>> callbacks;
-	uint64_t pad0;
 	function<void()> error_handler;
 	function<void(const char *)> default_handler;
 };
@@ -168,10 +167,8 @@ struct CLIParser
 
 	CLICallbacks cbs;
 	int argc;
-	uint32_t pad0;
 	char **argv;
 	bool ended_state = false;
-	uint8_t pad1[15];
 };
 
 static vector<uint32_t> read_spirv_file(const char *path)
@@ -347,8 +344,6 @@ static void print_resources(const Compiler &compiler, const ShaderResources &res
 			CHECK_MODE(VecTypeHint);
 			CHECK_MODE(ContractionOff);
 
-		default:
-			break;
 		}
 	}
 	fprintf(stderr, "\n");
@@ -400,7 +395,6 @@ static void print_spec_constants(const Compiler &compiler)
 struct PLSArg
 {
 	PlsFormat format;
-	uint32_t pad0;
 	string name;
 };
 
@@ -409,7 +403,6 @@ struct Remap
 	string src_name;
 	string dst_name;
 	unsigned components;
-	uint32_t pad0;
 };
 
 struct VariableTypeRemap
@@ -431,7 +424,6 @@ struct CLIArguments
 	bool force_temporary = false;
 	bool flatten_ubo = false;
 	bool fixup = false;
-	uint8_t pad0[5];
 	vector<PLSArg> pls_in;
 	vector<PLSArg> pls_out;
 	vector<Remap> remaps;
@@ -446,7 +438,6 @@ struct CLIArguments
 	bool vulkan_semantics = false;
 	bool remove_unused = false;
 	bool cfg_analysis = true;
-	uint8_t pad1[6];
 };
 
 static void print_help()
@@ -583,7 +574,7 @@ int main(int argc, char *argv[])
 		string src = parser.next_string();
 		string dst = parser.next_string();
 		uint32_t components = parser.next_uint();
-		args.remaps.push_back({ move(src), move(dst), components, /* pad */ 0 });
+		args.remaps.push_back({ move(src), move(dst), components });
 	});
 
 	cbs.add("--remap-variable-type", [&args](CLIParser &parser) {
@@ -595,12 +586,12 @@ int main(int argc, char *argv[])
 	cbs.add("--pls-in", [&args](CLIParser &parser) {
 		auto fmt = pls_format(parser.next_string());
 		auto name = parser.next_string();
-		args.pls_in.push_back({ move(fmt), /* pad */ 0, move(name) });
+		args.pls_in.push_back({ move(fmt), move(name) });
 	});
 	cbs.add("--pls-out", [&args](CLIParser &parser) {
 		auto fmt = pls_format(parser.next_string());
 		auto name = parser.next_string();
-		args.pls_out.push_back({ move(fmt), /* pad */ 0, move(name) });
+		args.pls_out.push_back({ move(fmt), move(name) });
 	});
 
 	cbs.add("--remove-unused-variables", [&args](CLIParser &) { args.remove_unused = true; });

--- a/spirv_cfg.cpp
+++ b/spirv_cfg.cpp
@@ -18,6 +18,10 @@
 #include <algorithm>
 #include <assert.h>
 
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wswitch-enum"
+#endif
+
 using namespace std;
 
 namespace spirv_cross
@@ -130,7 +134,7 @@ bool CFG::post_order_visit(uint32_t block_id)
 	}
 
 	// Then visit ourselves. Start counting at one, to let 0 be a magic value for testing back vs. crossing edges.
-	visit_order[block_id] = ++visit_count;
+	visit_order[block_id] = static_cast<int>(++visit_count);
 	post_order.push_back(block_id);
 	return true;
 }

--- a/spirv_cfg.hpp
+++ b/spirv_cfg.hpp
@@ -83,6 +83,9 @@ private:
 	std::vector<int> visit_order;
 	std::vector<uint32_t> post_order;
 
+public:
+	uint32_t pad0;
+
 	void add_branch(uint32_t from, uint32_t to);
 	void build_post_order_visit_order();
 	void build_immediate_dominators();
@@ -109,6 +112,9 @@ public:
 private:
 	const CFG &cfg;
 	uint32_t dominator = 0;
+
+public:
+	uint32_t pad0;
 };
 }
 

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -23,6 +23,12 @@
 #include <locale>
 #include <sstream>
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#pragma clang diagnostic ignored "-Wdeprecated"
+#endif
+
 namespace spirv_cross
 {
 
@@ -43,6 +49,7 @@ namespace spirv_cross
 
 #define SPIRV_CROSS_THROW(x) report_and_abort(x)
 #else
+
 class CompilerError : public std::runtime_error
 {
 public:
@@ -113,7 +120,7 @@ inline std::string convert_to_string(float t)
 	// std::to_string for floating point values is broken.
 	// Fallback to something more sane.
 	char buf[64];
-	sprintf(buf, SPIRV_CROSS_FLT_FMT, t);
+	sprintf(buf, SPIRV_CROSS_FLT_FMT, static_cast<double>(t));
 	// Ensure that the literal is float.
 	if (!strchr(buf, '.') && !strchr(buf, 'e'))
 		strcat(buf, ".0");
@@ -151,6 +158,7 @@ struct IVariant
 {
 	virtual ~IVariant() = default;
 	uint32_t self = 0;
+	uint32_t pad0;
 };
 
 enum Types
@@ -180,6 +188,7 @@ struct SPIRUndef : IVariant
 	{
 	}
 	uint32_t basetype;
+	uint32_t pad0;
 };
 
 struct SPIRConstantOp : IVariant
@@ -197,8 +206,10 @@ struct SPIRConstantOp : IVariant
 	}
 
 	spv::Op opcode;
+	uint32_t pad0;
 	std::vector<uint32_t> arguments;
 	uint32_t basetype;
+	uint32_t pad1;
 };
 
 struct SPIRType : IVariant
@@ -245,6 +256,7 @@ struct SPIRType : IVariant
 
 	// Pointers
 	bool pointer = false;
+	uint8_t pad[3];
 	spv::StorageClass storage = spv::StorageClassGeneric;
 
 	std::vector<uint32_t> member_types;
@@ -256,6 +268,7 @@ struct SPIRType : IVariant
 		bool depth;
 		bool arrayed;
 		bool ms;
+		uint8_t pad0;
 		uint32_t sampled;
 		spv::ImageFormat format;
 	} image;
@@ -268,6 +281,8 @@ struct SPIRType : IVariant
 	// Denotes the type which this type is based on.
 	// Allows the backend to traverse how a complex type is built up during access chains.
 	uint32_t parent_type = 0;
+
+	uint32_t pad0;
 
 	// Used in backends to avoid emitting members with conflicting names.
 	std::unordered_set<std::string> member_name_cache;
@@ -291,6 +306,7 @@ struct SPIRExtension : IVariant
 	}
 
 	Extension ext;
+	uint32_t pad0;
 };
 
 // SPIREntryPoint is not a variant since its IDs are used to decorate OpFunction,
@@ -306,6 +322,7 @@ struct SPIREntryPoint
 	SPIREntryPoint() = default;
 
 	uint32_t self = 0;
+	uint32_t pad0;
 	std::string name;
 	std::vector<uint32_t> interface_variables;
 
@@ -338,6 +355,7 @@ struct SPIRExpression : IVariant
 	// Used in amortizing multiple calls to to_expression()
 	// where in certain cases that would quickly force a temporary when not needed.
 	uint32_t base_expression = 0;
+	uint32_t pad0;
 
 	std::string expression;
 	uint32_t expression_type = 0;
@@ -358,6 +376,7 @@ struct SPIRExpression : IVariant
 	// Before use, this expression must be transposed.
 	// This is needed for targets which don't support row_major layouts.
 	bool need_transpose = false;
+	uint8_t pad1[5];
 
 	// A list of expressions which this expression depends on.
 	std::vector<uint32_t> expression_dependencies;
@@ -376,6 +395,7 @@ struct SPIRFunctionPrototype : IVariant
 	}
 
 	uint32_t return_type;
+	uint32_t pad0;
 	std::vector<uint32_t> parameter_types;
 };
 
@@ -477,6 +497,8 @@ struct SPIRBlock : IVariant
 	// If the continue block is complex, fallback to "dumb" for loops.
 	bool complex_continue = false;
 
+	uint16_t pad0;
+
 	// The dominating block which this block might be within.
 	// Used in continue; blocks to determine if we really need to write continue.
 	uint32_t loop_dominator = 0;
@@ -526,6 +548,7 @@ struct SPIRFunction : IVariant
 		uint32_t sampler_id;
 		bool global_image;
 		bool global_sampler;
+		uint16_t pad0;
 	};
 
 	uint32_t return_type;
@@ -538,6 +561,7 @@ struct SPIRFunction : IVariant
 	std::vector<Parameter> shadow_arguments;
 	std::vector<uint32_t> local_variables;
 	uint32_t entry_block = 0;
+	uint32_t pad0;
 	std::vector<uint32_t> blocks;
 	std::vector<CombinedImageSamplerParameter> combined_parameters;
 
@@ -556,6 +580,7 @@ struct SPIRFunction : IVariant
 	bool flush_undeclared = true;
 	bool do_combined_parameters = true;
 	bool analyzed_variable_scope = false;
+	uint32_t pad1;
 };
 
 struct SPIRVariable : IVariant
@@ -586,6 +611,7 @@ struct SPIRVariable : IVariant
 	// When we read the variable as an expression, just forward
 	// shadowed_id as the expression.
 	bool statically_assigned = false;
+	uint16_t pad0;
 	uint32_t static_expression = 0;
 
 	// Temporaries which can remain forwarded as long as this variable is not modified.
@@ -605,6 +631,7 @@ struct SPIRVariable : IVariant
 	bool loop_variable = false;
 	// Set to true while we're inside the for loop.
 	bool loop_variable_enable = false;
+	uint16_t pad1;
 
 	SPIRFunction::Parameter *parameter = nullptr;
 };
@@ -630,12 +657,14 @@ struct SPIRConstant : IVariant
 	{
 		Constant r[4];
 		uint32_t vecsize;
+		uint32_t pad;
 	};
 
 	struct ConstantMatrix
 	{
 		ConstantVector c[4];
 		uint32_t columns;
+		uint32_t pad;
 	};
 
 	inline uint32_t scalar(uint32_t col = 0, uint32_t row = 0) const
@@ -800,8 +829,10 @@ struct SPIRConstant : IVariant
 	}
 
 	uint32_t constant_type;
+	uint32_t pad0;
 	ConstantMatrix m;
 	bool specialization = false; // If the constant is a specialization constant.
+	uint8_t pad1[7];
 
 	// For composites which are constant arrays, etc.
 	std::vector<uint32_t> subconstants;
@@ -814,6 +845,7 @@ public:
 	Variant() = default;
 	Variant(Variant &&other)
 	{
+		pad0 = 0; // Suppress clang's `-Wunused-private-field' warning.
 		*this = std::move(other);
 	}
 	Variant &operator=(Variant &&other)
@@ -872,6 +904,7 @@ public:
 private:
 	std::unique_ptr<IVariant> holder;
 	uint32_t type = TypeNone;
+	uint32_t pad0;
 };
 
 template <typename T>
@@ -912,11 +945,13 @@ struct Meta
 		uint32_t input_attachment = 0;
 		uint32_t spec_id = 0;
 		bool builtin = false;
+		uint8_t pad0[3];
 	};
 
 	Decoration decoration;
 	std::vector<Decoration> members;
 	uint32_t sampler = 0;
+	uint32_t pad0;
 };
 
 // A user callback that remaps the type of any variable.
@@ -941,5 +976,9 @@ private:
 	std::locale old;
 };
 }
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 #endif

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -540,6 +540,8 @@ struct SPIRFunction : IVariant
 		// read and write counts as access to the function arguments
 		// is not local to the function in question.
 		bool alias_global_variable;
+		uint8_t pad0;
+		uint16_t pad1;
 	};
 
 	// When calling a function, and we're remapping separate image samplers,
@@ -581,7 +583,7 @@ struct SPIRFunction : IVariant
 	void add_parameter(uint32_t parameter_type, uint32_t id, bool alias_global_variable = false)
 	{
 		// Arguments are read-only until proven otherwise.
-		arguments.push_back({ parameter_type, id, 0u, 0u, alias_global_variable });
+		arguments.push_back({ parameter_type, id, 0u, 0u, alias_global_variable, /* pad0 */ 0, /* pad1 */ 0 });
 	}
 
 	bool active = false;

--- a/spirv_cpp.cpp
+++ b/spirv_cpp.cpp
@@ -16,6 +16,10 @@
 
 #include "spirv_cpp.hpp"
 
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wswitch-enum"
+#endif
+
 using namespace spv;
 using namespace spirv_cross;
 using namespace std;

--- a/spirv_cpp.hpp
+++ b/spirv_cpp.hpp
@@ -64,7 +64,10 @@ private:
 	std::string resource_type;
 	uint32_t shared_counter = 0;
 
+	uint32_t pad0;
 	std::string interface_name;
+
+	uint64_t pad1;
 };
 }
 

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -2605,7 +2605,7 @@ void Compiler::CombinedImageSamplerHandler::register_combined_image_sampler(SPIR
 		                  join("SPIRV_Cross_Combined", compiler.to_name(image_id), compiler.to_name(sampler_id)));
 
 		caller.combined_parameters.push_back(param);
-		caller.shadow_arguments.push_back({ ptr_type_id, combined_id, 0u, 0u, true });
+		caller.shadow_arguments.push_back({ ptr_type_id, combined_id, 0u, 0u, true, /* pad0 */ 0, /* pad1 */ 0 });
 	}
 }
 

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -29,6 +29,11 @@
 
 #include "spirv_common.hpp"
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
+
 namespace spirv_cross
 {
 struct Resource
@@ -47,6 +52,8 @@ struct Resource
 	// This is mostly useful to parse decorations of the underlying type.
 	// base_type_id can also be obtained with get_type(get_type(type_id).self).
 	uint32_t base_type_id;
+
+	uint32_t pad0;
 
 	// The declared name (OpName) of the resource.
 	// For Buffer blocks, the name actually reflects the externally
@@ -102,6 +109,7 @@ struct SpecializationConstant
 struct BufferRange
 {
 	unsigned index;
+	uint32_t pad0;
 	size_t offset;
 	size_t range;
 };
@@ -383,6 +391,7 @@ protected:
 			return nullptr;
 	}
 
+	uint8_t pad0[3];
 	uint32_t entry_point = 0;
 	// Normally, we'd stick SPIREntryPoint in ids array, but it conflicts with SPIRFunction.
 	// Entry points can therefore be seen as some sort of meta structure.
@@ -395,6 +404,7 @@ protected:
 		uint32_t version = 0;
 		bool es = false;
 		bool known = false;
+		uint16_t pad0;
 
 		Source() = default;
 	} source;
@@ -474,6 +484,7 @@ protected:
 	// variable is part of that entry points interface.
 	bool interface_variable_exists_in_entry_point(uint32_t id) const;
 
+	uint8_t pad1[7];
 	std::vector<CombinedImageSampler> combined_image_samplers;
 
 	void remap_variable_type_name(const SPIRType &type, const std::string &var_name, std::string &type_name) const
@@ -531,6 +542,7 @@ protected:
 		const Compiler &compiler;
 		std::vector<BufferRange> &ranges;
 		uint32_t id;
+		uint32_t pad0;
 
 		std::unordered_set<uint32_t> seen;
 	};
@@ -584,5 +596,9 @@ protected:
 	bool get_common_basic_type(const SPIRType &type, SPIRType::BaseType &base_type);
 };
 }
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 #endif

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -20,6 +20,14 @@
 #include <assert.h>
 #include <utility>
 
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wswitch-enum"
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#pragma clang diagnostic ignored "-Wexit-time-destructors"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wunused-macros"
+#endif
+
 using namespace spv;
 using namespace spirv_cross;
 using namespace std;
@@ -3351,7 +3359,7 @@ std::string CompilerGLSL::flattened_access_chain_struct(uint32_t base, const uin
 			expr += ", ";
 
 		const SPIRType &member_type = get<SPIRType>(target_type.member_types[i]);
-		uint32_t member_offset = type_struct_member_offset(target_type, i);
+		uint32_t member_offset = type_struct_member_offset(target_type, static_cast<uint32_t>(i));
 
 		// The access chain terminates at the struct, so we need to find matrix strides and row-major information
 		// ahead of time.
@@ -3359,8 +3367,9 @@ std::string CompilerGLSL::flattened_access_chain_struct(uint32_t base, const uin
 		uint32_t matrix_stride = 0;
 		if (member_type.columns > 1)
 		{
-			need_transpose = (combined_decoration_for_member(target_type, i) & (1ull << DecorationRowMajor)) != 0;
-			matrix_stride = type_struct_member_matrix_stride(target_type, i);
+			need_transpose = (combined_decoration_for_member(target_type, static_cast<uint32_t>(i)) &
+			                  (1ull << DecorationRowMajor)) != 0;
+			matrix_stride = type_struct_member_matrix_stride(target_type, static_cast<uint32_t>(i));
 		}
 
 		auto tmp = flattened_access_chain(base, indices, count, member_type, offset + member_offset, matrix_stride,
@@ -3463,7 +3472,7 @@ std::string CompilerGLSL::flattened_access_chain_vector(uint32_t base, const uin
 		expr += convert_to_string(index / 4);
 		expr += "]";
 
-		expr += vector_swizzle(target_type.vecsize, index % 4);
+		expr += vector_swizzle(static_cast<int>(target_type.vecsize), index % 4);
 
 		return expr;
 	}

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -66,6 +66,7 @@ public:
 		// If true, Vulkan GLSL features are used instead of GL-compatible features.
 		// Mostly useful for debugging SPIR-V files.
 		bool vulkan_semantics = false;
+		uint8_t pad0[3];
 
 		enum Precision
 		{
@@ -247,10 +248,12 @@ protected:
 	bool member_is_non_native_row_major_matrix(const SPIRType &type, uint32_t index);
 	virtual std::string convert_row_major_matrix(std::string exp_str);
 
+	uint32_t pad0;
 	std::unordered_set<std::string> local_variable_names;
 	std::unordered_set<std::string> resource_names;
 
 	bool processing_entry_point = false;
+	uint8_t pad1[7];
 
 	// Can be overriden by subclass backends for trivial things which
 	// shouldn't need polymorphism.
@@ -261,6 +264,7 @@ protected:
 		bool double_literal_suffix = true;
 		bool uint32_t_literal_suffix = true;
 		bool long_long_literal_suffix = false;
+		uint32_t pad0;
 		const char *basic_int_type = "int";
 		const char *basic_uint_type = "uint";
 		bool swizzle_is_function = false;
@@ -270,6 +274,7 @@ protected:
 		bool use_initializer_list = false;
 		bool native_row_major_matrix = true;
 		bool use_constructor_splatting = true;
+		uint8_t pad1;
 	} backend;
 
 	void emit_struct(SPIRType &type);
@@ -380,6 +385,7 @@ protected:
 	std::string legacy_tex_op(const std::string &op, const SPIRType &imgtype);
 
 	uint32_t indent = 0;
+	uint32_t pad2;
 
 	std::unordered_set<uint32_t> emitted_functions;
 
@@ -416,6 +422,8 @@ protected:
 	void register_call_out_argument(uint32_t id);
 	void register_impure_function_call();
 
+	uint32_t pad3;
+
 	// GL_EXT_shader_pixel_local_storage support.
 	std::vector<PlsRemap> pls_inputs;
 	std::vector<PlsRemap> pls_outputs;
@@ -432,6 +440,8 @@ protected:
 	std::string emit_for_loop_initializers(const SPIRBlock &block);
 	bool optimize_read_modify_write(const std::string &lhs, const std::string &rhs);
 	void fixup_image_load_store_access();
+
+	uint64_t pad4;
 };
 }
 

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -18,6 +18,13 @@
 #include "GLSL.std.450.h"
 #include <algorithm>
 
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wswitch-enum"
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#pragma clang diagnostic ignored "-Wexit-time-destructors"
+#pragma clang diagnostic ignored "-Wunused-macros"
+#endif
+
 using namespace spv;
 using namespace spirv_cross;
 using namespace std;

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -31,6 +31,7 @@ public:
 		uint32_t shader_model = 30; // TODO: map ps_4_0_level_9_0,... somehow
 		bool fixup_clipspace = false;
 		bool flip_vert_y = false;
+		uint8_t pad0[2];
 	};
 
 	CompilerHLSL(std::vector<uint32_t> spirv_)
@@ -68,6 +69,9 @@ private:
 
 	Options options;
 	bool requires_op_fmod = false;
+
+public:
+	uint8_t pad0[7];
 };
 }
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -19,6 +19,15 @@
 #include <algorithm>
 #include <numeric>
 
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wswitch-enum"
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#pragma clang diagnostic ignored "-Wexit-time-destructors"
+#pragma clang diagnostic ignored "-Wunused-macros"
+//#pragma clang diagnostic ignored "-Wunreachable-code-return"
+#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
+#endif
+
 using namespace spv;
 using namespace spirv_cross;
 using namespace std;
@@ -310,7 +319,7 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage)
 	set_decoration(ib_type_id, DecorationBlock);
 
 	uint32_t ib_var_id = next_id++;
-	auto &var = set<SPIRVariable>(ib_var_id, ib_type_id, storage, 0);
+	auto &var = set<SPIRVariable>(ib_var_id, ib_type_id, storage, 0u);
 	var.initializer = next_id++;
 
 	string ib_var_ref;
@@ -976,7 +985,7 @@ string CompilerMSL::to_component_argument(uint32_t id)
 	if (ids[id].get_type() != TypeConstant)
 	{
 		SPIRV_CROSS_THROW("ID " + to_string(id) + " is not an OpConstant.");
-		return "component::x";
+		//return "component::x";
 	}
 
 	uint32_t component_index = get<SPIRConstant>(id).scalar();
@@ -994,7 +1003,7 @@ string CompilerMSL::to_component_argument(uint32_t id)
 	default:
 		SPIRV_CROSS_THROW("The value (" + to_string(component_index) + ") of OpConstant ID " + to_string(id) +
 		                  " is not a valid Component index, which must be one of 0, 1, 2, or 3.");
-		return "component::x";
+		//return "component::x";
 	}
 }
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -34,7 +34,7 @@ using namespace spv;
 using namespace spirv_cross;
 using namespace std;
 
-static const uint32_t k_unknown_location = ~0;
+static const uint32_t k_unknown_location = ~0u;
 
 CompilerMSL::CompilerMSL(vector<uint32_t> spirv_)
     : CompilerGLSL(move(spirv_))
@@ -573,7 +573,7 @@ uint32_t CompilerMSL::get_input_buffer_block_var_id(uint32_t msl_buffer)
 		set_decoration(ib_type_id, DecorationBlock);
 
 		ib_var_id = next_id++;
-		auto &var = set<SPIRVariable>(ib_var_id, ib_type_id, StorageClassInput, 0);
+		auto &var = set<SPIRVariable>(ib_var_id, ib_type_id, StorageClassInput, 0u);
 		var.initializer = next_id++;
 
 		string ib_var_name = stage_in_var_name + convert_to_string(msl_buffer);
@@ -2168,7 +2168,7 @@ void CompilerMSL::MemberSorter::sort()
 	// the members should be reordered, based on builtin and sorting aspect meta info.
 	size_t mbr_cnt = type.member_types.size();
 	vector<uint32_t> mbr_idxs(mbr_cnt);
-	iota(mbr_idxs.begin(), mbr_idxs.end(), 0);          // Fill with consecutive indices
+	iota(mbr_idxs.begin(), mbr_idxs.end(), 0); // Fill with consecutive indices
 	std::sort(mbr_idxs.begin(), mbr_idxs.end(), *this); // Sort member indices based on sorting aspect
 
 	// Move type and meta member info to the order defined by the sorted member indices.

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -48,7 +48,7 @@ struct MSLVertexAttr
 	uint32_t msl_stride = 0;
 	bool per_instance = false;
 	bool used_by_shader = false;
-	uint8_t pad0[3];
+	uint8_t pad0[6];
 };
 
 // Matches the binding index of a MSL resource for a binding within a descriptor set.
@@ -182,11 +182,13 @@ protected:
 	uint32_t stage_uniforms_var_id = 0;
 	bool needs_vertex_idx_arg = false;
 	bool needs_instance_idx_arg = false;
+	uint8_t pad0[6];
 	std::string qual_pos_var_name;
 	std::string stage_in_var_name = "in";
 	std::string stage_out_var_name = "out";
 	std::string stage_uniform_var_name = "uniforms";
 	std::string sampler_name_suffix = "Smplr";
+	uint64_t pad1;
 
 	// OpcodeHandler that handles several MSL preprocessing operations.
 	struct OpCodePreprocessor : OpcodeHandler

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -32,6 +32,7 @@ struct MSLConfiguration
 	bool flip_vert_y = false;
 	bool flip_frag_y = false;
 	bool is_rendering_points = false;
+	uint8_t pad0[5];
 	std::string entry_point_name;
 };
 
@@ -42,6 +43,7 @@ struct MSLVertexAttr
 {
 	uint32_t location = 0;
 	bool used_by_shader = false;
+	uint8_t pad0[3];
 };
 
 // Matches the binding index of a MSL resource for a binding within a descriptor set.
@@ -60,6 +62,7 @@ struct MSLResourceBinding
 	uint32_t msl_sampler = 0;
 
 	bool used_by_shader = false;
+	uint8_t pad0[3];
 };
 
 // Special constant used in a MSLResourceBinding desc_set
@@ -179,6 +182,7 @@ protected:
 
 		CompilerMSL &compiler;
 		bool suppress_missing_prototypes = false;
+		uint8_t pad0[7];
 	};
 
 	// Sorts the members of a SPIRType and associated Meta info based on a settable sorting
@@ -206,6 +210,7 @@ protected:
 		SPIRType &type;
 		Meta &meta;
 		SortAspect sort_aspect;
+		uint32_t pad0;
 	};
 };
 }


### PR DESCRIPTION
Suppress clang warnings which reveals when CXXFLAGS has strict warning level, i.e, `"-Weverything -Werror -Wno-c++98-compat-pedantic -std=c++11"`

Add data padding to classes and structs for preventing future potential memory/data align bugs(these could be found with the above clang CXXFLAGS)

There are some tests failing but this is also happen in recent `glslang`, `SPIRV-Tools` and `SPIRV-Cross` master branch combination, thus I'm not sure this patch gives some side effect to unit tests.

