### PR TITLE
Geometry shader core since GLSL 150

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -275,7 +275,7 @@ void CompilerGLSL::find_static_extensions()
 	case ExecutionModelGeometry:
 		if (options.es && options.version < 320)
 			require_extension("GL_EXT_geometry_shader");
-		if (!options.es && options.version < 320)
+		if (!options.es && options.version < 150)
 			require_extension("GL_ARB_geometry_shader4");
 
 		if ((execution.flags & (1ull << ExecutionModeInvocations)) && execution.invocations != 1)


### PR DESCRIPTION
According to https://www.khronos.org/opengl/wiki/History_of_OpenGL#OpenGL_3.2_.282009.29

I am getting errors on OS X when output GLSL version is set to 150 and the unnecessary 
`#extension GL_ARB_geometry_shader4 : require`
string is still generated
