### PR TITLE
Use the correct cbuffer binding for HLSL SM 4.0-5.0

### DIFF
--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1690,7 +1690,7 @@ string CompilerHLSL::to_resource_binding(const SPIRVariable &var)
 				space = "u"; // UAV
 			else if (has_decoration(type.self, DecorationBlock))
 			{
-				if (options.shader_model >= 51)
+				if (options.shader_model >= 40)
 					space = "b"; // Constant buffers
 				else
 					space = "c"; // Constant buffers
@@ -1698,7 +1698,7 @@ string CompilerHLSL::to_resource_binding(const SPIRVariable &var)
 		}
 		else if (storage == StorageClassPushConstant)
 		{
-			if (options.shader_model >= 51)
+			if (options.shader_model >= 40)
 				space = "b"; // Constant buffers
 			else
 				space = "c"; // Constant buffers


### PR DESCRIPTION
I'm using SPIRV-Cross to port an OpenGL application to Direct3D 11. It's working fairly well, but explicit UBO bindings fail with the following error:

```
D3DCompile failed: Unspecified error (0x80004005)
C:\msys64\home\rossy\mpv\Shader@0x000000000742B570(21,24-25): error X3530: invalid register specification, expected 'b' binding
```

This change fixes the error for me. I think b# bindings should be used for cbuffers on shader model 4.0-5.0 as well as 5.1.

Reference: https://msdn.microsoft.com/en-us/library/windows/desktop/bb509581.aspx