### PR TITLE
CompilerMSL mark the legacy compile() function as deprecated

### DIFF
--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -117,6 +117,7 @@ public:
 
 	// This legacy method is deprecated.
 	typedef Options MSLConfiguration;
+	SPIRV_CROSS_DEPRECATED("Please use get_options() and set_options() instead.")
 	std::string compile(MSLConfiguration &msl_cfg, std::vector<MSLVertexAttr> *p_vtx_attrs = nullptr,
 	                    std::vector<MSLResourceBinding> *p_res_bindings = nullptr);
 


### PR DESCRIPTION
Using new deprecation option to formally mark existing deprecated compile() function overload as deprecated.