### PR TITLE
Added a Compiler ctor that takes IR as raw array and count

### DIFF
--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -70,6 +70,12 @@ Compiler::Compiler(vector<uint32_t> ir)
 	parse();
 }
 
+Compiler::Compiler(const uint32_t *ir, size_t word_count)
+    : spirv(ir, ir + word_count)
+{
+	parse();
+}
+
 string Compiler::compile()
 {
 	// Force a classic "C" locale, reverts when function returns

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -106,6 +106,7 @@ public:
 
 	// The constructor takes a buffer of SPIR-V words and parses it.
 	Compiler(std::vector<uint32_t> ir);
+	Compiler(const uint32_t *ir, size_t word_count);
 
 	virtual ~Compiler() = default;
 


### PR DESCRIPTION
This avoids the need to construct a temporary std::vector on the application side just to create a Compiler instance if application itself doesn't use STL containers.