### PR TITLE
CompilerMSL output [[point_size]] attribute for BuiltInPointSize member by default.

### DIFF
--- a/reference/shaders-msl/flatten/basic.flatten.vert
+++ b/reference/shaders-msl/flatten/basic.flatten.vert
@@ -18,7 +18,7 @@ struct main0_out
 {
     float3 vNormal [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize;
+    float gl_PointSize [[point_size]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _16 [[buffer(0)]])

--- a/reference/shaders-msl/flatten/multiindex.flatten.vert
+++ b/reference/shaders-msl/flatten/multiindex.flatten.vert
@@ -16,7 +16,7 @@ struct main0_in
 struct main0_out
 {
     float4 gl_Position [[position]];
-    float gl_PointSize;
+    float gl_PointSize [[point_size]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _20 [[buffer(0)]])

--- a/reference/shaders-msl/flatten/push-constant.flatten.vert
+++ b/reference/shaders-msl/flatten/push-constant.flatten.vert
@@ -20,7 +20,7 @@ struct main0_out
 {
     float2 vRot [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize;
+    float gl_PointSize [[point_size]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant PushMe& registers [[buffer(0)]])

--- a/reference/shaders-msl/flatten/struct.flatten.vert
+++ b/reference/shaders-msl/flatten/struct.flatten.vert
@@ -26,7 +26,7 @@ struct main0_out
 {
     float4 vColor [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize;
+    float gl_PointSize [[point_size]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _18 [[buffer(0)]])

--- a/reference/shaders-msl/flatten/swizzle.flatten.vert
+++ b/reference/shaders-msl/flatten/swizzle.flatten.vert
@@ -30,7 +30,7 @@ struct main0_out
     float4 oB [[user(locn4)]];
     float4 oA [[user(locn5)]];
     float4 gl_Position [[position]];
-    float gl_PointSize;
+    float gl_PointSize [[point_size]];
 };
 
 vertex main0_out main0(constant UBO& _22 [[buffer(0)]])

--- a/reference/shaders-msl/legacy/vert/transpose.legacy.vert
+++ b/reference/shaders-msl/legacy/vert/transpose.legacy.vert
@@ -18,7 +18,7 @@ struct main0_in
 struct main0_out
 {
     float4 gl_Position [[position]];
-    float gl_PointSize;
+    float gl_PointSize [[point_size]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant Buffer& _13 [[buffer(0)]])

--- a/reference/shaders-msl/vert/basic.vert
+++ b/reference/shaders-msl/vert/basic.vert
@@ -18,7 +18,7 @@ struct main0_out
 {
     float3 vNormal [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize;
+    float gl_PointSize [[point_size]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _16 [[buffer(0)]])

--- a/reference/shaders-msl/vert/copy.flatten.vert
+++ b/reference/shaders-msl/vert/copy.flatten.vert
@@ -26,7 +26,7 @@ struct main0_out
 {
     float4 vColor [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize;
+    float gl_PointSize [[point_size]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _21 [[buffer(0)]])

--- a/reference/shaders-msl/vert/dynamic.flatten.vert
+++ b/reference/shaders-msl/vert/dynamic.flatten.vert
@@ -26,7 +26,7 @@ struct main0_out
 {
     float4 vColor [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize;
+    float gl_PointSize [[point_size]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _21 [[buffer(0)]])

--- a/reference/shaders-msl/vert/pointsize.vert
+++ b/reference/shaders-msl/vert/pointsize.vert
@@ -1,0 +1,34 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct params
+{
+    float4x4 mvp;
+    float psize;
+};
+
+struct main0_in
+{
+    float4 position [[attribute(0)]];
+    float4 color0 [[attribute(1)]];
+};
+
+struct main0_out
+{
+    float4 color [[user(locn0)]];
+    float4 gl_Position [[position]];
+    float gl_PointSize [[point_size]];
+    float gl_ClipDistance[1] /* [[clip_distance]] built-in not yet supported under Metal. */;
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant params& _19 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = _19.mvp * in.position;
+    out.gl_PointSize = _19.psize;
+    out.color = in.color0;
+    return out;
+}
+

--- a/reference/shaders-msl/vert/ubo.alignment.vert
+++ b/reference/shaders-msl/vert/ubo.alignment.vert
@@ -24,7 +24,7 @@ struct main0_out
     float3 vNormal [[user(locn1)]];
     float3 vColor [[user(locn2)]];
     float4 gl_Position [[position]];
-    float gl_PointSize;
+    float gl_PointSize [[point_size]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _18 [[buffer(0)]])

--- a/reference/shaders-msl/vert/ubo.vert
+++ b/reference/shaders-msl/vert/ubo.vert
@@ -18,7 +18,7 @@ struct main0_out
 {
     float3 vNormal [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize;
+    float gl_PointSize [[point_size]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _16 [[buffer(0)]])

--- a/reference/shaders-msl/vulkan/vert/vulkan-vertex.vk.vert
+++ b/reference/shaders-msl/vulkan/vert/vulkan-vertex.vk.vert
@@ -6,7 +6,7 @@ using namespace metal;
 struct main0_out
 {
     float4 gl_Position [[position]];
-    float gl_PointSize;
+    float gl_PointSize [[point_size]];
 };
 
 vertex main0_out main0(uint gl_VertexIndex [[vertex_id]], uint gl_InstanceIndex [[instance_id]])

--- a/shaders-msl/vert/pointsize.vert
+++ b/shaders-msl/vert/pointsize.vert
@@ -1,0 +1,15 @@
+#version 330
+uniform params {
+    mat4 mvp;
+    float psize;
+};
+
+in vec4 position;
+in vec4 color0;
+out vec4 color;
+
+void main() {
+    gl_Position = mvp * position;
+    gl_PointSize = psize;
+    color = color0;
+}

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -77,7 +77,7 @@ public:
 	struct Options
 	{
 		bool flip_vert_y = false;
-		bool is_rendering_points = false;
+		bool is_rendering_points = true;
 		bool pad_and_pack_uniform_structs = false;
 		std::string entry_point_name;
 	};


### PR DESCRIPTION
This is a convenience fix for Issue #169. More sophisticated fix to that issue may come later.