### PR TITLE
Fix default member name implementation.

### DIFF
--- a/reference/shaders/asm/comp/bitcast_iadd.asm.comp
+++ b/reference/shaders/asm/comp/bitcast_iadd.asm.comp
@@ -3,25 +3,25 @@ layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(binding = 0, std430) restrict buffer _3
 {
-    ivec4 _0;
-    uvec4 _1;
+    ivec4 _m0;
+    uvec4 _m1;
 } _5;
 
 layout(binding = 1, std430) restrict buffer _4
 {
-    uvec4 _0;
-    ivec4 _1;
+    uvec4 _m0;
+    ivec4 _m1;
 } _6;
 
 void main()
 {
-    _6._0 = _5._1 + uvec4(_5._0);
-    _6._0 = uvec4(_5._0) + _5._1;
-    _6._0 = _5._1 + _5._1;
-    _6._0 = uvec4(_5._0 + _5._0);
-    _6._1 = ivec4(_5._1 + _5._1);
-    _6._1 = _5._0 + _5._0;
-    _6._1 = ivec4(_5._1) + _5._0;
-    _6._1 = _5._0 + ivec4(_5._1);
+    _6._m0 = _5._m1 + uvec4(_5._m0);
+    _6._m0 = uvec4(_5._m0) + _5._m1;
+    _6._m0 = _5._m1 + _5._m1;
+    _6._m0 = uvec4(_5._m0 + _5._m0);
+    _6._m1 = ivec4(_5._m1 + _5._m1);
+    _6._m1 = _5._m0 + _5._m0;
+    _6._m1 = ivec4(_5._m1) + _5._m0;
+    _6._m1 = _5._m0 + ivec4(_5._m1);
 }
 

--- a/reference/shaders/asm/comp/bitcast_iequal.asm.comp
+++ b/reference/shaders/asm/comp/bitcast_iequal.asm.comp
@@ -3,29 +3,29 @@ layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(binding = 0, std430) buffer _3
 {
-    ivec4 _0;
-    uvec4 _1;
+    ivec4 _m0;
+    uvec4 _m1;
 } _5;
 
 layout(binding = 1, std430) buffer _4
 {
-    uvec4 _0;
-    ivec4 _1;
+    uvec4 _m0;
+    ivec4 _m1;
 } _6;
 
 void main()
 {
-    bvec4 _34 = equal(ivec4(_5._1), _5._0);
-    bvec4 _35 = equal(_5._0, ivec4(_5._1));
-    bvec4 _36 = equal(_5._1, _5._1);
-    bvec4 _37 = equal(_5._0, _5._0);
-    _6._0 = mix(uvec4(0u), uvec4(1u), _34);
-    _6._0 = mix(uvec4(0u), uvec4(1u), _35);
-    _6._0 = mix(uvec4(0u), uvec4(1u), _36);
-    _6._0 = mix(uvec4(0u), uvec4(1u), _37);
-    _6._1 = mix(ivec4(0), ivec4(1), _34);
-    _6._1 = mix(ivec4(0), ivec4(1), _35);
-    _6._1 = mix(ivec4(0), ivec4(1), _36);
-    _6._1 = mix(ivec4(0), ivec4(1), _37);
+    bvec4 _34 = equal(ivec4(_5._m1), _5._m0);
+    bvec4 _35 = equal(_5._m0, ivec4(_5._m1));
+    bvec4 _36 = equal(_5._m1, _5._m1);
+    bvec4 _37 = equal(_5._m0, _5._m0);
+    _6._m0 = mix(uvec4(0u), uvec4(1u), _34);
+    _6._m0 = mix(uvec4(0u), uvec4(1u), _35);
+    _6._m0 = mix(uvec4(0u), uvec4(1u), _36);
+    _6._m0 = mix(uvec4(0u), uvec4(1u), _37);
+    _6._m1 = mix(ivec4(0), ivec4(1), _34);
+    _6._m1 = mix(ivec4(0), ivec4(1), _35);
+    _6._m1 = mix(ivec4(0), ivec4(1), _36);
+    _6._m1 = mix(ivec4(0), ivec4(1), _37);
 }
 

--- a/reference/shaders/asm/comp/bitcast_sar.asm.comp
+++ b/reference/shaders/asm/comp/bitcast_sar.asm.comp
@@ -3,25 +3,25 @@ layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(binding = 0, std430) buffer _3
 {
-    ivec4 _0;
-    uvec4 _1;
+    ivec4 _m0;
+    uvec4 _m1;
 } _5;
 
 layout(binding = 1, std430) buffer _4
 {
-    uvec4 _0;
-    ivec4 _1;
+    uvec4 _m0;
+    ivec4 _m1;
 } _6;
 
 void main()
 {
-    _6._0 = uvec4(ivec4(_5._1) >> _5._0);
-    _6._0 = uvec4(_5._0 >> ivec4(_5._1));
-    _6._0 = uvec4(ivec4(_5._1) >> ivec4(_5._1));
-    _6._0 = uvec4(_5._0 >> _5._0);
-    _6._1 = ivec4(_5._1) >> ivec4(_5._1);
-    _6._1 = _5._0 >> _5._0;
-    _6._1 = ivec4(_5._1) >> _5._0;
-    _6._1 = _5._0 >> ivec4(_5._1);
+    _6._m0 = uvec4(ivec4(_5._m1) >> _5._m0);
+    _6._m0 = uvec4(_5._m0 >> ivec4(_5._m1));
+    _6._m0 = uvec4(ivec4(_5._m1) >> ivec4(_5._m1));
+    _6._m0 = uvec4(_5._m0 >> _5._m0);
+    _6._m1 = ivec4(_5._m1) >> ivec4(_5._m1);
+    _6._m1 = _5._m0 >> _5._m0;
+    _6._m1 = ivec4(_5._m1) >> _5._m0;
+    _6._m1 = _5._m0 >> ivec4(_5._m1);
 }
 

--- a/reference/shaders/asm/comp/bitcast_sdiv.asm.comp
+++ b/reference/shaders/asm/comp/bitcast_sdiv.asm.comp
@@ -3,25 +3,25 @@ layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(binding = 0, std430) buffer _3
 {
-    ivec4 _0;
-    uvec4 _1;
+    ivec4 _m0;
+    uvec4 _m1;
 } _5;
 
 layout(binding = 1, std430) buffer _4
 {
-    uvec4 _0;
-    ivec4 _1;
+    uvec4 _m0;
+    ivec4 _m1;
 } _6;
 
 void main()
 {
-    _6._0 = uvec4(ivec4(_5._1) / _5._0);
-    _6._0 = uvec4(_5._0 / ivec4(_5._1));
-    _6._0 = uvec4(ivec4(_5._1) / ivec4(_5._1));
-    _6._0 = uvec4(_5._0 / _5._0);
-    _6._1 = ivec4(_5._1) / ivec4(_5._1);
-    _6._1 = _5._0 / _5._0;
-    _6._1 = ivec4(_5._1) / _5._0;
-    _6._1 = _5._0 / ivec4(_5._1);
+    _6._m0 = uvec4(ivec4(_5._m1) / _5._m0);
+    _6._m0 = uvec4(_5._m0 / ivec4(_5._m1));
+    _6._m0 = uvec4(ivec4(_5._m1) / ivec4(_5._m1));
+    _6._m0 = uvec4(_5._m0 / _5._m0);
+    _6._m1 = ivec4(_5._m1) / ivec4(_5._m1);
+    _6._m1 = _5._m0 / _5._m0;
+    _6._m1 = ivec4(_5._m1) / _5._m0;
+    _6._m1 = _5._m0 / ivec4(_5._m1);
 }
 

--- a/reference/shaders/asm/comp/bitcast_slr.asm.comp
+++ b/reference/shaders/asm/comp/bitcast_slr.asm.comp
@@ -3,25 +3,25 @@ layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(binding = 0, std430) buffer _3
 {
-    ivec4 _0;
-    uvec4 _1;
+    ivec4 _m0;
+    uvec4 _m1;
 } _5;
 
 layout(binding = 1, std430) buffer _4
 {
-    uvec4 _0;
-    ivec4 _1;
+    uvec4 _m0;
+    ivec4 _m1;
 } _6;
 
 void main()
 {
-    _6._0 = _5._1 >> uvec4(_5._0);
-    _6._0 = uvec4(_5._0) >> _5._1;
-    _6._0 = _5._1 >> _5._1;
-    _6._0 = uvec4(_5._0) >> uvec4(_5._0);
-    _6._1 = ivec4(_5._1 >> _5._1);
-    _6._1 = ivec4(uvec4(_5._0) >> uvec4(_5._0));
-    _6._1 = ivec4(_5._1 >> uvec4(_5._0));
-    _6._1 = ivec4(uvec4(_5._0) >> _5._1);
+    _6._m0 = _5._m1 >> uvec4(_5._m0);
+    _6._m0 = uvec4(_5._m0) >> _5._m1;
+    _6._m0 = _5._m1 >> _5._m1;
+    _6._m0 = uvec4(_5._m0) >> uvec4(_5._m0);
+    _6._m1 = ivec4(_5._m1 >> _5._m1);
+    _6._m1 = ivec4(uvec4(_5._m0) >> uvec4(_5._m0));
+    _6._m1 = ivec4(_5._m1 >> uvec4(_5._m0));
+    _6._m1 = ivec4(uvec4(_5._m0) >> _5._m1);
 }
 

--- a/reference/shaders/asm/comp/bitcast_udiv.asm.comp
+++ b/reference/shaders/asm/comp/bitcast_udiv.asm.comp
@@ -3,25 +3,25 @@ layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(binding = 0, std430) buffer _3
 {
-    ivec4 _0;
-    uvec4 _1;
+    ivec4 _m0;
+    uvec4 _m1;
 } _5;
 
 layout(binding = 1, std430) buffer _4
 {
-    uvec4 _0;
-    ivec4 _1;
+    uvec4 _m0;
+    ivec4 _m1;
 } _6;
 
 void main()
 {
-    _6._0 = _5._1 / uvec4(_5._0);
-    _6._0 = uvec4(_5._0) / _5._1;
-    _6._0 = _5._1 / _5._1;
-    _6._0 = uvec4(_5._0) / uvec4(_5._0);
-    _6._1 = ivec4(_5._1 / _5._1);
-    _6._1 = ivec4(uvec4(_5._0) / uvec4(_5._0));
-    _6._1 = ivec4(_5._1 / uvec4(_5._0));
-    _6._1 = ivec4(uvec4(_5._0) / _5._1);
+    _6._m0 = _5._m1 / uvec4(_5._m0);
+    _6._m0 = uvec4(_5._m0) / _5._m1;
+    _6._m0 = _5._m1 / _5._m1;
+    _6._m0 = uvec4(_5._m0) / uvec4(_5._m0);
+    _6._m1 = ivec4(_5._m1 / _5._m1);
+    _6._m1 = ivec4(uvec4(_5._m0) / uvec4(_5._m0));
+    _6._m1 = ivec4(_5._m1 / uvec4(_5._m0));
+    _6._m1 = ivec4(uvec4(_5._m0) / _5._m1);
 }
 

--- a/reference/shaders/asm/comp/multiple-entry.asm.comp
+++ b/reference/shaders/asm/comp/multiple-entry.asm.comp
@@ -3,25 +3,25 @@ layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(binding = 0, std430) restrict buffer _6
 {
-    ivec4 _0;
-    uvec4 _1;
+    ivec4 _m0;
+    uvec4 _m1;
 } _8;
 
 layout(binding = 1, std430) restrict buffer _7
 {
-    uvec4 _0;
-    ivec4 _1;
+    uvec4 _m0;
+    ivec4 _m1;
 } _9;
 
 void main()
 {
-    _9._0 = _8._1 + uvec4(_8._0);
-    _9._0 = uvec4(_8._0) + _8._1;
-    _9._0 = _8._1 + _8._1;
-    _9._0 = uvec4(_8._0 + _8._0);
-    _9._1 = ivec4(_8._1 + _8._1);
-    _9._1 = _8._0 + _8._0;
-    _9._1 = ivec4(_8._1) + _8._0;
-    _9._1 = _8._0 + ivec4(_8._1);
+    _9._m0 = _8._m1 + uvec4(_8._m0);
+    _9._m0 = uvec4(_8._m0) + _8._m1;
+    _9._m0 = _8._m1 + _8._m1;
+    _9._m0 = uvec4(_8._m0 + _8._m0);
+    _9._m1 = ivec4(_8._m1 + _8._m1);
+    _9._m1 = _8._m0 + _8._m0;
+    _9._m1 = ivec4(_8._m1) + _8._m0;
+    _9._m1 = _8._m0 + ivec4(_8._m1);
 }
 

--- a/reference/shaders/asm/frag/default-member-names.asm.frag
+++ b/reference/shaders/asm/frag/default-member-names.asm.frag
@@ -1,0 +1,32 @@
+#version 450
+
+struct _9
+{
+    float _m0;
+};
+
+struct _10
+{
+    float _m0;
+    float _m1;
+    float _m2;
+    float _m3;
+    float _m4;
+    float _m5;
+    float _m6;
+    float _m7;
+    float _m8;
+    float _m9;
+    float _m10;
+    float _m11;
+    _9 _m12;
+};
+
+layout(location = 0) out vec4 _3;
+
+void main()
+{
+    _10 _21;
+    _3 = vec4(_21._m0, _21._m1, _21._m2, _21._m3);
+}
+

--- a/shaders/asm/frag/default-member-names.asm.frag
+++ b/shaders/asm/frag/default-member-names.asm.frag
@@ -1,0 +1,57 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 1
+; Bound: 43
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main" %3
+               OpExecutionMode %2 OriginLowerLeft
+               OpDecorate %3 Location 0
+       %void = OpTypeVoid
+          %9 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+         %12 = OpTypeFunction %v4float
+  %_struct_5 = OpTypeStruct %float
+  %_struct_6 = OpTypeStruct %float %float %float %float %float %float %float %float %float %float %float %float %_struct_5
+%_ptr_Function__struct_6 = OpTypePointer Function %_struct_6
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Function_float = OpTypePointer Function %float
+      %int_1 = OpConstant %int 1
+      %int_2 = OpConstant %int 2
+      %int_3 = OpConstant %int 3
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+          %3 = OpVariable %_ptr_Output_v4float Output
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+          %2 = OpFunction %void None %9
+         %22 = OpLabel
+         %23 = OpVariable %_ptr_Function__struct_6 Function
+         %24 = OpAccessChain %_ptr_Function_float %23 %int_0
+         %25 = OpLoad %float %24
+         %26 = OpAccessChain %_ptr_Function_float %23 %int_1
+         %27 = OpLoad %float %26
+         %28 = OpAccessChain %_ptr_Function_float %23 %int_2
+         %29 = OpLoad %float %28
+         %30 = OpAccessChain %_ptr_Function_float %23 %int_3
+         %31 = OpLoad %float %30
+         %32 = OpCompositeConstruct %v4float %25 %27 %29 %31
+               OpStore %3 %32
+               OpReturn
+               OpFunctionEnd
+          %4 = OpFunction %v4float None %12
+         %33 = OpLabel
+          %7 = OpVariable %_ptr_Function__struct_6 Function
+         %34 = OpAccessChain %_ptr_Function_float %7 %int_0
+         %35 = OpLoad %float %34
+         %36 = OpAccessChain %_ptr_Function_float %7 %int_1
+         %37 = OpLoad %float %36
+         %38 = OpAccessChain %_ptr_Function_float %7 %int_2
+         %39 = OpLoad %float %38
+         %40 = OpAccessChain %_ptr_Function_float %7 %int_3
+         %41 = OpLoad %float %40
+         %42 = OpCompositeConstruct %v4float %35 %37 %39 %41
+               OpReturnValue %42
+               OpFunctionEnd

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -5815,7 +5815,7 @@ string CompilerGLSL::to_member_name(const SPIRType &type, uint32_t index)
 	if (index < memb.size() && !memb[index].alias.empty())
 		return memb[index].alias;
 	else
-		return join("_", index);
+		return join("_m", index);
 }
 
 void CompilerGLSL::add_member_name(SPIRType &type, uint32_t index)


### PR DESCRIPTION
Use a unique prefix for member since they can easily conflict with types.