### PR TITLE
CompilerMSL add support for texel buffers.

### DIFF
--- a/reference/shaders-msl/frag/basic.frag
+++ b/reference/shaders-msl/frag/basic.frag
@@ -17,7 +17,7 @@ struct main0_out
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> uTex [[texture(0)]], sampler uTexSmplr [[sampler(0)]])
 {
     main0_out out = {};
-    out.FragColor = in.vColor * uTex.sample(uTexSmplr, in.vTex.xy);
+    out.FragColor = in.vColor * uTex.sample(uTexSmplr, in.vTex);
     return out;
 }
 

--- a/reference/shaders-msl/frag/composite-extract-forced-temporary.frag
+++ b/reference/shaders-msl/frag/composite-extract-forced-temporary.frag
@@ -16,7 +16,7 @@ struct main0_out
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> Texture [[texture(0)]], sampler TextureSmplr [[sampler(0)]])
 {
     main0_out out = {};
-    float f = Texture.sample(TextureSmplr, in.vTexCoord.xy).x;
+    float f = Texture.sample(TextureSmplr, in.vTexCoord).x;
     out.FragColor = float4(f * f);
     return out;
 }

--- a/reference/shaders-msl/frag/mix.frag
+++ b/reference/shaders-msl/frag/mix.frag
@@ -23,26 +23,8 @@ fragment main0_out main0(main0_in in [[stage_in]])
     out.FragColor = float4(l.x ? in.vIn1.x : in.vIn0.x, l.y ? in.vIn1.y : in.vIn0.y, l.z ? in.vIn1.z : in.vIn0.z, l.w ? in.vIn1.w : in.vIn0.w);
     bool f = true;
     out.FragColor = float4(f ? in.vIn3 : in.vIn2);
-    float4 _35;
-    if (f)
-    {
-        _35 = in.vIn0;
-    }
-    else
-    {
-        _35 = in.vIn1;
-    }
-    out.FragColor = _35;
-    float _44;
-    if (f)
-    {
-        _44 = in.vIn2;
-    }
-    else
-    {
-        _44 = in.vIn3;
-    }
-    out.FragColor = float4(_44);
+    out.FragColor = f ? in.vIn0 : in.vIn1;
+    out.FragColor = float4(f ? in.vIn2 : in.vIn3);
     return out;
 }
 

--- a/reference/shaders-msl/frag/sampler-ms.frag
+++ b/reference/shaders-msl/frag/sampler-ms.frag
@@ -12,7 +12,7 @@ fragment main0_out main0(float4 gl_FragCoord [[position]], texture2d_ms<float> u
 {
     main0_out out = {};
     int2 coord = int2(gl_FragCoord.xy);
-    out.FragColor = ((uSampler.read(uint2(coord.xy), 0) + uSampler.read(uint2(coord.xy), 1)) + uSampler.read(uint2(coord.xy), 2)) + uSampler.read(uint2(coord.xy), 3);
+    out.FragColor = ((uSampler.read(uint2(coord), 0) + uSampler.read(uint2(coord), 1)) + uSampler.read(uint2(coord), 2)) + uSampler.read(uint2(coord), 3);
     return out;
 }
 

--- a/reference/shaders-msl/frag/sampler.frag
+++ b/reference/shaders-msl/frag/sampler.frag
@@ -18,7 +18,7 @@ struct main0_out
 
 float4 sample_texture(thread const texture2d<float> tex, thread const sampler& texSmplr, thread const float2& uv)
 {
-    return tex.sample(texSmplr, uv.xy);
+    return tex.sample(texSmplr, uv);
 }
 
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> uTex [[texture(0)]], sampler uTexSmplr [[sampler(0)]])

--- a/reference/shaders-msl/frag/swizzle.frag
+++ b/reference/shaders-msl/frag/swizzle.frag
@@ -17,9 +17,9 @@ struct main0_out
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> samp [[texture(0)]], sampler sampSmplr [[sampler(0)]])
 {
     main0_out out = {};
-    out.FragColor = float4(samp.sample(sampSmplr, in.vUV.xy).xyz, 1.0);
-    out.FragColor = float4(samp.sample(sampSmplr, in.vUV.xy).xz, 1.0, 4.0);
-    out.FragColor = float4(samp.sample(sampSmplr, in.vUV.xy).xx, samp.sample(sampSmplr, (in.vUV + float2(0.100000001490116119384765625)).xy).yy);
+    out.FragColor = float4(samp.sample(sampSmplr, in.vUV).xyz, 1.0);
+    out.FragColor = float4(samp.sample(sampSmplr, in.vUV).xz, 1.0, 4.0);
+    out.FragColor = float4(samp.sample(sampSmplr, in.vUV).xx, samp.sample(sampSmplr, (in.vUV + float2(0.100000001490116119384765625))).yy);
     out.FragColor = float4(in.vNormal, 1.0);
     out.FragColor = float4(in.vNormal + float3(1.7999999523162841796875), 1.0);
     out.FragColor = float4(in.vUV, in.vUV + float2(1.7999999523162841796875));


### PR DESCRIPTION
Compiler MSL support DimBuffer as image dimension.
CompilerMSL check texture coordinate result type dimension before adding swizzles.
Update MSL reference shaders affected by this update.