### PR TITLE
Fix HLSL matrix unrolling

### DIFF
--- a/reference/shaders-hlsl/vert/matrix-attribute.vert
+++ b/reference/shaders-hlsl/vert/matrix-attribute.vert
@@ -1,0 +1,35 @@
+static float4 gl_Position;
+static float4x4 m;
+static float3 pos;
+
+struct SPIRV_Cross_Input
+{
+    float4 m_0 : TEXCOORD0;
+    float4 m_1 : TEXCOORD1;
+    float4 m_2 : TEXCOORD2;
+    float4 m_3 : TEXCOORD3;
+    float3 pos : TEXCOORD4;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 gl_Position : SV_Position;
+};
+
+void vert_main()
+{
+    gl_Position = mul(float4(pos, 1.0f), m);
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    m[0] = stage_input.m_0;
+    m[1] = stage_input.m_1;
+    m[2] = stage_input.m_2;
+    m[3] = stage_input.m_3;
+    pos = stage_input.pos;
+    vert_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    return stage_output;
+}

--- a/shaders-hlsl/vert/matrix-attribute.vert
+++ b/shaders-hlsl/vert/matrix-attribute.vert
@@ -1,0 +1,9 @@
+#version 310 es
+
+in vec3 pos;
+in mat4 m;
+
+void main()
+{
+	gl_Position = m * vec4(pos, 1.0);
+}

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -862,7 +862,7 @@ void CompilerHLSL::emit_hlsl_entry_point()
 				{
 					// Unroll matrices.
 					for (uint32_t col = 0; col < mtype.columns; col++)
-						statement(name, "[", col, "] = stage_input.", name, "_0;");
+						statement(name, "[", col, "] = stage_input.", name, "_", col, ";");
 				}
 				else
 				{


### PR DESCRIPTION
HLSL doesn't support matrix attributes so we pack them into vectors. Fixed a little bug in the generated unpacking code and added a test.