### PR TITLE
better? type handling when initial parsing OpStore by MSL generator

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -3319,9 +3319,12 @@ CompilerMSL::SPVFuncImpl CompilerMSL::OpCodePreprocessor::get_spv_func_impl(Op o
 		// we must extract the result type directly from the Instruction, rather than the ID.
 		uint32_t id_rhs = args[1];
 		uint32_t type_id_rhs = result_types[id_rhs];
-		if ((compiler.ids[id_rhs].get_type() != TypeConstant) && type_id_rhs &&
-		    compiler.is_array(compiler.get<SPIRType>(type_id_rhs)))
-			return SPVFuncImplArrayCopy;
+		if ((compiler.ids[id_rhs].get_type() != TypeConstant) && type_id_rhs)
+		{
+			auto & type = compiler.ids[type_id_rhs].get_type() != TypeType ? compiler.expression_type(type_id_rhs) : compiler.get<SPIRType>(type_id_rhs);
+			if (compiler.is_array(type))
+				return SPVFuncImplArrayCopy;
+		}
 
 		break;
 	}


### PR DESCRIPTION
We're trying to add SPIRV-Tools optimizer to our shader pipeline and MSL generator is failing to parse optimized SPIRV which seems pretty legit (https://gist.github.com/fatkas/2337cb50ed713c2586d949e6dec651c7) . The following diff seems to workaround the issue but i'm not sure if it makes sense 