### PR TITLE
HLSL: Only unroll matrices for vertex input.

### DIFF
--- a/reference/shaders-hlsl/frag/matrix-input.frag
+++ b/reference/shaders-hlsl/frag/matrix-input.frag
@@ -1,0 +1,26 @@
+static float4 FragColor;
+static float4x4 m;
+
+struct SPIRV_Cross_Input
+{
+    float4x4 m : TEXCOORD1;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    FragColor = ((m[0] + m[1]) + m[2]) + m[3];
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    m = stage_input.m;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/vert/matrix-output.vert
+++ b/reference/shaders-hlsl/vert/matrix-output.vert
@@ -1,0 +1,23 @@
+static float4 gl_Position;
+static float4x4 m;
+
+struct SPIRV_Cross_Output
+{
+    float4x4 m : TEXCOORD0;
+    float4 gl_Position : SV_Position;
+};
+
+void vert_main()
+{
+    gl_Position = float4(1.0f, 1.0f, 1.0f, 1.0f);
+    m = float4x4(float4(1.0f, 0.0f, 0.0f, 0.0f), float4(0.0f, 1.0f, 0.0f, 0.0f), float4(0.0f, 0.0f, 1.0f, 0.0f), float4(0.0f, 0.0f, 0.0f, 1.0f));
+}
+
+SPIRV_Cross_Output main()
+{
+    vert_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    stage_output.m = m;
+    return stage_output;
+}

--- a/shaders-hlsl/frag/matrix-input.frag
+++ b/shaders-hlsl/frag/matrix-input.frag
@@ -1,0 +1,9 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 1) in mat4 m;
+
+void main()
+{
+	FragColor = m[0] + m[1] + m[2] + m[3];
+}

--- a/shaders-hlsl/vert/matrix-output.vert
+++ b/shaders-hlsl/vert/matrix-output.vert
@@ -1,0 +1,9 @@
+#version 450
+
+layout(location = 0) out mat4 m;
+
+void main()
+{
+	gl_Position = vec4(1.0);
+	m = mat4(1.0);
+}


### PR DESCRIPTION
Bandaid, might have to revisit this later.
Fixes #264 