### PR TITLE
Fix compilation with clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,9 @@ spirv_cross_add_library(spirv-cross-hlsl spirv_cross_hlsl STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/spirv_hlsl.cpp)
 
 add_executable(spirv-cross main.cpp)
+target_compile_options(spirv-cross PRIVATE ${spirv-compiler-options})
+target_compile_definitions(spirv-cross PRIVATE ${spirv-compiler-defines})
+
 install(TARGETS spirv-cross RUNTIME DESTINATION bin)
 target_link_libraries(spirv-cross spirv-cross-glsl spirv-cross-hlsl spirv-cross-cpp spirv-cross-msl spirv-cross-core)
 target_link_libraries(spirv-cross-glsl spirv-cross-core)


### PR DESCRIPTION
Hi,

Project doesn't compile on my machine (clang 5.0.0, linux), spirv-cross doesn't have the correct compile options set. It was working on gcc since c++11 is enabled by default. 
The commit adds compile options & defines. 