### PR TITLE
Update glslang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ dist: trusty
 
 # We check out glslang at a specific revision to avoid test output mismatches
 env:
-  - GLSLANG_REV=de1cc06c1d1c1eeae31aa5cae686ccf24064730f
+  - GLSLANG_REV=f0bc598dd7871689f25514b22a82f7455d762bef
 
 before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi

--- a/reference/shaders-hlsl/vert/basic.vert
+++ b/reference/shaders-hlsl/vert/basic.vert
@@ -15,8 +15,8 @@ static float3 aNormal;
 
 struct SPIRV_Cross_Input
 {
-    float3 aNormal : TEXCOORD0;
-    float4 aVertex : TEXCOORD1;
+    float4 aVertex : TEXCOORD0;
+    float3 aNormal : TEXCOORD1;
 };
 
 struct SPIRV_Cross_Output

--- a/reference/shaders-hlsl/vert/locations.vert
+++ b/reference/shaders-hlsl/vert/locations.vert
@@ -25,9 +25,9 @@ static VertexOut vout;
 
 struct SPIRV_Cross_Input
 {
+    float4 Input0 : TEXCOORD0;
     float4 Input2 : TEXCOORD2;
     float4 Input4 : TEXCOORD4;
-    float4 Input0 : TEXCOORD0;
 };
 
 struct SPIRV_Cross_Output

--- a/reference/shaders-hlsl/vert/matrix-attribute.vert
+++ b/reference/shaders-hlsl/vert/matrix-attribute.vert
@@ -4,11 +4,11 @@ static float3 pos;
 
 struct SPIRV_Cross_Input
 {
-    float4 m_0 : TEXCOORD0;
-    float4 m_1 : TEXCOORD1;
-    float4 m_2 : TEXCOORD2;
-    float4 m_3 : TEXCOORD3;
-    float3 pos : TEXCOORD4;
+    float3 pos : TEXCOORD0;
+    float4 m_0 : TEXCOORD1;
+    float4 m_1 : TEXCOORD2;
+    float4 m_2 : TEXCOORD3;
+    float4 m_3 : TEXCOORD4;
 };
 
 struct SPIRV_Cross_Output

--- a/reference/shaders-msl/flatten/basic.flatten.vert
+++ b/reference/shaders-msl/flatten/basic.flatten.vert
@@ -10,8 +10,8 @@ struct UBO
 
 struct main0_in
 {
-    float4 aVertex [[attribute(0)]];
     float3 aNormal [[attribute(1)]];
+    float4 aVertex [[attribute(0)]];
 };
 
 struct main0_out

--- a/reference/shaders-msl/flatten/struct.flatten.vert
+++ b/reference/shaders-msl/flatten/struct.flatten.vert
@@ -18,8 +18,8 @@ struct UBO
 
 struct main0_in
 {
-    float4 aVertex [[attribute(0)]];
     float3 aNormal [[attribute(1)]];
+    float4 aVertex [[attribute(0)]];
 };
 
 struct main0_out

--- a/reference/shaders-msl/flatten/swizzle.flatten.vert
+++ b/reference/shaders-msl/flatten/swizzle.flatten.vert
@@ -23,12 +23,12 @@ struct UBO
 
 struct main0_out
 {
-    float4 oF [[user(locn0)]];
-    float4 oE [[user(locn1)]];
-    float4 oD [[user(locn2)]];
-    float4 oC [[user(locn3)]];
-    float4 oB [[user(locn4)]];
-    float4 oA [[user(locn5)]];
+    float4 oF [[user(locn5)]];
+    float4 oE [[user(locn4)]];
+    float4 oD [[user(locn3)]];
+    float4 oC [[user(locn2)]];
+    float4 oB [[user(locn1)]];
+    float4 oA [[user(locn0)]];
     float4 gl_Position [[position]];
 };
 

--- a/reference/shaders-msl/frag/basic.frag
+++ b/reference/shaders-msl/frag/basic.frag
@@ -5,8 +5,8 @@ using namespace metal;
 
 struct main0_in
 {
-    float2 vTex [[user(locn0)]];
-    float4 vColor [[user(locn1)]];
+    float2 vTex [[user(locn1)]];
+    float4 vColor [[user(locn0)]];
 };
 
 struct main0_out

--- a/reference/shaders-msl/frag/in_block.frag
+++ b/reference/shaders-msl/frag/in_block.frag
@@ -1,0 +1,23 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_in
+{
+    float4 VertexOut_color2 [[user(locn3)]];
+    float4 VertexOut_color [[user(locn2)]];
+};
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    out.FragColor = in.VertexOut_color + in.VertexOut_color2;
+    return out;
+}
+

--- a/reference/shaders-msl/frag/pls.frag
+++ b/reference/shaders-msl/frag/pls.frag
@@ -5,8 +5,8 @@ using namespace metal;
 
 struct main0_in
 {
-    float4 PLSIn3 [[user(locn0)]];
-    float4 PLSIn2 [[user(locn1)]];
+    float4 PLSIn3 [[user(locn3)]];
+    float4 PLSIn2 [[user(locn2)]];
     float4 PLSIn1 [[user(locn1)]];
     float4 PLSIn0 [[user(locn0)]];
 };

--- a/reference/shaders-msl/frag/sampler.frag
+++ b/reference/shaders-msl/frag/sampler.frag
@@ -7,8 +7,8 @@ using namespace metal;
 
 struct main0_in
 {
-    float2 vTex [[user(locn0)]];
-    float4 vColor [[user(locn1)]];
+    float2 vTex [[user(locn1)]];
+    float4 vColor [[user(locn0)]];
 };
 
 struct main0_out

--- a/reference/shaders-msl/vert/copy.flatten.vert
+++ b/reference/shaders-msl/vert/copy.flatten.vert
@@ -18,8 +18,8 @@ struct UBO
 
 struct main0_in
 {
-    float4 aVertex [[attribute(0)]];
     float3 aNormal [[attribute(1)]];
+    float4 aVertex [[attribute(0)]];
 };
 
 struct main0_out

--- a/reference/shaders-msl/vert/dynamic.flatten.vert
+++ b/reference/shaders-msl/vert/dynamic.flatten.vert
@@ -18,8 +18,8 @@ struct UBO
 
 struct main0_in
 {
-    float4 aVertex [[attribute(0)]];
     float3 aNormal [[attribute(1)]];
+    float4 aVertex [[attribute(0)]];
 };
 
 struct main0_out

--- a/reference/shaders-msl/vert/functions.vert
+++ b/reference/shaders-msl/vert/functions.vert
@@ -21,11 +21,11 @@ struct main0_in
 
 struct main0_out
 {
-    float3 vRotRad [[user(locn0)]];
+    float3 vRotRad [[user(locn2)]];
     float3 vRotDeg [[user(locn1)]];
-    float3 vNormal [[user(locn2)]];
-    int2 vMSB [[user(locn3)]];
-    int2 vLSB [[user(locn4)]];
+    float3 vNormal [[user(locn0)]];
+    int2 vMSB [[user(locn4)]];
+    int2 vLSB [[user(locn3)]];
     float4 gl_Position [[position]];
 };
 

--- a/reference/shaders-msl/vert/out_block.vert
+++ b/reference/shaders-msl/vert/out_block.vert
@@ -10,8 +10,8 @@ struct Transform
 
 struct main0_in
 {
-    float3 position [[attribute(0)]];
     float4 color [[attribute(1)]];
+    float3 position [[attribute(0)]];
 };
 
 struct main0_out

--- a/reference/shaders-msl/vert/out_block.vert
+++ b/reference/shaders-msl/vert/out_block.vert
@@ -16,7 +16,8 @@ struct main0_in
 
 struct main0_out
 {
-    float4 VertexOut_color [[user(locn0)]];
+    float4 VertexOut_color2 [[user(locn3)]];
+    float4 VertexOut_color [[user(locn2)]];
     float4 gl_Position [[position]];
 };
 
@@ -25,6 +26,7 @@ vertex main0_out main0(main0_in in [[stage_in]], constant Transform& block [[buf
     main0_out out = {};
     out.gl_Position = block.transform * float4(in.position, 1.0);
     out.VertexOut_color = in.color;
+    out.VertexOut_color2 = in.color + float4(1.0);
     return out;
 }
 

--- a/reference/shaders-msl/vert/pointsize.vert
+++ b/reference/shaders-msl/vert/pointsize.vert
@@ -11,8 +11,8 @@ struct params
 
 struct main0_in
 {
-    float4 position [[attribute(0)]];
     float4 color0 [[attribute(1)]];
+    float4 position [[attribute(0)]];
 };
 
 struct main0_out

--- a/reference/shaders-msl/vert/ubo.alignment.vert
+++ b/reference/shaders-msl/vert/ubo.alignment.vert
@@ -14,15 +14,15 @@ struct UBO
 
 struct main0_in
 {
-    float4 aVertex [[attribute(0)]];
     float3 aNormal [[attribute(1)]];
+    float4 aVertex [[attribute(0)]];
 };
 
 struct main0_out
 {
-    float2 vSize [[user(locn0)]];
-    float3 vNormal [[user(locn1)]];
-    float3 vColor [[user(locn2)]];
+    float2 vSize [[user(locn2)]];
+    float3 vNormal [[user(locn0)]];
+    float3 vColor [[user(locn1)]];
     float4 gl_Position [[position]];
 };
 

--- a/reference/shaders-msl/vert/ubo.vert
+++ b/reference/shaders-msl/vert/ubo.vert
@@ -10,8 +10,8 @@ struct UBO
 
 struct main0_in
 {
-    float4 aVertex [[attribute(0)]];
     float3 aNormal [[attribute(1)]];
+    float4 aVertex [[attribute(0)]];
 };
 
 struct main0_out

--- a/reference/shaders/desktop-only/frag/in-block-qualifiers.frag
+++ b/reference/shaders/desktop-only/frag/in-block-qualifiers.frag
@@ -1,12 +1,12 @@
 #version 450
 
 layout(location = 0) out vec4 FragColor;
-in VertexData
+layout(location = 0) in VertexData
 {
-    layout(location = 0) flat float f;
-    layout(location = 1) centroid vec4 g;
-    layout(location = 2) flat int h;
-    layout(location = 3) float i;
+    flat float f;
+    centroid vec4 g;
+    flat int h;
+    float i;
 } vin;
 
 layout(location = 4) flat in float f;

--- a/reference/shaders/desktop-only/geom/basic.desktop.sso.geom
+++ b/reference/shaders/desktop-only/geom/basic.desktop.sso.geom
@@ -12,8 +12,8 @@ out gl_PerVertex
     vec4 gl_Position;
 };
 
-out vec3 vNormal;
-in VertexData
+layout(location = 0) out vec3 vNormal;
+layout(location = 0) in VertexData
 {
     vec3 normal;
 } vin[3];

--- a/reference/shaders/desktop-only/tesc/basic.desktop.sso.tesc
+++ b/reference/shaders/desktop-only/tesc/basic.desktop.sso.tesc
@@ -11,7 +11,7 @@ out gl_PerVertex
     vec4 gl_Position;
 } gl_out[1];
 
-patch out vec3 vFoo;
+layout(location = 0) patch out vec3 vFoo;
 
 void main()
 {

--- a/reference/shaders/desktop-only/vert/basic.desktop.sso.vert
+++ b/reference/shaders/desktop-only/vert/basic.desktop.sso.vert
@@ -10,9 +10,9 @@ layout(std140) uniform UBO
     mat4 uMVP;
 } _16;
 
-in vec4 aVertex;
-out vec3 vNormal;
-in vec3 aNormal;
+layout(location = 0) in vec4 aVertex;
+layout(location = 0) out vec3 vNormal;
+layout(location = 1) in vec3 aNormal;
 
 void main()
 {

--- a/reference/shaders/desktop-only/vert/out-block-qualifiers.vert
+++ b/reference/shaders/desktop-only/vert/out-block-qualifiers.vert
@@ -1,11 +1,11 @@
 #version 450
 
-out VertexData
+layout(location = 0) out VertexData
 {
-    layout(location = 0) flat float f;
-    layout(location = 1) centroid vec4 g;
-    layout(location = 2) flat int h;
-    layout(location = 3) float i;
+    flat float f;
+    centroid vec4 g;
+    flat int h;
+    float i;
 } vout;
 
 layout(location = 4) flat out float f;

--- a/reference/shaders/flatten/array.flatten.vert
+++ b/reference/shaders/flatten/array.flatten.vert
@@ -1,7 +1,7 @@
 #version 310 es
 
 uniform vec4 UBO[56];
-in vec4 aVertex;
+layout(location = 0) in vec4 aVertex;
 
 void main()
 {

--- a/reference/shaders/flatten/basic.flatten.vert
+++ b/reference/shaders/flatten/basic.flatten.vert
@@ -1,9 +1,9 @@
 #version 310 es
 
 uniform vec4 UBO[4];
-in vec4 aVertex;
-out vec3 vNormal;
-in vec3 aNormal;
+layout(location = 0) in vec4 aVertex;
+layout(location = 0) out vec3 vNormal;
+layout(location = 1) in vec3 aNormal;
 
 void main()
 {

--- a/reference/shaders/flatten/copy.flatten.vert
+++ b/reference/shaders/flatten/copy.flatten.vert
@@ -8,9 +8,9 @@ struct Light
 };
 
 uniform vec4 UBO[12];
-in vec4 aVertex;
-out vec4 vColor;
-in vec3 aNormal;
+layout(location = 0) in vec4 aVertex;
+layout(location = 0) out vec4 vColor;
+layout(location = 1) in vec3 aNormal;
 
 void main()
 {

--- a/reference/shaders/flatten/dynamic.flatten.vert
+++ b/reference/shaders/flatten/dynamic.flatten.vert
@@ -8,9 +8,9 @@ struct Light
 };
 
 uniform vec4 UBO[12];
-in vec4 aVertex;
-out vec4 vColor;
-in vec3 aNormal;
+layout(location = 0) in vec4 aVertex;
+layout(location = 0) out vec4 vColor;
+layout(location = 1) in vec3 aNormal;
 
 void main()
 {

--- a/reference/shaders/flatten/matrixindex.flatten.vert
+++ b/reference/shaders/flatten/matrixindex.flatten.vert
@@ -1,11 +1,11 @@
 #version 310 es
 
 uniform vec4 UBO[14];
-out vec4 oA;
-out vec4 oB;
-out vec4 oC;
-out vec4 oD;
-out vec4 oE;
+layout(location = 0) out vec4 oA;
+layout(location = 1) out vec4 oB;
+layout(location = 2) out vec4 oC;
+layout(location = 3) out vec4 oD;
+layout(location = 4) out vec4 oE;
 
 void main()
 {

--- a/reference/shaders/flatten/multiindex.flatten.vert
+++ b/reference/shaders/flatten/multiindex.flatten.vert
@@ -1,7 +1,7 @@
 #version 310 es
 
 uniform vec4 UBO[15];
-in ivec2 aIndex;
+layout(location = 0) in ivec2 aIndex;
 
 void main()
 {

--- a/reference/shaders/flatten/rowmajor.flatten.vert
+++ b/reference/shaders/flatten/rowmajor.flatten.vert
@@ -1,7 +1,7 @@
 #version 310 es
 
 uniform vec4 UBO[12];
-in vec4 aVertex;
+layout(location = 0) in vec4 aVertex;
 
 void main()
 {

--- a/reference/shaders/flatten/struct.flatten.vert
+++ b/reference/shaders/flatten/struct.flatten.vert
@@ -8,9 +8,9 @@ struct Light
 };
 
 uniform vec4 UBO[6];
-in vec4 aVertex;
-out vec4 vColor;
-in vec3 aNormal;
+layout(location = 0) in vec4 aVertex;
+layout(location = 0) out vec4 vColor;
+layout(location = 1) in vec3 aNormal;
 
 void main()
 {

--- a/reference/shaders/flatten/swizzle.flatten.vert
+++ b/reference/shaders/flatten/swizzle.flatten.vert
@@ -1,12 +1,12 @@
 #version 310 es
 
 uniform vec4 UBO[8];
-out vec4 oA;
-out vec4 oB;
-out vec4 oC;
-out vec4 oD;
-out vec4 oE;
-out vec4 oF;
+layout(location = 0) out vec4 oA;
+layout(location = 1) out vec4 oB;
+layout(location = 2) out vec4 oC;
+layout(location = 3) out vec4 oD;
+layout(location = 4) out vec4 oE;
+layout(location = 5) out vec4 oF;
 
 void main()
 {

--- a/reference/shaders/frag/basic.frag
+++ b/reference/shaders/frag/basic.frag
@@ -5,8 +5,8 @@ precision highp int;
 layout(binding = 0) uniform mediump sampler2D uTex;
 
 layout(location = 0) out vec4 FragColor;
-in vec4 vColor;
-in vec2 vTex;
+layout(location = 0) in vec4 vColor;
+layout(location = 1) in vec2 vTex;
 
 void main()
 {

--- a/reference/shaders/frag/pls.frag
+++ b/reference/shaders/frag/pls.frag
@@ -7,9 +7,9 @@ layout(location = 0) in vec4 PLSIn0;
 layout(location = 1) out vec4 PLSOut1;
 layout(location = 1) in vec4 PLSIn1;
 layout(location = 2) out vec4 PLSOut2;
-in vec4 PLSIn2;
+layout(location = 2) in vec4 PLSIn2;
 layout(location = 3) out vec4 PLSOut3;
-in vec4 PLSIn3;
+layout(location = 3) in vec4 PLSIn3;
 
 void main()
 {

--- a/reference/shaders/frag/sampler.frag
+++ b/reference/shaders/frag/sampler.frag
@@ -5,8 +5,8 @@ precision highp int;
 layout(binding = 0) uniform mediump sampler2D uTex;
 
 layout(location = 0) out vec4 FragColor;
-in vec4 vColor;
-in vec2 vTex;
+layout(location = 0) in vec4 vColor;
+layout(location = 1) in vec2 vTex;
 
 vec4 sample_texture(mediump sampler2D tex, vec2 uv)
 {

--- a/reference/shaders/geom/basic.geom
+++ b/reference/shaders/geom/basic.geom
@@ -3,8 +3,8 @@
 layout(invocations = 4, triangles) in;
 layout(max_vertices = 3, triangle_strip) out;
 
-out vec3 vNormal;
-in VertexData
+layout(location = 0) out vec3 vNormal;
+layout(location = 0) in VertexData
 {
     vec3 normal;
 } vin[3];

--- a/reference/shaders/geom/lines-adjacency.geom
+++ b/reference/shaders/geom/lines-adjacency.geom
@@ -3,8 +3,8 @@
 layout(lines_adjacency) in;
 layout(max_vertices = 3, line_strip) out;
 
-out vec3 vNormal;
-in VertexData
+layout(location = 0) out vec3 vNormal;
+layout(location = 0) in VertexData
 {
     vec3 normal;
 } vin[4];

--- a/reference/shaders/geom/lines.geom
+++ b/reference/shaders/geom/lines.geom
@@ -3,8 +3,8 @@
 layout(lines) in;
 layout(max_vertices = 2, line_strip) out;
 
-out vec3 vNormal;
-in VertexData
+layout(location = 0) out vec3 vNormal;
+layout(location = 0) in VertexData
 {
     vec3 normal;
 } vin[2];

--- a/reference/shaders/geom/points.geom
+++ b/reference/shaders/geom/points.geom
@@ -3,8 +3,8 @@
 layout(points) in;
 layout(max_vertices = 3, points) out;
 
-out vec3 vNormal;
-in VertexData
+layout(location = 0) out vec3 vNormal;
+layout(location = 0) in VertexData
 {
     vec3 normal;
 } vin[1];

--- a/reference/shaders/geom/single-invocation.geom
+++ b/reference/shaders/geom/single-invocation.geom
@@ -3,8 +3,8 @@
 layout(triangles) in;
 layout(max_vertices = 3, triangle_strip) out;
 
-out vec3 vNormal;
-in VertexData
+layout(location = 0) out vec3 vNormal;
+layout(location = 0) in VertexData
 {
     vec3 normal;
 } vin[3];

--- a/reference/shaders/geom/triangles-adjacency.geom
+++ b/reference/shaders/geom/triangles-adjacency.geom
@@ -3,8 +3,8 @@
 layout(triangles_adjacency) in;
 layout(max_vertices = 3, triangle_strip) out;
 
-out vec3 vNormal;
-in VertexData
+layout(location = 0) out vec3 vNormal;
+layout(location = 0) in VertexData
 {
     vec3 normal;
 } vin[6];

--- a/reference/shaders/geom/triangles.geom
+++ b/reference/shaders/geom/triangles.geom
@@ -3,8 +3,8 @@
 layout(triangles) in;
 layout(max_vertices = 3, triangle_strip) out;
 
-out vec3 vNormal;
-in VertexData
+layout(location = 0) out vec3 vNormal;
+layout(location = 0) in VertexData
 {
     vec3 normal;
 } vin[3];

--- a/reference/shaders/tesc/basic.tesc
+++ b/reference/shaders/tesc/basic.tesc
@@ -2,7 +2,7 @@
 #extension GL_EXT_tessellation_shader : require
 layout(vertices = 1) out;
 
-patch out vec3 vFoo;
+layout(location = 0) patch out vec3 vFoo;
 
 void main()
 {

--- a/reference/shaders/tesc/water_tess.tesc
+++ b/reference/shaders/tesc/water_tess.tesc
@@ -12,9 +12,9 @@ layout(std140) uniform UBO
     vec4 uFrustum[6];
 } _41;
 
-patch out vec2 vOutPatchPosBase;
-patch out vec4 vPatchLods;
-in vec2 vPatchPosBase[32];
+layout(location = 1) patch out vec2 vOutPatchPosBase;
+layout(location = 2) patch out vec4 vPatchLods;
+layout(location = 0) in vec2 vPatchPosBase[32];
 
 bool frustum_cull(vec2 p0)
 {

--- a/reference/shaders/tese/water_tess.tese
+++ b/reference/shaders/tese/water_tess.tese
@@ -14,10 +14,10 @@ layout(binding = 1, std140) uniform UBO
 
 layout(binding = 0) uniform mediump sampler2D uHeightmapDisplacement;
 
-patch in vec2 vOutPatchPosBase;
-patch in vec4 vPatchLods;
-out vec4 vGradNormalTex;
-out vec3 vWorld;
+layout(location = 0) patch in vec2 vOutPatchPosBase;
+layout(location = 1) patch in vec4 vPatchLods;
+layout(location = 1) out vec4 vGradNormalTex;
+layout(location = 0) out vec3 vWorld;
 
 vec2 lerp_vertex(vec2 tess_coord)
 {

--- a/reference/shaders/vert/basic.vert
+++ b/reference/shaders/vert/basic.vert
@@ -5,9 +5,9 @@ layout(std140) uniform UBO
     mat4 uMVP;
 } _16;
 
-in vec4 aVertex;
-out vec3 vNormal;
-in vec3 aNormal;
+layout(location = 0) in vec4 aVertex;
+layout(location = 0) out vec3 vNormal;
+layout(location = 1) in vec3 aNormal;
 
 void main()
 {

--- a/reference/shaders/vert/ubo.vert
+++ b/reference/shaders/vert/ubo.vert
@@ -5,9 +5,9 @@ layout(binding = 0, std140) uniform UBO
     mat4 mvp;
 } _16;
 
-in vec4 aVertex;
-out vec3 vNormal;
-in vec3 aNormal;
+layout(location = 0) in vec4 aVertex;
+layout(location = 0) out vec3 vNormal;
+layout(location = 1) in vec3 aNormal;
 
 void main()
 {

--- a/reference/shaders/vulkan/frag/spec-constant.vk.frag
+++ b/reference/shaders/vulkan/frag/spec-constant.vk.frag
@@ -51,9 +51,9 @@ void main()
     mediump int c35 = int(false);
     mediump uint c36 = uint(false);
     float c37 = float(false);
-    float vec0[4][(3 + 3)];
-    float vec1[(3 + 2)][(4 + 5)];
+    float vec0[(3 + 3)][8];
+    float vec1[(3 + 2)];
     Foo foo;
-    FragColor = ((vec4(t0 + t1) + vec4(vec0[0][0])) + vec4(vec1[0][0])) + vec4(foo.elems[3]);
+    FragColor = ((vec4(t0 + t1) + vec4(vec0[0][0])) + vec4(vec1[0])) + vec4(foo.elems[3]);
 }
 

--- a/reference/shaders/vulkan/frag/spec-constant.vk.frag.vk
+++ b/reference/shaders/vulkan/frag/spec-constant.vk.frag.vk
@@ -60,9 +60,9 @@ void main()
     mediump int c35 = int(g);
     mediump uint c36 = uint(g);
     float c37 = float(g);
-    float vec0[d][(c + 3)];
-    float vec1[(c + 2)][(d + 5)];
+    float vec0[(c + 3)][8];
+    float vec1[(c + 2)];
     Foo foo;
-    FragColor = ((vec4(t0 + t1) + vec4(vec0[0][0])) + vec4(vec1[0][0])) + vec4(foo.elems[c]);
+    FragColor = ((vec4(t0 + t1) + vec4(vec0[0][0])) + vec4(vec1[0])) + vec4(foo.elems[c]);
 }
 

--- a/shaders-hlsl/frag/basic.frag
+++ b/shaders-hlsl/frag/basic.frag
@@ -1,8 +1,8 @@
 #version 310 es
 precision mediump float;
 
-in vec4 vColor;
-in vec2 vTex;
+layout(location = 0) in vec4 vColor;
+layout(location = 1) in vec2 vTex;
 layout(binding = 0) uniform sampler2D uTex;
 layout(location = 0) out vec4 FragColor;
 

--- a/shaders-hlsl/frag/tex-sampling.frag
+++ b/shaders-hlsl/frag/tex-sampling.frag
@@ -18,12 +18,12 @@ uniform sampler samplerNonDepth;
 uniform texture2D separateTex2d;
 uniform texture2D separateTex2dDepth;
 
-in float texCoord1d;
-in vec2 texCoord2d;
-in vec3 texCoord3d;
-in vec4 texCoord4d;
+layout(location = 0) in float texCoord1d;
+layout(location = 1) in vec2 texCoord2d;
+layout(location = 2) in vec3 texCoord3d;
+layout(location = 3) in vec4 texCoord4d;
 
-out vec4 FragColor;
+layout(location = 0) out vec4 FragColor;
 
 void main()
 {

--- a/shaders-hlsl/frag/various-glsl-ops.frag
+++ b/shaders-hlsl/frag/various-glsl-ops.frag
@@ -1,8 +1,8 @@
 #version 450
 
-in vec2 interpolant;
+layout(location = 0) in vec2 interpolant;
 
-out vec4 FragColor;
+layout(location = 0) out vec4 FragColor;
 
 void main()
 {

--- a/shaders-hlsl/vert/basic.vert
+++ b/shaders-hlsl/vert/basic.vert
@@ -4,9 +4,9 @@ layout(std140) uniform UBO
 {
     uniform mat4 uMVP;
 };
-in vec4 aVertex;
-in vec3 aNormal;
-out vec3 vNormal;
+layout(location = 0) in vec4 aVertex;
+layout(location = 1) in vec3 aNormal;
+layout(location = 0) out vec3 vNormal;
 
 void main()
 {

--- a/shaders-hlsl/vert/locations.vert
+++ b/shaders-hlsl/vert/locations.vert
@@ -13,18 +13,18 @@ layout(location = 2) in vec4 Input2;
 // This will lock to input location 4.
 layout(location = 4) in vec4 Input4;
 // This will pick first available, which is 0.
-in vec4 Input0;
+layout(location = 0) in vec4 Input0;
 
 // Locks output 0.
 layout(location = 0) out float vLocation0;
 // Locks output 1.
 layout(location = 1) out float vLocation1;
 // Picks first available two locations, so, 2 and 3.
-out float vLocation2[2];
+layout(location = 2) out float vLocation2[2];
 // Picks first available location, 4.
-out Foo vLocation4;
+layout(location = 4) out Foo vLocation4;
 // Picks first available location 9.
-out float vLocation9;
+layout(location = 9) out float vLocation9;
 
 // Locks location 7 and 8.
 layout(location = 7) out VertexOut

--- a/shaders-hlsl/vert/matrix-attribute.vert
+++ b/shaders-hlsl/vert/matrix-attribute.vert
@@ -1,7 +1,7 @@
 #version 310 es
 
-in vec3 pos;
-in mat4 m;
+layout(location = 0) in vec3 pos;
+layout(location = 1) in mat4 m;
 
 void main()
 {

--- a/shaders-msl/flatten/basic.flatten.vert
+++ b/shaders-msl/flatten/basic.flatten.vert
@@ -4,9 +4,10 @@ layout(std140) uniform UBO
 {
     mat4 uMVP;
 };
-in vec4 aVertex;
-in vec3 aNormal;
-out vec3 vNormal;
+
+layout(location = 0) in vec4 aVertex;
+layout(location = 1) in vec3 aNormal;
+layout(location = 0) out vec3 vNormal;
 
 void main()
 {

--- a/shaders-msl/flatten/multiindex.flatten.vert
+++ b/shaders-msl/flatten/multiindex.flatten.vert
@@ -5,7 +5,7 @@ layout(std140) uniform UBO
     vec4 Data[3][5];
 };
 
-in ivec2 aIndex;
+layout(location = 0) in ivec2 aIndex;
 
 void main()
 {

--- a/shaders-msl/flatten/struct.flatten.vert
+++ b/shaders-msl/flatten/struct.flatten.vert
@@ -15,9 +15,9 @@ layout(std140) uniform UBO
     Light light;
 };
 
-in vec4 aVertex;
-in vec3 aNormal;
-out vec4 vColor;
+layout(location = 0) in vec4 aVertex;
+layout(location = 1) in vec3 aNormal;
+layout(location = 0) out vec4 vColor;
 
 void main()
 {

--- a/shaders-msl/flatten/swizzle.flatten.vert
+++ b/shaders-msl/flatten/swizzle.flatten.vert
@@ -27,7 +27,12 @@ layout(std140) uniform UBO
     float F2;
 };
 
-out vec4 oA, oB, oC, oD, oE, oF;
+layout(location = 0) out vec4 oA;
+layout(location = 1) out vec4 oB;
+layout(location = 2) out vec4 oC;
+layout(location = 3) out vec4 oD;
+layout(location = 4) out vec4 oE;
+layout(location = 5) out vec4 oF;
 
 void main()
 {

--- a/shaders-msl/frag/basic.frag
+++ b/shaders-msl/frag/basic.frag
@@ -1,8 +1,8 @@
 #version 310 es
 precision mediump float;
 
-in vec4 vColor;
-in vec2 vTex;
+layout(location = 0) in vec4 vColor;
+layout(location = 1) in vec2 vTex;
 layout(binding = 0) uniform sampler2D uTex;
 layout(location = 0) out vec4 FragColor;
 

--- a/shaders-msl/frag/in_block.frag
+++ b/shaders-msl/frag/in_block.frag
@@ -1,0 +1,14 @@
+#version 450
+
+layout(location = 2) in VertexOut
+{
+    vec4 color;
+    vec4 color2;
+} inputs;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = inputs.color + inputs.color2;
+}

--- a/shaders-msl/frag/pls.frag
+++ b/shaders-msl/frag/pls.frag
@@ -3,8 +3,8 @@ precision mediump float;
 
 layout(location = 0) in vec4 PLSIn0;
 layout(location = 1) in vec4 PLSIn1;
-in vec4 PLSIn2;
-in vec4 PLSIn3;
+layout(location = 2) in vec4 PLSIn2;
+layout(location = 3) in vec4 PLSIn3;
 
 layout(location = 0) out vec4 PLSOut0;
 layout(location = 1) out vec4 PLSOut1;

--- a/shaders-msl/frag/sampler.frag
+++ b/shaders-msl/frag/sampler.frag
@@ -1,8 +1,8 @@
 #version 310 es
 precision mediump float;
 
-in vec4 vColor;
-in vec2 vTex;
+layout(location = 0) in vec4 vColor;
+layout(location = 1) in vec2 vTex;
 layout(binding = 0) uniform sampler2D uTex;
 layout(location = 0) out vec4 FragColor;
 

--- a/shaders-msl/vert/basic.vert
+++ b/shaders-msl/vert/basic.vert
@@ -8,7 +8,7 @@ layout(std140) uniform UBO
 layout(location = 0) in vec4 aVertex;
 layout(location = 1) in vec3 aNormal;
 
-out vec3 vNormal;
+layout(location = 0) out vec3 vNormal;
 
 void main()
 {

--- a/shaders-msl/vert/copy.flatten.vert
+++ b/shaders-msl/vert/copy.flatten.vert
@@ -15,9 +15,9 @@ layout(std140) uniform UBO
     Light lights[4];
 };
 
-in vec4 aVertex;
-in vec3 aNormal;
-out vec4 vColor;
+layout(location = 0) in vec4 aVertex;
+layout(location = 1) in vec3 aNormal;
+layout(location = 0) out vec4 vColor;
 
 void main()
 {

--- a/shaders-msl/vert/dynamic.flatten.vert
+++ b/shaders-msl/vert/dynamic.flatten.vert
@@ -15,9 +15,9 @@ layout(std140) uniform UBO
     Light lights[4];
 };
 
-in vec4 aVertex;
-in vec3 aNormal;
-out vec4 vColor;
+layout(location = 0) in vec4 aVertex;
+layout(location = 1) in vec3 aNormal;
+layout(location = 0) out vec4 vColor;
 
 void main()
 {

--- a/shaders-msl/vert/functions.vert
+++ b/shaders-msl/vert/functions.vert
@@ -11,11 +11,11 @@ layout(std140) uniform UBO
 layout(location = 0) in vec4 aVertex;
 layout(location = 1) in vec3 aNormal;
 
-out vec3 vNormal;
-out vec3 vRotDeg;
-out vec3 vRotRad;
-out ivec2 vLSB;
-out ivec2 vMSB;
+layout(location = 0) out vec3 vNormal;
+layout(location = 1) out vec3 vRotDeg;
+layout(location = 2) out vec3 vRotRad;
+layout(location = 3) out ivec2 vLSB;
+layout(location = 4) out ivec2 vMSB;
 
 void main()
 {

--- a/shaders-msl/vert/out_block.vert
+++ b/shaders-msl/vert/out_block.vert
@@ -8,13 +8,15 @@ uniform Transform
 layout(location = 0) in vec3 position;
 layout(location = 1) in vec4 color;
 
-layout(location = 0) out VertexOut
+layout(location = 2) out VertexOut
 {
     vec4 color;
+    vec4 color2;
 } outputs;
 
 void main()
 {
-    gl_Position = block.transform*vec4(position, 1.0);
+    gl_Position = block.transform * vec4(position, 1.0);
     outputs.color = color;
+    outputs.color2 = color + vec4(1.0);
 }

--- a/shaders-msl/vert/out_block.vert
+++ b/shaders-msl/vert/out_block.vert
@@ -1,14 +1,14 @@
-#version 330
+#version 450
 
 uniform Transform
 {
     mat4 transform;
 } block;
 
-in vec3 position;
-in vec4 color;
+layout(location = 0) in vec3 position;
+layout(location = 1) in vec4 color;
 
-out VertexOut
+layout(location = 0) out VertexOut
 {
     vec4 color;
 } outputs;

--- a/shaders-msl/vert/pointsize.vert
+++ b/shaders-msl/vert/pointsize.vert
@@ -1,12 +1,12 @@
-#version 330
+#version 450
 uniform params {
     mat4 mvp;
     float psize;
 };
 
-in vec4 position;
-in vec4 color0;
-out vec4 color;
+layout(location = 0) in vec4 position;
+layout(location = 1) in vec4 color0;
+layout(location = 0) out vec4 color;
 
 void main() {
     gl_Position = mvp * position;

--- a/shaders-msl/vert/ubo.alignment.vert
+++ b/shaders-msl/vert/ubo.alignment.vert
@@ -8,11 +8,11 @@ layout(binding = 0, std140) uniform UBO
    float opacity;   // Single float following vec3 should cause MSL float3 to pack
 };
 
-in vec4 aVertex;
-in vec3 aNormal;
-out vec3 vNormal;
-out vec3 vColor;
-out vec2 vSize;
+layout(location = 0) in vec4 aVertex;
+layout(location = 1) in vec3 aNormal;
+layout(location = 0) out vec3 vNormal;
+layout(location = 1) out vec3 vColor;
+layout(location = 2) out vec2 vSize;
 
 void main()
 {

--- a/shaders-msl/vert/ubo.vert
+++ b/shaders-msl/vert/ubo.vert
@@ -5,9 +5,9 @@ layout(binding = 0, std140) uniform UBO
    mat4 mvp; 
 };
 
-in vec4 aVertex;
-in vec3 aNormal;
-out vec3 vNormal;
+layout(location = 0) in vec4 aVertex;
+layout(location = 1) in vec3 aNormal;
+layout(location = 0) out vec3 vNormal;
 
 void main()
 {

--- a/shaders/desktop-only/geom/basic.desktop.sso.geom
+++ b/shaders/desktop-only/geom/basic.desktop.sso.geom
@@ -13,11 +13,11 @@ out gl_PerVertex
    vec4 gl_Position;
 };
 
-in VertexData {
+layout(location = 0) in VertexData {
     vec3 normal;
 } vin[];
 
-out vec3 vNormal;
+layout(location = 0) out vec3 vNormal;
 
 void main()
 {

--- a/shaders/desktop-only/tesc/basic.desktop.sso.tesc
+++ b/shaders/desktop-only/tesc/basic.desktop.sso.tesc
@@ -11,7 +11,7 @@ out gl_PerVertex
    vec4 gl_Position;
 } gl_out[1];
 
-patch out vec3 vFoo;
+layout(location = 0) patch out vec3 vFoo;
 
 
 void main()

--- a/shaders/desktop-only/vert/basic.desktop.sso.vert
+++ b/shaders/desktop-only/vert/basic.desktop.sso.vert
@@ -9,9 +9,9 @@ layout(std140) uniform UBO
 {
     mat4 uMVP;
 };
-in vec4 aVertex;
-in vec3 aNormal;
-out vec3 vNormal;
+layout(location = 0) in vec4 aVertex;
+layout(location = 1) in vec3 aNormal;
+layout(location = 0) out vec3 vNormal;
 
 void main()
 {

--- a/shaders/flatten/array.flatten.vert
+++ b/shaders/flatten/array.flatten.vert
@@ -9,7 +9,7 @@ layout(std140) uniform UBO
     float A3[3];
     vec4 Offset;
 };
-in vec4 aVertex;
+layout(location = 0) in vec4 aVertex;
 
 void main()
 {

--- a/shaders/flatten/basic.flatten.vert
+++ b/shaders/flatten/basic.flatten.vert
@@ -4,9 +4,10 @@ layout(std140) uniform UBO
 {
     mat4 uMVP;
 };
-in vec4 aVertex;
-in vec3 aNormal;
-out vec3 vNormal;
+
+layout(location = 0) in vec4 aVertex;
+layout(location = 1) in vec3 aNormal;
+layout(location = 0) out vec3 vNormal;
 
 void main()
 {

--- a/shaders/flatten/copy.flatten.vert
+++ b/shaders/flatten/copy.flatten.vert
@@ -15,9 +15,9 @@ layout(std140) uniform UBO
     Light lights[4];
 };
 
-in vec4 aVertex;
-in vec3 aNormal;
-out vec4 vColor;
+layout(location = 0) in vec4 aVertex;
+layout(location = 1) in vec3 aNormal;
+layout(location = 0) out vec4 vColor;
 
 void main()
 {

--- a/shaders/flatten/dynamic.flatten.vert
+++ b/shaders/flatten/dynamic.flatten.vert
@@ -15,9 +15,9 @@ layout(std140) uniform UBO
     Light lights[4];
 };
 
-in vec4 aVertex;
-in vec3 aNormal;
-out vec4 vColor;
+layout(location = 0) in vec4 aVertex;
+layout(location = 1) in vec3 aNormal;
+layout(location = 0) out vec4 vColor;
 
 void main()
 {

--- a/shaders/flatten/matrixindex.flatten.vert
+++ b/shaders/flatten/matrixindex.flatten.vert
@@ -8,11 +8,11 @@ layout(std140) uniform UBO
     layout(row_major) mat2x4 M2R;
 };
 
-out vec4 oA;
-out vec4 oB;
-out vec4 oC;
-out vec4 oD;
-out vec4 oE;
+layout(location = 0) out vec4 oA;
+layout(location = 1) out vec4 oB;
+layout(location = 2) out vec4 oC;
+layout(location = 3) out vec4 oD;
+layout(location = 4) out vec4 oE;
 
 void main()
 {

--- a/shaders/flatten/multiindex.flatten.vert
+++ b/shaders/flatten/multiindex.flatten.vert
@@ -5,7 +5,7 @@ layout(std140) uniform UBO
     vec4 Data[3][5];
 };
 
-in ivec2 aIndex;
+layout(location = 0) in ivec2 aIndex;
 
 void main()
 {

--- a/shaders/flatten/rowmajor.flatten.vert
+++ b/shaders/flatten/rowmajor.flatten.vert
@@ -7,7 +7,7 @@ layout(std140) uniform UBO
     layout(row_major) mat2x4 uMVP;
 };
 
-in vec4 aVertex;
+layout(location = 0) in vec4 aVertex;
 
 void main()
 {

--- a/shaders/flatten/struct.flatten.vert
+++ b/shaders/flatten/struct.flatten.vert
@@ -15,9 +15,9 @@ layout(std140) uniform UBO
     Light light;
 };
 
-in vec4 aVertex;
-in vec3 aNormal;
-out vec4 vColor;
+layout(location = 0) in vec4 aVertex;
+layout(location = 1) in vec3 aNormal;
+layout(location = 0) out vec4 vColor;
 
 void main()
 {

--- a/shaders/flatten/swizzle.flatten.vert
+++ b/shaders/flatten/swizzle.flatten.vert
@@ -1,7 +1,7 @@
 #version 310 es
 
 // comments note the 16b alignment boundaries (see GL spec 7.6.2.2 Standard Uniform Block Layout)
-layout(std140) uniform UBO
+layout(std140, binding = 0) uniform UBO
 {
     // 16b boundary
     vec4 A;
@@ -27,7 +27,12 @@ layout(std140) uniform UBO
     float F2;
 };
 
-out vec4 oA, oB, oC, oD, oE, oF;
+layout(location = 0) out vec4 oA;
+layout(location = 1) out vec4 oB;
+layout(location = 2) out vec4 oC;
+layout(location = 3) out vec4 oD;
+layout(location = 4) out vec4 oE;
+layout(location = 5) out vec4 oF;
 
 void main()
 {

--- a/shaders/frag/basic.frag
+++ b/shaders/frag/basic.frag
@@ -1,8 +1,8 @@
 #version 310 es
 precision mediump float;
 
-in vec4 vColor;
-in vec2 vTex;
+layout(location = 0) in vec4 vColor;
+layout(location = 1) in vec2 vTex;
 layout(binding = 0) uniform sampler2D uTex;
 layout(location = 0) out vec4 FragColor;
 

--- a/shaders/frag/pls.frag
+++ b/shaders/frag/pls.frag
@@ -3,8 +3,8 @@ precision mediump float;
 
 layout(location = 0) in vec4 PLSIn0;
 layout(location = 1) in vec4 PLSIn1;
-in vec4 PLSIn2;
-in vec4 PLSIn3;
+layout(location = 2) in vec4 PLSIn2;
+layout(location = 3) in vec4 PLSIn3;
 
 layout(location = 0) out vec4 PLSOut0;
 layout(location = 1) out vec4 PLSOut1;

--- a/shaders/frag/sampler.frag
+++ b/shaders/frag/sampler.frag
@@ -1,8 +1,8 @@
 #version 310 es
 precision mediump float;
 
-in vec4 vColor;
-in vec2 vTex;
+layout(location = 0) in vec4 vColor;
+layout(location = 1) in vec2 vTex;
 layout(binding = 0) uniform sampler2D uTex;
 layout(location = 0) out vec4 FragColor;
 

--- a/shaders/geom/basic.geom
+++ b/shaders/geom/basic.geom
@@ -4,11 +4,11 @@
 layout(triangles, invocations = 4) in;
 layout(triangle_strip, max_vertices = 3) out;
 
-in VertexData {
+layout(location = 0) in VertexData {
     vec3 normal;
 } vin[];
 
-out vec3 vNormal;
+layout(location = 0) out vec3 vNormal;
 
 void main()
 {

--- a/shaders/geom/lines-adjacency.geom
+++ b/shaders/geom/lines-adjacency.geom
@@ -4,11 +4,11 @@
 layout(lines_adjacency) in;
 layout(line_strip, max_vertices = 3) out;
 
-in VertexData {
+layout(location = 0) in VertexData {
     vec3 normal;
 } vin[];
 
-out vec3 vNormal;
+layout(location = 0) out vec3 vNormal;
 
 void main()
 {

--- a/shaders/geom/lines.geom
+++ b/shaders/geom/lines.geom
@@ -4,11 +4,11 @@
 layout(lines) in;
 layout(line_strip, max_vertices = 2) out;
 
-in VertexData {
+layout(location = 0) in VertexData {
     vec3 normal;
 } vin[];
 
-out vec3 vNormal;
+layout(location = 0) out vec3 vNormal;
 
 void main()
 {

--- a/shaders/geom/points.geom
+++ b/shaders/geom/points.geom
@@ -4,11 +4,11 @@
 layout(points) in;
 layout(points, max_vertices = 3) out;
 
-in VertexData {
+layout(location = 0) in VertexData {
     vec3 normal;
 } vin[];
 
-out vec3 vNormal;
+layout(location = 0) out vec3 vNormal;
 
 void main()
 {

--- a/shaders/geom/single-invocation.geom
+++ b/shaders/geom/single-invocation.geom
@@ -4,11 +4,11 @@
 layout(triangles) in;
 layout(triangle_strip, max_vertices = 3) out;
 
-in VertexData {
+layout(location = 0) in VertexData {
     vec3 normal;
 } vin[];
 
-out vec3 vNormal;
+layout(location = 0) out vec3 vNormal;
 
 void main()
 {

--- a/shaders/geom/triangles-adjacency.geom
+++ b/shaders/geom/triangles-adjacency.geom
@@ -4,11 +4,11 @@
 layout(triangles_adjacency) in;
 layout(triangle_strip, max_vertices = 3) out;
 
-in VertexData {
+layout(location = 0) in VertexData {
     vec3 normal;
 } vin[];
 
-out vec3 vNormal;
+layout(location = 0) out vec3 vNormal;
 
 void main()
 {

--- a/shaders/geom/triangles.geom
+++ b/shaders/geom/triangles.geom
@@ -4,11 +4,11 @@
 layout(triangles) in;
 layout(triangle_strip, max_vertices = 3) out;
 
-in VertexData {
+layout(location = 0) in VertexData {
     vec3 normal;
 } vin[];
 
-out vec3 vNormal;
+layout(location = 0) out vec3 vNormal;
 
 void main()
 {

--- a/shaders/tesc/basic.tesc
+++ b/shaders/tesc/basic.tesc
@@ -1,7 +1,7 @@
 #version 310 es
 #extension GL_EXT_tessellation_shader : require
 
-patch out vec3 vFoo;
+layout(location = 0) patch out vec3 vFoo;
 
 layout(vertices = 1) out;
 

--- a/shaders/tesc/water_tess.tesc
+++ b/shaders/tesc/water_tess.tesc
@@ -2,7 +2,7 @@
 #extension GL_EXT_tessellation_shader : require
 
 layout(vertices = 1) out;
-in vec2 vPatchPosBase[];
+layout(location = 0) in vec2 vPatchPosBase[];
 
 layout(std140) uniform UBO
 {
@@ -14,8 +14,8 @@ layout(std140) uniform UBO
     vec4 uFrustum[6];
 };
 
-patch out vec2 vOutPatchPosBase;
-patch out vec4 vPatchLods;
+layout(location = 1) patch out vec2 vOutPatchPosBase;
+layout(location = 2) patch out vec4 vPatchLods;
 
 float lod_factor(vec2 pos_)
 {

--- a/shaders/tese/water_tess.tese
+++ b/shaders/tese/water_tess.tese
@@ -4,8 +4,8 @@ precision highp int;
 
 layout(cw, quads, fractional_even_spacing) in;
 
-patch in vec2 vOutPatchPosBase;
-patch in vec4 vPatchLods;
+layout(location = 0) patch in vec2 vOutPatchPosBase;
+layout(location = 1) patch in vec4 vPatchLods;
 
 layout(binding = 1, std140) uniform UBO
 {
@@ -18,8 +18,8 @@ layout(binding = 1, std140) uniform UBO
 };
 layout(binding = 0) uniform mediump sampler2D uHeightmapDisplacement;
 
-highp out vec3 vWorld;
-highp out vec4 vGradNormalTex;
+layout(location = 0) highp out vec3 vWorld;
+layout(location = 1) highp out vec4 vGradNormalTex;
 
 vec2 lerp_vertex(vec2 tess_coord)
 {

--- a/shaders/vert/basic.vert
+++ b/shaders/vert/basic.vert
@@ -4,9 +4,10 @@ layout(std140) uniform UBO
 {
     uniform mat4 uMVP;
 };
-in vec4 aVertex;
-in vec3 aNormal;
-out vec3 vNormal;
+
+layout(location = 0) in vec4 aVertex;
+layout(location = 1) in vec3 aNormal;
+layout(location = 0) out vec3 vNormal;
 
 void main()
 {

--- a/shaders/vert/ubo.vert
+++ b/shaders/vert/ubo.vert
@@ -5,9 +5,9 @@ layout(binding = 0, std140) uniform UBO
    mat4 mvp; 
 };
 
-in vec4 aVertex;
-in vec3 aNormal;
-out vec3 vNormal;
+layout(location = 0) in vec4 aVertex;
+layout(location = 1) in vec3 aNormal;
+layout(location = 0) out vec3 vNormal;
 
 void main()
 {

--- a/shaders/vulkan/frag/spec-constant.vk.frag
+++ b/shaders/vulkan/frag/spec-constant.vk.frag
@@ -69,9 +69,9 @@ void main()
 	float c37 = float(g); // bool -> float
 
 	// Flexible sized arrays with spec constants and spec constant ops.
-	float vec0[d][c + 3];
-	float vec1[c + 2][d + 5];
+	float vec0[c + 3][8];
+	float vec1[c + 2];
 
 	Foo foo;
-	FragColor = vec4(t0 + t1) + vec0[0][0] + vec1[0][0] + foo.elems[c];
+	FragColor = vec4(t0 + t1) + vec0[0][0] + vec1[0] + foo.elems[c];
 }

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -434,12 +434,22 @@ void CompilerHLSL::emit_io_block(const SPIRVariable &var)
 	begin_scope();
 	type.member_name_cache.clear();
 
+	uint32_t base_location = get_decoration(var.self, DecorationLocation);
+
 	for (uint32_t i = 0; i < uint32_t(type.member_types.size()); i++)
 	{
 		string semantic;
 		if (has_member_decoration(type.self, i, DecorationLocation))
 		{
 			uint32_t location = get_member_decoration(type.self, i, DecorationLocation);
+			semantic = join(" : TEXCOORD", location);
+		}
+		else
+		{
+			// If the block itself has a location, but not its members, use the implicit location.
+			// There could be a conflict if the block members partially specialize the locations.
+			// It is unclear how SPIR-V deals with this. Assume this does not happen for now.
+			uint32_t location = base_location + i;
 			semantic = join(" : TEXCOORD", location);
 		}
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -414,8 +414,9 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage)
 
 				auto &mbr_type = get<SPIRType>(mbr_type_id);
 				if (is_matrix(mbr_type))
+				{
 					exclude_member_from_stage_in(type, mbr_idx);
-
+				}
 				else if (!is_builtin || has_active_builtin(builtin, storage))
 				{
 					// Add a reference to the member to the interface struct.
@@ -434,6 +435,14 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage)
 					if (has_member_decoration(type_id, mbr_idx, DecorationLocation))
 					{
 						uint32_t locn = get_member_decoration(type_id, mbr_idx, DecorationLocation);
+						set_member_decoration(ib_type_id, ib_mbr_idx, DecorationLocation, locn);
+						mark_location_as_used_by_shader(locn, storage);
+					}
+					else if (has_decoration(p_var->self, DecorationLocation))
+					{
+						// The block itself might have a location and in this case, all members of the block
+						// receive incrementing locations.
+						uint32_t locn = get_decoration(p_var->self, DecorationLocation) + mbr_idx;
 						set_member_decoration(ib_type_id, ib_mbr_idx, DecorationLocation, locn);
 						mark_location_as_used_by_shader(locn, storage);
 					}


### PR DESCRIPTION
glslang now mandates location() to be set on IO variables, so a lot of the test shaders and reference shaders had slight changes.

For IO blocks, locations are only assigned to the block itself, not the members anymore, so I added support for that to HLSL and MSL (location = block location + member index).