### PR TITLE
Just fix a few minor warnings.

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -3531,7 +3531,7 @@ std::string CompilerGLSL::flattened_access_chain_struct(uint32_t base, const uin
 	expr += type_to_glsl_constructor(target_type);
 	expr += "(";
 
-	for (size_t i = 0; i < target_type.member_types.size(); ++i)
+	for (uint32_t i = 0; i < uint32_t(target_type.member_types.size()); ++i)
 	{
 		if (i != 0)
 			expr += ", ";


### PR DESCRIPTION
 The variable i was used as a uint32_t in multiple places, like type_member_for_offset, so changed its type.

I build SPIRV-Cross as part of my project so I see these quite a bit.