### PR TITLE
Basic support for HLSL compute shaders with StructuredBuffers

### DIFF
--- a/reference/shaders-hlsl/comp/global-invocation-id-writable-ssbo-in-function.comp
+++ b/reference/shaders-hlsl/comp/global-invocation-id-writable-ssbo-in-function.comp
@@ -1,0 +1,36 @@
+struct myBlock
+{
+    int a;
+    float b[1];
+};
+
+RWStructuredBuffer<myBlock> myStorage : register(u0);
+
+static uint3 gl_GlobalInvocationID;
+struct SPIRV_Cross_Input
+{
+    uint3 gl_GlobalInvocationID : SV_DispatchThreadID;
+};
+
+float mod(float x, float y)
+{
+    return x - y * floor(x / y);
+}
+
+float getB()
+{
+    return myStorage[0].b[gl_GlobalInvocationID.x];
+}
+
+void comp_main()
+{
+    myStorage[0].a = (myStorage[0].a + 1) % 256;
+    myStorage[0].b[gl_GlobalInvocationID.x] = mod(getB() + 0.0199999995529651641845703125f, 1.0f);
+}
+
+[numthreads(1, 1, 1)]
+void main(SPIRV_Cross_Input stage_input)
+{
+    gl_GlobalInvocationID = stage_input.gl_GlobalInvocationID;
+    comp_main();
+}

--- a/reference/shaders-hlsl/comp/global-invocation-id.comp
+++ b/reference/shaders-hlsl/comp/global-invocation-id.comp
@@ -1,0 +1,31 @@
+struct myBlock
+{
+    int a;
+    float b[1];
+};
+
+RWStructuredBuffer<myBlock> myStorage : register(u0);
+
+static uint3 gl_GlobalInvocationID;
+struct SPIRV_Cross_Input
+{
+    uint3 gl_GlobalInvocationID : SV_DispatchThreadID;
+};
+
+float mod(float x, float y)
+{
+    return x - y * floor(x / y);
+}
+
+void comp_main()
+{
+    myStorage[0].a = (myStorage[0].a + 1) % 256;
+    myStorage[0].b[gl_GlobalInvocationID.x] = mod(myStorage[0].b[gl_GlobalInvocationID.x] + 0.0199999995529651641845703125f, 1.0f);
+}
+
+[numthreads(1, 1, 1)]
+void main(SPIRV_Cross_Input stage_input)
+{
+    gl_GlobalInvocationID = stage_input.gl_GlobalInvocationID;
+    comp_main();
+}

--- a/reference/shaders-hlsl/comp/local-invocation-id.comp
+++ b/reference/shaders-hlsl/comp/local-invocation-id.comp
@@ -1,0 +1,31 @@
+struct myBlock
+{
+    int a;
+    float b[1];
+};
+
+RWStructuredBuffer<myBlock> myStorage : register(u0);
+
+static uint3 gl_LocalInvocationID;
+struct SPIRV_Cross_Input
+{
+    uint3 gl_LocalInvocationID : SV_GroupThreadID;
+};
+
+float mod(float x, float y)
+{
+    return x - y * floor(x / y);
+}
+
+void comp_main()
+{
+    myStorage[0].a = (myStorage[0].a + 1) % 256;
+    myStorage[0].b[gl_LocalInvocationID.x] = mod(myStorage[0].b[gl_LocalInvocationID.x] + 0.0199999995529651641845703125f, 1.0f);
+}
+
+[numthreads(1, 1, 1)]
+void main(SPIRV_Cross_Input stage_input)
+{
+    gl_LocalInvocationID = stage_input.gl_LocalInvocationID;
+    comp_main();
+}

--- a/reference/shaders-hlsl/comp/local-invocation-index.comp
+++ b/reference/shaders-hlsl/comp/local-invocation-index.comp
@@ -1,0 +1,31 @@
+struct myBlock
+{
+    int a;
+    float b[1];
+};
+
+RWStructuredBuffer<myBlock> myStorage : register(u0);
+
+static uint gl_LocalInvocationIndex;
+struct SPIRV_Cross_Input
+{
+    uint gl_LocalInvocationIndex : SV_GroupIndex;
+};
+
+float mod(float x, float y)
+{
+    return x - y * floor(x / y);
+}
+
+void comp_main()
+{
+    myStorage[0].a = (myStorage[0].a + 1) % 256;
+    myStorage[0].b[gl_LocalInvocationIndex] = mod(myStorage[0].b[gl_LocalInvocationIndex] + 0.0199999995529651641845703125f, 1.0f);
+}
+
+[numthreads(1, 1, 1)]
+void main(SPIRV_Cross_Input stage_input)
+{
+    gl_LocalInvocationIndex = stage_input.gl_LocalInvocationIndex;
+    comp_main();
+}

--- a/reference/shaders-hlsl/comp/read-write-only.comp
+++ b/reference/shaders-hlsl/comp/read-write-only.comp
@@ -1,0 +1,33 @@
+struct SSBO2
+{
+    float4 data4;
+    float4 data5;
+};
+
+RWStructuredBuffer<SSBO2> _10 : register(u2);
+struct SSBO0
+{
+    float4 data0;
+    float4 data1;
+};
+
+RWStructuredBuffer<SSBO0> _15 : register(u0);
+struct SSBO1
+{
+    float4 data2;
+    float4 data3;
+};
+
+RWStructuredBuffer<SSBO1> _21 : register(u1);
+
+void comp_main()
+{
+    _10[0].data4 = _15[0].data0 + _21[0].data2;
+    _10[0].data5 = _15[0].data1 + _21[0].data3;
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    comp_main();
+}

--- a/reference/shaders-hlsl/comp/ssbo-array.comp
+++ b/reference/shaders-hlsl/comp/ssbo-array.comp
@@ -1,0 +1,25 @@
+struct SSBO
+{
+    float4 data[1];
+};
+
+RWStructuredBuffer<SSBO> ssbos : register(u0);
+
+static uint3 gl_GlobalInvocationID;
+struct SPIRV_Cross_Input
+{
+    uint3 gl_GlobalInvocationID : SV_DispatchThreadID;
+};
+
+void comp_main()
+{
+    uint ident = gl_GlobalInvocationID.x;
+    ssbos[1].data[ident] = ssbos[0].data[ident];
+}
+
+[numthreads(1, 1, 1)]
+void main(SPIRV_Cross_Input stage_input)
+{
+    gl_GlobalInvocationID = stage_input.gl_GlobalInvocationID;
+    comp_main();
+}

--- a/reference/shaders-hlsl/comp/writable-ssbo.comp
+++ b/reference/shaders-hlsl/comp/writable-ssbo.comp
@@ -1,0 +1,24 @@
+struct myBlock
+{
+    int a;
+    float b;
+};
+
+RWStructuredBuffer<myBlock> myStorage : register(u0);
+
+float mod(float x, float y)
+{
+    return x - y * floor(x / y);
+}
+
+void comp_main()
+{
+    myStorage[0].a = (myStorage[0].a + 1) % 256;
+    myStorage[0].b = mod(myStorage[0].b + 0.0199999995529651641845703125f, 1.0f);
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    comp_main();
+}

--- a/shaders-hlsl/comp/global-invocation-id-writable-ssbo-in-function.comp
+++ b/shaders-hlsl/comp/global-invocation-id-writable-ssbo-in-function.comp
@@ -1,0 +1,12 @@
+#version 450
+layout(set = 0, binding = 0) buffer myBlock {
+    int a;
+    float b[1];
+} myStorage;
+float getB() {
+    return myStorage.b[gl_GlobalInvocationID.x];
+}
+void main() {
+    myStorage.a = (myStorage.a + 1) % 256;
+    myStorage.b[gl_GlobalInvocationID.x] = mod((getB() + 0.02), 1.0);
+}

--- a/shaders-hlsl/comp/global-invocation-id.comp
+++ b/shaders-hlsl/comp/global-invocation-id.comp
@@ -1,0 +1,9 @@
+#version 450
+layout(set = 0, binding = 0) buffer myBlock {
+    int a;
+    float b[1];
+} myStorage;
+void main() {
+    myStorage.a = (myStorage.a + 1) % 256;
+    myStorage.b[gl_GlobalInvocationID.x] = mod((myStorage.b[gl_GlobalInvocationID.x] + 0.02), 1.0);
+}

--- a/shaders-hlsl/comp/local-invocation-id.comp
+++ b/shaders-hlsl/comp/local-invocation-id.comp
@@ -1,0 +1,9 @@
+#version 450
+layout(set = 0, binding = 0) buffer myBlock {
+    int a;
+    float b[1];
+} myStorage;
+void main() {
+    myStorage.a = (myStorage.a + 1) % 256;
+    myStorage.b[gl_LocalInvocationID.x] = mod((myStorage.b[gl_LocalInvocationID.x] + 0.02), 1.0);
+}

--- a/shaders-hlsl/comp/local-invocation-index.comp
+++ b/shaders-hlsl/comp/local-invocation-index.comp
@@ -1,0 +1,9 @@
+#version 450
+layout(set = 0, binding = 0) buffer myBlock {
+    int a;
+    float b[1];
+} myStorage;
+void main() {
+    myStorage.a = (myStorage.a + 1) % 256;
+    myStorage.b[gl_LocalInvocationIndex.x] = mod((myStorage.b[gl_LocalInvocationIndex.x] + 0.02), 1.0);
+}

--- a/shaders-hlsl/comp/read-write-only.comp
+++ b/shaders-hlsl/comp/read-write-only.comp
@@ -1,0 +1,26 @@
+#version 310 es
+layout(local_size_x = 1) in;
+
+layout(binding = 0, std430) readonly buffer SSBO0
+{
+   vec4 data0;
+   vec4 data1;
+};
+
+layout(binding = 1, std430) restrict buffer SSBO1
+{
+   vec4 data2;
+   vec4 data3;
+};
+
+layout(binding = 2, std430) restrict writeonly buffer SSBO2
+{
+   vec4 data4;
+   vec4 data5;
+};
+
+void main()
+{
+   data4 = data0 + data2;
+   data5 = data1 + data3;
+}

--- a/shaders-hlsl/comp/ssbo-array.comp
+++ b/shaders-hlsl/comp/ssbo-array.comp
@@ -1,0 +1,14 @@
+#version 310 es
+layout(local_size_x = 1) in;
+
+layout(std430, binding = 0) buffer SSBO
+{
+    vec4 data[];
+} ssbos[2];
+
+void main()
+{
+    uint ident = gl_GlobalInvocationID.x;
+    ssbos[1].data[ident] = ssbos[0].data[ident];
+}
+

--- a/shaders-hlsl/comp/writable-ssbo.comp
+++ b/shaders-hlsl/comp/writable-ssbo.comp
@@ -1,0 +1,9 @@
+#version 450
+layout(set = 0, binding = 0) buffer myBlock {
+    int a;
+    float b;
+} myStorage;
+void main() {
+    myStorage.a = (myStorage.a + 1) % 256;
+    myStorage.b = mod((myStorage.b + 0.02), 1.0);
+}

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -3360,6 +3360,8 @@ bool Compiler::ActiveBuiltinHandler::handle(spv::Op opcode, const uint32_t *args
 		if (!var)
 			break;
 
+		add_if_builtin(args[2]);
+
 		auto *type = &compiler.get<SPIRType>(var->basetype);
 
 		// Start traversing type hierarchy at the proper non-pointer types.

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -84,6 +84,7 @@ private:
 	std::string to_interpolation_qualifiers(uint64_t flags) override;
 	std::string bitcast_glsl_op(const SPIRType &result_type, const SPIRType &argument_type) override;
 	std::string to_func_call_arg(uint32_t id) override;
+	std::string to_name(uint32_t id, bool allow_alias = true) const override;
 	std::string to_sampler_expression(uint32_t id);
 	std::string to_resource_binding(const SPIRVariable &var);
 	std::string to_resource_binding_sampler(const SPIRVariable &var);


### PR DESCRIPTION
This adds HLSL support for StructuredBuffers / Unordered Access Views in order to get basic compute shaders working.

StructuredBuffer<T> and RWStructuredBuffer<T> must be accessed as arrays so in HLSL it is impossible to do something like:
```
struct myBuffer {
  int a;
};
RWStructuredBuffer<myBuffer> buffer : register(u0);

void main() {
  buffer.a = 2;
}
```

an array access is required:
`buffer[0].a = 2;`

So essentially all structured buffers are unsized arrays.

To account for this, I've added `HLSLCompiler::to_name` to replace struct-usages of structured buffers with an array-usage that accesses element 0. Would this be the best place to do this (modifying the HLSL interpretation of the SPIRV) or would it be better to modify the SPIRV to always treat these as arrays?