### PR TITLE
Fix HLSL atan2() argument order

### DIFF
--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1916,7 +1916,7 @@ void CompilerHLSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop,
 		break;
 
 	case GLSLstd450Atan2:
-		emit_binary_func_op(result_type, id, args[1], args[0], "atan2");
+		emit_binary_func_op(result_type, id, args[0], args[1], "atan2");
 		break;
 
 	case GLSLstd450Fma:


### PR DESCRIPTION
It seems like HLSL uses the same atan2(y, x) argument order as GLSL. Fixing this corrected an error in one of our cross-compiled shaders.

I also used a small test shader to verify that this was correct. Left is a GLSL shader that graphs the range of atan(y, x), cross-compiled to HLSL with glslang and SPIRV-Cross (with this fix.) Right is the same shader running natively in OpenGL.
![image](https://user-images.githubusercontent.com/162837/30775346-d4d4a2be-a0d4-11e7-8ea5-debffe2a948b.png)

References:
http://docs.gl/sl4/atan
https://msdn.microsoft.com/en-us/library/windows/desktop/bb509575.aspx