### PR TITLE
Shader model 4/5 style texture sampling

### DIFF
--- a/reference/shaders-hlsl/frag/basic.frag
+++ b/reference/shaders-hlsl/frag/basic.frag
@@ -1,4 +1,5 @@
-uniform sampler2D uTex;
+Texture2D<float4> uTex;
+SamplerState _uTex_sampler;
 
 static float4 FragColor;
 static float4 vColor;
@@ -17,7 +18,7 @@ struct SPIRV_Cross_Output
 
 void frag_main()
 {
-    FragColor = vColor * tex2D(uTex, vTex);
+    FragColor = vColor * uTex.Sample(_uTex_sampler, vTex);
 }
 
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)

--- a/reference/shaders-hlsl/frag/tex-sampling.frag
+++ b/reference/shaders-hlsl/frag/tex-sampling.frag
@@ -12,10 +12,17 @@ Texture2D<float4> tex2dShadow;
 SamplerComparisonState _tex2dShadow_sampler;
 TextureCube<float4> texCubeShadow;
 SamplerComparisonState _texCubeShadow_sampler;
+Texture1DArray<float4> tex1dArray;
+SamplerState _tex1dArray_sampler;
+Texture2DArray<float4> tex2dArray;
+SamplerState _tex2dArray_sampler;
+TextureCubeArray<float4> texCubeArray;
+SamplerState _texCubeArray_sampler;
 
 static float texCoord1d;
 static float2 texCoord2d;
 static float3 texCoord3d;
+static float4 texCoord4d;
 static float4 FragColor;
 
 struct SPIRV_Cross_Input
@@ -23,6 +30,7 @@ struct SPIRV_Cross_Input
     float texCoord1d : TEXCOORD0;
     float2 texCoord2d : TEXCOORD1;
     float3 texCoord3d : TEXCOORD2;
+    float4 texCoord4d : TEXCOORD3;
 };
 
 struct SPIRV_Cross_Output
@@ -74,6 +82,11 @@ void frag_main()
     texcolor.w += tex2dShadow.SampleCmp(_tex2dShadow_sampler, _188.xy, _188.z);
     float4 _204 = float4(texCoord3d, 0.0f);
     texcolor.w += texCubeShadow.SampleCmp(_texCubeShadow_sampler, _204.xyz, _204.w);
+    texcolor += tex1dArray.Sample(_tex1dArray_sampler, texCoord2d);
+    texcolor += tex2dArray.Sample(_tex2dArray_sampler, texCoord3d);
+    texcolor += texCubeArray.Sample(_texCubeArray_sampler, texCoord4d);
+    texcolor += tex2d.Gather(_tex2d_sampler, texCoord2d, 0);
+    texcolor += tex2d.Load(int3(int2(1, 2), 0));
     FragColor = texcolor;
 }
 
@@ -82,6 +95,7 @@ SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
     texCoord1d = stage_input.texCoord1d;
     texCoord2d = stage_input.texCoord2d;
     texCoord3d = stage_input.texCoord3d;
+    texCoord4d = stage_input.texCoord4d;
     frag_main();
     SPIRV_Cross_Output stage_output;
     stage_output.FragColor = FragColor;

--- a/reference/shaders-hlsl/frag/tex-sampling.frag
+++ b/reference/shaders-hlsl/frag/tex-sampling.frag
@@ -1,0 +1,50 @@
+Texture2D<float4> tex;
+SamplerState _tex_sampler;
+
+static float2 texCoord;
+static float4 FragColor;
+
+struct SPIRV_Cross_Input
+{
+    float2 texCoord : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+float SPIRV_Cross_projectTextureCoordinate(float2 coord)
+{
+    return coord.x / coord.y;
+}
+
+float2 SPIRV_Cross_projectTextureCoordinate(float3 coord)
+{
+    return float2(coord.x, coord.y) / coord.z;
+}
+
+float3 SPIRV_Cross_projectTextureCoordinate(float4 coord)
+{
+    return float3(coord.x, coord.y, coord.z) / coord.w;
+}
+
+void frag_main()
+{
+    float4 texcolor = tex.Sample(_tex_sampler, texCoord);
+    texcolor += tex.Sample(_tex_sampler, texCoord, int2(1, 2));
+    texcolor += tex.SampleLevel(_tex_sampler, texCoord, 2.0f);
+    texcolor += tex.SampleGrad(_tex_sampler, texCoord, float2(1.0f, 2.0f), float2(3.0f, 4.0f));
+    texcolor += tex.Sample(_tex_sampler, SPIRV_Cross_projectTextureCoordinate(float3(texCoord, 2.0f)));
+    texcolor += tex.SampleBias(_tex_sampler, texCoord, 1.0f);
+    FragColor = texcolor;
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    texCoord = stage_input.texCoord;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/frag/tex-sampling.frag
+++ b/reference/shaders-hlsl/frag/tex-sampling.frag
@@ -4,6 +4,8 @@ Texture2D<float4> tex2d;
 SamplerState _tex2d_sampler;
 Texture3D<float4> tex3d;
 SamplerState _tex3d_sampler;
+TextureCube<float4> texCube;
+SamplerState _texCube_sampler;
 
 static float texCoord1d;
 static float2 texCoord2d;
@@ -57,6 +59,9 @@ void frag_main()
     texcolor += tex3d.SampleGrad(_tex3d_sampler, texCoord3d, float3(1.0f, 2.0f, 3.0f), float3(4.0f, 5.0f, 6.0f));
     texcolor += tex3d.Sample(_tex3d_sampler, SPIRV_Cross_projectTextureCoordinate(float4(texCoord3d, 2.0f)));
     texcolor += tex3d.SampleBias(_tex3d_sampler, texCoord3d, 1.0f);
+    texcolor += texCube.Sample(_texCube_sampler, texCoord3d);
+    texcolor += texCube.SampleLevel(_texCube_sampler, texCoord3d, 2.0f);
+    texcolor += texCube.SampleBias(_texCube_sampler, texCoord3d, 1.0f);
     FragColor = texcolor;
 }
 

--- a/reference/shaders-hlsl/frag/tex-sampling.frag
+++ b/reference/shaders-hlsl/frag/tex-sampling.frag
@@ -6,6 +6,12 @@ Texture3D<float4> tex3d;
 SamplerState _tex3d_sampler;
 TextureCube<float4> texCube;
 SamplerState _texCube_sampler;
+Texture1D<float4> tex1dShadow;
+SamplerComparisonState _tex1dShadow_sampler;
+Texture2D<float4> tex2dShadow;
+SamplerComparisonState _tex2dShadow_sampler;
+TextureCube<float4> texCubeShadow;
+SamplerComparisonState _texCubeShadow_sampler;
 
 static float texCoord1d;
 static float2 texCoord2d;
@@ -62,6 +68,12 @@ void frag_main()
     texcolor += texCube.Sample(_texCube_sampler, texCoord3d);
     texcolor += texCube.SampleLevel(_texCube_sampler, texCoord3d, 2.0f);
     texcolor += texCube.SampleBias(_texCube_sampler, texCoord3d, 1.0f);
+    float3 _170 = float3(texCoord1d, 0.0f, 0.0f);
+    texcolor.w += tex1dShadow.SampleCmp(_tex1dShadow_sampler, _170.x, _170.z);
+    float3 _188 = float3(texCoord2d, 0.0f);
+    texcolor.w += tex2dShadow.SampleCmp(_tex2dShadow_sampler, _188.xy, _188.z);
+    float4 _204 = float4(texCoord3d, 0.0f);
+    texcolor.w += texCubeShadow.SampleCmp(_texCubeShadow_sampler, _204.xyz, _204.w);
     FragColor = texcolor;
 }
 

--- a/reference/shaders-hlsl/frag/tex-sampling.frag
+++ b/reference/shaders-hlsl/frag/tex-sampling.frag
@@ -1,12 +1,20 @@
-Texture2D<float4> tex;
-SamplerState _tex_sampler;
+Texture1D<float4> tex1d;
+SamplerState _tex1d_sampler;
+Texture2D<float4> tex2d;
+SamplerState _tex2d_sampler;
+Texture3D<float4> tex3d;
+SamplerState _tex3d_sampler;
 
-static float2 texCoord;
+static float texCoord1d;
+static float2 texCoord2d;
+static float3 texCoord3d;
 static float4 FragColor;
 
 struct SPIRV_Cross_Input
 {
-    float2 texCoord : TEXCOORD0;
+    float texCoord1d : TEXCOORD0;
+    float2 texCoord2d : TEXCOORD1;
+    float3 texCoord3d : TEXCOORD2;
 };
 
 struct SPIRV_Cross_Output
@@ -31,18 +39,32 @@ float3 SPIRV_Cross_projectTextureCoordinate(float4 coord)
 
 void frag_main()
 {
-    float4 texcolor = tex.Sample(_tex_sampler, texCoord);
-    texcolor += tex.Sample(_tex_sampler, texCoord, int2(1, 2));
-    texcolor += tex.SampleLevel(_tex_sampler, texCoord, 2.0f);
-    texcolor += tex.SampleGrad(_tex_sampler, texCoord, float2(1.0f, 2.0f), float2(3.0f, 4.0f));
-    texcolor += tex.Sample(_tex_sampler, SPIRV_Cross_projectTextureCoordinate(float3(texCoord, 2.0f)));
-    texcolor += tex.SampleBias(_tex_sampler, texCoord, 1.0f);
+    float4 texcolor = tex1d.Sample(_tex1d_sampler, texCoord1d);
+    texcolor += tex1d.Sample(_tex1d_sampler, texCoord1d, 1);
+    texcolor += tex1d.SampleLevel(_tex1d_sampler, texCoord1d, 2.0f);
+    texcolor += tex1d.SampleGrad(_tex1d_sampler, texCoord1d, 1.0f, 2.0f);
+    texcolor += tex1d.Sample(_tex1d_sampler, SPIRV_Cross_projectTextureCoordinate(float2(texCoord1d, 2.0f)));
+    texcolor += tex1d.SampleBias(_tex1d_sampler, texCoord1d, 1.0f);
+    texcolor += tex2d.Sample(_tex2d_sampler, texCoord2d);
+    texcolor += tex2d.Sample(_tex2d_sampler, texCoord2d, int2(1, 2));
+    texcolor += tex2d.SampleLevel(_tex2d_sampler, texCoord2d, 2.0f);
+    texcolor += tex2d.SampleGrad(_tex2d_sampler, texCoord2d, float2(1.0f, 2.0f), float2(3.0f, 4.0f));
+    texcolor += tex2d.Sample(_tex2d_sampler, SPIRV_Cross_projectTextureCoordinate(float3(texCoord2d, 2.0f)));
+    texcolor += tex2d.SampleBias(_tex2d_sampler, texCoord2d, 1.0f);
+    texcolor += tex3d.Sample(_tex3d_sampler, texCoord3d);
+    texcolor += tex3d.Sample(_tex3d_sampler, texCoord3d, int3(1, 2, 3));
+    texcolor += tex3d.SampleLevel(_tex3d_sampler, texCoord3d, 2.0f);
+    texcolor += tex3d.SampleGrad(_tex3d_sampler, texCoord3d, float3(1.0f, 2.0f, 3.0f), float3(4.0f, 5.0f, 6.0f));
+    texcolor += tex3d.Sample(_tex3d_sampler, SPIRV_Cross_projectTextureCoordinate(float4(texCoord3d, 2.0f)));
+    texcolor += tex3d.SampleBias(_tex3d_sampler, texCoord3d, 1.0f);
     FragColor = texcolor;
 }
 
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
-    texCoord = stage_input.texCoord;
+    texCoord1d = stage_input.texCoord1d;
+    texCoord2d = stage_input.texCoord2d;
+    texCoord3d = stage_input.texCoord3d;
     frag_main();
     SPIRV_Cross_Output stage_output;
     stage_output.FragColor = FragColor;

--- a/shaders-hlsl/frag/tex-sampling.frag
+++ b/shaders-hlsl/frag/tex-sampling.frag
@@ -9,9 +9,14 @@ uniform sampler1DShadow tex1dShadow;
 uniform sampler2DShadow tex2dShadow;
 uniform samplerCubeShadow texCubeShadow;
 
+uniform sampler1DArray tex1dArray;
+uniform sampler2DArray tex2dArray;
+uniform samplerCubeArray texCubeArray;
+
 in float texCoord1d;
 in vec2 texCoord2d;
 in vec3 texCoord3d;
+in vec4 texCoord4d;
 
 out vec4 FragColor;
 
@@ -45,6 +50,14 @@ void main()
 	texcolor.a += texture(tex1dShadow, vec3(texCoord1d, 0.0, 0.0));
 	texcolor.a += texture(tex2dShadow, vec3(texCoord2d, 0.0));
 	texcolor.a += texture(texCubeShadow, vec4(texCoord3d, 0.0));
+
+	texcolor += texture(tex1dArray, texCoord2d);
+	texcolor += texture(tex2dArray, texCoord3d);
+	texcolor += texture(texCubeArray, texCoord4d);
+
+	texcolor += textureGather(tex2d, texCoord2d);
+
+	texcolor += texelFetch(tex2d, ivec2(1, 2), 0);
 
 	FragColor = texcolor;
 }

--- a/shaders-hlsl/frag/tex-sampling.frag
+++ b/shaders-hlsl/frag/tex-sampling.frag
@@ -3,6 +3,7 @@
 uniform sampler1D tex1d;
 uniform sampler2D tex2d;
 uniform sampler3D tex3d;
+uniform samplerCube texCube;
 
 in float texCoord1d;
 in vec2 texCoord2d;
@@ -31,6 +32,10 @@ void main() {
 	texcolor += textureGrad(tex3d, texCoord3d, vec3(1.0, 2.0, 3.0), vec3(4.0, 5.0, 6.0));
 	texcolor += textureProj(tex3d, vec4(texCoord3d, 2.0));
 	texcolor += texture(tex3d, texCoord3d, 1.0);
+
+	texcolor += texture(texCube, texCoord3d);
+	texcolor += textureLod(texCube, texCoord3d, 2);
+	texcolor += texture(texCube, texCoord3d, 1.0);
 
 	FragColor = texcolor;
 }

--- a/shaders-hlsl/frag/tex-sampling.frag
+++ b/shaders-hlsl/frag/tex-sampling.frag
@@ -1,0 +1,16 @@
+#version 450
+
+uniform sampler2D tex;
+in vec2 texCoord;
+
+out vec4 FragColor;
+
+void main() {
+	vec4 texcolor = texture(tex, texCoord);
+	texcolor += textureOffset(tex, texCoord, ivec2(1, 2));
+	texcolor += textureLod(tex, texCoord, 2);
+	texcolor += textureGrad(tex, texCoord, vec2(1.0, 2.0), vec2(3.0, 4.0));
+	texcolor += textureProj(tex, vec3(texCoord, 2.0));
+	texcolor += texture(tex, texCoord, 1.0);
+	FragColor = texcolor;
+}

--- a/shaders-hlsl/frag/tex-sampling.frag
+++ b/shaders-hlsl/frag/tex-sampling.frag
@@ -1,16 +1,36 @@
 #version 450
 
-uniform sampler2D tex;
-in vec2 texCoord;
+uniform sampler1D tex1d;
+uniform sampler2D tex2d;
+uniform sampler3D tex3d;
+
+in float texCoord1d;
+in vec2 texCoord2d;
+in vec3 texCoord3d;
 
 out vec4 FragColor;
 
 void main() {
-	vec4 texcolor = texture(tex, texCoord);
-	texcolor += textureOffset(tex, texCoord, ivec2(1, 2));
-	texcolor += textureLod(tex, texCoord, 2);
-	texcolor += textureGrad(tex, texCoord, vec2(1.0, 2.0), vec2(3.0, 4.0));
-	texcolor += textureProj(tex, vec3(texCoord, 2.0));
-	texcolor += texture(tex, texCoord, 1.0);
+	vec4 texcolor = texture(tex1d, texCoord1d);
+	texcolor += textureOffset(tex1d, texCoord1d, 1);
+	texcolor += textureLod(tex1d, texCoord1d, 2);
+	texcolor += textureGrad(tex1d, texCoord1d, 1.0, 2.0);
+	texcolor += textureProj(tex1d, vec2(texCoord1d, 2.0));
+	texcolor += texture(tex1d, texCoord1d, 1.0);
+
+	texcolor += texture(tex2d, texCoord2d);
+	texcolor += textureOffset(tex2d, texCoord2d, ivec2(1, 2));
+	texcolor += textureLod(tex2d, texCoord2d, 2);
+	texcolor += textureGrad(tex2d, texCoord2d, vec2(1.0, 2.0), vec2(3.0, 4.0));
+	texcolor += textureProj(tex2d, vec3(texCoord2d, 2.0));
+	texcolor += texture(tex2d, texCoord2d, 1.0);
+
+	texcolor += texture(tex3d, texCoord3d);
+	texcolor += textureOffset(tex3d, texCoord3d, ivec3(1, 2, 3));
+	texcolor += textureLod(tex3d, texCoord3d, 2);
+	texcolor += textureGrad(tex3d, texCoord3d, vec3(1.0, 2.0, 3.0), vec3(4.0, 5.0, 6.0));
+	texcolor += textureProj(tex3d, vec4(texCoord3d, 2.0));
+	texcolor += texture(tex3d, texCoord3d, 1.0);
+
 	FragColor = texcolor;
 }

--- a/shaders-hlsl/frag/tex-sampling.frag
+++ b/shaders-hlsl/frag/tex-sampling.frag
@@ -5,13 +5,18 @@ uniform sampler2D tex2d;
 uniform sampler3D tex3d;
 uniform samplerCube texCube;
 
+uniform sampler1DShadow tex1dShadow;
+uniform sampler2DShadow tex2dShadow;
+uniform samplerCubeShadow texCubeShadow;
+
 in float texCoord1d;
 in vec2 texCoord2d;
 in vec3 texCoord3d;
 
 out vec4 FragColor;
 
-void main() {
+void main()
+{
 	vec4 texcolor = texture(tex1d, texCoord1d);
 	texcolor += textureOffset(tex1d, texCoord1d, 1);
 	texcolor += textureLod(tex1d, texCoord1d, 2);
@@ -36,6 +41,10 @@ void main() {
 	texcolor += texture(texCube, texCoord3d);
 	texcolor += textureLod(texCube, texCoord3d, 2);
 	texcolor += texture(texCube, texCoord3d, 1.0);
+
+	texcolor.a += texture(tex1dShadow, vec3(texCoord1d, 0.0, 0.0));
+	texcolor.a += texture(tex2dShadow, vec3(texCoord2d, 0.0));
+	texcolor.a += texture(texCubeShadow, vec4(texCoord3d, 0.0));
 
 	FragColor = texcolor;
 }

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1273,9 +1273,119 @@ void CompilerHLSL::emit_uniform(const SPIRVariable &var)
 {
 	add_resource_name(var.self);
 	auto &type = get<SPIRType>(var.basetype);
-	if (options.shader_model >= 40 && (type.basetype == SPIRType::Image || type.basetype == SPIRType::SampledImage))
+	if (options.shader_model >= 40 && type.basetype == SPIRType::SampledImage)
 	{
-		statement("Texture2D<float4> ", to_name(var.self), ";");
+		string format = "float4";
+		
+		switch (type.image.format) {
+		case ImageFormatUnknown:
+			format = "float4";
+			break;
+
+		case ImageFormatRgba32f:
+			format = "float4";
+			break;
+
+		case ImageFormatRgba16f:
+			format = "half4";
+			break;
+
+		case ImageFormatR32f:
+			format = "float";
+			break;
+
+		case ImageFormatRgba8:
+			format = "uint4";
+			break;
+		
+		case ImageFormatRg32f:
+			format = "float2";
+			break;
+
+		case ImageFormatRg16f:
+			format = "half2";
+			break;
+
+		case ImageFormatR11fG11fB10f:
+			format = "half3";
+			break;
+
+		case ImageFormatR16f:
+			format = "half";
+			break;
+
+		case ImageFormatRgba16:
+		case ImageFormatRgb10A2:
+			format = "uint4";
+			break;
+		
+		case ImageFormatRg16:
+		case ImageFormatRg8:
+			format = "uint";
+			break;
+
+		case ImageFormatR16:
+		case ImageFormatR8:
+			format = "uint";
+			break;
+
+		case ImageFormatRgba8Snorm:
+		case ImageFormatRgba16Snorm:
+			format = "snorm float4";
+			break;
+
+		case ImageFormatRg16Snorm:
+		case ImageFormatRg8Snorm:
+			format = "snorm float2";
+			break;
+
+		case ImageFormatR16Snorm:
+		case ImageFormatR8Snorm:
+			format = "snorm float";
+			break;
+
+		case ImageFormatRgba32i:
+		case ImageFormatRgba16i:
+		case ImageFormatRgba8i:
+			format = "int4";
+			break;
+
+		case ImageFormatRg32i:
+		case ImageFormatRg16i:
+		case ImageFormatRg8i:
+			format = "int2";
+			break;
+
+		case ImageFormatR32i:
+		case ImageFormatR16i:
+		case ImageFormatR8i:
+			format = "int";
+			break;
+
+		case ImageFormatRgba32ui:
+		case ImageFormatRgba16ui:
+		case ImageFormatRgba8ui:
+			format = "uint4";
+			break;
+
+		case ImageFormatRgb10a2ui:
+			format = "uint4";
+			break;
+		
+		case ImageFormatRg32ui:
+		case ImageFormatRg16ui:
+		case ImageFormatRg8ui:
+			format = "uint2";
+			break;
+
+		case ImageFormatR32ui:
+		case ImageFormatR16ui:
+		case ImageFormatR8ui:
+			format = "uint";
+			break;
+		}
+
+		statement("Texture2D<", format, "> ", to_name(var.self), ";");
 		statement("SamplerState _", to_name(var.self), "_sampler;");
 	}
 	else

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1337,7 +1337,25 @@ void CompilerHLSL::emit_uniform(const SPIRVariable &var)
 	if (options.shader_model >= 40 && type.basetype == SPIRType::SampledImage)
 	{
 		auto &imagetype = get<SPIRType>(type.image.type);
-		statement("Texture2D<", type_to_glsl(imagetype), "4> ", to_name(var.self), ";");
+		string dim;
+		switch (type.image.dim)
+		{
+		case Dim1D:
+			dim = "1D";
+			break;
+		case Dim2D:
+			dim = "2D";
+			break;
+		case Dim3D:
+			dim = "3D";
+			break;
+		case DimCube:
+		case DimRect:
+		case DimBuffer:
+		case DimSubpassData:
+			SPIRV_CROSS_THROW("Cube/Buffer texture support is not yet implemented for HLSL"); // TODO
+		}
+		statement("Texture", dim, "<", type_to_glsl(imagetype), "4> ", to_name(var.self), ";");
 		statement("SamplerState _", to_name(var.self), "_sampler;");
 	}
 	else

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1146,6 +1146,12 @@ void CompilerHLSL::emit_texture_op(const Instruction &i)
 		texop += "texelFetch";
 	else
 	{
+		auto &imgformat = get<SPIRType>(imgtype.image.type);
+		if (imgformat.basetype != SPIRType::Float)
+		{
+			SPIRV_CROSS_THROW("Sampling non-float textures is not supported in HLSL.");
+		}
+
 		if (options.shader_model >= 40)
 		{
 			texop += to_expression(img);

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1129,7 +1129,7 @@ void CompilerHLSL::emit_texture_op(const Instruction &i)
 
 			if (gather)
 				texop += ".Gather";
-			else if (offset || coffsets || bias)
+			else if (bias)
 				texop += ".SampleBias";
 			else if (proj)
 				texop += ".Sample";
@@ -1158,9 +1158,6 @@ void CompilerHLSL::emit_texture_op(const Instruction &i)
 				texop += "bias";
 		}
 	}
-
-	if (coffset || offset)
-		texop += "Offset";
 
 	expr += texop;
 	expr += "(_";
@@ -1263,20 +1260,12 @@ void CompilerHLSL::emit_texture_op(const Instruction &i)
 
 	if (coffset)
 	{
-		if (!bias)
-		{
-			expr += ", 0";
-		}
 		forward = forward && should_forward(coffset);
 		expr += ", ";
 		expr += to_expression(coffset);
 	}
 	else if (offset)
 	{
-		if (!bias)
-		{
-			expr += ", 0";
-		}
 		forward = forward && should_forward(offset);
 		expr += ", ";
 		expr += to_expression(offset);

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1146,7 +1146,7 @@ void CompilerHLSL::emit_texture_op(const Instruction &i)
 	expr += to_expression(img);
 	if (options.shader_model >= 40)
 	{
-		expr += "_sample";
+		expr += "_sampler";
 	}
 
 	bool swizz_func = backend.swizzle_is_function;
@@ -1276,7 +1276,7 @@ void CompilerHLSL::emit_uniform(const SPIRVariable &var)
 	if (options.shader_model >= 40 && (type.basetype == SPIRType::Image || type.basetype == SPIRType::SampledImage))
 	{
 		statement("Texture2D<float4> ", to_name(var.self), ";");
-		statement("SamplerState _", to_name(var.self), "_sample;");
+		statement("SamplerState _", to_name(var.self), "_sampler;");
 	}
 	else
 	{

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1438,7 +1438,8 @@ void CompilerHLSL::emit_uniform(const SPIRVariable &var)
 		case DimSubpassData:
 			SPIRV_CROSS_THROW("Buffer texture support is not yet implemented for HLSL"); // TODO
 		}
-		statement("Texture", dim, "<", type_to_glsl(imagetype), "4> ", to_name(var.self), ";");
+		string arrayed = type.image.arrayed ? "Array" : "";
+		statement("Texture", dim, arrayed, "<", type_to_glsl(imagetype), "4> ", to_name(var.self), ";");
 		if (type.image.depth)
 			statement("SamplerComparisonState _", to_name(var.self), "_sampler;");
 		else

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1132,7 +1132,7 @@ void CompilerHLSL::emit_texture_op(const Instruction &i)
 			else if (offset || coffsets || bias)
 				texop += ".SampleBias";
 			else if (proj)
-				texop += ".Sample";  // SPIRV_CROSS_THROW("textureProj is not supported in HLSL shader model 4/5.");
+				texop += ".Sample";
 			else if (grad_x || grad_y)
 				texop += ".SampleGrad";
 			else if (lod)
@@ -1302,117 +1302,8 @@ void CompilerHLSL::emit_uniform(const SPIRVariable &var)
 	auto &type = get<SPIRType>(var.basetype);
 	if (options.shader_model >= 40 && type.basetype == SPIRType::SampledImage)
 	{
-		string format = "float4";
-		
-		switch (type.image.format) {
-		case ImageFormatUnknown:
-			format = "float4";
-			break;
-
-		case ImageFormatRgba32f:
-			format = "float4";
-			break;
-
-		case ImageFormatRgba16f:
-			format = "half4";
-			break;
-
-		case ImageFormatR32f:
-			format = "float";
-			break;
-
-		case ImageFormatRgba8:
-			format = "uint4";
-			break;
-		
-		case ImageFormatRg32f:
-			format = "float2";
-			break;
-
-		case ImageFormatRg16f:
-			format = "half2";
-			break;
-
-		case ImageFormatR11fG11fB10f:
-			format = "half3";
-			break;
-
-		case ImageFormatR16f:
-			format = "half";
-			break;
-
-		case ImageFormatRgba16:
-		case ImageFormatRgb10A2:
-			format = "uint4";
-			break;
-		
-		case ImageFormatRg16:
-		case ImageFormatRg8:
-			format = "uint";
-			break;
-
-		case ImageFormatR16:
-		case ImageFormatR8:
-			format = "uint";
-			break;
-
-		case ImageFormatRgba8Snorm:
-		case ImageFormatRgba16Snorm:
-			format = "snorm float4";
-			break;
-
-		case ImageFormatRg16Snorm:
-		case ImageFormatRg8Snorm:
-			format = "snorm float2";
-			break;
-
-		case ImageFormatR16Snorm:
-		case ImageFormatR8Snorm:
-			format = "snorm float";
-			break;
-
-		case ImageFormatRgba32i:
-		case ImageFormatRgba16i:
-		case ImageFormatRgba8i:
-			format = "int4";
-			break;
-
-		case ImageFormatRg32i:
-		case ImageFormatRg16i:
-		case ImageFormatRg8i:
-			format = "int2";
-			break;
-
-		case ImageFormatR32i:
-		case ImageFormatR16i:
-		case ImageFormatR8i:
-			format = "int";
-			break;
-
-		case ImageFormatRgba32ui:
-		case ImageFormatRgba16ui:
-		case ImageFormatRgba8ui:
-			format = "uint4";
-			break;
-
-		case ImageFormatRgb10a2ui:
-			format = "uint4";
-			break;
-		
-		case ImageFormatRg32ui:
-		case ImageFormatRg16ui:
-		case ImageFormatRg8ui:
-			format = "uint2";
-			break;
-
-		case ImageFormatR32ui:
-		case ImageFormatR16ui:
-		case ImageFormatR8ui:
-			format = "uint";
-			break;
-		}
-
-		statement("Texture2D<", format, "> ", to_name(var.self), ";");
+		auto &imagetype = get<SPIRType>(type.image.type);
+		statement("Texture2D<", type_to_glsl(imagetype), "4> ", to_name(var.self), ";");
 		statement("SamplerState _", to_name(var.self), "_sampler;");
 	}
 	else

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1146,7 +1146,7 @@ void CompilerHLSL::emit_texture_op(const Instruction &i)
 
 			if (gather)
 				SPIRV_CROSS_THROW("textureGather is not supported in HLSL shader model 2/3.");
-			if (offset || coffsets)
+			if (offset || coffset)
 				SPIRV_CROSS_THROW("textureOffset is not supported in HLSL shader model 2/3.");
 			if (proj)
 				texop += "proj";
@@ -1160,7 +1160,11 @@ void CompilerHLSL::emit_texture_op(const Instruction &i)
 	}
 
 	expr += texop;
-	expr += "(_";
+	expr += "(";
+	if (options.shader_model >= 40)
+	{
+		expr += "_";
+	}
 	expr += to_expression(img);
 	if (options.shader_model >= 40)
 	{

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1195,7 +1195,11 @@ void CompilerHLSL::emit_texture_op(const Instruction &i)
 
 	if (options.shader_model >= 40 && proj)
 	{
-		requires_textureProj = true;
+		if (!requires_textureProj)
+		{
+			requires_textureProj = true;
+			force_recompile = true;
+		}
 		coord_expr = "SPIRV_Cross_projectTextureCoordinate(" + coord_expr + ")";
 	}
 
@@ -1424,7 +1428,11 @@ void CompilerHLSL::emit_instruction(const Instruction &instruction)
 
 	case OpFMod:
 	{
-		requires_op_fmod = true;
+		if (!requires_op_fmod)
+		{
+			requires_op_fmod = true;
+			force_recompile = true;
+		}
 		CompilerGLSL::emit_instruction(instruction);
 		break;
 	}

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -80,6 +80,7 @@ private:
 
 	Options options;
 	bool requires_op_fmod = false;
+	bool requires_textureProj = false;
 
 	void emit_builtin_variables();
 	bool require_output = false;

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -57,6 +57,7 @@ public:
 
 private:
 	std::string type_to_glsl(const SPIRType &type) override;
+	std::string image_type_hlsl(const SPIRType &type);
 	void emit_function_prototype(SPIRFunction &func, uint64_t return_flags) override;
 	void emit_hlsl_entry_point();
 	void emit_header() override;


### PR DESCRIPTION
For #125 aka no more need for D3DCOMPILE_ENABLE_BACKWARDS_COMPATIBILITY.
Also improves texture calls for shader model 2/3.