### PR TITLE
CompilerMSL map many GLSL functions to MSL functions

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -442,7 +442,6 @@ struct CLIArguments
 	uint32_t iterations = 1;
 	bool cpp = false;
 	bool msl = false;
-	bool msl_pack_ubos = true;
 	bool hlsl = false;
 	bool hlsl_compat = false;
 	bool vulkan_semantics = false;
@@ -456,7 +455,7 @@ static void print_help()
 	                "[--version <GLSL version>] [--dump-resources] [--help] [--force-temporary] "
 	                "[--vulkan-semantics] [--flatten-ubo] [--fixup-clipspace] [--iterations iter] "
 	                "[--cpp] [--cpp-interface-name <name>] "
-	                "[--msl] [--msl-no-pack-ubos] "
+	                "[--msl] "
 	                "[--hlsl] [--shader-model] [--hlsl-enable-compat] "
 	                "[--pls-in format input-name] [--pls-out format output-name] [--remap source_name target_name "
 	                "components] [--extension ext] [--entry name] [--remove-unused-variables] "
@@ -579,7 +578,6 @@ int main(int argc, char *argv[])
 	cbs.add("--cpp-interface-name", [&args](CLIParser &parser) { args.cpp_interface_name = parser.next_string(); });
 	cbs.add("--metal", [&args](CLIParser &) { args.msl = true; }); // Legacy compatibility
 	cbs.add("--msl", [&args](CLIParser &) { args.msl = true; });
-	cbs.add("--msl-no-pack-ubos", [&args](CLIParser &) { args.msl_pack_ubos = false; });
 	cbs.add("--hlsl", [&args](CLIParser &) { args.hlsl = true; });
 	cbs.add("--hlsl-enable-compat", [&args](CLIParser &) { args.hlsl_compat = true; });
 	cbs.add("--vulkan-semantics", [&args](CLIParser &) { args.vulkan_semantics = true; });
@@ -651,7 +649,6 @@ int main(int argc, char *argv[])
 
 		auto *msl_comp = static_cast<CompilerMSL *>(compiler.get());
 		auto msl_opts = msl_comp->get_options();
-		msl_opts.pad_and_pack_uniform_structs = args.msl_pack_ubos;
 		msl_comp->set_options(msl_opts);
 	}
 	else if (args.hlsl)

--- a/reference/shaders-msl/comp/atomic.comp
+++ b/reference/shaders-msl/comp/atomic.comp
@@ -1,0 +1,36 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct SSBO
+{
+    uint u32;
+    int i32;
+};
+
+kernel void main0(device SSBO& ssbo [[buffer(0)]])
+{
+    uint _16 = atomic_fetch_add_explicit((volatile device atomic_uint*)&(ssbo.u32), 1u, memory_order_relaxed);
+    uint _18 = atomic_fetch_or_explicit((volatile device atomic_uint*)&(ssbo.u32), 1u, memory_order_relaxed);
+    uint _20 = atomic_fetch_xor_explicit((volatile device atomic_uint*)&(ssbo.u32), 1u, memory_order_relaxed);
+    uint _22 = atomic_fetch_and_explicit((volatile device atomic_uint*)&(ssbo.u32), 1u, memory_order_relaxed);
+    uint _24 = atomic_fetch_min_explicit((volatile device atomic_uint*)&(ssbo.u32), 1u, memory_order_relaxed);
+    uint _26 = atomic_fetch_max_explicit((volatile device atomic_uint*)&(ssbo.u32), 1u, memory_order_relaxed);
+    uint _28 = atomic_exchange_explicit((volatile device atomic_uint*)&(ssbo.u32), 1u, memory_order_relaxed);
+    uint _30 = 10u;
+    uint _32 = atomic_compare_exchange_weak_explicit((volatile device atomic_uint*)&(ssbo.u32), &(_30), 2u, memory_order_relaxed, memory_order_relaxed);
+    int _36 = atomic_fetch_add_explicit((volatile device atomic_int*)&(ssbo.i32), 1, memory_order_relaxed);
+    int _38 = atomic_fetch_or_explicit((volatile device atomic_int*)&(ssbo.i32), 1, memory_order_relaxed);
+    int _40 = atomic_fetch_xor_explicit((volatile device atomic_int*)&(ssbo.i32), 1, memory_order_relaxed);
+    int _42 = atomic_fetch_and_explicit((volatile device atomic_int*)&(ssbo.i32), 1, memory_order_relaxed);
+    int _44 = atomic_fetch_min_explicit((volatile device atomic_int*)&(ssbo.i32), 1, memory_order_relaxed);
+    int _46 = atomic_fetch_max_explicit((volatile device atomic_int*)&(ssbo.i32), 1, memory_order_relaxed);
+    int _48 = atomic_exchange_explicit((volatile device atomic_int*)&(ssbo.i32), 1, memory_order_relaxed);
+    int _50 = 10;
+    int _52 = atomic_compare_exchange_weak_explicit((volatile device atomic_int*)&(ssbo.i32), &(_50), 2, memory_order_relaxed, memory_order_relaxed);
+}
+

--- a/reference/shaders-msl/comp/global-invocation-id-writable-ssbo-in-function.comp
+++ b/reference/shaders-msl/comp/global-invocation-id-writable-ssbo-in-function.comp
@@ -11,7 +11,7 @@ struct myBlock
     float b[1];
 };
 
-// Support GLSL mod(), which is slightly different than Metal fmod()
+// Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
 Tx mod(Tx x, Ty y)
 {

--- a/reference/shaders-msl/comp/global-invocation-id.comp
+++ b/reference/shaders-msl/comp/global-invocation-id.comp
@@ -1,3 +1,5 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
 #include <metal_stdlib>
 #include <simd/simd.h>
 
@@ -9,7 +11,7 @@ struct myBlock
     float b[1];
 };
 
-// Support GLSL mod(), which is slightly different than Metal fmod()
+// Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
 Tx mod(Tx x, Ty y)
 {

--- a/reference/shaders-msl/comp/local-invocation-id.comp
+++ b/reference/shaders-msl/comp/local-invocation-id.comp
@@ -1,3 +1,5 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
 #include <metal_stdlib>
 #include <simd/simd.h>
 
@@ -9,7 +11,7 @@ struct myBlock
     float b[1];
 };
 
-// Support GLSL mod(), which is slightly different than Metal fmod()
+// Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
 Tx mod(Tx x, Ty y)
 {

--- a/reference/shaders-msl/comp/local-invocation-index.comp
+++ b/reference/shaders-msl/comp/local-invocation-index.comp
@@ -1,3 +1,5 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
 #include <metal_stdlib>
 #include <simd/simd.h>
 
@@ -9,7 +11,7 @@ struct myBlock
     float b[1];
 };
 
-// Support GLSL mod(), which is slightly different than Metal fmod()
+// Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
 Tx mod(Tx x, Ty y)
 {

--- a/reference/shaders-msl/comp/writable-ssbo.comp
+++ b/reference/shaders-msl/comp/writable-ssbo.comp
@@ -1,3 +1,5 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
 #include <metal_stdlib>
 #include <simd/simd.h>
 
@@ -9,7 +11,7 @@ struct myBlock
     float b;
 };
 
-// Support GLSL mod(), which is slightly different than Metal fmod()
+// Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
 Tx mod(Tx x, Ty y)
 {

--- a/reference/shaders-msl/desktop-only/frag/image-ms.desktop.frag
+++ b/reference/shaders-msl/desktop-only/frag/image-ms.desktop.frag
@@ -1,0 +1,13 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+fragment void main0(texture2d_ms<float> uImageMS [[texture(0)]], texture2d_array<float, access::read_write> uImageArray [[texture(1)]], texture2d<float, access::write> uImage [[texture(2)]])
+{
+    float4 a = uImageMS.read(uint2(int2(1, 2)), 2);
+    float4 b = uImageArray.read(uint2(int3(1, 2, 4).xy), uint(int3(1, 2, 4).z));
+    uImage.write(a, uint2(int2(2, 3)));
+    uImageArray.write(b, uint2(int3(2, 3, 7).xy), uint(int3(2, 3, 7).z));
+}
+

--- a/reference/shaders-msl/desktop-only/frag/query-levels.desktop.frag
+++ b/reference/shaders-msl/desktop-only/frag/query-levels.desktop.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(texture2d<float> uSampler [[texture(0)]], sampler uSamplerSmplr [[sampler(0)]])
+{
+    main0_out out = {};
+    out.FragColor = float4(float(int(uSampler.get_num_mip_levels())));
+    return out;
+}
+

--- a/reference/shaders-msl/desktop-only/frag/sampler-ms-query.desktop.frag
+++ b/reference/shaders-msl/desktop-only/frag/sampler-ms-query.desktop.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(texture2d_ms<float> uSampler [[texture(0)]], sampler uSamplerSmplr [[sampler(0)]], texture2d_ms<float> uSamplerArray [[texture(1)]], sampler uSamplerArraySmplr [[sampler(1)]], texture2d_ms<float> uImage [[texture(2)]], texture2d_ms<float> uImageArray [[texture(3)]])
+{
+    main0_out out = {};
+    out.FragColor = float4(float(((int(uSampler.get_num_samples()) + int(uSamplerArray.get_num_samples())) + int(uImage.get_num_samples())) + int(uImageArray.get_num_samples())));
+    return out;
+}
+

--- a/reference/shaders-msl/frag/bitcasting.frag
+++ b/reference/shaders-msl/frag/bitcasting.frag
@@ -1,0 +1,30 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_in
+{
+    float4 VertGeom [[user(locn0)]];
+};
+
+struct main0_out
+{
+    float4 FragColor0 [[color(0)]];
+    float4 FragColor1 [[color(1)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> TextureBase [[texture(0)]], sampler TextureBaseSmplr [[sampler(0)]], texture2d<float> TextureDetail [[texture(1)]], sampler TextureDetailSmplr [[sampler(1)]])
+{
+    main0_out out = {};
+    float4 texSample0 = TextureBase.sample(TextureBaseSmplr, in.VertGeom.xy);
+    float4 texSample1 = TextureDetail.sample(TextureDetailSmplr, in.VertGeom.xy, int2(3, 2));
+    int4 iResult0 = as_type<int4>(texSample0);
+    int4 iResult1 = as_type<int4>(texSample1);
+    out.FragColor0 = as_type<float4>(iResult0) * as_type<float4>(iResult1);
+    uint4 uResult0 = as_type<uint4>(texSample0);
+    uint4 uResult1 = as_type<uint4>(texSample1);
+    out.FragColor1 = as_type<float4>(uResult0) * as_type<float4>(uResult1);
+    return out;
+}
+

--- a/reference/shaders-msl/vert/functions.vert
+++ b/reference/shaders-msl/vert/functions.vert
@@ -1,0 +1,120 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBO
+{
+    float4x4 uMVP;
+    float3 rotDeg;
+    float3 rotRad;
+    int2 bits;
+};
+
+struct main0_in
+{
+    float3 aNormal [[attribute(1)]];
+    float4 aVertex [[attribute(0)]];
+};
+
+struct main0_out
+{
+    float3 vRotRad [[user(locn0)]];
+    float3 vRotDeg [[user(locn1)]];
+    float3 vNormal [[user(locn2)]];
+    int2 vMSB [[user(locn3)]];
+    int2 vLSB [[user(locn4)]];
+    float4 gl_Position [[position]];
+    float gl_PointSize [[point_size]];
+};
+
+// Implementation of the GLSL radians() function
+template<typename T>
+T radians(T d)
+{
+    return d * 0.01745329251;
+}
+
+// Implementation of the GLSL degrees() function
+template<typename T>
+T degrees(T r)
+{
+    return r * 57.2957795131;
+}
+
+// Implementation of the GLSL findLSB() function
+template<typename T>
+T findLSB(T x)
+{
+    return select(ctz(x), -1, x == 0);
+}
+
+// Implementation of the signed GLSL findMSB() function
+template<typename T>
+T findSMSB(T x)
+{
+    T v = select(x, -1 - x, x < 0);
+    return select(clz(0) - (clz(v) + 1), -1, v == 0);
+}
+
+// Returns the determinant of a 2x2 matrix.
+inline float spvDet2x2(float a1, float a2, float b1, float b2)
+{
+    return a1 * b2 - b1 * a2;
+}
+
+// Returns the determinant of a 3x3 matrix.
+inline float spvDet3x3(float a1, float a2, float a3, float b1, float b2, float b3, float c1, float c2, float c3)
+{
+    return a1 * spvDet2x2(b2, b3, c2, c3) - b1 * spvDet2x2(a2, a3, c2, c3) + c1 * spvDet2x2(a2, a3, b2, b3);
+}
+
+// Returns the inverse of a matrix, by using the algorithm of calculating the classical
+// adjoint and dividing by the determinant. The contents of the matrix are changed.
+float4x4 spvInverse4x4(float4x4 m)
+{
+    float4x4 adj;	// The adjoint matrix (inverse after dividing by determinant)
+    
+    // Create the transpose of the cofactors, as the classical adjoint of the matrix.
+    adj[0][0] =  spvDet3x3(m[1][1], m[1][2], m[1][3], m[2][1], m[2][2], m[2][3], m[3][1], m[3][2], m[3][3]);
+    adj[0][1] = -spvDet3x3(m[0][1], m[0][2], m[0][3], m[2][1], m[2][2], m[2][3], m[3][1], m[3][2], m[3][3]);
+    adj[0][2] =  spvDet3x3(m[0][1], m[0][2], m[0][3], m[1][1], m[1][2], m[1][3], m[3][1], m[3][2], m[3][3]);
+    adj[0][3] = -spvDet3x3(m[0][1], m[0][2], m[0][3], m[1][1], m[1][2], m[1][3], m[2][1], m[2][2], m[2][3]);
+    
+    adj[1][0] = -spvDet3x3(m[1][0], m[1][2], m[1][3], m[2][0], m[2][2], m[2][3], m[3][0], m[3][2], m[3][3]);
+    adj[1][1] =  spvDet3x3(m[0][0], m[0][2], m[0][3], m[2][0], m[2][2], m[2][3], m[3][0], m[3][2], m[3][3]);
+    adj[1][2] = -spvDet3x3(m[0][0], m[0][2], m[0][3], m[1][0], m[1][2], m[1][3], m[3][0], m[3][2], m[3][3]);
+    adj[1][3] =  spvDet3x3(m[0][0], m[0][2], m[0][3], m[1][0], m[1][2], m[1][3], m[2][0], m[2][2], m[2][3]);
+    
+    adj[2][0] =  spvDet3x3(m[1][0], m[1][1], m[1][3], m[2][0], m[2][1], m[2][3], m[3][0], m[3][1], m[3][3]);
+    adj[2][1] = -spvDet3x3(m[0][0], m[0][1], m[0][3], m[2][0], m[2][1], m[2][3], m[3][0], m[3][1], m[3][3]);
+    adj[2][2] =  spvDet3x3(m[0][0], m[0][1], m[0][3], m[1][0], m[1][1], m[1][3], m[3][0], m[3][1], m[3][3]);
+    adj[2][3] = -spvDet3x3(m[0][0], m[0][1], m[0][3], m[1][0], m[1][1], m[1][3], m[2][0], m[2][1], m[2][3]);
+    
+    adj[3][0] = -spvDet3x3(m[1][0], m[1][1], m[1][2], m[2][0], m[2][1], m[2][2], m[3][0], m[3][1], m[3][2]);
+    adj[3][1] =  spvDet3x3(m[0][0], m[0][1], m[0][2], m[2][0], m[2][1], m[2][2], m[3][0], m[3][1], m[3][2]);
+    adj[3][2] = -spvDet3x3(m[0][0], m[0][1], m[0][2], m[1][0], m[1][1], m[1][2], m[3][0], m[3][1], m[3][2]);
+    adj[3][3] =  spvDet3x3(m[0][0], m[0][1], m[0][2], m[1][0], m[1][1], m[1][2], m[2][0], m[2][1], m[2][2]);
+    
+    // Calculate the determinant as a combination of the cofactors of the first row.
+    float det = (adj[0][0] * m[0][0]) + (adj[0][1] * m[1][0]) + (adj[0][2] * m[2][0]) + (adj[0][3] * m[3][0]);
+    
+    // Divide the classical adjoint matrix by the determinant.
+    // If determinant is zero, matrix is not invertable, so leave it unchanged.
+    return (det != 0.0f) ? (adj * (1.0f / det)) : m;
+}
+
+vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _18 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = spvInverse4x4(_18.uMVP) * in.aVertex;
+    out.vNormal = in.aNormal;
+    out.vRotDeg = degrees(_18.rotRad);
+    out.vRotRad = radians(_18.rotDeg);
+    out.vLSB = findLSB(_18.bits);
+    out.vMSB = findSMSB(_18.bits);
+    return out;
+}
+

--- a/reference/shaders-msl/vert/out_block.vert
+++ b/reference/shaders-msl/vert/out_block.vert
@@ -1,0 +1,32 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Transform
+{
+    float4x4 transform;
+};
+
+struct main0_in
+{
+    float3 position [[attribute(0)]];
+    float4 color [[attribute(1)]];
+};
+
+struct main0_out
+{
+    float4 VertexOut_color [[user(locn0)]];
+    float4 gl_Position [[position]];
+    float gl_PointSize [[point_size]];
+    float gl_ClipDistance[1] /* [[clip_distance]] built-in not yet supported under Metal. */;
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant Transform& block [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = block.transform * float4(in.position, 1.0);
+    out.VertexOut_color = in.color;
+    return out;
+}
+

--- a/reference/shaders-msl/vert/texture_buffer.vert
+++ b/reference/shaders-msl/vert/texture_buffer.vert
@@ -1,0 +1,18 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+    float gl_PointSize [[point_size]];
+};
+
+vertex main0_out main0(texture2d<float> uSamp [[texture(0)]], texture2d<float> uSampo [[texture(1)]])
+{
+    main0_out out = {};
+    out.gl_Position = uSamp.read(uint2(10, 0)) + uSampo.read(uint2(100, 0));
+    return out;
+}
+

--- a/shaders-msl/comp/atomic.comp
+++ b/shaders-msl/comp/atomic.comp
@@ -1,0 +1,33 @@
+#version 310 es
+#extension GL_OES_shader_image_atomic : require
+layout(local_size_x = 1) in;
+
+layout(r32ui, binding = 0) uniform highp uimage2D uImage;
+layout(r32i, binding = 1) uniform highp iimage2D iImage;
+layout(binding = 2, std430) buffer SSBO
+{
+    uint u32;
+    int  i32;
+} ssbo;
+
+void main()
+{
+    atomicAdd(ssbo.u32, 1u);
+    atomicOr(ssbo.u32, 1u);
+    atomicXor(ssbo.u32, 1u);
+    atomicAnd(ssbo.u32, 1u);
+    atomicMin(ssbo.u32, 1u);
+    atomicMax(ssbo.u32, 1u);
+    atomicExchange(ssbo.u32, 1u);
+    atomicCompSwap(ssbo.u32, 10u, 2u);
+
+    atomicAdd(ssbo.i32, 1);
+    atomicOr(ssbo.i32, 1);
+    atomicXor(ssbo.i32, 1);
+    atomicAnd(ssbo.i32, 1);
+    atomicMin(ssbo.i32, 1);
+    atomicMax(ssbo.i32, 1);
+    atomicExchange(ssbo.i32, 1);
+    atomicCompSwap(ssbo.i32, 10, 2);
+}
+

--- a/shaders-msl/desktop-only/frag/image-ms.desktop.frag
+++ b/shaders-msl/desktop-only/frag/image-ms.desktop.frag
@@ -1,0 +1,13 @@
+#version 450
+
+layout(rgba8, binding = 0) uniform image2D uImage;
+layout(rgba8, binding = 1) uniform image2DArray uImageArray;
+layout(rgba8, binding = 2) uniform image2DMS uImageMS;
+
+void main()
+{
+	vec4 a = imageLoad(uImageMS, ivec2(1, 2), 2);
+	vec4 b = imageLoad(uImageArray, ivec3(1, 2, 4));
+	imageStore(uImage, ivec2(2, 3), a);
+	imageStore(uImageArray, ivec3(2, 3, 7), b);
+}

--- a/shaders-msl/desktop-only/frag/query-levels.desktop.frag
+++ b/shaders-msl/desktop-only/frag/query-levels.desktop.frag
@@ -1,0 +1,11 @@
+#version 450
+
+layout(binding = 0) uniform sampler2D uSampler;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    FragColor = vec4(float(textureQueryLevels(uSampler)));
+}
+

--- a/shaders-msl/desktop-only/frag/sampler-ms-query.desktop.frag
+++ b/shaders-msl/desktop-only/frag/sampler-ms-query.desktop.frag
@@ -1,0 +1,14 @@
+#version 450
+
+layout(binding = 0) uniform sampler2DMS uSampler;
+layout(binding = 1) uniform sampler2DMSArray uSamplerArray;
+layout(binding = 2, rgba8) uniform readonly writeonly image2DMS uImage;
+layout(binding = 3, rgba8) uniform readonly writeonly image2DMSArray uImageArray;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    FragColor = vec4(float(((textureSamples(uSampler) + textureSamples(uSamplerArray)) + imageSamples(uImage)) + imageSamples(uImageArray)));
+}
+

--- a/shaders-msl/frag/bitcasting.frag
+++ b/shaders-msl/frag/bitcasting.frag
@@ -1,0 +1,24 @@
+#version 310 es
+precision mediump float;
+
+layout(binding = 0) uniform sampler2D TextureBase;
+layout(binding = 1) uniform sampler2D TextureDetail;
+
+layout(location = 0) in vec4 VertGeom;
+
+layout(location = 0) out vec4 FragColor0;
+layout(location = 1) out vec4 FragColor1;
+
+void main()
+{
+	vec4 texSample0 = texture(TextureBase, VertGeom.xy);
+	vec4 texSample1 = textureOffset(TextureDetail, VertGeom.xy, ivec2(3, 2));
+	
+    ivec4 iResult0 = floatBitsToInt(texSample0);
+    ivec4 iResult1 = floatBitsToInt(texSample1);
+    FragColor0 = (intBitsToFloat(iResult0) * intBitsToFloat(iResult1));    
+    
+    uvec4 uResult0 = floatBitsToUint(texSample0);
+    uvec4 uResult1 = floatBitsToUint(texSample1);
+    FragColor1 = (uintBitsToFloat(uResult0) * uintBitsToFloat(uResult1));    
+}

--- a/shaders-msl/vert/functions.vert
+++ b/shaders-msl/vert/functions.vert
@@ -1,0 +1,28 @@
+#version 310 es
+
+layout(std140) uniform UBO
+{
+    uniform mat4 uMVP;
+    uniform vec3 rotDeg;
+    uniform vec3 rotRad;
+    uniform ivec2 bits;
+};
+
+layout(location = 0) in vec4 aVertex;
+layout(location = 1) in vec3 aNormal;
+
+out vec3 vNormal;
+out vec3 vRotDeg;
+out vec3 vRotRad;
+out ivec2 vLSB;
+out ivec2 vMSB;
+
+void main()
+{
+    gl_Position = inverse(uMVP) * aVertex;
+    vNormal = aNormal;
+    vRotDeg = degrees(rotRad);
+    vRotRad = radians(rotDeg);
+    vLSB = findLSB(bits);
+    vMSB = findMSB(bits);
+}

--- a/shaders-msl/vert/out_block.vert
+++ b/shaders-msl/vert/out_block.vert
@@ -1,0 +1,20 @@
+#version 330
+
+uniform Transform
+{
+    mat4 transform;
+} block;
+
+in vec3 position;
+in vec4 color;
+
+out VertexOut
+{
+    vec4 color;
+} outputs;
+
+void main()
+{
+    gl_Position = block.transform*vec4(position, 1.0);
+    outputs.color = color;
+}

--- a/shaders-msl/vert/texture_buffer.vert
+++ b/shaders-msl/vert/texture_buffer.vert
@@ -1,0 +1,10 @@
+#version 310 es
+#extension GL_OES_texture_buffer : require
+
+layout(binding = 4) uniform highp samplerBuffer uSamp;
+layout(rgba32f, binding = 5) uniform readonly highp imageBuffer uSampo;
+
+void main()
+{
+   gl_Position = texelFetch(uSamp, 10) + imageLoad(uSampo, 100);
+}

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -276,6 +276,8 @@ struct SPIRType : IVariant
 		bool depth;
 		bool arrayed;
 		bool ms;
+		bool is_read = false;
+		bool is_written = false;
 		uint32_t sampled;
 		spv::ImageFormat format;
 	} image;

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -127,6 +127,7 @@ bool Compiler::block_is_pure(const SPIRBlock &block)
 		case OpAtomicStore:
 		case OpAtomicExchange:
 		case OpAtomicCompareExchange:
+		case OpAtomicCompareExchangeWeak:
 		case OpAtomicIIncrement:
 		case OpAtomicIDecrement:
 		case OpAtomicIAdd:
@@ -538,6 +539,7 @@ bool Compiler::InterfaceVariableAccessHandler::handle(Op opcode, const uint32_t 
 	case OpAtomicLoad:
 	case OpAtomicExchange:
 	case OpAtomicCompareExchange:
+	case OpAtomicCompareExchangeWeak:
 	case OpAtomicIIncrement:
 	case OpAtomicIDecrement:
 	case OpAtomicIAdd:

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -170,6 +170,10 @@ public:
 	// Sets the member identifier for OpTypeStruct ID, member number "index".
 	void set_member_name(uint32_t id, uint32_t index, const std::string &name);
 
+	// Returns the qualified member identifier for OpTypeStruct ID, member number "index",
+	// or an empty string if no qualified alias exists
+	const std::string &get_member_qualified_name(uint32_t id, uint32_t index) const;
+
 	// Sets the qualified member identifier for OpTypeStruct ID, member number "index".
 	void set_member_qualified_name(uint32_t id, uint32_t index, const std::string &name);
 

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -2802,7 +2802,7 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 	auto &imgtype = get<SPIRType>(type.self);
 
 	// Mark that this shader reads from this image
-	((SPIRType &)imgtype).image.is_read = true;
+	imgtype.image.is_read = true;
 
 	uint32_t coord_components = 0;
 	switch (imgtype.image.dim)

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -3483,8 +3483,15 @@ string CompilerGLSL::access_chain_internal(uint32_t base, const uint32_t *indice
 			}
 			else
 			{
-				expr += ".";
-				expr += to_member_name(*type, index);
+				// If the member has a qualified name, use it as the entire chain
+				string qual_mbr_name = get_member_qualified_name(type->self, index);
+				if (!qual_mbr_name.empty())
+					expr = qual_mbr_name;
+				else
+				{
+					expr += ".";
+					expr += to_member_name(*type, index);
+				}
 			}
 
 			if (member_is_packed_type(*type, index))

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -2769,6 +2769,7 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 		break;
 
 	case OpImageFetch:
+	case OpImageRead: // Reads == fetches in Metal (other langs will not get here)
 		opt = &ops[4];
 		length -= 4;
 		fetch = true;
@@ -2787,7 +2788,13 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 		break;
 	}
 
-	auto &imgtype = expression_type(img);
+	// Bypass pointers because we need the real image struct
+	auto &type = expression_type(img);
+	auto &imgtype = get<SPIRType>(type.self);
+
+	// Mark that this shader reads from this image
+	((SPIRType &)imgtype).image.is_read = true;
+
 	uint32_t coord_components = 0;
 	switch (imgtype.image.dim)
 	{

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -969,9 +969,7 @@ void CompilerMSL::emit_resources()
 			    (has_decoration(type.self, DecorationBlock) || has_decoration(type.self, DecorationBufferBlock)) &&
 			    !is_hidden_variable(var))
 			{
-				if (options.pad_and_pack_uniform_structs)
-					align_struct(type);
-
+				align_struct(type);
 				emit_struct(type);
 			}
 		}

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -78,7 +78,6 @@ public:
 	{
 		bool flip_vert_y = false;
 		bool is_rendering_points = true;
-		bool pad_and_pack_uniform_structs = false;
 		std::string entry_point_name;
 	};
 

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -92,6 +92,22 @@ public:
 		options = opts;
 	}
 
+	// An enum of SPIR-V functions that are implemented in additional
+	// source code that is added to the shader if necessary.
+	enum SPVFuncImpl
+	{
+		SPVFuncImplNone,
+		SPVFuncImplMod,
+		SPVFuncImplRadians,
+		SPVFuncImplDegrees,
+		SPVFuncImplFindILsb,
+		SPVFuncImplFindSMsb,
+		SPVFuncImplFindUMsb,
+		SPVFuncImplInverse2x2,
+		SPVFuncImplInverse3x3,
+		SPVFuncImplInverse4x4,
+	};
+
 	// Constructs an instance to compile the SPIR-V code into Metal Shading Language,
 	// using the configuration parameters, if provided:
 	//  - p_vtx_attrs is an optional list of vertex attribute bindings used to match
@@ -149,8 +165,7 @@ protected:
 	                             uint32_t grad_y, uint32_t lod, uint32_t coffset, uint32_t offset, uint32_t bias,
 	                             uint32_t comp, uint32_t sample, bool *p_forward) override;
 	std::string unpack_expression_type(std::string expr_str, const SPIRType &type) override;
-
-	std::string get_argument_address_space(const SPIRVariable &argument);
+	std::string bitcast_glsl_op(const SPIRType &result_type, const SPIRType &argument_type) override;
 
 	void preprocess_op_codes();
 	void emit_custom_functions();
@@ -196,14 +211,22 @@ protected:
 	void align_struct(SPIRType &ib_type);
 	bool is_member_packable(SPIRType &ib_type, uint32_t index);
 	MSLStructMemberKey get_struct_member_key(uint32_t type_id, uint32_t index);
+	SPVFuncImpl get_spv_func_impl(spv::Op opcode, const uint32_t *args);
+	std::string get_argument_address_space(const SPIRVariable &argument);
+	void emit_atomic_func_op(uint32_t result_type, uint32_t result_id, const char *op, uint32_t mem_order_1,
+	                         uint32_t mem_order_2, bool has_mem_order_2, uint32_t op0, uint32_t op1 = 0,
+	                         bool op1_is_pointer = false, uint32_t op2 = 0);
+	const char *get_memory_order(uint32_t spv_mem_sem);
+	void add_pragma_line(const std::string &line);
 
 	Options options;
 	std::unordered_map<std::string, std::string> func_name_overrides;
 	std::unordered_map<std::string, std::string> var_name_overrides;
-	std::set<uint32_t> custom_function_ops;
+	std::set<SPVFuncImpl> spv_function_implementations;
 	std::unordered_map<uint32_t, MSLVertexAttr *> vtx_attrs_by_location;
 	std::map<uint32_t, uint32_t> non_stage_in_input_var_ids;
 	std::unordered_map<MSLStructMemberKey, uint32_t> struct_member_padding;
+	std::vector<std::string> pragma_lines;
 	std::vector<MSLResourceBinding *> resource_bindings;
 	MSLResourceBinding next_metal_resource_index;
 	uint32_t stage_in_var_id = 0;
@@ -229,6 +252,7 @@ protected:
 
 		CompilerMSL &compiler;
 		bool suppress_missing_prototypes = false;
+		bool uses_atomics = false;
 	};
 
 	// Sorts the members of a SPIRType and associated Meta info based on a settable sorting

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -75,7 +75,8 @@ def print_msl_compiler_version():
 def validate_shader_msl(shader):
     msl_path = reference_path(shader[0], shader[1])
     try:
-        subprocess.check_call(['xcrun', '--sdk', 'iphoneos', 'metal', '-x', 'metal', '-std=ios-metal1.2', '-Werror', msl_path])
+        subprocess.check_call(['xcrun', '--sdk', 'macosx', 'metal', '-x', 'metal', '-std=osx-metal1.2', '-Werror', msl_path])
+#        subprocess.check_call(['xcrun', '--sdk', 'iphoneos', 'metal', '-x', 'metal', '-std=ios-metal1.2', '-Werror', msl_path])
         print('Compiled Metal shader: ' + msl_path)   # display after so xcrun FNF is silent
     except OSError as oe:
         if (oe.errno != os.errno.ENOENT):   # Ignore xcrun not found error


### PR DESCRIPTION
This started as a fix for #171, but extended to map a large number of GLSL functions to their Metal counterparts. 

See the commit note for details about the added functionality.