### PR TITLE
Rewrite HLSL backend handling of inputs and outputs

### DIFF
--- a/reference/shaders-hlsl/frag/basic.frag
+++ b/reference/shaders-hlsl/frag/basic.frag
@@ -4,15 +4,15 @@ static float4 FragColor;
 static float4 vColor;
 static float2 vTex;
 
-struct InputFrag
+struct SPIRV_Cross_Input
 {
     float4 vColor : TEXCOORD0;
     float2 vTex : TEXCOORD1;
 };
 
-struct OutputFrag
+struct SPIRV_Cross_Output
 {
-    float4 FragColor : COLOR;
+    float4 FragColor : COLOR0;
 };
 
 void frag_main()
@@ -20,12 +20,12 @@ void frag_main()
     FragColor = vColor * tex2D(uTex, vTex);
 }
 
-OutputFrag main(InputFrag input)
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
-    vColor = input.vColor;
-    vTex = input.vTex;
+    vColor = stage_input.vColor;
+    vTex = stage_input.vTex;
     frag_main();
-    OutputFrag output;
-    output.FragColor = FragColor;
-    return output;
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
 }

--- a/reference/shaders-hlsl/frag/basic.frag
+++ b/reference/shaders-hlsl/frag/basic.frag
@@ -12,7 +12,7 @@ struct SPIRV_Cross_Input
 
 struct SPIRV_Cross_Output
 {
-    float4 FragColor : COLOR0;
+    float4 FragColor : SV_Target0;
 };
 
 void frag_main()

--- a/reference/shaders-hlsl/frag/builtins.frag
+++ b/reference/shaders-hlsl/frag/builtins.frag
@@ -5,14 +5,14 @@ static float4 vColor;
 
 struct SPIRV_Cross_Input
 {
-    float4 gl_FragCoord : VPOS;
+    float4 gl_FragCoord : SV_Position;
     float4 vColor : TEXCOORD0;
 };
 
 struct SPIRV_Cross_Output
 {
-    float gl_FragDepth : DEPTH;
-    float4 FragColor : COLOR0;
+    float gl_FragDepth : SV_Depth;
+    float4 FragColor : SV_Target0;
 };
 
 void frag_main()
@@ -23,7 +23,7 @@ void frag_main()
 
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
-    gl_FragCoord = stage_input.gl_FragCoord + float4(0.5f, 0.5f, 0.0f, 0.0f);
+    gl_FragCoord = stage_input.gl_FragCoord;
     vColor = stage_input.vColor;
     frag_main();
     SPIRV_Cross_Output stage_output;

--- a/reference/shaders-hlsl/frag/builtins.frag
+++ b/reference/shaders-hlsl/frag/builtins.frag
@@ -1,0 +1,33 @@
+static float4 gl_FragCoord;
+static float gl_FragDepth;
+static float4 FragColor;
+static float4 vColor;
+
+struct SPIRV_Cross_Input
+{
+    float4 gl_FragCoord : VPOS;
+    float4 vColor : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float gl_FragDepth : DEPTH;
+    float4 FragColor : COLOR0;
+};
+
+void frag_main()
+{
+    FragColor = gl_FragCoord + vColor;
+    gl_FragDepth = 0.5f;
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    gl_FragCoord = stage_input.gl_FragCoord + float4(0.5f, 0.5f, 0.0f, 0.0f);
+    vColor = stage_input.vColor;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_FragDepth = gl_FragDepth;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/frag/io-block.frag
+++ b/reference/shaders-hlsl/frag/io-block.frag
@@ -1,0 +1,28 @@
+static float4 FragColor;
+
+struct VertexOut
+{
+    float4 a : TEXCOORD1;
+    float4 b : TEXCOORD2;
+};
+
+static VertexOut _12;
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    FragColor = _12.a + _12.b;
+}
+
+SPIRV_Cross_Output main(in VertexOut stage_input_12)
+{
+    _12 = stage_input_12;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/frag/mrt.frag
+++ b/reference/shaders-hlsl/frag/mrt.frag
@@ -5,10 +5,10 @@ static float4 RT3;
 
 struct SPIRV_Cross_Output
 {
-    float4 RT0 : COLOR0;
-    float4 RT1 : COLOR1;
-    float4 RT2 : COLOR2;
-    float4 RT3 : COLOR3;
+    float4 RT0 : SV_Target0;
+    float4 RT1 : SV_Target1;
+    float4 RT2 : SV_Target2;
+    float4 RT3 : SV_Target3;
 };
 
 void frag_main()

--- a/reference/shaders-hlsl/frag/mrt.frag
+++ b/reference/shaders-hlsl/frag/mrt.frag
@@ -1,0 +1,31 @@
+static float4 RT0;
+static float4 RT1;
+static float4 RT2;
+static float4 RT3;
+
+struct SPIRV_Cross_Output
+{
+    float4 RT0 : COLOR0;
+    float4 RT1 : COLOR1;
+    float4 RT2 : COLOR2;
+    float4 RT3 : COLOR3;
+};
+
+void frag_main()
+{
+    RT0 = float4(1.0f, 1.0f, 1.0f, 1.0f);
+    RT1 = float4(2.0f, 2.0f, 2.0f, 2.0f);
+    RT2 = float4(3.0f, 3.0f, 3.0f, 3.0f);
+    RT3 = float4(4.0f, 4.0f, 4.0f, 4.0f);
+}
+
+SPIRV_Cross_Output main()
+{
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.RT0 = RT0;
+    stage_output.RT1 = RT1;
+    stage_output.RT2 = RT2;
+    stage_output.RT3 = RT3;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/frag/no-return.frag
+++ b/reference/shaders-hlsl/frag/no-return.frag
@@ -1,0 +1,8 @@
+void frag_main()
+{
+}
+
+void main()
+{
+    frag_main();
+}

--- a/reference/shaders-hlsl/frag/no-return2.frag
+++ b/reference/shaders-hlsl/frag/no-return2.frag
@@ -1,0 +1,17 @@
+static float4 vColor;
+
+struct SPIRV_Cross_Input
+{
+    float4 vColor : TEXCOORD0;
+};
+
+void frag_main()
+{
+    float4 v = vColor;
+}
+
+void main(SPIRV_Cross_Input stage_input)
+{
+    vColor = stage_input.vColor;
+    frag_main();
+}

--- a/reference/shaders-hlsl/vert/basic.vert
+++ b/reference/shaders-hlsl/vert/basic.vert
@@ -14,16 +14,16 @@ static float4 aVertex;
 static float3 vNormal;
 static float3 aNormal;
 
-struct InputVert
+struct SPIRV_Cross_Input
 {
     float3 aNormal : TEXCOORD0;
     float4 aVertex : TEXCOORD1;
 };
 
-struct OutputVert
+struct SPIRV_Cross_Output
 {
-    float3 vNormal : TEXCOORD0;
     float4 gl_Position : POSITION;
+    float3 vNormal : TEXCOORD2;
 };
 
 void vert_main()
@@ -32,15 +32,15 @@ void vert_main()
     vNormal = aNormal;
 }
 
-OutputVert main(InputVert input)
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
-    aVertex = input.aVertex;
-    aNormal = input.aNormal;
+    aVertex = stage_input.aVertex;
+    aNormal = stage_input.aNormal;
     vert_main();
-    OutputVert output;
-    output.gl_Position = gl_Position;
-    output.vNormal = vNormal;
-    output.gl_Position.x = output.gl_Position.x - gl_HalfPixel.x * output.gl_Position.w;
-    output.gl_Position.y = output.gl_Position.y + gl_HalfPixel.y * output.gl_Position.w;
-    return output;
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    stage_output.vNormal = vNormal;
+    stage_output.gl_Position.x = stage_output.gl_Position.x - gl_HalfPixel.x * stage_output.gl_Position.w;
+    stage_output.gl_Position.y = stage_output.gl_Position.y + gl_HalfPixel.y * stage_output.gl_Position.w;
+    return stage_output;
 }

--- a/reference/shaders-hlsl/vert/basic.vert
+++ b/reference/shaders-hlsl/vert/basic.vert
@@ -23,7 +23,7 @@ struct SPIRV_Cross_Input
 struct SPIRV_Cross_Output
 {
     float4 gl_Position : POSITION;
-    float3 vNormal : TEXCOORD2;
+    float3 vNormal : TEXCOORD0;
 };
 
 void vert_main()

--- a/reference/shaders-hlsl/vert/basic.vert
+++ b/reference/shaders-hlsl/vert/basic.vert
@@ -7,7 +7,6 @@ cbuffer UBO
 {
     _UBO _16;
 };
-uniform float4 gl_HalfPixel;
 
 static float4 gl_Position;
 static float4 aVertex;
@@ -22,7 +21,7 @@ struct SPIRV_Cross_Input
 
 struct SPIRV_Cross_Output
 {
-    float4 gl_Position : POSITION;
+    float4 gl_Position : SV_Position;
     float3 vNormal : TEXCOORD0;
 };
 
@@ -40,7 +39,5 @@ SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
     SPIRV_Cross_Output stage_output;
     stage_output.gl_Position = gl_Position;
     stage_output.vNormal = vNormal;
-    stage_output.gl_Position.x = stage_output.gl_Position.x - gl_HalfPixel.x * stage_output.gl_Position.w;
-    stage_output.gl_Position.y = stage_output.gl_Position.y + gl_HalfPixel.y * stage_output.gl_Position.w;
     return stage_output;
 }

--- a/reference/shaders-hlsl/vert/instancing.vert
+++ b/reference/shaders-hlsl/vert/instancing.vert
@@ -1,0 +1,29 @@
+static float4 gl_Position;
+static int gl_VertexIndex;
+static int gl_InstanceIndex;
+struct SPIRV_Cross_Input
+{
+    uint gl_VertexIndex : SV_VertexID;
+    uint gl_InstanceIndex : SV_InstanceID;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 gl_Position : SV_Position;
+};
+
+void vert_main()
+{
+    float _19 = float(gl_VertexIndex + gl_InstanceIndex);
+    gl_Position = float4(_19, _19, _19, _19);
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    gl_VertexIndex = int(stage_input.gl_VertexIndex);
+    gl_InstanceIndex = int(stage_input.gl_InstanceIndex);
+    vert_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/vert/locations.vert
+++ b/reference/shaders-hlsl/vert/locations.vert
@@ -1,0 +1,68 @@
+struct Foo
+{
+    float3 a;
+    float3 b;
+    float3 c;
+};
+
+uniform float4 gl_HalfPixel;
+
+static float4 gl_Position;
+static float4 Input2;
+static float4 Input4;
+static float4 Input0;
+static float vLocation0;
+static float vLocation1;
+static float vLocation2[2];
+static Foo vLocation4;
+static float vLocation7;
+
+struct SPIRV_Cross_Input
+{
+    float4 Input2 : TEXCOORD2;
+    float4 Input4 : TEXCOORD4;
+    float4 Input0 : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 gl_Position : POSITION;
+    float vLocation0 : TEXCOORD0;
+    float vLocation1 : TEXCOORD1;
+    float vLocation2[2] : TEXCOORD2;
+    Foo vLocation4 : TEXCOORD4;
+    float vLocation7 : TEXCOORD7;
+};
+
+void vert_main()
+{
+    gl_Position = ((float4(1.0f, 1.0f, 1.0f, 1.0f) + Input2) + Input4) + Input0;
+    vLocation0 = 0.0f;
+    vLocation1 = 1.0f;
+    vLocation2[0] = 2.0f;
+    vLocation2[1] = 2.0f;
+    Foo foo;
+    foo.a = float3(1.0f, 1.0f, 1.0f);
+    foo.b = float3(1.0f, 1.0f, 1.0f);
+    foo.c = float3(1.0f, 1.0f, 1.0f);
+    vLocation4 = foo;
+    vLocation7 = 7.0f;
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    Input2 = stage_input.Input2;
+    Input4 = stage_input.Input4;
+    Input0 = stage_input.Input0;
+    vert_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    stage_output.vLocation0 = vLocation0;
+    stage_output.vLocation1 = vLocation1;
+    stage_output.vLocation2 = vLocation2;
+    stage_output.vLocation4 = vLocation4;
+    stage_output.vLocation7 = vLocation7;
+    stage_output.gl_Position.x = stage_output.gl_Position.x - gl_HalfPixel.x * stage_output.gl_Position.w;
+    stage_output.gl_Position.y = stage_output.gl_Position.y + gl_HalfPixel.y * stage_output.gl_Position.w;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/vert/locations.vert
+++ b/reference/shaders-hlsl/vert/locations.vert
@@ -5,8 +5,6 @@ struct Foo
     float3 c;
 };
 
-uniform float4 gl_HalfPixel;
-
 static float4 gl_Position;
 static float4 Input2;
 static float4 Input4;
@@ -26,7 +24,7 @@ struct SPIRV_Cross_Input
 
 struct SPIRV_Cross_Output
 {
-    float4 gl_Position : POSITION;
+    float4 gl_Position : SV_Position;
     float vLocation0 : TEXCOORD0;
     float vLocation1 : TEXCOORD1;
     float vLocation2[2] : TEXCOORD2;
@@ -62,7 +60,5 @@ SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
     stage_output.vLocation2 = vLocation2;
     stage_output.vLocation4 = vLocation4;
     stage_output.vLocation7 = vLocation7;
-    stage_output.gl_Position.x = stage_output.gl_Position.x - gl_HalfPixel.x * stage_output.gl_Position.w;
-    stage_output.gl_Position.y = stage_output.gl_Position.y + gl_HalfPixel.y * stage_output.gl_Position.w;
     return stage_output;
 }

--- a/reference/shaders-hlsl/vert/locations.vert
+++ b/reference/shaders-hlsl/vert/locations.vert
@@ -13,7 +13,15 @@ static float vLocation0;
 static float vLocation1;
 static float vLocation2[2];
 static Foo vLocation4;
-static float vLocation7;
+static float vLocation9;
+
+struct VertexOut
+{
+    float3 color : TEXCOORD7;
+    float3 foo : TEXCOORD8;
+};
+
+static VertexOut vout;
 
 struct SPIRV_Cross_Input
 {
@@ -29,7 +37,7 @@ struct SPIRV_Cross_Output
     float vLocation1 : TEXCOORD1;
     float vLocation2[2] : TEXCOORD2;
     Foo vLocation4 : TEXCOORD4;
-    float vLocation7 : TEXCOORD7;
+    float vLocation9 : TEXCOORD9;
 };
 
 void vert_main()
@@ -44,21 +52,24 @@ void vert_main()
     foo.b = float3(1.0f, 1.0f, 1.0f);
     foo.c = float3(1.0f, 1.0f, 1.0f);
     vLocation4 = foo;
-    vLocation7 = 7.0f;
+    vLocation9 = 9.0f;
+    vout.color = float3(2.0f, 2.0f, 2.0f);
+    vout.foo = float3(4.0f, 4.0f, 4.0f);
 }
 
-SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input, out VertexOut stage_outputvout)
 {
     Input2 = stage_input.Input2;
     Input4 = stage_input.Input4;
     Input0 = stage_input.Input0;
     vert_main();
+    stage_outputvout = vout;
     SPIRV_Cross_Output stage_output;
     stage_output.gl_Position = gl_Position;
     stage_output.vLocation0 = vLocation0;
     stage_output.vLocation1 = vLocation1;
     stage_output.vLocation2 = vLocation2;
     stage_output.vLocation4 = vLocation4;
-    stage_output.vLocation7 = vLocation7;
+    stage_output.vLocation9 = vLocation9;
     return stage_output;
 }

--- a/reference/shaders-hlsl/vert/no-input.vert
+++ b/reference/shaders-hlsl/vert/no-input.vert
@@ -1,0 +1,18 @@
+static float4 gl_Position;
+struct SPIRV_Cross_Output
+{
+    float4 gl_Position : SV_Position;
+};
+
+void vert_main()
+{
+    gl_Position = float4(1.0f, 1.0f, 1.0f, 1.0f);
+}
+
+SPIRV_Cross_Output main()
+{
+    vert_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/vert/qualifiers.vert
+++ b/reference/shaders-hlsl/vert/qualifiers.vert
@@ -1,8 +1,8 @@
 static float4 gl_Position;
-static nointerpolation float vFlat;
-static centroid float vCentroid;
-static sample float vSample;
-static noperspective float vNoperspective;
+static float vFlat;
+static float vCentroid;
+static float vSample;
+static float vNoperspective;
 
 struct Block
 {

--- a/reference/shaders-hlsl/vert/qualifiers.vert
+++ b/reference/shaders-hlsl/vert/qualifiers.vert
@@ -1,0 +1,50 @@
+static float4 gl_Position;
+static nointerpolation float vFlat;
+static centroid float vCentroid;
+static sample float vSample;
+static noperspective float vNoperspective;
+
+struct Block
+{
+    nointerpolation float vFlat : TEXCOORD4;
+    centroid float vCentroid : TEXCOORD5;
+    sample float vSample : TEXCOORD6;
+    noperspective float vNoperspective : TEXCOORD7;
+};
+
+static Block vout;
+
+struct SPIRV_Cross_Output
+{
+    float4 gl_Position : SV_Position;
+    nointerpolation float vFlat : TEXCOORD0;
+    centroid float vCentroid : TEXCOORD1;
+    sample float vSample : TEXCOORD2;
+    noperspective float vNoperspective : TEXCOORD3;
+};
+
+void vert_main()
+{
+    gl_Position = float4(1.0f, 1.0f, 1.0f, 1.0f);
+    vFlat = 0.0f;
+    vCentroid = 1.0f;
+    vSample = 2.0f;
+    vNoperspective = 3.0f;
+    vout.vFlat = 0.0f;
+    vout.vCentroid = 1.0f;
+    vout.vSample = 2.0f;
+    vout.vNoperspective = 3.0f;
+}
+
+SPIRV_Cross_Output main(out Block stage_outputvout)
+{
+    vert_main();
+    stage_outputvout = vout;
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    stage_output.vFlat = vFlat;
+    stage_output.vCentroid = vCentroid;
+    stage_output.vSample = vSample;
+    stage_output.vNoperspective = vNoperspective;
+    return stage_output;
+}

--- a/shaders-hlsl/frag/builtins.frag
+++ b/shaders-hlsl/frag/builtins.frag
@@ -1,0 +1,11 @@
+#version 310 es
+precision mediump float;
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) in vec4 vColor;
+
+void main()
+{
+	FragColor = gl_FragCoord + vColor;
+	gl_FragDepth = 0.5;
+}

--- a/shaders-hlsl/frag/io-block.frag
+++ b/shaders-hlsl/frag/io-block.frag
@@ -1,0 +1,16 @@
+#version 310 es
+#extension GL_EXT_shader_io_blocks : require
+precision mediump float;
+
+layout(location = 1) in VertexOut
+{
+	vec4 a;
+	vec4 b;
+};
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = a + b;
+}

--- a/shaders-hlsl/frag/mrt.frag
+++ b/shaders-hlsl/frag/mrt.frag
@@ -1,0 +1,15 @@
+#version 310 es
+precision mediump float;
+
+layout(location = 0) out vec4 RT0;
+layout(location = 1) out vec4 RT1;
+layout(location = 2) out vec4 RT2;
+layout(location = 3) out vec4 RT3;
+
+void main()
+{
+	RT0 = vec4(1.0);
+	RT1 = vec4(2.0);
+	RT2 = vec4(3.0);
+	RT3 = vec4(4.0);
+}

--- a/shaders-hlsl/frag/no-return.frag
+++ b/shaders-hlsl/frag/no-return.frag
@@ -1,0 +1,5 @@
+#version 310 es
+
+void main()
+{
+}

--- a/shaders-hlsl/frag/no-return2.frag
+++ b/shaders-hlsl/frag/no-return2.frag
@@ -1,0 +1,9 @@
+#version 310 es
+precision mediump float;
+
+layout(location = 0) in vec4 vColor;
+
+void main()
+{
+	vec4 v = vColor;
+}

--- a/shaders-hlsl/vert/instancing.vert
+++ b/shaders-hlsl/vert/instancing.vert
@@ -1,0 +1,6 @@
+#version 310 es
+
+void main()
+{
+	gl_Position = vec4(float(gl_VertexIndex + gl_InstanceIndex));
+}

--- a/shaders-hlsl/vert/locations.vert
+++ b/shaders-hlsl/vert/locations.vert
@@ -1,0 +1,33 @@
+#version 310 es
+
+struct Foo
+{
+	vec3 a;
+	vec3 b;
+	vec3 c;
+};
+
+layout(location = 2) in vec4 Input2;
+layout(location = 4) in vec4 Input4;
+in vec4 Input0;
+
+layout(location = 0) out float vLocation0;
+layout(location = 1) out float vLocation1;
+out float vLocation2[2];
+out Foo vLocation4;
+out float vLocation7;
+
+void main()
+{
+	gl_Position = vec4(1.0) + Input2 + Input4 + Input0;
+	vLocation0 = 0.0;
+	vLocation1 = 1.0;
+	vLocation2[0] = 2.0;
+	vLocation2[1] = 2.0;
+	Foo foo;
+	foo.a = vec3(1.0);
+	foo.b = vec3(1.0);
+	foo.c = vec3(1.0);
+	vLocation4 = foo;
+	vLocation7 = 7.0;
+}

--- a/shaders-hlsl/vert/locations.vert
+++ b/shaders-hlsl/vert/locations.vert
@@ -1,4 +1,5 @@
 #version 310 es
+#extension GL_EXT_shader_io_blocks : require
 
 struct Foo
 {
@@ -7,15 +8,30 @@ struct Foo
 	vec3 c;
 };
 
+// This will lock to input location 2.
 layout(location = 2) in vec4 Input2;
+// This will lock to input location 4.
 layout(location = 4) in vec4 Input4;
+// This will pick first available, which is 0.
 in vec4 Input0;
 
+// Locks output 0.
 layout(location = 0) out float vLocation0;
+// Locks output 1.
 layout(location = 1) out float vLocation1;
+// Picks first available two locations, so, 2 and 3.
 out float vLocation2[2];
+// Picks first available location, 4.
 out Foo vLocation4;
-out float vLocation7;
+// Picks first available location 9.
+out float vLocation9;
+
+// Locks location 7 and 8.
+layout(location = 7) out VertexOut
+{
+	vec3 color;
+	vec3 foo;
+} vout;
 
 void main()
 {
@@ -29,5 +45,7 @@ void main()
 	foo.b = vec3(1.0);
 	foo.c = vec3(1.0);
 	vLocation4 = foo;
-	vLocation7 = 7.0;
+	vLocation9 = 9.0;
+	vout.color = vec3(2.0);
+	vout.foo = vec3(4.0);
 }

--- a/shaders-hlsl/vert/no-input.vert
+++ b/shaders-hlsl/vert/no-input.vert
@@ -1,0 +1,6 @@
+#version 310 es
+
+void main()
+{
+	gl_Position = vec4(1.0);
+}

--- a/shaders-hlsl/vert/qualifiers.vert
+++ b/shaders-hlsl/vert/qualifiers.vert
@@ -1,0 +1,27 @@
+#version 450
+
+layout(location = 0) flat out float vFlat;
+layout(location = 1) centroid out float vCentroid;
+layout(location = 2) sample out float vSample;
+layout(location = 3) noperspective out float vNoperspective;
+
+layout(location = 4) out Block
+{
+	flat float vFlat;
+	centroid float vCentroid;
+	sample float vSample;
+	noperspective float vNoperspective;
+} vout;
+
+void main()
+{
+	gl_Position = vec4(1.0);
+	vFlat = 0.0;
+	vCentroid = 1.0;
+	vSample = 2.0;
+	vNoperspective = 3.0;
+	vout.vFlat = 0.0;
+	vout.vCentroid = 1.0;
+	vout.vSample = 2.0;
+	vout.vNoperspective = 3.0;
+}

--- a/spirv_cpp.cpp
+++ b/spirv_cpp.cpp
@@ -297,6 +297,8 @@ string CompilerCPP::compile()
 	backend.explicit_struct_type = true;
 	backend.use_initializer_list = true;
 
+	update_active_builtins();
+
 	uint32_t pass_count = 0;
 	do
 	{

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -136,7 +136,7 @@ bool Compiler::block_is_pure(const SPIRBlock &block)
 	return true;
 }
 
-string Compiler::to_name(uint32_t id, bool allow_alias)
+string Compiler::to_name(uint32_t id, bool allow_alias) const
 {
 	if (allow_alias && ids.at(id).get_type() == TypeType)
 	{

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -3127,7 +3127,7 @@ bool Compiler::ActiveBuiltinHandler::handle(spv::Op opcode, const uint32_t *args
 		{
 			auto &type = compiler.get<SPIRType>(var->basetype);
 			auto &flags =
-				type.storage == StorageClassInput ? compiler.active_input_builtins : compiler.active_output_builtins;
+			    type.storage == StorageClassInput ? compiler.active_input_builtins : compiler.active_output_builtins;
 			flags |= 1ull << compiler.meta[id].decoration.builtin_type;
 		}
 	};
@@ -3190,7 +3190,8 @@ bool Compiler::ActiveBuiltinHandler::handle(spv::Op opcode, const uint32_t *args
 			type = &compiler.get<SPIRType>(type->parent_type);
 		}
 
-		auto &flags = type->storage == StorageClassInput ? compiler.active_input_builtins : compiler.active_output_builtins;
+		auto &flags =
+		    type->storage == StorageClassInput ? compiler.active_input_builtins : compiler.active_output_builtins;
 
 		uint32_t count = length - 3;
 		args += 3;

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -577,6 +577,17 @@ protected:
 		void register_combined_image_sampler(SPIRFunction &caller, uint32_t texture_id, uint32_t sampler_id);
 	};
 
+	struct ActiveBuiltinHandler : OpcodeHandler
+	{
+		ActiveBuiltinHandler(Compiler &compiler_)
+			: compiler(compiler_)
+		{
+		}
+
+		bool handle(spv::Op opcode, const uint32_t *args, uint32_t length) override;
+		Compiler &compiler;
+	};
+
 	bool traverse_all_reachable_opcodes(const SPIRBlock &block, OpcodeHandler &handler) const;
 	bool traverse_all_reachable_opcodes(const SPIRFunction &block, OpcodeHandler &handler) const;
 	// This must be an ordered data structure so we always pick the same type aliases.
@@ -591,6 +602,10 @@ protected:
 
 	std::unordered_set<uint32_t> forced_temporaries;
 	std::unordered_set<uint32_t> forwarded_temporaries;
+
+	uint64_t active_builtins = 0;
+	// Traverses all reachable opcodes and sets active_builtins to a bitmask of all builtin variables which are accessed in the shader.
+	void update_active_builtins();
 };
 }
 

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -603,7 +603,8 @@ protected:
 	std::unordered_set<uint32_t> forced_temporaries;
 	std::unordered_set<uint32_t> forwarded_temporaries;
 
-	uint64_t active_builtins = 0;
+	uint64_t active_input_builtins = 0;
+	uint64_t active_output_builtins = 0;
 	// Traverses all reachable opcodes and sets active_builtins to a bitmask of all builtin variables which are accessed in the shader.
 	void update_active_builtins();
 };

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -411,7 +411,7 @@ protected:
 	std::unordered_set<uint32_t> selection_merge_targets;
 	std::unordered_set<uint32_t> multiselect_merge_targets;
 
-	virtual std::string to_name(uint32_t id, bool allow_alias = true);
+	virtual std::string to_name(uint32_t id, bool allow_alias = true) const;
 	bool is_builtin_variable(const SPIRVariable &var) const;
 	bool is_hidden_variable(const SPIRVariable &var, bool include_builtins = false) const;
 	bool is_immutable(uint32_t id) const;

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -580,7 +580,7 @@ protected:
 	struct ActiveBuiltinHandler : OpcodeHandler
 	{
 		ActiveBuiltinHandler(Compiler &compiler_)
-			: compiler(compiler_)
+		    : compiler(compiler_)
 		{
 		}
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -358,7 +358,7 @@ protected:
 	const char *flags_to_precision_qualifiers_glsl(const SPIRType &type, uint64_t flags);
 	const char *format_to_glsl(spv::ImageFormat format);
 	virtual std::string layout_for_member(const SPIRType &type, uint32_t index);
-	std::string to_interpolation_qualifiers(uint64_t flags);
+	virtual std::string to_interpolation_qualifiers(uint64_t flags);
 	uint64_t combined_decoration_for_member(const SPIRType &type, uint32_t index);
 	std::string layout_for_variable(const SPIRVariable &variable);
 	std::string to_combined_image_sampler(uint32_t image_id, uint32_t samp_id);

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -357,7 +357,7 @@ protected:
 	virtual const char *to_storage_qualifiers_glsl(const SPIRVariable &var);
 	const char *flags_to_precision_qualifiers_glsl(const SPIRType &type, uint64_t flags);
 	const char *format_to_glsl(spv::ImageFormat format);
-	std::string layout_for_member(const SPIRType &type, uint32_t index);
+	virtual std::string layout_for_member(const SPIRType &type, uint32_t index);
 	std::string to_interpolation_qualifiers(uint64_t flags);
 	uint64_t combined_decoration_for_member(const SPIRType &type, uint32_t index);
 	std::string layout_for_variable(const SPIRVariable &variable);

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -27,14 +27,16 @@ namespace
 struct VariableComparator
 {
 	VariableComparator(const CompilerHLSL &compiler_)
-		: compiler(compiler_)
+	    : compiler(compiler_)
 	{
 	}
 
 	bool operator()(SPIRVariable *var1, SPIRVariable *var2)
 	{
-		if (compiler.get_decoration_mask(var1->self) & compiler.get_decoration_mask(var2->self) & (1ull << DecorationLocation))
-			return compiler.get_decoration(var1->self, DecorationLocation) < compiler.get_decoration(var2->self, DecorationLocation);
+		if (compiler.get_decoration_mask(var1->self) & compiler.get_decoration_mask(var2->self) &
+		    (1ull << DecorationLocation))
+			return compiler.get_decoration(var1->self, DecorationLocation) <
+			       compiler.get_decoration(var2->self, DecorationLocation);
 
 		auto &name1 = compiler.get_name(var1->self);
 		auto &name2 = compiler.get_name(var2->self);
@@ -407,8 +409,7 @@ void CompilerHLSL::emit_resources()
 			auto &type = get<SPIRType>(var.basetype);
 
 			if (var.storage != StorageClassFunction && !var.remapped_variable && type.pointer &&
-			    (var.storage == StorageClassInput || var.storage == StorageClassOutput) &&
-				!is_builtin_variable(var) &&
+			    (var.storage == StorageClassInput || var.storage == StorageClassOutput) && !is_builtin_variable(var) &&
 			    interface_variable_exists_in_entry_point(var.self))
 			{
 				// Only emit non-builtins here. Builtin variables are handled separately.
@@ -433,9 +434,8 @@ void CompilerHLSL::emit_resources()
 			auto &type = get<SPIRType>(var.basetype);
 
 			if (!var.remapped_variable && type.pointer &&
-				(var.storage == StorageClassInput || var.storage == StorageClassOutput) &&
-				!is_builtin_variable(var) &&
-				interface_variable_exists_in_entry_point(var.self))
+			    (var.storage == StorageClassInput || var.storage == StorageClassOutput) && !is_builtin_variable(var) &&
+			    interface_variable_exists_in_entry_point(var.self))
 			{
 				if (var.storage == StorageClassInput)
 					input_variables.push_back(&var);
@@ -590,7 +590,8 @@ void CompilerHLSL::emit_function_prototype(SPIRFunction &func, uint64_t return_f
 void CompilerHLSL::emit_hlsl_entry_point()
 {
 	auto &execution = get_entry_point();
-	statement(require_output ? "SPIRV_Cross_Output " : "void ", "main(", require_input ? "SPIRV_Cross_Input stage_input)" : ")");
+	statement(require_output ? "SPIRV_Cross_Output " : "void ", "main(",
+	          require_input ? "SPIRV_Cross_Input stage_input)" : ")");
 	begin_scope();
 
 	if (require_input)
@@ -664,7 +665,7 @@ void CompilerHLSL::emit_hlsl_entry_point()
 
 				if (var.storage != StorageClassFunction && !var.remapped_variable && type.pointer &&
 				    var.storage == StorageClassOutput && !is_builtin_variable(var) &&
-					interface_variable_exists_in_entry_point(var.self))
+				    interface_variable_exists_in_entry_point(var.self))
 				{
 					auto name = to_name(var.self);
 					statement("stage_output.", name, " = ", name, ";");
@@ -676,8 +677,10 @@ void CompilerHLSL::emit_hlsl_entry_point()
 		{
 			if (options.shader_model <= 30)
 			{
-				statement("stage_output.gl_Position.x = stage_output.gl_Position.x - gl_HalfPixel.x * stage_output.gl_Position.w;");
-				statement("stage_output.gl_Position.y = stage_output.gl_Position.y + gl_HalfPixel.y * stage_output.gl_Position.w;");
+				statement("stage_output.gl_Position.x = stage_output.gl_Position.x - gl_HalfPixel.x * "
+				          "stage_output.gl_Position.w;");
+				statement("stage_output.gl_Position.y = stage_output.gl_Position.y + gl_HalfPixel.y * "
+				          "stage_output.gl_Position.w;");
 			}
 			if (options.flip_vert_y)
 			{
@@ -685,7 +688,8 @@ void CompilerHLSL::emit_hlsl_entry_point()
 			}
 			if (options.fixup_clipspace)
 			{
-				statement("stage_output.gl_Position.z = (stage_output.gl_Position.z + stage_output.gl_Position.w) * 0.5;");
+				statement(
+				    "stage_output.gl_Position.z = (stage_output.gl_Position.z + stage_output.gl_Position.w) * 0.5;");
 			}
 		}
 

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1142,6 +1142,7 @@ string CompilerHLSL::compile()
 	// Do not deal with ES-isms like precision, older extensions and such.
 	CompilerGLSL::options.es = false;
 	CompilerGLSL::options.version = 450;
+	CompilerGLSL::options.vulkan_semantics = true;
 	backend.float_literal_suffix = true;
 	backend.double_literal_suffix = false;
 	backend.long_long_literal_suffix = true;

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -131,7 +131,14 @@ void CompilerHLSL::emit_header()
 void CompilerHLSL::emit_interface_block_globally(const SPIRVariable &var)
 {
 	add_resource_name(var.self);
+
+	// The global copies of I/O variables should not contain interpolation qualifiers.
+	// These are emitted inside the interface structs.
+	auto &flags = meta[var.self].decoration.decoration_flags;
+	auto old_flags = flags;
+	flags = 0;
 	statement("static ", variable_decl(var), ";");
+	flags = old_flags;
 }
 
 const char *CompilerHLSL::to_storage_qualifiers_glsl(const SPIRVariable &var)

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -508,8 +508,7 @@ void CompilerHLSL::emit_resources()
 			// Do not emit I/O blocks here.
 			// I/O blocks can be arrayed, so we must deal with them separately to support geometry shaders
 			// and tessellation down the line.
-			if (!block && !var.remapped_variable && type.pointer &&
-			    !is_builtin_variable(var) &&
+			if (!block && !var.remapped_variable && type.pointer && !is_builtin_variable(var) &&
 			    interface_variable_exists_in_entry_point(var.self))
 			{
 				if (var.storage == StorageClassInput)
@@ -549,8 +548,7 @@ void CompilerHLSL::emit_resources()
 
 		if (has_location_a && has_location_b)
 		{
-			return get_decoration(a->self, DecorationLocation) <
-			       get_decoration(b->self, DecorationLocation);
+			return get_decoration(a->self, DecorationLocation) < get_decoration(b->self, DecorationLocation);
 		}
 		else if (has_location_a && !has_location_b)
 			return true;
@@ -731,8 +729,7 @@ void CompilerHLSL::emit_hlsl_entry_point()
 			if (var.storage != StorageClassInput && var.storage != StorageClassOutput)
 				continue;
 
-			if (block && !is_builtin_variable(var) &&
-			    interface_variable_exists_in_entry_point(var.self))
+			if (block && !is_builtin_variable(var) && interface_variable_exists_in_entry_point(var.self))
 			{
 				if (var.storage == StorageClassInput)
 				{
@@ -794,8 +791,7 @@ void CompilerHLSL::emit_hlsl_entry_point()
 			if (var.storage != StorageClassInput)
 				continue;
 
-			if (!block && !var.remapped_variable && type.pointer &&
-			    !is_builtin_variable(var) &&
+			if (!block && !var.remapped_variable && type.pointer && !is_builtin_variable(var) &&
 			    interface_variable_exists_in_entry_point(var.self))
 			{
 				auto name = to_name(var.self);
@@ -813,8 +809,7 @@ void CompilerHLSL::emit_hlsl_entry_point()
 			}
 
 			// I/O blocks don't use the common stage input/output struct, but separate outputs.
-			if (block && !is_builtin_variable(var) &&
-			    interface_variable_exists_in_entry_point(var.self))
+			if (block && !is_builtin_variable(var) && interface_variable_exists_in_entry_point(var.self))
 			{
 				auto name = to_name(var.self);
 				statement(name, " = stage_input", name, ";");
@@ -843,8 +838,7 @@ void CompilerHLSL::emit_hlsl_entry_point()
 				continue;
 
 			// I/O blocks don't use the common stage input/output struct, but separate outputs.
-			if (block && !is_builtin_variable(var) &&
-			    interface_variable_exists_in_entry_point(var.self))
+			if (block && !is_builtin_variable(var) && interface_variable_exists_in_entry_point(var.self))
 			{
 				auto name = to_name(var.self);
 				statement("stage_output", name, " = ", name, ";");
@@ -879,8 +873,7 @@ void CompilerHLSL::emit_hlsl_entry_point()
 					continue;
 
 				if (!block && var.storage != StorageClassFunction && !var.remapped_variable && type.pointer &&
-				    !is_builtin_variable(var) &&
-				    interface_variable_exists_in_entry_point(var.self))
+				    !is_builtin_variable(var) && interface_variable_exists_in_entry_point(var.self))
 				{
 					auto name = to_name(var.self);
 					statement("stage_output.", name, " = ", name, ";");

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -358,8 +358,8 @@ void CompilerHLSL::emit_interface_block_in_struct(const SPIRVariable &var, unord
 		}
 		else
 		{
-			statement(to_interpolation_qualifiers(get_decoration_mask(var.self)),
-			          variable_decl(type, name), " : TEXCOORD", binding_number, ";");
+			statement(to_interpolation_qualifiers(get_decoration_mask(var.self)), variable_decl(type, name),
+			          " : TEXCOORD", binding_number, ";");
 
 			// Structs and arrays should consume more locations.
 			uint32_t consumed_locations = type_to_consumed_locations(type);

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1006,6 +1006,8 @@ string CompilerHLSL::compile()
 	backend.use_initializer_list = true;
 	backend.use_constructor_splatting = false;
 
+	update_active_builtins();
+
 	uint32_t pass_count = 0;
 	do
 	{

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -57,7 +57,9 @@ private:
 	void emit_header() override;
 	void emit_resources();
 	void emit_interface_block_globally(const SPIRVariable &type);
-	void emit_interface_block_in_struct(const SPIRVariable &type, uint32_t &binding_number, bool builtins);
+	void emit_interface_block_in_struct(const SPIRVariable &type, uint32_t &binding_number);
+	void emit_builtin_inputs_in_struct();
+	void emit_builtin_outputs_in_struct();
 	void emit_texture_op(const Instruction &i) override;
 	void emit_instruction(const Instruction &instruction) override;
 	void emit_glsl_op(uint32_t result_type, uint32_t result_id, uint32_t op, const uint32_t *args,
@@ -70,6 +72,10 @@ private:
 
 	Options options;
 	bool requires_op_fmod = false;
+
+	void emit_builtin_variables();
+	bool require_output = false;
+	bool require_input = false;
 };
 }
 

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -57,7 +57,7 @@ private:
 	void emit_header() override;
 	void emit_resources();
 	void emit_interface_block_globally(const SPIRVariable &type);
-	void emit_interface_block_in_struct(const SPIRVariable &type, uint32_t &binding_number);
+	void emit_interface_block_in_struct(const SPIRVariable &type, std::unordered_set<uint32_t> &active_locations);
 	void emit_builtin_inputs_in_struct();
 	void emit_builtin_outputs_in_struct();
 	void emit_texture_op(const Instruction &i) override;
@@ -76,6 +76,8 @@ private:
 	void emit_builtin_variables();
 	bool require_output = false;
 	bool require_input = false;
+
+	uint32_t type_to_consumed_locations(const SPIRType &type) const;
 };
 }
 

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -68,6 +68,7 @@ private:
 	void emit_push_constant_block(const SPIRVariable &var) override;
 	void emit_uniform(const SPIRVariable &var) override;
 	std::string layout_for_member(const SPIRType &type, uint32_t index) override;
+	std::string to_interpolation_qualifiers(uint64_t flags) override;
 
 	const char *to_storage_qualifiers_glsl(const SPIRVariable &var) override;
 

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -67,6 +67,7 @@ private:
 	void emit_buffer_block(const SPIRVariable &type) override;
 	void emit_push_constant_block(const SPIRVariable &var) override;
 	void emit_uniform(const SPIRVariable &var) override;
+	std::string layout_for_member(const SPIRType &type, uint32_t index) override;
 
 	const char *to_storage_qualifiers_glsl(const SPIRVariable &var) override;
 
@@ -78,6 +79,8 @@ private:
 	bool require_input = false;
 
 	uint32_t type_to_consumed_locations(const SPIRType &type) const;
+
+	void emit_io_block(const SPIRVariable &var);
 };
 }
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1794,7 +1794,7 @@ string CompilerMSL::argument_decl(const SPIRFunction::Parameter &arg)
 
 // If we're currently in the entry point function, and the object
 // has a qualified name, use it, otherwise use the standard name.
-string CompilerMSL::to_name(uint32_t id, bool allow_alias)
+string CompilerMSL::to_name(uint32_t id, bool allow_alias) const
 {
 	if (current_function && (current_function->self == entry_point))
 	{

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -68,6 +68,8 @@ string CompilerMSL::compile()
 	non_stage_in_input_var_ids.clear();
 	struct_member_padding.clear();
 
+	update_active_builtins();
+
 	// Preprocess OpCodes to extract the need to output additional header content
 	set_enabled_interface_variables(get_active_interface_variables());
 	preprocess_op_codes();

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -136,7 +136,7 @@ protected:
 	std::string constant_expression(const SPIRConstant &c) override;
 	size_t get_declared_struct_member_size(const SPIRType &struct_type, uint32_t index) const override;
 	std::string to_func_call_arg(uint32_t id) override;
-	std::string to_name(uint32_t id, bool allow_alias = true) override;
+	std::string to_name(uint32_t id, bool allow_alias = true) const override;
 	std::string to_function_name(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather, bool is_proj,
 	                             bool has_array_offsets, bool has_offset, bool has_grad, bool has_lod,
 	                             bool has_dref) override;

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -107,7 +107,7 @@ def cross_compile_hlsl(shader):
     os.close(hlsl_f)
     subprocess.check_call(['glslangValidator', '-V', '-o', spirv_path, shader])
     spirv_cross_path = './spirv-cross'
-    subprocess.check_call([spirv_cross_path, '--entry', 'main', '--output', hlsl_path, spirv_path, '--hlsl'])
+    subprocess.check_call([spirv_cross_path, '--entry', 'main', '--output', hlsl_path, spirv_path, '--hlsl', '--shader-model', '50'])
     subprocess.check_call(['spirv-val', spirv_path])
 
     validate_shader_hlsl(hlsl_path)


### PR DESCRIPTION
Rewrote the implementation of HLSL inputs and outputs to be more robust and support more stuff.

- A traversal is done to find all statically accessed builtin variables in the shader. This is common to all APIs, so Metal might benefit from this as well.
- Separate out logic for builtins from the handling of user-defined inputs and outputs.
- Add support for the more common builtins like frag-coord, frag-depth, vertex-id, instance-id and MRT.
- Location decorations are now used always if the shader uses it. For varyings and attributes which are not using these, the locations (TEXCOORD[N]) are assigned based on their name, and failing that, their ID. All sensible SPIR-V shaders really should use locations, so these serve as crude fallbacks.
- I/O blocks are now supported by having extra in/out struct arguments from main(). This is to support geometry shaders and tessellation in the future ...
- VPOS in SM 3.0 gets a half-pixel offset applied to match all other APIs, not sure if this offset depends on the SM, or the API being used (like, D3D11 using D3D9 shaders, will that have half-pixel offset already applied?)
- Interpolation qualifiers are supported.

I need some review of this because while the test shaders pass glslangValidator HLSL mode, I'm not sure how HLSL really treats the vertex output/fragment input semantics, are they ignored, does ordering matter, and so on.

The HLSL linking interface between stages seems kinda shaky to me, so I'd like some clarification from someone who knows HLSL better.