### PR TITLE
Make image2dBase::load const

### DIFF
--- a/include/spirv_cross/image.hpp
+++ b/include/spirv_cross/image.hpp
@@ -33,7 +33,7 @@ template <typename T>
 struct image2DBase
 {
 	virtual ~image2DBase() = default;
-	inline virtual T load(glm::ivec2 coord)
+	inline virtual T load(glm::ivec2 coord) const
 	{
 		return T(0, 0, 0, 1);
 	}


### PR DESCRIPTION
imageLoad takes a const-ref to image and calls load on it, make the load method const to prevent compile error.