### PR TITLE
Handle empty struct declarations with best effort.

### DIFF
--- a/reference/shaders-hlsl/asm/vert/empty-struct-composite.asm.vert
+++ b/reference/shaders-hlsl/asm/vert/empty-struct-composite.asm.vert
@@ -1,0 +1,8 @@
+void vert_main()
+{
+}
+
+void main()
+{
+    vert_main();
+}

--- a/reference/shaders-msl/asm/vert/empty-struct-composite.asm.vert
+++ b/reference/shaders-msl/asm/vert/empty-struct-composite.asm.vert
@@ -1,0 +1,9 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+vertex void main0()
+{
+}
+

--- a/reference/shaders/asm/vert/empty-struct-composite.asm.vert
+++ b/reference/shaders/asm/vert/empty-struct-composite.asm.vert
@@ -1,0 +1,6 @@
+#version 450
+
+void main()
+{
+}
+

--- a/shaders-hlsl/asm/vert/empty-struct-composite.asm.vert
+++ b/shaders-hlsl/asm/vert/empty-struct-composite.asm.vert
@@ -1,0 +1,37 @@
+; SPIR-V
+; Version: 1.1
+; Generator: Google rspirv; 0
+; Bound: 17
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpName %Test "Test"
+               OpName %t "t"
+               OpName %retvar "retvar"
+               OpName %main "main"
+               OpName %retvar_0 "retvar"
+       %void = OpTypeVoid
+          %6 = OpTypeFunction %void
+       %Test = OpTypeStruct
+%_ptr_Function_Test = OpTypePointer Function %Test
+%_ptr_Function_void = OpTypePointer Function %void
+          %2 = OpFunction %void None %6
+          %7 = OpLabel
+          %t = OpVariable %_ptr_Function_Test Function
+     %retvar = OpVariable %_ptr_Function_void Function
+               OpBranch %4
+          %4 = OpLabel
+         %13 = OpCompositeConstruct %Test
+               OpStore %t %13
+               OpReturn
+               OpFunctionEnd
+       %main = OpFunction %void None %6
+         %15 = OpLabel
+   %retvar_0 = OpVariable %_ptr_Function_void Function
+               OpBranch %14
+         %14 = OpLabel
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl/asm/vert/empty-struct-composite.asm.vert
+++ b/shaders-msl/asm/vert/empty-struct-composite.asm.vert
@@ -1,0 +1,37 @@
+; SPIR-V
+; Version: 1.1
+; Generator: Google rspirv; 0
+; Bound: 17
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpName %Test "Test"
+               OpName %t "t"
+               OpName %retvar "retvar"
+               OpName %main "main"
+               OpName %retvar_0 "retvar"
+       %void = OpTypeVoid
+          %6 = OpTypeFunction %void
+       %Test = OpTypeStruct
+%_ptr_Function_Test = OpTypePointer Function %Test
+%_ptr_Function_void = OpTypePointer Function %void
+          %2 = OpFunction %void None %6
+          %7 = OpLabel
+          %t = OpVariable %_ptr_Function_Test Function
+     %retvar = OpVariable %_ptr_Function_void Function
+               OpBranch %4
+          %4 = OpLabel
+         %13 = OpCompositeConstruct %Test
+               OpStore %t %13
+               OpReturn
+               OpFunctionEnd
+       %main = OpFunction %void None %6
+         %15 = OpLabel
+   %retvar_0 = OpVariable %_ptr_Function_void Function
+               OpBranch %14
+         %14 = OpLabel
+               OpReturn
+               OpFunctionEnd

--- a/shaders/asm/vert/empty-struct-composite.asm.vert
+++ b/shaders/asm/vert/empty-struct-composite.asm.vert
@@ -1,0 +1,37 @@
+; SPIR-V
+; Version: 1.1
+; Generator: Google rspirv; 0
+; Bound: 17
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpName %Test "Test"
+               OpName %t "t"
+               OpName %retvar "retvar"
+               OpName %main "main"
+               OpName %retvar_0 "retvar"
+       %void = OpTypeVoid
+          %6 = OpTypeFunction %void
+       %Test = OpTypeStruct
+%_ptr_Function_Test = OpTypePointer Function %Test
+%_ptr_Function_void = OpTypePointer Function %void
+          %2 = OpFunction %void None %6
+          %7 = OpLabel
+          %t = OpVariable %_ptr_Function_Test Function
+     %retvar = OpVariable %_ptr_Function_void Function
+               OpBranch %4
+          %4 = OpLabel
+         %13 = OpCompositeConstruct %Test
+               OpStore %t %13
+               OpReturn
+               OpFunctionEnd
+       %main = OpFunction %void None %6
+         %15 = OpLabel
+   %retvar_0 = OpVariable %_ptr_Function_void Function
+               OpBranch %14
+         %14 = OpLabel
+               OpReturn
+               OpFunctionEnd


### PR DESCRIPTION
This "feature" is a bit icky as we have no useful representation of it,
so never emit code which has anything to do with empty structs.

Fixes #292 .