### PR TITLE
Use 'static const' for spec constants in HLSL

### DIFF
--- a/reference/shaders-hlsl/asm/comp/specialization-constant-workgroup.asm.comp
+++ b/reference/shaders-hlsl/asm/comp/specialization-constant-workgroup.asm.comp
@@ -1,6 +1,6 @@
-const uint _5 = 9u;
-const uint _6 = 4u;
-const uint3 gl_WorkGroupSize = uint3(_5, 20u, _6);
+static const uint _5 = 9u;
+static const uint _6 = 4u;
+static const uint3 gl_WorkGroupSize = uint3(_5, 20u, _6);
 
 RWByteAddressBuffer _4 : register(u0);
 

--- a/reference/shaders-hlsl/asm/comp/storage-buffer-basic.asm.comp
+++ b/reference/shaders-hlsl/asm/comp/storage-buffer-basic.asm.comp
@@ -1,6 +1,6 @@
-const uint _3 = 1u;
-const uint _4 = 3u;
-const uint3 gl_WorkGroupSize = uint3(_3, 2u, _4);
+static const uint _3 = 1u;
+static const uint _4 = 3u;
+static const uint3 gl_WorkGroupSize = uint3(_3, 2u, _4);
 
 RWByteAddressBuffer _8 : register(u0);
 RWByteAddressBuffer _9 : register(u1);

--- a/reference/shaders-hlsl/comp/builtins.comp
+++ b/reference/shaders-hlsl/comp/builtins.comp
@@ -1,4 +1,4 @@
-const uint3 gl_WorkGroupSize = uint3(8u, 4u, 2u);
+static const uint3 gl_WorkGroupSize = uint3(8u, 4u, 2u);
 
 static uint3 gl_WorkGroupID;
 static uint3 gl_LocalInvocationID;

--- a/reference/shaders-hlsl/frag/spec-constant.frag
+++ b/reference/shaders-hlsl/frag/spec-constant.frag
@@ -1,11 +1,11 @@
-const float a = 1.0f;
-const float b = 2.0f;
-const int c = 3;
-const int d = 4;
-const uint e = 5u;
-const uint f = 6u;
-const bool g = false;
-const bool h = true;
+static const float a = 1.0f;
+static const float b = 2.0f;
+static const int c = 3;
+static const int d = 4;
+static const uint e = 5u;
+static const uint f = 6u;
+static const bool g = false;
+static const bool h = true;
 
 struct Foo
 {

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -644,14 +644,15 @@ void CompilerHLSL::emit_specialization_constants()
 			auto &type = get<SPIRType>(c.constant_type);
 			auto name = to_name(c.self);
 
-			statement("const ", variable_decl(type, name), " = ", constant_expression(c), ";");
+			statement("static const ", variable_decl(type, name), " = ", constant_expression(c), ";");
 			emitted = true;
 		}
 	}
 
 	if (workgroup_size_id)
 	{
-		statement("const uint3 gl_WorkGroupSize = ", constant_expression(get<SPIRConstant>(workgroup_size_id)), ";");
+		statement("static const uint3 gl_WorkGroupSize = ",
+		          constant_expression(get<SPIRConstant>(workgroup_size_id)), ";");
 		emitted = true;
 	}
 


### PR DESCRIPTION
At least, I think this is correct. I don't know if HLSL has an equivalent for specialization constants in SPIR-V where the work group size can be specified after the shader is compiled. Without this change, the HLSL compiler ignores the initializers for the constants and expects them to be provided by a cbuffer.