### PR TITLE
Add support for flattening I/O blocks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,13 @@ The command line client calls `Compiler::build_combined_image_samplers` automati
 Descriptor sets are unique to Vulkan, so make sure that descriptor set + binding is remapped to a flat binding scheme (set always 0), so that other APIs can make sense of the bindings.
 This can be done with `Compiler::set_decoration(id, spv::DecorationDescriptorSet)`.
 
+#### Linking by name for targets which do not support explicit locations (legacy GLSL/ESSL)
+
+Modern GLSL and HLSL sources will rely on explicit layout(location) qualifiers to guide the linking process,
+but legacy GLSL relies on symbol names to perform the linking. When emitting legacy shaders, these layout statements will be dropped,
+so it is important that the API user ensures that the names of I/O variables are sanitized to ensure that linking will work properly.
+The reflection API can rename variables, struct types and struct members to deal with these scenarios using `Compiler::set_name` and friends.
+
 ## Contributing
 
 Contributions to SPIRV-Cross are welcome. See Testing and Licensing sections for details.

--- a/reference/shaders/legacy/fragment/io-blocks.legacy.frag
+++ b/reference/shaders/legacy/fragment/io-blocks.legacy.frag
@@ -1,0 +1,12 @@
+#version 100
+precision mediump float;
+precision highp int;
+
+varying vec4 VertexOut_color;
+varying highp vec3 VertexOut_normal;
+
+void main()
+{
+    gl_FragData[0] = VertexOut_color + VertexOut_normal.xyzz;
+}
+

--- a/reference/shaders/legacy/vert/io-block.legacy.vert
+++ b/reference/shaders/legacy/vert/io-block.legacy.vert
@@ -1,0 +1,13 @@
+#version 100
+
+attribute vec4 Position;
+varying vec4 VertexOut_color;
+varying vec3 VertexOut_normal;
+
+void main()
+{
+    gl_Position = Position;
+    VertexOut_color = vec4(1.0);
+    VertexOut_normal = vec3(0.5);
+}
+

--- a/shaders/legacy/fragment/io-blocks.legacy.frag
+++ b/shaders/legacy/fragment/io-blocks.legacy.frag
@@ -1,0 +1,16 @@
+#version 310 es
+#extension GL_EXT_shader_io_blocks : require
+precision mediump float;
+
+layout(location = 1) in VertexOut
+{
+   vec4 color;
+   highp vec3 normal;
+} vin;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+   FragColor = vin.color + vin.normal.xyzz;
+}

--- a/shaders/legacy/vert/io-block.legacy.vert
+++ b/shaders/legacy/vert/io-block.legacy.vert
@@ -1,0 +1,17 @@
+#version 310 es
+#extension GL_EXT_shader_io_blocks : require
+
+layout(location = 0) out VertexOut
+{
+   vec4 color;
+   vec3 normal;
+} vout;
+
+layout(location = 0) in vec4 Position;
+
+void main()
+{
+   gl_Position = Position;
+   vout.color = vec4(1.0);
+   vout.normal = vec3(0.5);
+}

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -282,6 +282,7 @@ protected:
 	void emit_push_constant_block_vulkan(const SPIRVariable &var);
 	void emit_push_constant_block_glsl(const SPIRVariable &var);
 	void emit_interface_block(const SPIRVariable &type);
+	void emit_flattened_io_block(const SPIRVariable &var, const char *qual);
 	void emit_block_chain(SPIRBlock &block);
 	void emit_specialization_constant(const SPIRConstant &constant);
 	std::string emit_continue_block(uint32_t continue_block);


### PR DESCRIPTION
Fix issue where layout() qualifiers are emitted for members in legacy
targets.