### PR TITLE
Improve handling of block name declaration in GLSL.

### DIFF
--- a/reference/opt/shaders/asm/comp/name-alias.asm.invalid.comp
+++ b/reference/opt/shaders/asm/comp/name-alias.asm.invalid.comp
@@ -19,19 +19,19 @@ struct alias_2
     alias_1 alias_1;
 };
 
-layout(binding = 0, std430) buffer _10_11
-{
-    alias_2 alias;
-} alias_3;
-
-layout(binding = 1, std140) buffer _15_16
+layout(binding = 0, std430) buffer alias_3
 {
     alias_2 alias;
 } alias_4;
 
+layout(binding = 1, std140) buffer alias_5
+{
+    alias_2 alias;
+} alias_6;
+
 void main()
 {
-    alias_2 alias_5 = alias_3.alias;
-    alias_4.alias = alias_5;
+    alias_2 alias_7 = alias_4.alias;
+    alias_6.alias = alias_7;
 }
 

--- a/reference/opt/shaders/desktop-only/frag/hlsl-uav-block-alias.asm.frag
+++ b/reference/opt/shaders/desktop-only/frag/hlsl-uav-block-alias.asm.frag
@@ -1,0 +1,19 @@
+#version 450
+
+layout(binding = 0, std430) buffer Foobar
+{
+    vec4 _data[];
+} Foobar_1;
+
+layout(binding = 1, std430) buffer Foobaz
+{
+    vec4 _data[];
+} Foobaz_1;
+
+layout(location = 0) out vec4 _entryPointOutput;
+
+void main()
+{
+    _entryPointOutput = Foobar_1._data[0] + Foobaz_1._data[0];
+}
+

--- a/reference/shaders/asm/comp/name-alias.asm.invalid.comp
+++ b/reference/shaders/asm/comp/name-alias.asm.invalid.comp
@@ -19,19 +19,19 @@ struct alias_2
     alias_1 alias_1;
 };
 
-layout(binding = 0, std430) buffer _10_11
-{
-    alias_2 alias;
-} alias_3;
-
-layout(binding = 1, std140) buffer _15_16
+layout(binding = 0, std430) buffer alias_3
 {
     alias_2 alias;
 } alias_4;
 
+layout(binding = 1, std140) buffer alias_5
+{
+    alias_2 alias;
+} alias_6;
+
 void main()
 {
-    alias_2 alias_5 = alias_3.alias;
-    alias_4.alias = alias_5;
+    alias_2 alias_7 = alias_4.alias;
+    alias_6.alias = alias_7;
 }
 

--- a/reference/shaders/desktop-only/frag/hlsl-uav-block-alias.asm.frag
+++ b/reference/shaders/desktop-only/frag/hlsl-uav-block-alias.asm.frag
@@ -1,0 +1,24 @@
+#version 450
+
+layout(binding = 0, std430) buffer Foobar
+{
+    vec4 _data[];
+} Foobar_1;
+
+layout(binding = 1, std430) buffer Foobaz
+{
+    vec4 _data[];
+} Foobaz_1;
+
+layout(location = 0) out vec4 _entryPointOutput;
+
+vec4 _main()
+{
+    return Foobar_1._data[0] + Foobaz_1._data[0];
+}
+
+void main()
+{
+    _entryPointOutput = _main();
+}
+

--- a/shaders/desktop-only/frag/hlsl-uav-block-alias.asm.frag
+++ b/shaders/desktop-only/frag/hlsl-uav-block-alias.asm.frag
@@ -1,0 +1,56 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 2
+; Bound: 29
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %_entryPointOutput
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 500
+               OpName %main "main"
+               OpName %_main_ "@main("
+               OpName %Foobar "Foobar"
+               OpMemberName %Foobar 0 "@data"
+               OpName %Foobar_0 "Foobar"
+               OpName %Foobaz "Foobaz"
+               OpName %_entryPointOutput "@entryPointOutput"
+               OpDecorate %_runtimearr_v4float ArrayStride 16
+               OpMemberDecorate %Foobar 0 Offset 0
+               OpDecorate %Foobar BufferBlock
+               OpDecorate %Foobar_0 DescriptorSet 0
+               OpDecorate %Foobar_0 Binding 0
+               OpDecorate %Foobaz DescriptorSet 0
+               OpDecorate %Foobaz Binding 1
+               OpDecorate %_entryPointOutput Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+          %8 = OpTypeFunction %v4float
+%_runtimearr_v4float = OpTypeRuntimeArray %v4float
+     %Foobar = OpTypeStruct %_runtimearr_v4float
+%_ptr_Uniform_Foobar = OpTypePointer Uniform %Foobar
+   %Foobar_0 = OpVariable %_ptr_Uniform_Foobar Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
+     %Foobaz = OpVariable %_ptr_Uniform_Foobar Uniform
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%_entryPointOutput = OpVariable %_ptr_Output_v4float Output
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %28 = OpFunctionCall %v4float %_main_
+               OpStore %_entryPointOutput %28
+               OpReturn
+               OpFunctionEnd
+     %_main_ = OpFunction %v4float None %8
+         %10 = OpLabel
+         %18 = OpAccessChain %_ptr_Uniform_v4float %Foobar_0 %int_0 %int_0
+         %19 = OpLoad %v4float %18
+         %21 = OpAccessChain %_ptr_Uniform_v4float %Foobaz %int_0 %int_0
+         %22 = OpLoad %v4float %21
+         %23 = OpFAdd %v4float %19 %22
+               OpReturnValue %23
+               OpFunctionEnd

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -410,6 +410,19 @@ public:
 	// Gets the list of all SPIR-V extensions which were declared in the SPIR-V module.
 	const std::vector<std::string> &get_declared_extensions() const;
 
+	// When declaring buffer blocks in GLSL, the name declared in the GLSL source
+	// might not be the same as the name declared in the SPIR-V module due to naming conflicts.
+	// In this case, SPIRV-Cross needs to find a fallback-name, and it might only
+	// be possible to know this name after compiling to GLSL.
+	// This is particularly important for HLSL input and UAVs which tends to reuse the same block type
+	// for multiple distinct blocks. For these cases it is not possible to modify the name of the type itself
+	// because it might be unique. Instead, you can use this interface to check after compilation which
+	// name was actually used if your input SPIR-V tends to have this problem.
+	// For other names like remapped names for variables, etc, it's generally enough to query the name of the variables
+	// after compiling, block names are an exception to this rule.
+	// ID is the name of a variable as returned by Resource::id, and must be a variable with a Block-like type.
+	std::string get_remapped_declared_block_name(uint32_t id) const;
+
 protected:
 	const uint32_t *stream(const Instruction &instr) const
 	{
@@ -729,6 +742,7 @@ protected:
 
 	std::vector<spv::Capability> declared_capabilities;
 	std::vector<std::string> declared_extensions;
+	std::unordered_map<uint32_t, std::string> declared_block_names;
 };
 }
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -488,6 +488,7 @@ protected:
 	void remap_pls_variables();
 
 	void add_variable(std::unordered_set<std::string> &variables, uint32_t id);
+	void add_variable(std::unordered_set<std::string> &variables, std::string &name);
 	void check_function_call_constraints(const uint32_t *args, uint32_t length);
 	void handle_invalid_expression(uint32_t id);
 	void find_static_extensions();


### PR DESCRIPTION
HLSL UAVs are a bit annoying because they can share block types,
so reflection becomes rather awkward. Sometimes we will need to make
some nasty fallbacks, so add a reflection interface which lets you query
post-shader compile which names was actually declared in the shader.

Fixes #345.