### PR TITLE
HLSL Vertex Attribute remap

### DIFF
--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -674,7 +674,7 @@ void CompilerHLSL::emit_interface_block_in_struct(const SPIRVariable &var, unord
 		{
 			for (auto &attribute : vertex_attributes)
 			{
-				if (attribute.name == name)
+				if (attribute.binding == binding_number)
 				{
 					semantic = attribute.semantic;
 					semantic_index = attribute.semantic_index;
@@ -3168,9 +3168,7 @@ string CompilerHLSL::compile(std::vector<HLSLVertexAttr> *p_vertex_attributes)
 {
 	if (p_vertex_attributes)
 	{
-		vertex_attributes.clear();
-		for (auto &va : *p_vertex_attributes)
-			vertex_attributes.emplace_back(va);
+		vertex_attributes = *p_vertex_attributes;
 	}
 
 	return compile();

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -23,6 +23,13 @@
 
 namespace spirv_cross
 {
+struct HLSLVertexAttr
+{
+	std::string name;
+	std::string semantic;
+	uint32_t semantic_index;
+};
+
 class CompilerHLSL : public CompilerGLSL
 {
 public:
@@ -54,6 +61,7 @@ public:
 		options = opts;
 	}
 
+	std::string compile(std::vector<HLSLVertexAttr> *p_vertex_attributes);
 	std::string compile() override;
 
 private:
@@ -133,6 +141,7 @@ private:
 	void emit_builtin_variables();
 	bool require_output = false;
 	bool require_input = false;
+	std::vector<HLSLVertexAttr> vertex_attributes;
 
 	uint32_t type_to_consumed_locations(const SPIRType &type) const;
 

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -25,7 +25,7 @@ namespace spirv_cross
 {
 struct HLSLVertexAttr
 {
-	std::string name;
+	uint32_t binding;
 	std::string semantic;
 	uint32_t semantic_index;
 };


### PR DESCRIPTION
Add overload compile method for hlsl with vertex attribute remap.
This adds remap to semantic and semantic_index as HLSL instead of always binding to TEXCOORD + binding_number.