### PR TITLE
Optimize CFG walking

### DIFF
--- a/spirv_cfg.hpp
+++ b/spirv_cfg.hpp
@@ -68,11 +68,15 @@ public:
 	}
 
 	template <typename Op>
-	void walk_from(uint32_t block, const Op &op) const
+	void walk_from(std::unordered_set<uint32_t> &seen_blocks, uint32_t block, const Op &op) const
 	{
+		if (seen_blocks.count(block))
+			return;
+		seen_blocks.insert(block);
+
 		op(block);
 		for (auto b : succeeding_edges[block])
-			walk_from(b, op);
+			walk_from(seen_blocks, b, op);
 	}
 
 private:

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -3166,6 +3166,8 @@ void Compiler::analyze_variable_scope(SPIRFunction &entry)
 		}
 	}
 
+	unordered_set<uint32_t> seen_blocks;
+
 	// Now, try to analyze whether or not these variables are actually loop variables.
 	for (auto &loop_variable : potential_loop_variables)
 	{
@@ -3229,7 +3231,9 @@ void Compiler::analyze_variable_scope(SPIRFunction &entry)
 		// The second condition we need to meet is that no access after the loop
 		// merge can occur. Walk the CFG to see if we find anything.
 		auto &blocks = handler.accessed_variables_to_block[loop_variable.first];
-		cfg.walk_from(header_block.merge_block, [&](uint32_t walk_block) {
+
+		seen_blocks.clear();
+		cfg.walk_from(seen_blocks, header_block.merge_block, [&](uint32_t walk_block) {
 			// We found a block which accesses the variable outside the loop.
 			if (blocks.find(walk_block) != end(blocks))
 				static_loop_init = false;

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1822,23 +1822,26 @@ string CompilerGLSL::enclose_expression(const string &expr)
 			need_parens = true;
 	}
 
-	uint32_t paren_count = 0;
-	for (auto c : expr)
+	if (!need_parens)
 	{
-		if (c == '(')
-			paren_count++;
-		else if (c == ')')
+		uint32_t paren_count = 0;
+		for (auto c : expr)
 		{
-			assert(paren_count);
-			paren_count--;
+			if (c == '(')
+				paren_count++;
+			else if (c == ')')
+			{
+				assert(paren_count);
+				paren_count--;
+			}
+			else if (c == ' ' && paren_count == 0)
+			{
+				need_parens = true;
+				break;
+			}
 		}
-		else if (c == ' ' && paren_count == 0)
-		{
-			need_parens = true;
-			break;
-		}
+		assert(paren_count == 0);
 	}
-	assert(paren_count == 0);
 
 	// If this expression contains any spaces which are not enclosed by parentheses,
 	// we need to enclose it so we can treat the whole string as an expression.


### PR DESCRIPTION
Old implementation would explode runtime for long shaders with many blocks.
Fixes https://github.com/KhronosGroup/SPIRV-Cross/issues/226.