### PR TITLE
Add support for Separate Shader Objects

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -432,6 +432,7 @@ struct CLIArguments
 	bool force_temporary = false;
 	bool flatten_ubo = false;
 	bool fixup = false;
+	bool sso = false;
 	vector<PLSArg> pls_in;
 	vector<PLSArg> pls_out;
 	vector<Remap> remaps;
@@ -458,6 +459,7 @@ static void print_help()
 	                "[--cpp] [--cpp-interface-name <name>] "
 	                "[--msl] [--msl-no-pack-ubos] "
 	                "[--hlsl] [--shader-model] [--hlsl-enable-compat] "
+	                "[--separate-shader-objects]"
 	                "[--pls-in format input-name] [--pls-out format output-name] [--remap source_name target_name "
 	                "components] [--extension ext] [--entry name] [--remove-unused-variables] "
 	                "[--remap-variable-type <variable_name> <new_variable_type>]\n");
@@ -585,6 +587,7 @@ int main(int argc, char *argv[])
 	cbs.add("--vulkan-semantics", [&args](CLIParser &) { args.vulkan_semantics = true; });
 	cbs.add("--extension", [&args](CLIParser &parser) { args.extensions.push_back(parser.next_string()); });
 	cbs.add("--entry", [&args](CLIParser &parser) { args.entry = parser.next_string(); });
+	cbs.add("--separate-shader-objects", [&args](CLIParser &) { args.sso = true; });
 	cbs.add("--remap", [&args](CLIParser &parser) {
 		string src = parser.next_string();
 		string dst = parser.next_string();
@@ -689,6 +692,7 @@ int main(int argc, char *argv[])
 	if (args.set_es)
 		opts.es = args.es;
 	opts.force_temporary = args.force_temporary;
+	opts.separate_shader_objects = args.sso;
 	opts.vulkan_semantics = args.vulkan_semantics;
 	opts.vertex.fixup_clipspace = args.fixup;
 	opts.cfg_analysis = args.cfg_analysis;

--- a/reference/shaders/desktop-only/geom/basic.desktop.sso.geom
+++ b/reference/shaders/desktop-only/geom/basic.desktop.sso.geom
@@ -1,0 +1,35 @@
+#version 450
+layout(invocations = 4, triangles) in;
+layout(max_vertices = 3, triangle_strip) out;
+
+in gl_PerVertex
+{
+    vec4 gl_Position;
+} gl_in[];
+
+out gl_PerVertex
+{
+    vec4 gl_Position;
+};
+
+out vec3 vNormal;
+in VertexData
+{
+    vec3 normal;
+} vin[3];
+
+
+void main()
+{
+    gl_Position = gl_in[0].gl_Position;
+    vNormal = vin[0].normal + vec3(float(gl_InvocationID));
+    EmitVertex();
+    gl_Position = gl_in[1].gl_Position;
+    vNormal = vin[1].normal + vec3(4.0 * float(gl_InvocationID));
+    EmitVertex();
+    gl_Position = gl_in[2].gl_Position;
+    vNormal = vin[2].normal + vec3(2.0 * float(gl_InvocationID));
+    EmitVertex();
+    EndPrimitive();
+}
+

--- a/reference/shaders/desktop-only/tesc/basic.desktop.sso.tesc
+++ b/reference/shaders/desktop-only/tesc/basic.desktop.sso.tesc
@@ -1,0 +1,27 @@
+#version 450
+layout(vertices = 1) out;
+
+in gl_PerVertex
+{
+    vec4 gl_Position;
+} gl_in[gl_MaxPatchVertices];
+
+out gl_PerVertex
+{
+    vec4 gl_Position;
+} gl_out[1];
+
+patch out vec3 vFoo;
+
+void main()
+{
+    gl_TessLevelInner[0] = 8.8999996185302734375;
+    gl_TessLevelInner[1] = 6.900000095367431640625;
+    gl_TessLevelOuter[0] = 8.8999996185302734375;
+    gl_TessLevelOuter[1] = 6.900000095367431640625;
+    gl_TessLevelOuter[2] = 3.900000095367431640625;
+    gl_TessLevelOuter[3] = 4.900000095367431640625;
+    vFoo = vec3(1.0);
+    gl_out[gl_InvocationID].gl_Position = gl_in[0].gl_Position + gl_in[1].gl_Position;
+}
+

--- a/reference/shaders/desktop-only/tese/triangle.desktop.sso.tese
+++ b/reference/shaders/desktop-only/tese/triangle.desktop.sso.tese
@@ -1,0 +1,18 @@
+#version 450
+layout(triangles, cw, fractional_even_spacing) in;
+
+in gl_PerVertex
+{
+    vec4 gl_Position;
+} gl_in[gl_MaxPatchVertices];
+
+out gl_PerVertex
+{
+    vec4 gl_Position;
+};
+
+void main()
+{
+    gl_Position = ((gl_in[0].gl_Position * gl_TessCoord.x) + (gl_in[1].gl_Position * gl_TessCoord.y)) + (gl_in[2].gl_Position * gl_TessCoord.z);
+}
+

--- a/reference/shaders/desktop-only/vert/basic.desktop.sso.vert
+++ b/reference/shaders/desktop-only/vert/basic.desktop.sso.vert
@@ -1,0 +1,22 @@
+#version 450
+
+out gl_PerVertex
+{
+    vec4 gl_Position;
+};
+
+layout(std140) uniform UBO
+{
+    mat4 uMVP;
+} _16;
+
+in vec4 aVertex;
+out vec3 vNormal;
+in vec3 aNormal;
+
+void main()
+{
+    gl_Position = _16.uMVP * aVertex;
+    vNormal = aNormal;
+}
+

--- a/shaders/desktop-only/geom/basic.desktop.sso.geom
+++ b/shaders/desktop-only/geom/basic.desktop.sso.geom
@@ -1,0 +1,37 @@
+#version 450
+
+layout(triangles, invocations = 4) in;
+layout(triangle_strip, max_vertices = 3) out;
+
+in gl_PerVertex
+{
+   vec4 gl_Position;
+} gl_in[];
+
+out gl_PerVertex
+{
+   vec4 gl_Position;
+};
+
+in VertexData {
+    vec3 normal;
+} vin[];
+
+out vec3 vNormal;
+
+void main()
+{
+    gl_Position = gl_in[0].gl_Position;
+    vNormal = vin[0].normal + float(gl_InvocationID);
+    EmitVertex();
+
+    gl_Position = gl_in[1].gl_Position;
+    vNormal = vin[1].normal + 4.0 * float(gl_InvocationID);
+    EmitVertex();
+
+    gl_Position = gl_in[2].gl_Position;
+    vNormal = vin[2].normal + 2.0 * float(gl_InvocationID);
+    EmitVertex();
+
+    EndPrimitive();
+}

--- a/shaders/desktop-only/tesc/basic.desktop.sso.tesc
+++ b/shaders/desktop-only/tesc/basic.desktop.sso.tesc
@@ -1,0 +1,28 @@
+#version 450
+layout(vertices = 1) out;
+
+in gl_PerVertex
+{
+   vec4 gl_Position;
+} gl_in[gl_MaxPatchVertices];
+
+out gl_PerVertex
+{
+   vec4 gl_Position;
+} gl_out[1];
+
+patch out vec3 vFoo;
+
+
+void main()
+{
+    gl_TessLevelInner[0] = 8.9;
+    gl_TessLevelInner[1] = 6.9;
+    gl_TessLevelOuter[0] = 8.9;
+    gl_TessLevelOuter[1] = 6.9;
+    gl_TessLevelOuter[2] = 3.9;
+    gl_TessLevelOuter[3] = 4.9;
+    vFoo = vec3(1.0);
+
+    gl_out[gl_InvocationID].gl_Position = gl_in[0].gl_Position + gl_in[1].gl_Position;
+}

--- a/shaders/desktop-only/tese/triangle.desktop.sso.tese
+++ b/shaders/desktop-only/tese/triangle.desktop.sso.tese
@@ -1,0 +1,22 @@
+#version 450
+
+layout(cw, triangles, fractional_even_spacing) in;
+
+in gl_PerVertex
+{
+   vec4 gl_Position;
+} gl_in[gl_MaxPatchVertices];
+
+out gl_PerVertex
+{
+   vec4 gl_Position;
+};
+
+void main()
+{
+   gl_Position =
+      gl_in[0].gl_Position * gl_TessCoord.x +
+      gl_in[1].gl_Position * gl_TessCoord.y +
+      gl_in[2].gl_Position * gl_TessCoord.z;
+}
+

--- a/shaders/desktop-only/vert/basic.desktop.sso.vert
+++ b/shaders/desktop-only/vert/basic.desktop.sso.vert
@@ -1,0 +1,20 @@
+#version 450
+
+out gl_PerVertex
+{
+   vec4 gl_Position;
+};
+
+layout(std140) uniform UBO
+{
+    mat4 uMVP;
+};
+in vec4 aVertex;
+in vec3 aNormal;
+out vec3 vNormal;
+
+void main()
+{
+    gl_Position = uMVP * aVertex;
+    vNormal = aNormal;
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1543,6 +1543,12 @@ void CompilerGLSL::emit_declared_builtin_block(StorageClass storage, ExecutionMo
 		bool tessellation = model == ExecutionModelTessellationEvaluation || model == ExecutionModelTessellationControl;
 		if (builtin_array)
 		{
+			// Make sure the array has a supported name in the code.
+			if (storage == StorageClassOutput)
+				set_name(var.self, "gl_out");
+			else if (storage == StorageClassInput)
+				set_name(var.self, "gl_in");
+
 			if (model == ExecutionModelTessellationControl && storage == StorageClassOutput)
 				end_scope_decl(join(to_name(var.self), "[", get_entry_point().output_vertices, "]"));
 			else

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -67,6 +67,12 @@ public:
 		// Mostly useful for debugging SPIR-V files.
 		bool vulkan_semantics = false;
 
+		// If true, gl_PerVertex is explicitly redeclared in vertex, geometry and tessellation shaders.
+		// The members of gl_PerVertex is determined by which built-ins are declared by the shader.
+		// This option is ignored in ES versions, as redeclaration in ES is not required, and it depends on a different extension
+		// (EXT_shader_io_blocks) which makes things a bit more fuzzy.
+		bool separate_shader_objects = false;
+
 		enum Precision
 		{
 			DontCare,
@@ -284,6 +290,7 @@ protected:
 	void emit_buffer_block_native(const SPIRVariable &var);
 	void emit_buffer_block_legacy(const SPIRVariable &var);
 	void emit_buffer_block_flattened(const SPIRVariable &type);
+	void emit_declared_builtin_block(spv::StorageClass storage, spv::ExecutionModel model);
 	void emit_push_constant_block_vulkan(const SPIRVariable &var);
 	void emit_push_constant_block_glsl(const SPIRVariable &var);
 	void emit_interface_block(const SPIRVariable &type);

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -120,7 +120,7 @@ def validate_shader(shader, vulkan):
     else:
         subprocess.check_call(['glslangValidator', shader])
 
-def cross_compile(shader, vulkan, spirv, invalid_spirv, eliminate, is_legacy, flatten_ubo):
+def cross_compile(shader, vulkan, spirv, invalid_spirv, eliminate, is_legacy, flatten_ubo, sso):
     spirv_f, spirv_path = tempfile.mkstemp()
     glsl_f, glsl_path = tempfile.mkstemp(suffix = os.path.basename(shader))
     os.close(spirv_f)
@@ -145,6 +145,8 @@ def cross_compile(shader, vulkan, spirv, invalid_spirv, eliminate, is_legacy, fl
         extra_args += ['--version', '100', '--es']
     if flatten_ubo:
         extra_args += ['--flatten-ubo']
+    if sso:
+        extra_args += ['--separate-shader-objects']
 
     spirv_cross_path = './spirv-cross'
     subprocess.check_call([spirv_cross_path, '--entry', 'main', '--output', glsl_path, spirv_path] + extra_args)
@@ -238,6 +240,9 @@ def shader_is_legacy(shader):
 def shader_is_flatten_ubo(shader):
     return '.flatten.' in shader
 
+def shader_is_sso(shader):
+    return '.sso.' in shader
+
 def test_shader(stats, shader, update, keep):
     joined_path = os.path.join(shader[0], shader[1])
     vulkan = shader_is_vulkan(shader[1])
@@ -247,9 +252,10 @@ def test_shader(stats, shader, update, keep):
     invalid_spirv = shader_is_invalid_spirv(shader[1])
     is_legacy = shader_is_legacy(shader[1])
     flatten_ubo = shader_is_flatten_ubo(shader[1])
+    sso = shader_is_sso(shader[1])
 
     print('Testing shader:', joined_path)
-    spirv, glsl, vulkan_glsl = cross_compile(joined_path, vulkan, is_spirv, invalid_spirv, eliminate, is_legacy, flatten_ubo)
+    spirv, glsl, vulkan_glsl = cross_compile(joined_path, vulkan, is_spirv, invalid_spirv, eliminate, is_legacy, flatten_ubo, sso)
 
     # Only test GLSL stats if we have a shader following GL semantics.
     if stats and (not vulkan) and (not is_spirv) and (not desktop):


### PR DESCRIPTION
SSO shaders need explicit declaration of gl_PerVertex between stages.
This PR adds support for SSO between vertex, geometry and tessellation shaders.

A CLI option for --separate-shader-objects and an API option will force gl_PerVertex to be redeclared with the builtin block inside the shader.

Only desktop is supported. ES is a bit weird here since SSO support does not imply block support.

gl_PerFragment is only for compatibility context, so it is not relevant for SPIR-V.