### PR TITLE
Fix texture GatherRed/Green/etc. methods for HLSL SM 5.0

### DIFF
--- a/reference/shaders-hlsl/frag/tex-sampling.frag
+++ b/reference/shaders-hlsl/frag/tex-sampling.frag
@@ -89,7 +89,16 @@ void frag_main()
     texcolor += tex1dArray.Sample(_tex1dArray_sampler, texCoord2d);
     texcolor += tex2dArray.Sample(_tex2dArray_sampler, texCoord3d);
     texcolor += texCubeArray.Sample(_texCubeArray_sampler, texCoord4d);
-    texcolor += tex2d.Gather(_tex2d_sampler, texCoord2d, 0);
+    texcolor += tex2d.GatherRed(_tex2d_sampler, texCoord2d);
+    texcolor += tex2d.GatherRed(_tex2d_sampler, texCoord2d);
+    texcolor += tex2d.GatherGreen(_tex2d_sampler, texCoord2d);
+    texcolor += tex2d.GatherBlue(_tex2d_sampler, texCoord2d);
+    texcolor += tex2d.GatherAlpha(_tex2d_sampler, texCoord2d);
+    texcolor += tex2d.GatherRed(_tex2d_sampler, texCoord2d, int2(1, 1));
+    texcolor += tex2d.GatherRed(_tex2d_sampler, texCoord2d, int2(1, 1));
+    texcolor += tex2d.GatherGreen(_tex2d_sampler, texCoord2d, int2(1, 1));
+    texcolor += tex2d.GatherBlue(_tex2d_sampler, texCoord2d, int2(1, 1));
+    texcolor += tex2d.GatherAlpha(_tex2d_sampler, texCoord2d, int2(1, 1));
     texcolor += tex2d.Load(int3(int2(1, 2), 0));
     texcolor += separateTex2d.Sample(samplerNonDepth, texCoord2d);
     texcolor.w += separateTex2dDepth.SampleCmp(samplerDepth, texCoord3d.xy, texCoord3d.z);

--- a/shaders-hlsl/frag/tex-sampling.frag
+++ b/shaders-hlsl/frag/tex-sampling.frag
@@ -61,6 +61,16 @@ void main()
 	texcolor += texture(texCubeArray, texCoord4d);
 
 	texcolor += textureGather(tex2d, texCoord2d);
+	texcolor += textureGather(tex2d, texCoord2d, 0);
+	texcolor += textureGather(tex2d, texCoord2d, 1);
+	texcolor += textureGather(tex2d, texCoord2d, 2);
+	texcolor += textureGather(tex2d, texCoord2d, 3);
+
+	texcolor += textureGatherOffset(tex2d, texCoord2d, ivec2(1, 1));
+	texcolor += textureGatherOffset(tex2d, texCoord2d, ivec2(1, 1), 0);
+	texcolor += textureGatherOffset(tex2d, texCoord2d, ivec2(1, 1), 1);
+	texcolor += textureGatherOffset(tex2d, texCoord2d, ivec2(1, 1), 2);
+	texcolor += textureGatherOffset(tex2d, texCoord2d, ivec2(1, 1), 3);
 
 	texcolor += texelFetch(tex2d, ivec2(1, 2), 0);
 


### PR DESCRIPTION
In GLSL, it seems like the component is selected with an integer constant argument, but in HLSL, it's selected by calling a different method on the texture itself.

EDIT: I noticed the Travis build didn't start again. I've contacted Travis support in case this is something to do with my account. 😕 The tests pass locally (including with fxc.exe.)