### PR TITLE
Do not emit layout(location) qualifiers for older GLSL targets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,9 +236,9 @@ This can be done with `Compiler::set_decoration(id, spv::DecorationDescriptorSet
 
 #### Linking by name for targets which do not support explicit locations (legacy GLSL/ESSL)
 
-Modern GLSL and HLSL sources will rely on explicit layout(location) qualifiers to guide the linking process,
-but legacy GLSL relies on symbol names to perform the linking. When emitting legacy shaders, these layout statements will be dropped,
-so it is important that the API user ensures that the names of I/O variables are sanitized to ensure that linking will work properly.
+Modern GLSL and HLSL sources (and SPIR-V) relies on explicit layout(location) qualifiers to guide the linking process between shader stages,
+but older GLSL relies on symbol names to perform the linking. When emitting shaders with older versions, these layout statements will be removed,
+so it is important that the API user ensures that the names of I/O variables are sanitized so that linking will work properly.
 The reflection API can rename variables, struct types and struct members to deal with these scenarios using `Compiler::set_name` and friends.
 
 ## Contributing


### PR DESCRIPTION
ESSL 300 and GLSL <410 do not support this along with legacy targets.

Fixes #222 