### PR TITLE
CompilerMSL aligns MSL struct members with SPIR-V offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ See `./test_shaders.py --help` for more.
 
 ### Metal backend
 
-To test the roundtrip path GLSL -> SPIR-V -> MSL, `--metal` can be added, e.g. `./test_shaders.py --metal shaders-msl`.
+To test the roundtrip path GLSL -> SPIR-V -> MSL, `--msl` can be added, e.g. `./test_shaders.py --msl shaders-msl`.
 
 ### HLSL backend
 

--- a/main.cpp
+++ b/main.cpp
@@ -432,7 +432,7 @@ struct CLIArguments
 
 	uint32_t iterations = 1;
 	bool cpp = false;
-	bool metal = false;
+	bool msl = false;
 	bool msl_pack_ubos = true;
 	bool hlsl = false;
 	bool vulkan_semantics = false;
@@ -443,10 +443,11 @@ struct CLIArguments
 static void print_help()
 {
 	fprintf(stderr, "Usage: spirv-cross [--output <output path>] [SPIR-V file] [--es] [--no-es] [--no-cfg-analysis] "
-	                "[--version <GLSL "
-	                "version>] [--dump-resources] [--help] [--force-temporary] [--cpp] [--cpp-interface-name <name>] "
-	                "[--metal] [--hlsl] [--shader-model] [--vulkan-semantics] [--flatten-ubo] [--fixup-clipspace] "
-	                "[--iterations iter] "
+	                "[--version <GLSL version>] [--dump-resources] [--help] [--force-temporary] "
+	                "[--vulkan-semantics] [--flatten-ubo] [--fixup-clipspace] [--iterations iter] "
+	                "[--cpp] [--cpp-interface-name <name>] "
+	                "[--msl] [--msl-no-pack-ubos] "
+	                "[--hlsl] [--shader-model] "
 	                "[--pls-in format input-name] [--pls-out format output-name] [--remap source_name target_name "
 	                "components] [--extension ext] [--entry name] [--remove-unused-variables] "
 	                "[--remap-variable-type <variable_name> <new_variable_type>]\n");
@@ -566,7 +567,8 @@ int main(int argc, char *argv[])
 	cbs.add("--iterations", [&args](CLIParser &parser) { args.iterations = parser.next_uint(); });
 	cbs.add("--cpp", [&args](CLIParser &) { args.cpp = true; });
 	cbs.add("--cpp-interface-name", [&args](CLIParser &parser) { args.cpp_interface_name = parser.next_string(); });
-	cbs.add("--metal", [&args](CLIParser &) { args.metal = true; });
+	cbs.add("--metal", [&args](CLIParser &) { args.msl = true; }); // Legacy compatibility
+	cbs.add("--msl", [&args](CLIParser &) { args.msl = true; });
 	cbs.add("--msl-no-pack-ubos", [&args](CLIParser &) { args.msl_pack_ubos = false; });
 	cbs.add("--hlsl", [&args](CLIParser &) { args.hlsl = true; });
 	cbs.add("--vulkan-semantics", [&args](CLIParser &) { args.vulkan_semantics = true; });
@@ -632,7 +634,7 @@ int main(int argc, char *argv[])
 		if (args.cpp_interface_name)
 			static_cast<CompilerCPP *>(compiler.get())->set_interface_name(args.cpp_interface_name);
 	}
-	else if (args.metal)
+	else if (args.msl)
 	{
 		compiler = unique_ptr<CompilerMSL>(new CompilerMSL(read_spirv_file(args.input)));
 

--- a/main.cpp
+++ b/main.cpp
@@ -433,6 +433,7 @@ struct CLIArguments
 	uint32_t iterations = 1;
 	bool cpp = false;
 	bool metal = false;
+	bool msl_pack_ubos = true;
 	bool hlsl = false;
 	bool vulkan_semantics = false;
 	bool remove_unused = false;
@@ -566,6 +567,7 @@ int main(int argc, char *argv[])
 	cbs.add("--cpp", [&args](CLIParser &) { args.cpp = true; });
 	cbs.add("--cpp-interface-name", [&args](CLIParser &parser) { args.cpp_interface_name = parser.next_string(); });
 	cbs.add("--metal", [&args](CLIParser &) { args.metal = true; });
+	cbs.add("--msl-no-pack-ubos", [&args](CLIParser &) { args.msl_pack_ubos = false; });
 	cbs.add("--hlsl", [&args](CLIParser &) { args.hlsl = true; });
 	cbs.add("--vulkan-semantics", [&args](CLIParser &) { args.vulkan_semantics = true; });
 	cbs.add("--extension", [&args](CLIParser &parser) { args.extensions.push_back(parser.next_string()); });
@@ -631,7 +633,14 @@ int main(int argc, char *argv[])
 			static_cast<CompilerCPP *>(compiler.get())->set_interface_name(args.cpp_interface_name);
 	}
 	else if (args.metal)
+	{
 		compiler = unique_ptr<CompilerMSL>(new CompilerMSL(read_spirv_file(args.input)));
+
+		auto *msl_comp = static_cast<CompilerMSL *>(compiler.get());
+		auto msl_opts = msl_comp->get_options();
+		msl_opts.pad_and_pack_uniform_structs = args.msl_pack_ubos;
+		msl_comp->set_options(msl_opts);
+	}
 	else if (args.hlsl)
 		compiler = unique_ptr<CompilerHLSL>(new CompilerHLSL(read_spirv_file(args.input)));
 	else

--- a/reference/shaders-msl/flatten/swizzle.flatten.vert
+++ b/reference/shaders-msl/flatten/swizzle.flatten.vert
@@ -10,7 +10,7 @@ struct UBO
     float2 B1;
     float C0;
     float3 C1;
-    float3 D0;
+    packed_float3 D0;
     float D1;
     float E0;
     float E1;
@@ -40,7 +40,7 @@ vertex main0_out main0(constant UBO& _22 [[buffer(0)]])
     out.oA = _22.A;
     out.oB = float4(_22.B0, _22.B1);
     out.oC = float4(_22.C0, _22.C1);
-    out.oD = float4(_22.D0, _22.D1);
+    out.oD = float4(float3(_22.D0), _22.D1);
     out.oE = float4(_22.E0, _22.E1, _22.E2, _22.E3);
     out.oF = float4(_22.F0, _22.F1, _22.F2);
     return out;

--- a/reference/shaders-msl/vert/ubo.alignment.vert
+++ b/reference/shaders-msl/vert/ubo.alignment.vert
@@ -1,0 +1,39 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBO
+{
+    float4x4 mvp;
+    float2 targSize;
+    char pad2[8];
+    packed_float3 color;
+    float opacity;
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
+};
+
+struct main0_out
+{
+    float2 vSize [[user(locn0)]];
+    float3 vNormal [[user(locn1)]];
+    float3 vColor [[user(locn2)]];
+    float4 gl_Position [[position]];
+    float gl_PointSize;
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _18 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = _18.mvp * in.aVertex;
+    out.vNormal = in.aNormal;
+    out.vColor = float3(_18.color) * _18.opacity;
+    out.vSize = _18.targSize * _18.opacity;
+    return out;
+}
+

--- a/shaders-msl/vert/ubo.alignment.vert
+++ b/shaders-msl/vert/ubo.alignment.vert
@@ -1,0 +1,23 @@
+#version 310 es
+
+layout(binding = 0, std140) uniform UBO
+{
+   mat4 mvp;
+   vec2 targSize;
+   vec3 color;      // vec3 following vec2 should cause MSL to add pad if float3 is packed
+   float opacity;   // Single float following vec3 should cause MSL float3 to pack
+};
+
+in vec4 aVertex;
+in vec3 aNormal;
+out vec3 vNormal;
+out vec3 vColor;
+out vec2 vSize;
+
+void main()
+{
+    gl_Position = mvp * aVertex;
+    vNormal = aNormal;
+    vColor = color * opacity;
+    vSize = targSize * opacity;
+}

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -920,6 +920,11 @@ uint64_t Compiler::get_member_decoration_mask(uint32_t id, uint32_t index) const
 	return m.members[index].decoration_flags;
 }
 
+bool Compiler::has_member_decoration(uint32_t id, uint32_t index, Decoration decoration)
+{
+	return (get_member_decoration_mask(id, index) & (1ull << decoration));
+}
+
 void Compiler::unset_member_decoration(uint32_t id, uint32_t index, Decoration decoration)
 {
 	auto &m = meta.at(id);
@@ -1015,6 +1020,11 @@ uint64_t Compiler::get_decoration_mask(uint32_t id) const
 {
 	auto &dec = meta.at(id).decoration;
 	return dec.decoration_flags;
+}
+
+bool Compiler::has_decoration(uint32_t id, Decoration decoration)
+{
+	return (get_decoration_mask(id) & (1ull << decoration));
 }
 
 uint32_t Compiler::get_decoration(uint32_t id, Decoration decoration) const

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -920,9 +920,9 @@ uint64_t Compiler::get_member_decoration_mask(uint32_t id, uint32_t index) const
 	return m.members[index].decoration_flags;
 }
 
-bool Compiler::has_member_decoration(uint32_t id, uint32_t index, Decoration decoration)
+bool Compiler::has_member_decoration(uint32_t id, uint32_t index, Decoration decoration) const
 {
-	return (get_member_decoration_mask(id, index) & (1ull << decoration));
+	return get_member_decoration_mask(id, index) & (1ull << decoration);
 }
 
 void Compiler::unset_member_decoration(uint32_t id, uint32_t index, Decoration decoration)
@@ -1022,9 +1022,9 @@ uint64_t Compiler::get_decoration_mask(uint32_t id) const
 	return dec.decoration_flags;
 }
 
-bool Compiler::has_decoration(uint32_t id, Decoration decoration)
+bool Compiler::has_decoration(uint32_t id, Decoration decoration) const
 {
-	return (get_decoration_mask(id) & (1ull << decoration));
+	return get_decoration_mask(id) & (1ull << decoration);
 }
 
 uint32_t Compiler::get_decoration(uint32_t id, Decoration decoration) const

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -138,7 +138,7 @@ public:
 	uint64_t get_decoration_mask(uint32_t id) const;
 
 	// Returns whether the decoration has been applied to the ID.
-	bool has_decoration(uint32_t id, spv::Decoration decoration);
+	bool has_decoration(uint32_t id, spv::Decoration decoration) const;
 
 	// Gets the value for decorations which take arguments.
 	// If the decoration is a boolean (i.e. spv::DecorationNonWritable),
@@ -183,7 +183,7 @@ public:
 	uint64_t get_member_decoration_mask(uint32_t id, uint32_t index) const;
 
 	// Returns whether the decoration has been applied to a member of a struct.
-	bool has_member_decoration(uint32_t id, uint32_t index, spv::Decoration decoration);
+	bool has_member_decoration(uint32_t id, uint32_t index, spv::Decoration decoration) const;
 
 	// Similar to set_decoration, but for struct members.
 	void set_member_decoration(uint32_t id, uint32_t index, spv::Decoration decoration, uint32_t argument = 0);

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -137,6 +137,9 @@ public:
 	// I.e. (1ull << spv::DecorationFoo) | (1ull << spv::DecorationBar)
 	uint64_t get_decoration_mask(uint32_t id) const;
 
+	// Returns whether the decoration has been applied to the ID.
+	bool has_decoration(uint32_t id, spv::Decoration decoration);
+
 	// Gets the value for decorations which take arguments.
 	// If the decoration is a boolean (i.e. spv::DecorationNonWritable),
 	// 1 will be returned.
@@ -178,6 +181,9 @@ public:
 
 	// Gets the decoration mask for a member of a struct, similar to get_decoration_mask.
 	uint64_t get_member_decoration_mask(uint32_t id, uint32_t index) const;
+
+	// Returns whether the decoration has been applied to a member of a struct.
+	bool has_member_decoration(uint32_t id, uint32_t index, spv::Decoration decoration);
 
 	// Similar to set_decoration, but for struct members.
 	void set_member_decoration(uint32_t id, uint32_t index, spv::Decoration decoration, uint32_t argument = 0);

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1646,6 +1646,15 @@ void CompilerGLSL::handle_invalid_expression(uint32_t id)
 	force_recompile = true;
 }
 
+// Converts the format of the current expression from packed to unpacked,
+// by wrapping the expression in a constructor of the appropriate type.
+// GLSL does not support packed formats, so simply return the expression.
+// Subclasses that do will override
+string CompilerGLSL::unpack_expression_type(string expr_str, const SPIRType &)
+{
+	return expr_str;
+}
+
 // Sometimes we proactively enclosed an expression where it turns out we might have not needed it after all.
 void CompilerGLSL::strip_enclosed_expression(string &expr)
 {
@@ -3337,6 +3346,13 @@ string CompilerGLSL::access_chain_internal(uint32_t base, const uint32_t *indice
 				expr += ".";
 				expr += to_member_name(*type, index);
 			}
+
+			if (member_is_packed_type(*type, index))
+			{
+				auto &membertype = get<SPIRType>(type->member_types[index]);
+				expr = unpack_expression_type(expr, membertype);
+			}
+
 			row_major_matrix_needs_conversion = member_is_non_native_row_major_matrix(*type, index);
 			type = &get<SPIRType>(type->member_types[index]);
 		}
@@ -5428,7 +5444,7 @@ void CompilerGLSL::add_member_name(SPIRType &type, uint32_t index)
 	}
 }
 
-// Checks whether the member is a row_major matrix that requires conversion before use
+// Checks whether the ID is a row_major matrix that requires conversion before use
 bool CompilerGLSL::is_non_native_row_major_matrix(uint32_t id)
 {
 	// Natively supported row-major matrices do not need to be converted.
@@ -5469,6 +5485,13 @@ bool CompilerGLSL::member_is_non_native_row_major_matrix(const SPIRType &type, u
 		SPIRV_CROSS_THROW("Row-major matrices must be square on this platform.");
 
 	return true;
+}
+
+// Checks whether the member is in packed data type, that might need to be unpacked.
+// GLSL does not define packed data types, but certain subclasses do.
+bool CompilerGLSL::member_is_packed_type(const SPIRType &type, uint32_t index)
+{
+	return has_member_decoration(type.self, index, DecorationCPacked);
 }
 
 // Wraps the expression string in a function call that converts the

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -504,7 +504,7 @@ void CompilerGLSL::emit_struct(SPIRType &type)
 	for (auto &member : type.member_types)
 	{
 		add_member_name(type, i);
-		emit_stuct_member(type, member, i);
+		emit_struct_member(type, member, i);
 		i++;
 		emitted = true;
 	}
@@ -1104,7 +1104,7 @@ void CompilerGLSL::emit_buffer_block_native(const SPIRVariable &var)
 	for (auto &member : type.member_types)
 	{
 		add_member_name(type, i);
-		emit_stuct_member(type, member, i);
+		emit_struct_member(type, member, i);
 		i++;
 	}
 
@@ -1194,7 +1194,7 @@ void CompilerGLSL::emit_flattened_io_block(const SPIRVariable &var, const char *
 		// which is not allowed.
 		auto member_name = get_member_name(type.self, i);
 		set_member_name(type.self, i, sanitize_underscores(join(to_name(type.self), "_", member_name)));
-		emit_stuct_member(type, member, i, qual);
+		emit_struct_member(type, member, i, qual);
 		// Restore member name.
 		set_member_name(type.self, i, member_name);
 		i++;
@@ -1256,7 +1256,7 @@ void CompilerGLSL::emit_interface_block(const SPIRVariable &var)
 			for (auto &member : type.member_types)
 			{
 				add_member_name(type, i);
-				emit_stuct_member(type, member, i);
+				emit_struct_member(type, member, i);
 				i++;
 			}
 
@@ -5541,8 +5541,8 @@ string CompilerGLSL::variable_decl(const SPIRType &type, const string &name)
 
 // Emit a structure member. Subclasses may override to modify output,
 // or to dynamically add a padding member if needed.
-void CompilerGLSL::emit_stuct_member(const SPIRType &type, const uint32_t member_type_id, uint32_t index,
-                                     const string &qualifier)
+void CompilerGLSL::emit_struct_member(const SPIRType &type, uint32_t member_type_id, uint32_t index,
+                                      const string &qualifier)
 {
 	auto &membertype = get<SPIRType>(member_type_id);
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -159,8 +159,8 @@ protected:
 	virtual void emit_texture_op(const Instruction &i);
 	virtual std::string type_to_glsl(const SPIRType &type);
 	virtual std::string builtin_to_glsl(spv::BuiltIn builtin);
-	virtual std::string member_decl(const SPIRType &type, const SPIRType &member_type, uint32_t member,
-	                                const std::string &qualifier = "");
+	virtual void emit_stuct_member(const SPIRType &type, const uint32_t member_type_id, uint32_t index,
+	                               const std::string &qualifier = "");
 	virtual std::string image_type_glsl(const SPIRType &type);
 	virtual std::string constant_expression(const SPIRConstant &c);
 	std::string constant_op_expression(const SPIRConstantOp &cop);

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -180,6 +180,7 @@ protected:
 	virtual void emit_buffer_block(const SPIRVariable &type);
 	virtual void emit_push_constant_block(const SPIRVariable &var);
 	virtual void emit_uniform(const SPIRVariable &var);
+	virtual std::string unpack_expression_type(std::string expr_str, const SPIRType &type);
 
 	std::unique_ptr<std::ostringstream> buffer;
 
@@ -247,6 +248,7 @@ protected:
 
 	bool is_non_native_row_major_matrix(uint32_t id);
 	bool member_is_non_native_row_major_matrix(const SPIRType &type, uint32_t index);
+	bool member_is_packed_type(const SPIRType &type, uint32_t index);
 	virtual std::string convert_row_major_matrix(std::string exp_str);
 
 	std::unordered_set<std::string> local_variable_names;

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -159,8 +159,8 @@ protected:
 	virtual void emit_texture_op(const Instruction &i);
 	virtual std::string type_to_glsl(const SPIRType &type);
 	virtual std::string builtin_to_glsl(spv::BuiltIn builtin);
-	virtual void emit_stuct_member(const SPIRType &type, const uint32_t member_type_id, uint32_t index,
-	                               const std::string &qualifier = "");
+	virtual void emit_struct_member(const SPIRType &type, uint32_t member_type_id, uint32_t index,
+	                                const std::string &qualifier = "");
 	virtual std::string image_type_glsl(const SPIRType &type);
 	virtual std::string constant_expression(const SPIRConstant &c);
 	std::string constant_op_expression(const SPIRConstantOp &cop);

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -471,9 +471,7 @@ void CompilerHLSL::emit_buffer_block(const SPIRVariable &var)
 	for (auto &member : type.member_types)
 	{
 		add_member_name(type, i);
-
-		auto &membertype = get<SPIRType>(member);
-		statement(member_decl(type, membertype, i), ";");
+		emit_stuct_member(type, member, i);
 		i++;
 	}
 	end_scope_decl();

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -471,7 +471,7 @@ void CompilerHLSL::emit_buffer_block(const SPIRVariable &var)
 	for (auto &member : type.member_types)
 	{
 		add_member_name(type, i);
-		emit_stuct_member(type, member, i);
+		emit_struct_member(type, member, i);
 		i++;
 	}
 	end_scope_decl();

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -623,6 +623,13 @@ MSLStructMemberKey CompilerMSL::get_struct_member_key(uint32_t type_id, uint32_t
 	return k;
 }
 
+// Converts the format of the current expression from packed to unpacked,
+// by wrapping the expression in a constructor of the appropriate type.
+string CompilerMSL::unpack_expression_type(string expr_str, const SPIRType &type)
+{
+	return join(type_to_glsl(type), "(", expr_str, ")");
+}
+
 // Emits the file header info
 void CompilerMSL::emit_header()
 {
@@ -1308,7 +1315,7 @@ void CompilerMSL::emit_stuct_member(const SPIRType &type, const uint32_t member_
 		statement("char pad", to_string(index), "[", to_string(pad_len), "];");
 
 	// If this member is packed, mark it as so.
-	string pack_pfx = has_member_decoration(type.self, index, DecorationCPacked) ? "packed_" : "";
+	string pack_pfx = member_is_packed_type(type, index) ? "packed_" : "";
 
 	statement(pack_pfx, type_to_glsl(membertype), " ", qualifier, to_member_name(type, index),
 	          type_to_array_glsl(membertype), member_attribute_qualifier(type, index), ";");

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1594,7 +1594,7 @@ string CompilerMSL::entry_point_args(bool append_comma)
 			auto &type = get<SPIRType>(var.basetype);
 
 			if ((var.storage == StorageClassUniform || var.storage == StorageClassUniformConstant ||
-			     var.storage == StorageClassPushConstant))
+			     var.storage == StorageClassPushConstant) && !is_hidden_variable(var))
 			{
 				switch (type.basetype)
 				{

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -28,7 +28,7 @@ using namespace std;
 static const uint32_t k_unknown_location = ~0;
 
 CompilerMSL::CompilerMSL(vector<uint32_t> spirv_, vector<MSLVertexAttr> *p_vtx_attrs,
-                         std::vector<MSLResourceBinding> *p_res_bindings)
+                         vector<MSLResourceBinding> *p_res_bindings)
     : CompilerGLSL(move(spirv_))
 {
 	populate_func_name_overrides();
@@ -119,7 +119,7 @@ string CompilerMSL::compile()
 	return buffer->str();
 }
 
-string CompilerMSL::compile(vector<MSLVertexAttr> *p_vtx_attrs, std::vector<MSLResourceBinding> *p_res_bindings)
+string CompilerMSL::compile(vector<MSLVertexAttr> *p_vtx_attrs, vector<MSLResourceBinding> *p_res_bindings)
 {
 	if (p_vtx_attrs)
 	{
@@ -139,7 +139,7 @@ string CompilerMSL::compile(vector<MSLVertexAttr> *p_vtx_attrs, std::vector<MSLR
 }
 
 string CompilerMSL::compile(MSLConfiguration &msl_cfg, vector<MSLVertexAttr> *p_vtx_attrs,
-                            std::vector<MSLResourceBinding> *p_res_bindings)
+                            vector<MSLResourceBinding> *p_res_bindings)
 {
 	options = msl_cfg;
 	return compile(p_vtx_attrs, p_res_bindings);
@@ -183,7 +183,7 @@ void CompilerMSL::extract_global_variables_from_functions()
 {
 
 	// Uniforms
-	std::unordered_set<uint32_t> global_var_ids;
+	unordered_set<uint32_t> global_var_ids;
 	for (auto &id : ids)
 	{
 		if (id.get_type() == TypeVariable)
@@ -203,7 +203,7 @@ void CompilerMSL::extract_global_variables_from_functions()
 		global_var_ids.insert(var);
 
 	std::set<uint32_t> added_arg_ids;
-	std::unordered_set<uint32_t> processed_func_ids;
+	unordered_set<uint32_t> processed_func_ids;
 	extract_global_variables_from_function(entry_point, added_arg_ids, global_var_ids, processed_func_ids);
 }
 
@@ -211,8 +211,8 @@ void CompilerMSL::extract_global_variables_from_functions()
 // For any global variable accessed directly by the specified function, extract that variable,
 // add it as an argument to that function, and the arg to the added_arg_ids collection.
 void CompilerMSL::extract_global_variables_from_function(uint32_t func_id, std::set<uint32_t> &added_arg_ids,
-                                                         std::unordered_set<uint32_t> &global_var_ids,
-                                                         std::unordered_set<uint32_t> &processed_func_ids)
+                                                         unordered_set<uint32_t> &global_var_ids,
+                                                         unordered_set<uint32_t> &processed_func_ids)
 {
 	// Avoid processing a function more than once
 	if (processed_func_ids.find(func_id) != processed_func_ids.end())
@@ -1814,7 +1814,7 @@ string CompilerMSL::to_qualified_member_name(const SPIRType &type, uint32_t inde
 	// Strip any underscore prefix from member name
 	string mbr_name = to_member_name(type, index);
 	size_t startPos = mbr_name.find_first_not_of("_");
-	mbr_name = (startPos != std::string::npos) ? mbr_name.substr(startPos) : "";
+	mbr_name = (startPos != string::npos) ? mbr_name.substr(startPos) : "";
 	return join(to_name(type.self), "_", mbr_name);
 }
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -606,7 +606,7 @@ void CompilerMSL::align_struct(SPIRType &ib_type)
 		// pass will mark the packed member, and the second pass will insert a padding member.
 		// If we ever move to a single-pass design, this will break.
 		uint32_t mbr_offset = get_member_decoration(ib_type_id, mbr_idx, DecorationOffset);
-		int32_t gap = mbr_offset - curr_offset;
+		int32_t gap = (int32_t)mbr_offset - (int32_t)curr_offset;
 		if (gap > 0)
 		{
 			// Since MSL and SPIR-V have slightly different struct member alignment and
@@ -1333,8 +1333,8 @@ void CompilerMSL::emit_fixup()
 }
 
 // Emit a structure member, padding and packing to maintain the correct memeber alignments.
-void CompilerMSL::emit_stuct_member(const SPIRType &type, const uint32_t member_type_id, uint32_t index,
-                                    const string &qualifier)
+void CompilerMSL::emit_struct_member(const SPIRType &type, uint32_t member_type_id, uint32_t index,
+                                     const string &qualifier)
 {
 	auto &membertype = get<SPIRType>(member_type_id);
 
@@ -2126,7 +2126,6 @@ size_t CompilerMSL::get_declared_type_size(uint32_t type_id, uint64_t dec_mask) 
 	case SPIRType::SampledImage:
 	case SPIRType::Sampler:
 		SPIRV_CROSS_THROW("Querying size of opaque object.");
-		return 4; // A pointer
 
 	case SPIRType::Struct:
 		return get_declared_struct_size(type);
@@ -2196,7 +2195,6 @@ size_t CompilerMSL::get_declared_type_alignment(uint32_t type_id, uint64_t dec_m
 	case SPIRType::SampledImage:
 	case SPIRType::Sampler:
 		SPIRV_CROSS_THROW("Querying alignment of opaque object.");
-		return 4; // A pointer
 
 	case SPIRType::Struct:
 		return 16; // Per Vulkan spec section 14.5.4

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -163,6 +163,8 @@ protected:
 	uint32_t get_ordered_member_location(uint32_t type_id, uint32_t index);
 	size_t get_declared_type_size(uint32_t type_id) const;
 	size_t get_declared_type_size(uint32_t type_id, uint64_t dec_mask) const;
+	size_t get_declared_struct_member_alignment(const SPIRType &struct_type, uint32_t index) const;
+	size_t get_declared_type_alignment(uint32_t type_id, uint64_t dec_mask) const;
 	std::string to_component_argument(uint32_t id);
 	void exclude_from_stage_in(SPIRVariable &var);
 	void exclude_member_from_stage_in(const SPIRType &type, uint32_t index);

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -126,6 +126,7 @@ protected:
 	                             uint32_t coord, uint32_t coord_components, uint32_t dref, uint32_t grad_x,
 	                             uint32_t grad_y, uint32_t lod, uint32_t coffset, uint32_t offset, uint32_t bias,
 	                             uint32_t comp, uint32_t sample, bool *p_forward) override;
+	std::string unpack_expression_type(std::string expr_str, const SPIRType &type) override;
 
 	std::string get_argument_address_space(const SPIRVariable &argument);
 

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -69,7 +69,7 @@ struct MSLResourceBinding
 };
 
 // Tracks the type ID and member index of a struct member
-typedef uint64_t MSLStructMemberKey;
+using MSLStructMemberKey = uint64_t;
 
 // Special constant used in a MSLResourceBinding desc_set
 // element to indicate the bindings for the push constants.
@@ -110,8 +110,8 @@ protected:
 	void emit_function_prototype(SPIRFunction &func, uint64_t return_flags) override;
 	void emit_sampled_image_op(uint32_t result_type, uint32_t result_id, uint32_t image_id, uint32_t samp_id) override;
 	void emit_fixup() override;
-	void emit_stuct_member(const SPIRType &type, const uint32_t member_type_id, uint32_t index,
-	                       const std::string &qualifier = "") override;
+	void emit_struct_member(const SPIRType &type, uint32_t member_type_id, uint32_t index,
+	                        const std::string &qualifier = "") override;
 	std::string type_to_glsl(const SPIRType &type) override;
 	std::string image_type_glsl(const SPIRType &type) override;
 	std::string builtin_to_glsl(spv::BuiltIn builtin) override;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -169,6 +169,7 @@ protected:
 	std::string add_input_buffer_block_member(uint32_t mbr_type_id, std::string mbr_name, uint32_t mbr_locn);
 	uint32_t get_input_buffer_block_var_id(uint32_t msl_buffer);
 	void align_struct(SPIRType &ib_type);
+	bool is_member_packable(SPIRType &ib_type, uint32_t index);
 	MSLStructMemberKey get_struct_member_key(uint32_t type_id, uint32_t index);
 
 	MSLConfiguration msl_config;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -27,9 +27,6 @@
 namespace spirv_cross
 {
 
-// Deprecated legacy syntax
-#define MSLConfiguration CompilerMSL::Options
-
 // Defines MSL characteristics of a vertex attribute at a particular location.
 // The used_by_shader flag is set to true during compilation of SPIR-V to MSL
 // if the shader makes use of this vertex attribute.
@@ -119,6 +116,7 @@ public:
 	std::string compile(std::vector<MSLVertexAttr> *p_vtx_attrs, std::vector<MSLResourceBinding> *p_res_bindings);
 
 	// This legacy method is deprecated.
+	typedef Options MSLConfiguration;
 	std::string compile(MSLConfiguration &msl_cfg, std::vector<MSLVertexAttr> *p_vtx_attrs = nullptr,
 	                    std::vector<MSLResourceBinding> *p_res_bindings = nullptr);
 

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -33,6 +33,7 @@ struct MSLConfiguration
 	bool flip_vert_y = false;
 	bool flip_frag_y = false;
 	bool is_rendering_points = false;
+	bool pad_and_pack_uniform_structs = false;
 	std::string entry_point_name;
 };
 
@@ -66,6 +67,9 @@ struct MSLResourceBinding
 
 	bool used_by_shader = false;
 };
+
+// Tracks the type ID and member index of a struct member
+typedef uint64_t MSLStructMemberKey;
 
 // Special constant used in a MSLResourceBinding desc_set
 // element to indicate the bindings for the push constants.
@@ -106,11 +110,11 @@ protected:
 	void emit_function_prototype(SPIRFunction &func, uint64_t return_flags) override;
 	void emit_sampled_image_op(uint32_t result_type, uint32_t result_id, uint32_t image_id, uint32_t samp_id) override;
 	void emit_fixup() override;
+	void emit_stuct_member(const SPIRType &type, const uint32_t member_type_id, uint32_t index,
+	                       const std::string &qualifier = "") override;
 	std::string type_to_glsl(const SPIRType &type) override;
 	std::string image_type_glsl(const SPIRType &type) override;
 	std::string builtin_to_glsl(spv::BuiltIn builtin) override;
-	std::string member_decl(const SPIRType &type, const SPIRType &member_type, uint32_t member,
-	                        const std::string &qualifier) override;
 	std::string constant_expression(const SPIRConstant &c) override;
 	size_t get_declared_struct_member_size(const SPIRType &struct_type, uint32_t index) const override;
 	std::string to_func_call_arg(uint32_t id) override;
@@ -163,8 +167,8 @@ protected:
 	void exclude_member_from_stage_in(const SPIRType &type, uint32_t index);
 	std::string add_input_buffer_block_member(uint32_t mbr_type_id, std::string mbr_name, uint32_t mbr_locn);
 	uint32_t get_input_buffer_block_var_id(uint32_t msl_buffer);
-	void pad_input_buffer_block(uint32_t ib_type_id);
-	SPIRType &get_pad_type(uint32_t pad_len);
+	void align_struct(SPIRType &ib_type);
+	MSLStructMemberKey get_struct_member_key(uint32_t type_id, uint32_t index);
 
 	MSLConfiguration msl_config;
 	std::unordered_map<std::string, std::string> func_name_overrides;
@@ -172,7 +176,7 @@ protected:
 	std::set<uint32_t> custom_function_ops;
 	std::unordered_map<uint32_t, MSLVertexAttr *> vtx_attrs_by_location;
 	std::map<uint32_t, uint32_t> non_stage_in_input_var_ids;
-	std::unordered_map<uint32_t, uint32_t> pad_type_ids_by_pad_len;
+	std::unordered_map<MSLStructMemberKey, uint32_t> struct_member_padding;
 	std::vector<MSLResourceBinding *> resource_bindings;
 	MSLResourceBinding next_metal_resource_index;
 	uint32_t stage_in_var_id = 0;
@@ -216,12 +220,8 @@ protected:
 
 		void sort();
 		bool operator()(uint32_t mbr_idx1, uint32_t mbr_idx2);
-		MemberSorter(SPIRType &t, Meta &m, SortAspect sa)
-		    : type(t)
-		    , meta(m)
-		    , sort_aspect(sa)
-		{
-		}
+		MemberSorter(SPIRType &t, Meta &m, SortAspect sa);
+
 		SPIRType &type;
 		Meta &meta;
 		SortAspect sort_aspect;

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -91,7 +91,7 @@ def cross_compile_msl(shader):
     os.close(msl_f)
     subprocess.check_call(['glslangValidator', '-V', '-o', spirv_path, shader])
     spirv_cross_path = './spirv-cross'
-    subprocess.check_call([spirv_cross_path, '--entry', 'main', '--output', msl_path, spirv_path, '--metal'])
+    subprocess.check_call([spirv_cross_path, '--entry', 'main', '--output', msl_path, spirv_path, '--msl'])
     subprocess.check_call(['spirv-val', spirv_path])
     return (spirv_path, msl_path)
 
@@ -294,7 +294,7 @@ def test_shaders_helper(stats, shader_dir, update, malisc, keep, backend):
         for i in files:
             path = os.path.join(root, i)
             relpath = os.path.relpath(path, shader_dir)
-            if backend == 'metal':
+            if backend == 'msl':
                 test_shader_msl(stats, (shader_dir, relpath), update, keep)
             elif backend == 'hlsl':
                 test_shader_hlsl(stats, (shader_dir, relpath), update, keep)
@@ -322,7 +322,7 @@ def main():
     parser.add_argument('--malisc',
             action = 'store_true',
             help = 'Use malisc offline compiler to determine static cycle counts before and after spirv-cross.')
-    parser.add_argument('--metal',
+    parser.add_argument('--msl',
             action = 'store_true',
             help = 'Test Metal backend.')
     parser.add_argument('--hlsl',
@@ -337,13 +337,13 @@ def main():
         sys.stderr.write('Need shader folder.\n')
         sys.exit(1)
 
-    if args.metal:
+    if args.msl:
         print_msl_compiler_version()
 
     global force_no_external_validation
     force_no_external_validation = args.force_no_external_validation
 
-    test_shaders(args.folder, args.update, args.malisc, args.keep, 'metal' if args.metal else ('hlsl' if args.hlsl else 'glsl'))
+    test_shaders(args.folder, args.update, args.malisc, args.keep, 'msl' if args.msl else ('hlsl' if args.hlsl else 'glsl'))
     if args.malisc:
         print('Stats in stats.csv!')
     print('Tests completed!')

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -325,6 +325,9 @@ def main():
     parser.add_argument('--msl',
             action = 'store_true',
             help = 'Test Metal backend.')
+    parser.add_argument('--metal',
+            action = 'store_true',
+            help = 'Deprecated Metal option. Use --msl instead.')
     parser.add_argument('--hlsl',
             action = 'store_true',
             help = 'Test HLSL backend.')
@@ -343,7 +346,7 @@ def main():
     global force_no_external_validation
     force_no_external_validation = args.force_no_external_validation
 
-    test_shaders(args.folder, args.update, args.malisc, args.keep, 'msl' if args.msl else ('hlsl' if args.hlsl else 'glsl'))
+    test_shaders(args.folder, args.update, args.malisc, args.keep, 'msl' if (args.msl or args.metal) else ('hlsl' if args.hlsl else 'glsl'))
     if args.malisc:
         print('Stats in stats.csv!')
     print('Tests completed!')


### PR DESCRIPTION
MSL and SPIR-V (std140) have slightly different structure member size and alignment rules.
This PR pads and packs MSL struct members to align them with the SPIR-V offsets.