### PR TITLE
Add support for querying binary offsets of decorations in SPIR-V.

### DIFF
--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -946,6 +946,8 @@ struct Meta
 	Decoration decoration;
 	std::vector<Decoration> members;
 	uint32_t sampler = 0;
+
+	std::unordered_map<spv::Decoration, uint32_t> decoration_word_offset;
 };
 
 // A user callback that remaps the type of any variable.

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -947,7 +947,7 @@ struct Meta
 	std::vector<Decoration> members;
 	uint32_t sampler = 0;
 
-	std::unordered_map<spv::Decoration, uint32_t> decoration_word_offset;
+	std::unordered_map<uint32_t, uint32_t> decoration_word_offset;
 };
 
 // A user callback that remaps the type of any variable.

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -1119,6 +1119,17 @@ void Compiler::unset_decoration(uint32_t id, Decoration decoration)
 	}
 }
 
+bool Compiler::get_binary_offset_for_decoration(uint32_t id, spv::Decoration decoration, uint32_t &word_offset) const
+{
+	auto &word_offsets = meta.at(id).decoration_word_offset;
+	auto itr = word_offsets.find(decoration);
+	if (itr == end(word_offsets))
+		return false;
+
+	word_offset = itr->second;
+	return true;
+}
+
 void Compiler::parse(const Instruction &instruction)
 {
 	auto ops = stream(instruction);
@@ -1260,7 +1271,10 @@ void Compiler::parse(const Instruction &instruction)
 
 		auto decoration = static_cast<Decoration>(ops[1]);
 		if (length >= 3)
+		{
+			meta[id].decoration_word_offset[decoration] = uint32_t(&ops[2] - spirv.data());
 			set_decoration(id, decoration, ops[2]);
+		}
 		else
 			set_decoration(id, decoration);
 

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -327,6 +327,14 @@ public:
 	uint32_t type_struct_member_array_stride(const SPIRType &type, uint32_t index) const;
 	uint32_t type_struct_member_matrix_stride(const SPIRType &type, uint32_t index) const;
 
+	// Gets the offset in SPIR-V words (uint32_t) for a decoration which was originally declared in the SPIR-V binary.
+	// The offset will point to one or more uint32_t literals which can be modified in-place before using the SPIR-V binary.
+	// Note that adding or removing decorations using the reflection API will not change the behavior of this function.
+	// If the decoration was declared, sets the word_offset to an offset into the provided SPIR-V binary buffer and returns true,
+	// otherwise, returns false.
+	// If the decoration does not have any value attached to it (e.g. DecorationRelaxedPrecision), this function will also return false.
+	bool get_binary_offset_for_decoration(uint32_t id, spv::Decoration decoration, uint32_t &word_offset) const;
+
 protected:
 	const uint32_t *stream(const Instruction &instr) const
 	{


### PR DESCRIPTION
Facilitates easy SPIR-V patching when needed.