### PR TITLE
Always make a copy when handling OpCompositeInsert

### DIFF
--- a/reference/shaders/frag/sampler-proj.frag
+++ b/reference/shaders/frag/sampler-proj.frag
@@ -1,0 +1,16 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+layout(binding = 0) uniform mediump sampler2D uTex;
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) in vec4 vTex;
+
+void main()
+{
+    highp vec4 _19 = vTex;
+    _19.z = vTex.w;
+    FragColor = textureProj(uTex, _19.xyz);
+}
+

--- a/shaders/frag/sampler-proj.frag
+++ b/shaders/frag/sampler-proj.frag
@@ -1,0 +1,12 @@
+#version 310 es
+precision mediump float;
+
+layout(location = 0) in vec4 vTex;
+layout(binding = 0) uniform sampler2D uTex;
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    FragColor = textureProj(uTex, vTex);
+}
+

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -4732,26 +4732,12 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 
 		flush_variable_declaration(composite);
 
-		auto *expr = maybe_get<SPIRExpression>(id);
-		if ((expr && expr->used_while_invalidated) || !should_forward(composite))
-		{
-			// Make a copy, then use access chain to store the variable.
-			statement(declare_temporary(result_type, id), to_expression(composite), ";");
-			set<SPIRExpression>(id, to_name(id), result_type, true);
-			auto chain = access_chain_internal(id, elems, length, true);
-			statement(chain, " = ", to_expression(obj), ";");
-		}
-		else
-		{
-			auto chain = access_chain_internal(composite, elems, length, true);
-			statement(chain, " = ", to_expression(obj), ";");
-			set<SPIRExpression>(id, to_expression(composite), result_type, true);
+		// Make a copy, then use access chain to store the variable.
+		statement(declare_temporary(result_type, id), to_expression(composite), ";");
+		set<SPIRExpression>(id, to_name(id), result_type, true);
+		auto chain = access_chain_internal(id, elems, length, true);
+		statement(chain, " = ", to_expression(obj), ";");
 
-			register_write(composite);
-			register_read(id, composite, true);
-			// Invalidate the old expression we inserted into.
-			invalid_expressions.insert(composite);
-		}
 		break;
 	}
 


### PR DESCRIPTION
The modified object might not be mutable (e.g. shader input).

Added a test for the case when this happens.