### PR TITLE
CompilerMSL round floating point tex coords for read() and tex array index.

### DIFF
--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1369,7 +1369,7 @@ void CompilerHLSL::emit_texture_op(const Instruction &i)
 		expr += ", ";
 	}
 	expr += coord_expr;
-	
+
 	if (dref)
 	{
 		forward = forward && should_forward(dref);

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1071,79 +1071,37 @@ string CompilerMSL::to_function_args(uint32_t img, const SPIRType &imgtype, bool
 		break;
 
 	case Dim2D:
-		if (options.flip_frag_y)
-		{
-			string coord_x = coord_expr + ".x";
-			string coord_y = coord_expr + ".y";
-			if (is_fetch)
-				tex_coords = "uint2(" + coord_x + ", (1.0 - " + coord_y + "))";
-			else
-				tex_coords = "float2(" + coord_x + ", (1.0 - " + coord_y + "))";
-		}
-		else
-		{
-			if (coord_type.vecsize > 2)
-				tex_coords += ".xy";
+		if (coord_type.vecsize > 2)
+			tex_coords += ".xy";
 
-			if (is_fetch)
-				tex_coords = "uint2(" + tex_coords + ")";
-		}
+		if (is_fetch)
+			tex_coords = "uint2(" + tex_coords + ")";
 
 		alt_coord = ".z";
 
 		break;
 
 	case Dim3D:
-		if (options.flip_frag_y)
-		{
-			string coord_x = coord_expr + ".x";
-			string coord_y = coord_expr + ".y";
-			string coord_z = coord_expr + ".z";
-			if (is_fetch)
-				tex_coords = "uint3(" + coord_x + ", (1.0 - " + coord_y + "), " + coord_z + ")";
-			else
-				tex_coords = "float3(" + coord_x + ", (1.0 - " + coord_y + "), " + coord_z + ")";
-		}
-		else
-		{
-			if (coord_type.vecsize > 3)
-				tex_coords += ".xyz";
+		if (coord_type.vecsize > 3)
+			tex_coords += ".xyz";
 
-			if (is_fetch)
-				tex_coords = "uint3(" + tex_coords + ")";
-		}
+		if (is_fetch)
+			tex_coords = "uint3(" + tex_coords + ")";
 
 		alt_coord = ".w";
 
 		break;
 
 	case DimCube:
-		if (options.flip_frag_y)
+		if (is_fetch)
 		{
-			string coord_x = coord_expr + ".x";
-			string coord_y = coord_expr + ".y";
-			string coord_z = coord_expr + ".z";
-
-			if (is_fetch)
-			{
-				tex_coords = "uint2(" + coord_x + ", (1.0 - " + coord_y + "))";
-				face_expr = coord_z;
-			}
-			else
-				tex_coords = "float3(" + coord_x + ", (1.0 - " + coord_y + "), " + coord_z + ")";
+			tex_coords = "uint2(" + tex_coords + ".xy)";
+			face_expr = coord_expr + ".z";
 		}
 		else
 		{
-			if (is_fetch)
-			{
-				tex_coords = "uint2(" + tex_coords + ".xy)";
-				face_expr = coord_expr + ".z";
-			}
-			else
-			{
-				if (coord_type.vecsize > 3)
-					tex_coords += ".xyz";
-			}
+			if (coord_type.vecsize > 3)
+				tex_coords += ".xyz";
 		}
 
 		alt_coord = ".w";
@@ -1239,34 +1197,15 @@ string CompilerMSL::to_function_args(uint32_t img, const SPIRType &imgtype, bool
 		switch (imgtype.image.dim)
 		{
 		case Dim2D:
-			if (options.flip_frag_y)
-			{
-				string coord_x = offset_expr + ".x";
-				string coord_y = offset_expr + ".y";
-				offset_expr = "float2(" + coord_x + ", (1.0 - " + coord_y + "))";
-			}
-			else
-			{
-				if (coord_type.vecsize > 2)
-					offset_expr += ".xy";
-			}
+			if (coord_type.vecsize > 2)
+				offset_expr += ".xy";
 
 			farg_str += ", " + offset_expr;
 			break;
 
 		case Dim3D:
-			if (options.flip_frag_y)
-			{
-				string coord_x = offset_expr + ".x";
-				string coord_y = offset_expr + ".y";
-				string coord_z = offset_expr + ".z";
-				offset_expr = "float3(" + coord_x + ", (1.0 - " + coord_y + "), " + coord_z + ")";
-			}
-			else
-			{
-				if (coord_type.vecsize > 3)
-					offset_expr += ".xyz";
-			}
+			if (coord_type.vecsize > 3)
+				offset_expr += ".xyz";
 
 			farg_str += ", " + offset_expr;
 			break;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -181,6 +181,7 @@ protected:
 	std::string built_in_func_arg(spv::BuiltIn builtin, bool prefix_comma);
 	std::string member_attribute_qualifier(const SPIRType &type, uint32_t index);
 	std::string argument_decl(const SPIRFunction::Parameter &arg);
+	std::string round_fp_tex_coords(std::string tex_coords, bool coord_is_fp);
 	uint32_t get_metal_resource_index(SPIRVariable &var, SPIRType::BaseType basetype);
 	uint32_t get_ordered_member_location(uint32_t type_id, uint32_t index);
 	size_t get_declared_type_size(uint32_t type_id) const;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -77,7 +77,6 @@ public:
 	struct Options
 	{
 		bool flip_vert_y = false;
-		bool flip_frag_y = false;
 		bool is_rendering_points = false;
 		bool pad_and_pack_uniform_structs = false;
 		std::string entry_point_name;


### PR DESCRIPTION
CompilerMSL round floating point tex coords for read() and tex array index, to avoid toggling arbitrarily between two tex array layers due to rounding errors.
CompilerMSL remove option to flip fragment coordinates.
