### PR TITLE
Fix null pointer dereference

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -192,7 +192,7 @@ static bool write_string_to_file(const char *path, const char *string)
 	FILE *file = fopen(path, "w");
 	if (!file)
 	{
-		fprintf(file, "Failed to write file: %s\n", path);
+		fprintf(stderr, "Failed to write file: %s\n", path);
 		return false;
 	}
 


### PR DESCRIPTION
write_string_to_file would try to write the error message that it failed to open a file stream to the very same file stream it just tried to open.
Fix this by writing to stderr instead.