### PR TITLE
Add support for building a shared library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@
 *.opensdf
 *.shader
 *.a
+*.so
 
 !CMakeLists.txt

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,12 @@ OBJECTS := $(SOURCES:.cpp=.o)
 CLI_OBJECTS := $(CLI_SOURCES:.cpp=.o)
 
 STATIC_LIB := lib$(TARGET).a
+SHARED_LIB := lib$(TARGET).so
 
 DEPS := $(OBJECTS:.o=.d) $(CLI_OBJECTS:.o=.d)
 
 CXXFLAGS += -std=c++11 -Wall -Wextra -Wshadow -D__STDC_LIMIT_MACROS
+CXXFLAGS += -fPIC
 
 ifeq ($(DEBUG), 1)
 	CXXFLAGS += -O0 -g
@@ -22,7 +24,7 @@ ifeq ($(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS), 1)
 	CXXFLAGS += -DSPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS -fno-exceptions
 endif
 
-all: $(TARGET)
+all: $(TARGET) $(SHARED_LIB)
 
 -include $(DEPS)
 
@@ -32,10 +34,13 @@ $(TARGET): $(CLI_OBJECTS) $(STATIC_LIB)
 $(STATIC_LIB): $(OBJECTS)
 	$(AR) rcs $@ $(OBJECTS)
 
+$(SHARED_LIB): $(OBJECTS)
+	$(CXX) -o $@ -shared $(OBJECTS) $(LDFLAGS)
+
 %.o: %.cpp
 	$(CXX) -c -o $@ $< $(CXXFLAGS) -MMD
 
 clean:
-	rm -f $(TARGET) $(OBJECTS) $(CLI_OBJECTS) $(STATIC_LIB) $(DEPS)
+	rm -f $(TARGET) $(OBJECTS) $(CLI_OBJECTS) $(STATIC_LIB) $(SHARED_LIB) $(DEPS)
 
 .PHONY: clean


### PR DESCRIPTION
Add support for buliding SPIRV-Cross as a shared library,
in addition to building a static library.

Shared libraries are better suited and generally preferred for
distribution via packages.