### PR TITLE
Ignore debug instruction OpString

### DIFF
--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -1189,6 +1189,7 @@ void Compiler::parse(const Instruction &instruction)
 	case OpSourceExtension:
 	case OpNop:
 	case OpLine:
+	case OpString:
 		break;
 
 	case OpSource:


### PR DESCRIPTION
It may be used with OpLine or OpSource to specify filename.