### PR TITLE
Basic HLSL compute shader support

### DIFF
--- a/reference/shaders-hlsl/comp/access-chains.comp
+++ b/reference/shaders-hlsl/comp/access-chains.comp
@@ -1,0 +1,21 @@
+RWByteAddressBuffer wo : register(u1);
+ByteAddressBuffer ro : register(u0);
+
+static uint3 gl_GlobalInvocationID;
+struct SPIRV_Cross_Input
+{
+    uint3 gl_GlobalInvocationID : SV_DispatchThreadID;
+};
+
+void comp_main()
+{
+    wo.Store4(gl_GlobalInvocationID.x * 64 + 272, asuint(asfloat(ro.Load4(gl_GlobalInvocationID.x * 64 + 160))));
+    wo.Store4(gl_GlobalInvocationID.x * 16 + 480, asuint(asfloat(ro.Load4(gl_GlobalInvocationID.x * 16 + 480))));
+}
+
+[numthreads(1, 1, 1)]
+void main(SPIRV_Cross_Input stage_input)
+{
+    gl_GlobalInvocationID = stage_input.gl_GlobalInvocationID;
+    comp_main();
+}

--- a/reference/shaders-hlsl/comp/address-buffers.comp
+++ b/reference/shaders-hlsl/comp/address-buffers.comp
@@ -1,0 +1,15 @@
+RWByteAddressBuffer WriteOnly : register(u2);
+ByteAddressBuffer ReadOnly : register(u0);
+RWByteAddressBuffer ReadWrite : register(u1);
+
+void comp_main()
+{
+    WriteOnly.Store4(0, asuint(asfloat(ReadOnly.Load4(0))));
+    ReadWrite.Store4(0, asuint(asfloat(ReadWrite.Load4(0)) + float4(10.0f, 10.0f, 10.0f, 10.0f)));
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    comp_main();
+}

--- a/reference/shaders-hlsl/comp/builtins.comp
+++ b/reference/shaders-hlsl/comp/builtins.comp
@@ -1,0 +1,26 @@
+static uint3 gl_LocalInvocationID;
+static uint3 gl_GlobalInvocationID;
+static uint gl_LocalInvocationIndex;
+struct SPIRV_Cross_Input
+{
+    uint3 gl_LocalInvocationID : SV_GroupThreadID;
+    uint3 gl_GlobalInvocationID : SV_DispatchThreadID;
+    uint gl_LocalInvocationIndex : SV_GroupIndex;
+};
+
+void comp_main()
+{
+    uint3 local_id = gl_LocalInvocationID;
+    uint3 global_id = gl_GlobalInvocationID;
+    uint local_index = gl_LocalInvocationIndex;
+    uint3 work_group_size = uint3(8u, 4u, 2u);
+}
+
+[numthreads(8, 4, 2)]
+void main(SPIRV_Cross_Input stage_input)
+{
+    gl_LocalInvocationID = stage_input.gl_LocalInvocationID;
+    gl_GlobalInvocationID = stage_input.gl_GlobalInvocationID;
+    gl_LocalInvocationIndex = stage_input.gl_LocalInvocationIndex;
+    comp_main();
+}

--- a/reference/shaders-hlsl/comp/ssbo-array.comp
+++ b/reference/shaders-hlsl/comp/ssbo-array.comp
@@ -1,0 +1,11 @@
+RWByteAddressBuffer ssbo0 : register(u0);
+
+void comp_main()
+{
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    comp_main();
+}

--- a/shaders-hlsl/comp/access-chains.comp
+++ b/shaders-hlsl/comp/access-chains.comp
@@ -1,0 +1,24 @@
+#version 310 es
+layout(local_size_x = 1) in;
+
+// TODO: Read structs, matrices and arrays.
+
+layout(std430, binding = 0) readonly buffer SSBO
+{
+	vec4 a[3][2][4];
+	float b[3][2][4];
+	vec4 unsized[];
+} ro;
+
+layout(std430, binding = 1) writeonly buffer SSBO1
+{
+	vec4 c[3][2][4];
+	float d[3][2][4];
+	vec4 unsized[];
+} wo;
+
+void main()
+{
+	wo.c[2][gl_GlobalInvocationID.x][1] = ro.a[1][gl_GlobalInvocationID.x][2];
+	wo.unsized[gl_GlobalInvocationID.x] = ro.unsized[gl_GlobalInvocationID.x];
+}

--- a/shaders-hlsl/comp/address-buffers.comp
+++ b/shaders-hlsl/comp/address-buffers.comp
@@ -1,0 +1,23 @@
+#version 310 es
+layout(local_size_x = 1) in;
+
+layout(binding = 0, std430) readonly buffer ReadOnlyBuffer
+{
+	vec4 ro;
+} ReadOnly;
+
+layout(binding = 1, std430) buffer ReadWriteBuffer
+{
+	vec4 rw;
+} ReadWrite;
+
+layout(binding = 2, std430) buffer WriteOnlyBuffer 
+{
+	vec4 wo;
+} WriteOnly;
+
+void main()
+{
+	WriteOnly.wo = ReadOnly.ro;
+	ReadWrite.rw += 10.0;
+}

--- a/shaders-hlsl/comp/builtins.comp
+++ b/shaders-hlsl/comp/builtins.comp
@@ -1,0 +1,10 @@
+#version 310 es
+layout(local_size_x = 8, local_size_y = 4, local_size_z = 2) in;
+
+void main()
+{
+	uvec3 local_id = gl_LocalInvocationID;
+	uvec3 global_id = gl_GlobalInvocationID;
+	uint local_index = gl_LocalInvocationIndex;
+	uvec3 work_group_size = gl_WorkGroupSize;
+}

--- a/shaders-hlsl/comp/ssbo-array.comp
+++ b/shaders-hlsl/comp/ssbo-array.comp
@@ -1,0 +1,29 @@
+#version 450
+layout(local_size_x = 1) in;
+
+layout(binding = 0, std430) buffer SSBO0
+{
+	vec4 a;
+} ssbo0;
+
+// Does not seem to work in glslang yet in HLSL output, disable for now.
+#if 0
+layout(binding = 1, std430) buffer SSBO1
+{
+	vec4 b;
+} ssbo1[2];
+
+layout(binding = 2, std430) buffer SSBO2
+{
+	vec4 c;
+} ssbo2[3][3];
+#endif
+
+void main()
+{
+#if 0
+	ssbo1[1].b = ssbo0.a;
+	ssbo2[1][2].c = ssbo0.a;
+#endif
+}
+

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -187,6 +187,7 @@ enum Types
 	TypeExpression,
 	TypeConstantOp,
 	TypeCombinedImageSampler,
+	TypeAccessChain,
 	TypeUndef
 };
 
@@ -604,6 +605,38 @@ struct SPIRFunction : IVariant
 	bool flush_undeclared = true;
 	bool do_combined_parameters = true;
 	bool analyzed_variable_scope = false;
+};
+
+struct SPIRAccessChain : IVariant
+{
+	enum
+	{
+		type = TypeAccessChain
+	};
+
+	SPIRAccessChain(uint32_t basetype_, spv::StorageClass storage_,
+	                std::string base_, std::string dynamic_index_, int32_t static_index_)
+		: basetype(basetype_),
+		  storage(storage_),
+		  base(base_),
+		  dynamic_index(std::move(dynamic_index_)),
+		  static_index(static_index_)
+	{
+	}
+
+	// The access chain represents an offset into a buffer.
+	// Some backends need more complicated handling of access chains to be able to use buffers, like HLSL
+	// which has no usable buffer type ala GLSL SSBOs.
+	// StructuredBuffer is too limited, so our only option is to deal with ByteAddressBuffer which works with raw addresses.
+
+	uint32_t basetype;
+	spv::StorageClass storage;
+	std::string base;
+	std::string dynamic_index;
+	int32_t static_index;
+
+	uint32_t loaded_from = 0;
+	bool need_transpose = false;
 };
 
 struct SPIRVariable : IVariant

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -637,6 +637,7 @@ struct SPIRAccessChain : IVariant
 
 	uint32_t loaded_from = 0;
 	bool need_transpose = false;
+	bool immutable = false;
 };
 
 struct SPIRVariable : IVariant

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -3409,6 +3409,9 @@ bool Compiler::ActiveBuiltinHandler::handle(spv::Op opcode, const uint32_t *args
 		if (!var)
 			break;
 
+		// Required if we access chain into builtins like gl_GlobalInvocationID.
+		add_if_builtin(args[2]);
+
 		auto *type = &compiler.get<SPIRType>(var->basetype);
 
 		// Start traversing type hierarchy at the proper non-pointer types.

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -359,6 +359,9 @@ uint32_t Compiler::expression_type_id(uint32_t id) const
 	case TypeCombinedImageSampler:
 		return get<SPIRCombinedImageSampler>(id).combined_type;
 
+	case TypeAccessChain:
+		return get<SPIRType>(get<SPIRAccessChain>(id).basetype);
+
 	default:
 		SPIRV_CROSS_THROW("Cannot resolve expression type.");
 	}

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -368,7 +368,7 @@ uint32_t Compiler::expression_type_id(uint32_t id) const
 		return get<SPIRCombinedImageSampler>(id).combined_type;
 
 	case TypeAccessChain:
-		return get<SPIRType>(get<SPIRAccessChain>(id).basetype);
+		return get<SPIRAccessChain>(id).basetype;
 
 	default:
 		SPIRV_CROSS_THROW("Cannot resolve expression type.");

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -249,6 +249,10 @@ SPIRVariable *Compiler::maybe_get_backing_variable(uint32_t chain)
 		auto *cexpr = maybe_get<SPIRExpression>(chain);
 		if (cexpr)
 			var = maybe_get<SPIRVariable>(cexpr->loaded_from);
+
+		auto *access_chain = maybe_get<SPIRAccessChain>(chain);
+		if (access_chain)
+			var = maybe_get<SPIRVariable>(access_chain->loaded_from);
 	}
 
 	return var;
@@ -283,6 +287,10 @@ void Compiler::register_write(uint32_t chain)
 		auto *expr = maybe_get<SPIRExpression>(chain);
 		if (expr && expr->loaded_from)
 			var = maybe_get<SPIRVariable>(expr->loaded_from);
+
+		auto *access_chain = maybe_get<SPIRAccessChain>(chain);
+		if (access_chain && access_chain->loaded_from)
+			var = maybe_get<SPIRVariable>(access_chain->loaded_from);
 	}
 
 	if (var)
@@ -397,6 +405,8 @@ bool Compiler::is_immutable(uint32_t id) const
 		bool pointer_to_const = var.storage == StorageClassUniformConstant;
 		return pointer_to_const || var.phi_variable || !expression_is_lvalue(id);
 	}
+	else if (ids[id].get_type() == TypeAccessChain)
+		return get<SPIRAccessChain>(id).immutable;
 	else if (ids[id].get_type() == TypeExpression)
 		return get<SPIRExpression>(id).immutable;
 	else if (ids[id].get_type() == TypeConstant || ids[id].get_type() == TypeConstantOp ||

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1979,6 +1979,10 @@ string CompilerGLSL::to_expression(uint32_t id)
 		// expression ala sampler2D(texture, sampler).
 		SPIRV_CROSS_THROW("Combined image samplers have no default expression representation.");
 
+	case TypeAccessChain:
+		// We cannot express this type. They only have meaning in other OpAccessChains, OpStore or OpLoad.
+		SPIRV_CROSS_THROW("Access chains have no default expression representation.");
+
 	default:
 		return to_name(id);
 	}

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -359,8 +359,9 @@ protected:
 	std::string flattened_access_chain_vector(uint32_t base, const uint32_t *indices, uint32_t count,
 	                                          const SPIRType &target_type, uint32_t offset, uint32_t matrix_stride,
 	                                          bool need_transpose);
-	std::pair<std::string, uint32_t> flattened_access_chain_offset(uint32_t base, const uint32_t *indices,
+	std::pair<std::string, uint32_t> flattened_access_chain_offset(const SPIRType &basetype, const uint32_t *indices,
 	                                                               uint32_t count, uint32_t offset,
+	                                                               uint32_t word_stride,
 	                                                               bool *need_transpose = nullptr,
 	                                                               uint32_t *matrix_stride = nullptr);
 

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1859,10 +1859,13 @@ string CompilerHLSL::read_access_chain(const SPIRAccessChain &chain)
 	target_type.vecsize = type.vecsize;
 	target_type.columns = type.columns;
 
+	// FIXME: Transposition?
 	if (type.columns != 1)
 		SPIRV_CROSS_THROW("Reading matrices from ByteAddressBuffer not yet supported.");
+
 	if (type.basetype == SPIRType::Struct)
 		SPIRV_CROSS_THROW("Reading structs from ByteAddressBuffer not yet supported.");
+
 	if (type.width != 32)
 		SPIRV_CROSS_THROW("Reading types other than 32-bit from ByteAddressBuffer not yet supported.");
 

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -88,6 +88,9 @@ private:
 	std::string to_resource_binding(const SPIRVariable &var);
 	std::string to_resource_binding_sampler(const SPIRVariable &var);
 	void emit_sampled_image_op(uint32_t result_type, uint32_t result_id, uint32_t image_id, uint32_t samp_id) override;
+	void emit_access_chain(const Instruction &instruction);
+	void emit_load(const Instruction &instruction);
+	void emit_store(const Instruction &instruction);
 
 	const char *to_storage_qualifiers_glsl(const SPIRVariable &var) override;
 

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -90,6 +90,7 @@ private:
 	void emit_sampled_image_op(uint32_t result_type, uint32_t result_id, uint32_t image_id, uint32_t samp_id) override;
 	void emit_access_chain(const Instruction &instruction);
 	void emit_load(const Instruction &instruction);
+	std::string read_access_chain(const SPIRAccessChain &chain);
 	void emit_store(const Instruction &instruction);
 
 	const char *to_storage_qualifiers_glsl(const SPIRVariable &var) override;


### PR DESCRIPTION
Built upon https://github.com/KhronosGroup/SPIRV-Cross/pull/220.
Fixes #249.

Lots of stuff is certainly missing, but it should be usable now for basic compute shaders.