### PR TITLE
SSBO reflection fix

### DIFF
--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -1042,9 +1042,8 @@ uint64_t Compiler::get_decoration_mask(uint32_t id) const
 		if (get_decoration_mask(type.self) & ((1ull << DecorationBufferBlock) | (1ull << DecorationBlock)))
 		{
 			inherit_flags = get_buffer_block_flags(*var);
-			inherit_flags &=
-				(1ull << DecorationNonWritable) | (1ull << DecorationNonReadable) | (1ull << DecorationAliased) |
-				(1ull << DecorationRestrict);
+			inherit_flags &= (1ull << DecorationNonWritable) | (1ull << DecorationNonReadable) |
+			                 (1ull << DecorationAliased) | (1ull << DecorationRestrict);
 		}
 
 		return dec.decoration_flags | inherit_flags;

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -580,8 +580,8 @@ protected:
 
 	VariableTypeRemapCallback variable_remap_callback;
 
-	uint64_t get_buffer_block_flags(const SPIRVariable &var);
-	bool get_common_basic_type(const SPIRType &type, SPIRType::BaseType &base_type);
+	uint64_t get_buffer_block_flags(const SPIRVariable &var) const;
+	bool get_common_basic_type(const SPIRType &type, SPIRType::BaseType &base_type) const;
 };
 }
 


### PR DESCRIPTION
When reflecting SSBO blocks, readonly/writeonly/restrict, etc are not exposed through get_decoration() and friends because these decorations are found in members. To make the interface for reflecting these decorations less awkward, propagate these decorations when appropriate.