### PR TITLE
Emit type declarations tuned for specified SPIR-V objects + MSL builtin enhancements.

### DIFF
--- a/reference/shaders-msl/flatten/basic.flatten.vert
+++ b/reference/shaders-msl/flatten/basic.flatten.vert
@@ -18,7 +18,6 @@ struct main0_out
 {
     float3 vNormal [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize;
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _16 [[buffer(0)]])

--- a/reference/shaders-msl/flatten/multiindex.flatten.vert
+++ b/reference/shaders-msl/flatten/multiindex.flatten.vert
@@ -16,7 +16,6 @@ struct main0_in
 struct main0_out
 {
     float4 gl_Position [[position]];
-    float gl_PointSize;
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _20 [[buffer(0)]])

--- a/reference/shaders-msl/flatten/push-constant.flatten.vert
+++ b/reference/shaders-msl/flatten/push-constant.flatten.vert
@@ -20,7 +20,6 @@ struct main0_out
 {
     float2 vRot [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize;
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant PushMe& registers [[buffer(0)]])

--- a/reference/shaders-msl/flatten/struct.flatten.vert
+++ b/reference/shaders-msl/flatten/struct.flatten.vert
@@ -26,7 +26,6 @@ struct main0_out
 {
     float4 vColor [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize;
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _18 [[buffer(0)]])

--- a/reference/shaders-msl/flatten/swizzle.flatten.vert
+++ b/reference/shaders-msl/flatten/swizzle.flatten.vert
@@ -30,7 +30,6 @@ struct main0_out
     float4 oB [[user(locn4)]];
     float4 oA [[user(locn5)]];
     float4 gl_Position [[position]];
-    float gl_PointSize;
 };
 
 vertex main0_out main0(constant UBO& _22 [[buffer(0)]])

--- a/reference/shaders-msl/legacy/vert/transpose.legacy.vert
+++ b/reference/shaders-msl/legacy/vert/transpose.legacy.vert
@@ -18,7 +18,6 @@ struct main0_in
 struct main0_out
 {
     float4 gl_Position [[position]];
-    float gl_PointSize;
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant Buffer& _13 [[buffer(0)]])

--- a/reference/shaders-msl/vert/basic.vert
+++ b/reference/shaders-msl/vert/basic.vert
@@ -18,7 +18,6 @@ struct main0_out
 {
     float3 vNormal [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize;
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _16 [[buffer(0)]])

--- a/reference/shaders-msl/vert/copy.flatten.vert
+++ b/reference/shaders-msl/vert/copy.flatten.vert
@@ -26,7 +26,6 @@ struct main0_out
 {
     float4 vColor [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize;
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _21 [[buffer(0)]])

--- a/reference/shaders-msl/vert/dynamic.flatten.vert
+++ b/reference/shaders-msl/vert/dynamic.flatten.vert
@@ -26,7 +26,6 @@ struct main0_out
 {
     float4 vColor [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize;
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _21 [[buffer(0)]])

--- a/reference/shaders-msl/vert/functions.vert
+++ b/reference/shaders-msl/vert/functions.vert
@@ -27,7 +27,6 @@ struct main0_out
     int2 vMSB [[user(locn3)]];
     int2 vLSB [[user(locn4)]];
     float4 gl_Position [[position]];
-    float gl_PointSize;
 };
 
 // Implementation of the GLSL radians() function

--- a/reference/shaders-msl/vert/out_block.vert
+++ b/reference/shaders-msl/vert/out_block.vert
@@ -18,8 +18,6 @@ struct main0_out
 {
     float4 VertexOut_color [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize;
-    float gl_ClipDistance [[clip_distance]] [1];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant Transform& block [[buffer(0)]])

--- a/reference/shaders-msl/vert/out_block.vert
+++ b/reference/shaders-msl/vert/out_block.vert
@@ -19,7 +19,7 @@ struct main0_out
     float4 VertexOut_color [[user(locn0)]];
     float4 gl_Position [[position]];
     float gl_PointSize;
-    float gl_ClipDistance[1] /* [[clip_distance]] built-in not yet supported under Metal. */;
+    float gl_ClipDistance [[clip_distance]] [1];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant Transform& block [[buffer(0)]])

--- a/reference/shaders-msl/vert/pointsize.vert
+++ b/reference/shaders-msl/vert/pointsize.vert
@@ -20,7 +20,6 @@ struct main0_out
     float4 color [[user(locn0)]];
     float4 gl_Position [[position]];
     float gl_PointSize [[point_size]];
-    float gl_ClipDistance [[clip_distance]] [1];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant params& _19 [[buffer(0)]])

--- a/reference/shaders-msl/vert/pointsize.vert
+++ b/reference/shaders-msl/vert/pointsize.vert
@@ -20,7 +20,7 @@ struct main0_out
     float4 color [[user(locn0)]];
     float4 gl_Position [[position]];
     float gl_PointSize [[point_size]];
-    float gl_ClipDistance[1] /* [[clip_distance]] built-in not yet supported under Metal. */;
+    float gl_ClipDistance [[clip_distance]] [1];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant params& _19 [[buffer(0)]])

--- a/reference/shaders-msl/vert/texture_buffer.vert
+++ b/reference/shaders-msl/vert/texture_buffer.vert
@@ -6,7 +6,6 @@ using namespace metal;
 struct main0_out
 {
     float4 gl_Position [[position]];
-    float gl_PointSize;
 };
 
 vertex main0_out main0(texture2d<float> uSamp [[texture(0)]], texture2d<float> uSampo [[texture(1)]])

--- a/reference/shaders-msl/vert/ubo.alignment.vert
+++ b/reference/shaders-msl/vert/ubo.alignment.vert
@@ -24,7 +24,6 @@ struct main0_out
     float3 vNormal [[user(locn1)]];
     float3 vColor [[user(locn2)]];
     float4 gl_Position [[position]];
-    float gl_PointSize;
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _18 [[buffer(0)]])

--- a/reference/shaders-msl/vert/ubo.vert
+++ b/reference/shaders-msl/vert/ubo.vert
@@ -18,7 +18,6 @@ struct main0_out
 {
     float3 vNormal [[user(locn0)]];
     float4 gl_Position [[position]];
-    float gl_PointSize;
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _16 [[buffer(0)]])

--- a/reference/shaders-msl/vulkan/vert/vulkan-vertex.vk.vert
+++ b/reference/shaders-msl/vulkan/vert/vulkan-vertex.vk.vert
@@ -6,7 +6,6 @@ using namespace metal;
 struct main0_out
 {
     float4 gl_Position [[position]];
-    float gl_PointSize;
 };
 
 vertex main0_out main0(uint gl_VertexIndex [[vertex_id]], uint gl_InstanceIndex [[instance_id]])

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -296,10 +296,9 @@ struct SPIRType : IVariant
 		bool depth;
 		bool arrayed;
 		bool ms;
-		bool is_read = false; // TODO: temp hack to be replaced with var-based type output
-		bool is_written = false; // TODO: temp hack to be replaced with var-based type output
 		uint32_t sampled;
 		spv::ImageFormat format;
+		spv::AccessQualifier access;
 	} image;
 
 	// Structs can be declared multiple times if they are used as part of interface blocks.

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -296,8 +296,8 @@ struct SPIRType : IVariant
 		bool depth;
 		bool arrayed;
 		bool ms;
-		bool is_read = false;       // TODO: temp hack to be replaced with var-based type output
-		bool is_written = false;    // TODO: temp hack to be replaced with var-based type output
+		bool is_read = false; // TODO: temp hack to be replaced with var-based type output
+		bool is_written = false; // TODO: temp hack to be replaced with var-based type output
 		uint32_t sampled;
 		spv::ImageFormat format;
 	} image;

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -1468,6 +1468,7 @@ void Compiler::parse(const Instruction &instruction)
 		type.image.ms = ops[5] != 0;
 		type.image.sampled = ops[6];
 		type.image.format = static_cast<ImageFormat>(ops[7]);
+		type.image.access = (length >= 9) ? static_cast<AccessQualifier>(ops[8]) : AccessQualifierMax;
 		break;
 	}
 

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -1469,6 +1469,10 @@ void Compiler::parse(const Instruction &instruction)
 		type.image.sampled = ops[6];
 		type.image.format = static_cast<ImageFormat>(ops[7]);
 		type.image.access = (length >= 9) ? static_cast<AccessQualifier>(ops[8]) : AccessQualifierMax;
+
+		if (type.image.sampled == 0)
+			SPIRV_CROSS_THROW("OpTypeImage Sampled parameter must not be zero.");
+
 		break;
 	}
 

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -3409,6 +3409,25 @@ void Compiler::update_active_builtins()
 	traverse_all_reachable_opcodes(get<SPIRFunction>(entry_point), handler);
 }
 
+// Returns whether this shader uses a builtin of the storage class
+bool Compiler::has_active_builtin(BuiltIn builtin, StorageClass storage)
+{
+	uint64_t flags;
+	switch (storage)
+	{
+	case StorageClassInput:
+		flags = active_input_builtins;
+		break;
+	case StorageClassOutput:
+		flags = active_output_builtins;
+		break;
+
+	default:
+		return false;
+	}
+	return flags & (1ull << builtin);
+}
+
 void Compiler::analyze_sampler_comparison_states()
 {
 	CombinedImageSamplerUsageHandler handler(*this);

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -640,6 +640,7 @@ protected:
 	uint64_t active_output_builtins = 0;
 	// Traverses all reachable opcodes and sets active_builtins to a bitmask of all builtin variables which are accessed in the shader.
 	void update_active_builtins();
+	bool has_active_builtin(spv::BuiltIn builtin, spv::StorageClass storage);
 
 	void analyze_parameter_preservation(
 	    SPIRFunction &entry, const CFG &cfg,

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -2893,11 +2893,6 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 	auto &type = expression_type(img);
 	auto &imgtype = get<SPIRType>(type.self);
 
-	// Mark that this shader reads from this image
-	auto *p_var = maybe_get_backing_variable(img);
-	if (p_var)
-		unset_decoration(p_var->self, DecorationNonReadable);
-
 	uint32_t coord_components = 0;
 	switch (imgtype.image.dim)
 	{

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -159,11 +159,11 @@ protected:
 	virtual void emit_header();
 	virtual void emit_sampled_image_op(uint32_t result_type, uint32_t result_id, uint32_t image_id, uint32_t samp_id);
 	virtual void emit_texture_op(const Instruction &i);
-	virtual std::string type_to_glsl(const SPIRType &type);
+	virtual std::string type_to_glsl(const SPIRType &type, uint32_t id = 0);
 	virtual std::string builtin_to_glsl(spv::BuiltIn builtin);
 	virtual void emit_struct_member(const SPIRType &type, uint32_t member_type_id, uint32_t index,
 	                                const std::string &qualifier = "");
-	virtual std::string image_type_glsl(const SPIRType &type);
+	virtual std::string image_type_glsl(const SPIRType &type, uint32_t id = 0);
 	virtual std::string constant_expression(const SPIRConstant &c);
 	std::string constant_op_expression(const SPIRConstantOp &cop);
 	virtual std::string constant_expression_vector(const SPIRConstant &c, uint32_t vector);

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -154,7 +154,10 @@ string CompilerHLSL::image_type_hlsl(const SPIRType &type)
 		return image_type_hlsl_modern(type);
 }
 
-string CompilerHLSL::type_to_glsl(const SPIRType &type)
+// The optional id parameter indicates the object whose type we are trying
+// to find the description for. It is optional. Most type descriptions do not
+// depend on a specific object's use of that type.
+string CompilerHLSL::type_to_glsl(const SPIRType &type, uint32_t /* id */)
 {
 	// Ignore the pointer type since GLSL doesn't have pointers.
 

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -59,7 +59,7 @@ public:
 	std::string compile() override;
 
 private:
-	std::string type_to_glsl(const SPIRType &type) override;
+	std::string type_to_glsl(const SPIRType &type, uint32_t id = 0) override;
 	std::string image_type_hlsl(const SPIRType &type);
 	std::string image_type_hlsl_modern(const SPIRType &type);
 	std::string image_type_hlsl_legacy(const SPIRType &type);

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1179,10 +1179,18 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 
 	// Images
 
-	// Reads == fetches in Metal
+	// Reads == Fetches in Metal
 	case OpImageRead:
+	{
+		// Mark that this shader reads from this image
+		uint32_t img_id = ops[2];
+		auto *p_var = maybe_get_backing_variable(img_id);
+		if (p_var)
+			unset_decoration(p_var->self, DecorationNonReadable);
+
 		emit_texture_op(instruction);
 		break;
+	}
 
 	case OpImageWrite:
 	{
@@ -2490,7 +2498,7 @@ string CompilerMSL::image_type_glsl(const SPIRType &type, uint32_t id)
 	// For unsampled images, append the sample/read/write access qualifier.
 	// For kernel images, the access qualifier my be supplied directly by SPIR-V.
 	// Otherwise it may be set based on whether the image is read from or written to within the shader.
-	if (type.basetype == SPIRType::Image)
+	if (type.basetype == SPIRType::Image && type.image.sampled == 2)
 	{
 		switch (img_type.access)
 		{

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -149,8 +149,8 @@ protected:
 	void emit_fixup() override;
 	void emit_struct_member(const SPIRType &type, uint32_t member_type_id, uint32_t index,
 	                        const std::string &qualifier = "") override;
-	std::string type_to_glsl(const SPIRType &type) override;
-	std::string image_type_glsl(const SPIRType &type) override;
+	std::string type_to_glsl(const SPIRType &type, uint32_t id = 0) override;
+	std::string image_type_glsl(const SPIRType &type, uint32_t id = 0) override;
 	std::string builtin_to_glsl(spv::BuiltIn builtin) override;
 	std::string constant_expression(const SPIRConstant &c) override;
 	size_t get_declared_struct_member_size(const SPIRType &struct_type, uint32_t index) const override;
@@ -165,6 +165,7 @@ protected:
 	                             uint32_t comp, uint32_t sample, bool *p_forward) override;
 	std::string unpack_expression_type(std::string expr_str, const SPIRType &type) override;
 	std::string bitcast_glsl_op(const SPIRType &result_type, const SPIRType &argument_type) override;
+	bool skip_argument(uint32_t id) const override;
 
 	void preprocess_op_codes();
 	void emit_custom_functions();
@@ -217,7 +218,6 @@ protected:
 	                         bool op1_is_pointer = false, uint32_t op2 = 0);
 	const char *get_memory_order(uint32_t spv_mem_sem);
 	void add_pragma_line(const std::string &line);
-	bool skip_argument(uint32_t id) const override;
 
 	Options options;
 	std::unordered_map<std::string, std::string> func_name_overrides;


### PR DESCRIPTION
Per extended discussion in issue #186, add support for emitting SPIR-V type declarations tuned for specified SPIR-V objects, as well as SPIR-V `OpTypeImage` access qualifiers. CompilerMSL uses this to output appropriate MSL image access qualifiers.

Also includes several MSL builtin enhancements, including eliding unused builtin inputs and outputs, and support for gl_ClipDistance in Metal.