### PR TITLE
Implement more sophisticated check for point_size.

### DIFF
--- a/reference/shaders-msl/flatten/basic.flatten.vert
+++ b/reference/shaders-msl/flatten/basic.flatten.vert
@@ -18,7 +18,7 @@ struct main0_out
 {
     float3 vNormal [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize [[point_size]];
+    float gl_PointSize;
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _16 [[buffer(0)]])

--- a/reference/shaders-msl/flatten/multiindex.flatten.vert
+++ b/reference/shaders-msl/flatten/multiindex.flatten.vert
@@ -16,7 +16,7 @@ struct main0_in
 struct main0_out
 {
     float4 gl_Position [[position]];
-    float gl_PointSize [[point_size]];
+    float gl_PointSize;
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _20 [[buffer(0)]])

--- a/reference/shaders-msl/flatten/push-constant.flatten.vert
+++ b/reference/shaders-msl/flatten/push-constant.flatten.vert
@@ -20,7 +20,7 @@ struct main0_out
 {
     float2 vRot [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize [[point_size]];
+    float gl_PointSize;
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant PushMe& registers [[buffer(0)]])

--- a/reference/shaders-msl/flatten/struct.flatten.vert
+++ b/reference/shaders-msl/flatten/struct.flatten.vert
@@ -26,7 +26,7 @@ struct main0_out
 {
     float4 vColor [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize [[point_size]];
+    float gl_PointSize;
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _18 [[buffer(0)]])

--- a/reference/shaders-msl/flatten/swizzle.flatten.vert
+++ b/reference/shaders-msl/flatten/swizzle.flatten.vert
@@ -30,7 +30,7 @@ struct main0_out
     float4 oB [[user(locn4)]];
     float4 oA [[user(locn5)]];
     float4 gl_Position [[position]];
-    float gl_PointSize [[point_size]];
+    float gl_PointSize;
 };
 
 vertex main0_out main0(constant UBO& _22 [[buffer(0)]])

--- a/reference/shaders-msl/legacy/vert/transpose.legacy.vert
+++ b/reference/shaders-msl/legacy/vert/transpose.legacy.vert
@@ -18,7 +18,7 @@ struct main0_in
 struct main0_out
 {
     float4 gl_Position [[position]];
-    float gl_PointSize [[point_size]];
+    float gl_PointSize;
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant Buffer& _13 [[buffer(0)]])

--- a/reference/shaders-msl/vert/basic.vert
+++ b/reference/shaders-msl/vert/basic.vert
@@ -18,7 +18,7 @@ struct main0_out
 {
     float3 vNormal [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize [[point_size]];
+    float gl_PointSize;
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _16 [[buffer(0)]])

--- a/reference/shaders-msl/vert/copy.flatten.vert
+++ b/reference/shaders-msl/vert/copy.flatten.vert
@@ -26,7 +26,7 @@ struct main0_out
 {
     float4 vColor [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize [[point_size]];
+    float gl_PointSize;
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _21 [[buffer(0)]])

--- a/reference/shaders-msl/vert/dynamic.flatten.vert
+++ b/reference/shaders-msl/vert/dynamic.flatten.vert
@@ -26,7 +26,7 @@ struct main0_out
 {
     float4 vColor [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize [[point_size]];
+    float gl_PointSize;
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _21 [[buffer(0)]])

--- a/reference/shaders-msl/vert/ubo.alignment.vert
+++ b/reference/shaders-msl/vert/ubo.alignment.vert
@@ -24,7 +24,7 @@ struct main0_out
     float3 vNormal [[user(locn1)]];
     float3 vColor [[user(locn2)]];
     float4 gl_Position [[position]];
-    float gl_PointSize [[point_size]];
+    float gl_PointSize;
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _18 [[buffer(0)]])

--- a/reference/shaders-msl/vert/ubo.vert
+++ b/reference/shaders-msl/vert/ubo.vert
@@ -18,7 +18,7 @@ struct main0_out
 {
     float3 vNormal [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize [[point_size]];
+    float gl_PointSize;
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _16 [[buffer(0)]])

--- a/reference/shaders-msl/vulkan/vert/vulkan-vertex.vk.vert
+++ b/reference/shaders-msl/vulkan/vert/vulkan-vertex.vk.vert
@@ -6,7 +6,7 @@ using namespace metal;
 struct main0_out
 {
     float4 gl_Position [[position]];
-    float gl_PointSize [[point_size]];
+    float gl_PointSize;
 };
 
 vertex main0_out main0(uint gl_VertexIndex [[vertex_id]], uint gl_InstanceIndex [[instance_id]])

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1380,7 +1380,14 @@ string CompilerMSL::member_attribute_qualifier(const SPIRType &type, uint32_t in
 				return " /* [[clip_distance]] built-in not yet supported under Metal. */";
 
 			case BuiltInPointSize: // Must output only if really rendering points
-				return options.is_rendering_points ? (string(" [[") + builtin_qualifier(builtin) + "]]") : "";
+				// SPIR-V might declare PointSize as a builtin even though it's not really used.
+				// In some cases PointSize builtin may be written without Point topology.
+				// This is not an issue on GL/Vulkan, but it is on Metal, so we also have some way to forcefully disable
+				// this builtin.
+				if (active_output_builtins & (1ull << BuiltInPointSize))
+					return options.enable_point_size_builtin ? (string(" [[") + builtin_qualifier(builtin) + "]]") : "";
+				else
+					return "";
 
 			case BuiltInPosition:
 			case BuiltInLayer:

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1384,10 +1384,9 @@ string CompilerMSL::member_attribute_qualifier(const SPIRType &type, uint32_t in
 				// In some cases PointSize builtin may be written without Point topology.
 				// This is not an issue on GL/Vulkan, but it is on Metal, so we also have some way to forcefully disable
 				// this builtin.
-				if (active_output_builtins & (1ull << BuiltInPointSize))
-					return options.enable_point_size_builtin ? (string(" [[") + builtin_qualifier(builtin) + "]]") : "";
-				else
-					return "";
+				return (active_output_builtins & (1ull << BuiltInPointSize)) && options.enable_point_size_builtin ?
+				           (string(" [[") + builtin_qualifier(builtin) + "]]") :
+				           "";
 
 			case BuiltInPosition:
 			case BuiltInLayer:

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -77,7 +77,7 @@ public:
 	struct Options
 	{
 		bool flip_vert_y = false;
-		bool is_rendering_points = true;
+		bool enable_point_size_builtin = true;
 		bool pad_and_pack_uniform_structs = false;
 		std::string entry_point_name;
 	};


### PR DESCRIPTION
This enables the point_size builtin based on the existing active_input/output_builtins variable.
Renames is_rendering_points to enable_point_size_builtin to be able to forcefully disable point_size when not using Point topology as before, but make the intention clearer.