### PR TITLE
Do not allow base expressions when extracting struct members.

### DIFF
--- a/reference/shaders/asm/frag/struct-composite-extract-swizzle.asm.frag
+++ b/reference/shaders/asm/frag/struct-composite-extract-swizzle.asm.frag
@@ -1,0 +1,21 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+struct Foo
+{
+    float var1;
+    float var2;
+};
+
+layout(binding = 0) uniform mediump sampler2D uSampler;
+
+layout(location = 0) out vec4 FragColor;
+
+Foo _22;
+
+void main()
+{
+    FragColor = texture(uSampler, vec2(_22.var1, _22.var2));
+}
+

--- a/shaders/asm/frag/struct-composite-extract-swizzle.asm.frag
+++ b/shaders/asm/frag/struct-composite-extract-swizzle.asm.frag
@@ -1,0 +1,55 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 1
+; Bound: 34
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource ESSL 310
+               OpName %main "main"
+               OpName %FragColor "FragColor"
+               OpName %uSampler "uSampler"
+               OpName %Foo "Foo"
+               OpMemberName %Foo 0 "var1"
+               OpMemberName %Foo 1 "var2"
+               OpName %foo "foo"
+               OpDecorate %FragColor RelaxedPrecision
+               OpDecorate %FragColor Location 0
+               OpDecorate %uSampler RelaxedPrecision
+               OpDecorate %uSampler DescriptorSet 0
+               OpDecorate %uSampler Binding 0
+               OpDecorate %14 RelaxedPrecision
+               OpMemberDecorate %Foo 0 RelaxedPrecision
+               OpMemberDecorate %Foo 1 RelaxedPrecision
+               OpDecorate %27 RelaxedPrecision
+               OpDecorate %28 RelaxedPrecision
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+         %10 = OpTypeImage %float 2D 0 0 0 1 Unknown
+         %11 = OpTypeSampledImage %10
+%_ptr_UniformConstant_11 = OpTypePointer UniformConstant %11
+   %uSampler = OpVariable %_ptr_UniformConstant_11 UniformConstant
+        %Foo = OpTypeStruct %float %float
+%_ptr_Function_Foo = OpTypePointer Function %Foo
+        %int = OpTypeInt 32 1
+%_ptr_Function_float = OpTypePointer Function %float
+    %v2float = OpTypeVector %float 2
+         %33 = OpUndef %Foo
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+        %foo = OpVariable %_ptr_Function_Foo Function
+         %14 = OpLoad %11 %uSampler
+         %30 = OpCompositeExtract %float %33 0
+         %32 = OpCompositeExtract %float %33 1
+         %27 = OpCompositeConstruct %v2float %30 %32
+         %28 = OpImageSampleImplicitLod %v4float %14 %27
+               OpStore %FragColor %28
+               OpReturn
+               OpFunctionEnd

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -5272,6 +5272,11 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		// We can only split the expression here if our expression is forwarded as a temporary.
 		bool allow_base_expression = forced_temporaries.find(id) == end(forced_temporaries);
 
+		// Do not allow base expression for struct members. We risk doing "swizzle" optimizations in this case.
+		auto &composite_type = expression_type(ops[2]);
+		if (composite_type.basetype == SPIRType::Struct)
+			allow_base_expression = false;
+
 		// Only apply this optimization if result is scalar.
 		if (allow_base_expression && should_forward(ops[2]) && type.vecsize == 1 && type.columns == 1 && length == 1)
 		{


### PR DESCRIPTION
Fixes #331.