### PR TITLE
Add support for flattening multidimensional arrays into single dimension

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -446,6 +446,7 @@ struct CLIArguments
 	bool hlsl = false;
 	bool hlsl_compat = false;
 	bool vulkan_semantics = false;
+	bool flatten_multidimensional_arrays = false;
 	bool remove_unused = false;
 	bool cfg_analysis = true;
 };
@@ -461,6 +462,7 @@ static void print_help()
 	                "[--separate-shader-objects]"
 	                "[--pls-in format input-name] [--pls-out format output-name] [--remap source_name target_name "
 	                "components] [--extension ext] [--entry name] [--remove-unused-variables] "
+	                "[--flatten-multidimensional-arrays] "
 	                "[--remap-variable-type <variable_name> <new_variable_type>]\n");
 }
 
@@ -583,6 +585,7 @@ int main(int argc, char *argv[])
 	cbs.add("--hlsl", [&args](CLIParser &) { args.hlsl = true; });
 	cbs.add("--hlsl-enable-compat", [&args](CLIParser &) { args.hlsl_compat = true; });
 	cbs.add("--vulkan-semantics", [&args](CLIParser &) { args.vulkan_semantics = true; });
+	cbs.add("--flatten-multidimensional-arrays", [&args](CLIParser &) { args.flatten_multidimensional_arrays = true; });
 	cbs.add("--extension", [&args](CLIParser &parser) { args.extensions.push_back(parser.next_string()); });
 	cbs.add("--entry", [&args](CLIParser &parser) { args.entry = parser.next_string(); });
 	cbs.add("--separate-shader-objects", [&args](CLIParser &) { args.sso = true; });
@@ -690,6 +693,7 @@ int main(int argc, char *argv[])
 		opts.es = args.es;
 	opts.force_temporary = args.force_temporary;
 	opts.separate_shader_objects = args.sso;
+	opts.flatten_multidimensional_arrays = args.flatten_multidimensional_arrays;
 	opts.vulkan_semantics = args.vulkan_semantics;
 	opts.vertex.fixup_clipspace = args.fixup;
 	opts.cfg_analysis = args.cfg_analysis;

--- a/reference/shaders/flatten/multi-dimensional.desktop.flatten_dim.frag
+++ b/reference/shaders/flatten/multi-dimensional.desktop.flatten_dim.frag
@@ -1,0 +1,24 @@
+#version 450
+
+layout(binding = 0) uniform sampler2D uTextures[2 * 3 * 1];
+
+layout(location = 1) in vec2 vUV;
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) flat in int vIndex;
+
+void main()
+{
+    vec4 values3[2 * 3 * 1];
+    for (int z = 0; z < 2; z++)
+    {
+        for (int y = 0; y < 3; y++)
+        {
+            for (int x = 0; x < 1; x++)
+            {
+                values3[z * 3 * 1 + y * 1 + x] = texture(uTextures[z * 3 * 1 + y * 1 + x], vUV);
+            }
+        }
+    }
+    FragColor = ((values3[1 * 3 * 1 + 2 * 1 + 0]) + (values3[0 * 3 * 1 + 2 * 1 + 0])) + (values3[(vIndex + 1) * 3 * 1 + 2 * 1 + vIndex]);
+}
+

--- a/shaders/flatten/multi-dimensional.desktop.flatten_dim.frag
+++ b/shaders/flatten/multi-dimensional.desktop.flatten_dim.frag
@@ -1,0 +1,18 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+layout(binding = 0) uniform sampler2D uTextures[2][3][1];
+layout(location = 0) flat in int vIndex;
+layout(location = 1) in vec2 vUV;
+
+void main()
+{
+   vec4 values3[2][3][1];
+
+   for (int z = 0; z < 2; z++)
+      for (int y = 0; y < 3; y++)
+         for (int x = 0; x < 1; x++)
+            values3[z][y][x] = texture(uTextures[z][y][x], vUV);
+
+   FragColor = values3[1][2][0] + values3[0][2][0] + values3[vIndex + 1][2][vIndex];
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -6186,8 +6186,15 @@ string CompilerGLSL::image_type_glsl(const SPIRType &type)
 
 string CompilerGLSL::type_to_glsl_constructor(const SPIRType &type)
 {
-	if (options.flatten_multidimensional_arrays && type.array.size() > 1)
-		SPIRV_CROSS_THROW("Cannot flatten constructors of multidimensional array constructors, e.g. float[][]().");
+	if (type.array.size() > 1)
+	{
+		if (options.flatten_multidimensional_arrays)
+			SPIRV_CROSS_THROW("Cannot flatten constructors of multidimensional array constructors, e.g. float[][]().");
+		else if (!options.es && options.version < 430)
+			require_extension("GL_ARB_arrays_of_arrays");
+		else if (options.es && options.version < 310)
+			SPIRV_CROSS_THROW("Arrays of arrays not supported before ESSL version 310.");
+	}
 
 	auto e = type_to_glsl(type);
 	for (uint32_t i = 0; i < type.array.size(); i++)

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -73,6 +73,12 @@ public:
 		// (EXT_shader_io_blocks) which makes things a bit more fuzzy.
 		bool separate_shader_objects = false;
 
+		// Flattens multidimensional arrays, e.g. float foo[a][b][c] into single-dimensional arrays,
+		// e.g. float foo[a * b * c].
+		// This function does not change the actual SPIRType of any object.
+		// Only the generated code, including declarations of interface variables are changed to be single array dimension.
+		bool flatten_multidimensional_arrays = true;
+
 		enum Precision
 		{
 			DontCare,
@@ -359,6 +365,7 @@ protected:
 	void append_global_func_args(const SPIRFunction &func, uint32_t index, std::vector<std::string> &arglist);
 	std::string to_expression(uint32_t id);
 	std::string to_enclosed_expression(uint32_t id);
+	std::string enclose_expression(const std::string &expr);
 	void strip_enclosed_expression(std::string &expr);
 	std::string to_member_name(const SPIRType &type, uint32_t index);
 	std::string type_to_glsl_constructor(const SPIRType &type);

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -77,7 +77,7 @@ public:
 		// e.g. float foo[a * b * c].
 		// This function does not change the actual SPIRType of any object.
 		// Only the generated code, including declarations of interface variables are changed to be single array dimension.
-		bool flatten_multidimensional_arrays = true;
+		bool flatten_multidimensional_arrays = false;
 
 		enum Precision
 		{

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -121,7 +121,7 @@ def validate_shader(shader, vulkan):
     else:
         subprocess.check_call(['glslangValidator', shader])
 
-def cross_compile(shader, vulkan, spirv, invalid_spirv, eliminate, is_legacy, flatten_ubo, sso):
+def cross_compile(shader, vulkan, spirv, invalid_spirv, eliminate, is_legacy, flatten_ubo, sso, flatten_dim):
     spirv_f, spirv_path = tempfile.mkstemp()
     glsl_f, glsl_path = tempfile.mkstemp(suffix = os.path.basename(shader))
     os.close(spirv_f)
@@ -148,6 +148,8 @@ def cross_compile(shader, vulkan, spirv, invalid_spirv, eliminate, is_legacy, fl
         extra_args += ['--flatten-ubo']
     if sso:
         extra_args += ['--separate-shader-objects']
+    if flatten_dim:
+        extra_args += ['--flatten-multidimensional-arrays']
 
     spirv_cross_path = './spirv-cross'
     subprocess.check_call([spirv_cross_path, '--entry', 'main', '--output', glsl_path, spirv_path] + extra_args)
@@ -244,6 +246,9 @@ def shader_is_flatten_ubo(shader):
 def shader_is_sso(shader):
     return '.sso.' in shader
 
+def shader_is_flatten_dimensions(shader):
+    return '.flatten_dim.' in shader
+
 def test_shader(stats, shader, update, keep):
     joined_path = os.path.join(shader[0], shader[1])
     vulkan = shader_is_vulkan(shader[1])
@@ -254,9 +259,10 @@ def test_shader(stats, shader, update, keep):
     is_legacy = shader_is_legacy(shader[1])
     flatten_ubo = shader_is_flatten_ubo(shader[1])
     sso = shader_is_sso(shader[1])
+    flatten_dim = shader_is_flatten_dimensions(shader[1])
 
     print('Testing shader:', joined_path)
-    spirv, glsl, vulkan_glsl = cross_compile(joined_path, vulkan, is_spirv, invalid_spirv, eliminate, is_legacy, flatten_ubo, sso)
+    spirv, glsl, vulkan_glsl = cross_compile(joined_path, vulkan, is_spirv, invalid_spirv, eliminate, is_legacy, flatten_ubo, sso, flatten_dim)
 
     # Only test GLSL stats if we have a shader following GL semantics.
     if stats and (not vulkan) and (not is_spirv) and (not desktop):


### PR DESCRIPTION
In older targets, multiple array dimensions are not supported.
This PR adds support to flatten `float[2][3][4]` to `float[2 * 3 * 4]` and access chains are modified to do this flattening.

The support is a bit limited. Constructors of multiple dimensions and partially accessing a multidimensional array is not supported.