### PR TITLE
SPIRV GLSL: Add vertex.flip_y option.

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -6567,6 +6567,10 @@ void CompilerGLSL::emit_fixup()
 		const char *suffix = backend.float_literal_suffix ? "f" : "";
 		statement("gl_Position.z = 2.0", suffix, " * gl_Position.z - gl_Position.w;");
 	}
+	if (execution.model == ExecutionModelVertex && options.vertex.flip_y)
+	{
+		statement("gl_Position.y = -gl_Position.y;");
+	}
 }
 
 bool CompilerGLSL::flush_phi_required(uint32_t from, uint32_t to)

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -91,6 +91,8 @@ public:
 		{
 			// In vertex shaders, rewrite [0, w] depth (Vulkan/D3D style) to [-w, w] depth (GL style).
 			bool fixup_clipspace = true;
+			// Inverts the Y coordinate so that the [-1, -1] pixel corresponds to texture coordinate [0, 0]
+			bool flip_y = false;
 		} vertex;
 
 		struct


### PR DESCRIPTION
This adds a "gl_Position = -gl_Position" at the end of the shader so
that the OpenGL pixel position correspond to Vulkan pixel positions.