### PR TITLE
Rename nested Image struct type.

### DIFF
--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -291,7 +291,7 @@ struct SPIRType : IVariant
 
 	std::vector<uint32_t> member_types;
 
-	struct Image
+	struct ImageType
 	{
 		uint32_t type;
 		spv::Dim dim;


### PR DESCRIPTION
Reuses an enum name as a struct type, creates friction for API wrappers.
Closes #313 