### PR TITLE
Fix swizzling of scalar integers in HLSL.

### DIFF
--- a/reference/opt/shaders-hlsl/comp/rwbuffer-matrix.comp
+++ b/reference/opt/shaders-hlsl/comp/rwbuffer-matrix.comp
@@ -62,25 +62,25 @@ void comp_main()
     _28.Store(UBO_index0 * 4 + UBO_index1 * 8 + 144, asuint(2.0f));
     _28.Store(UBO_index0 * 4 + UBO_index1 * 8 + 192, asuint(3.0f));
     _28.Store(UBO_index0 * 4 + UBO_index1 * 16 + 240, asuint(4.0f));
-    _28.Store(UBO_index0 * 4 + 64, asuint(float4(1.0f, 1.0f, 1.0f, 1.0f).x));
-    _28.Store(UBO_index0 * 4 + 80, asuint(float4(1.0f, 1.0f, 1.0f, 1.0f).y));
-    _28.Store(UBO_index0 * 4 + 96, asuint(float4(1.0f, 1.0f, 1.0f, 1.0f).z));
-    _28.Store(UBO_index0 * 4 + 112, asuint(float4(1.0f, 1.0f, 1.0f, 1.0f).w));
-    _28.Store(UBO_index0 * 4 + 144, asuint(float2(2.0f, 2.0f).x));
-    _28.Store(UBO_index0 * 4 + 152, asuint(float2(2.0f, 2.0f).y));
-    _28.Store(UBO_index0 * 4 + 192, asuint(float3(3.0f, 3.0f, 3.0f).x));
-    _28.Store(UBO_index0 * 4 + 200, asuint(float3(3.0f, 3.0f, 3.0f).y));
-    _28.Store(UBO_index0 * 4 + 208, asuint(float3(3.0f, 3.0f, 3.0f).z));
-    _28.Store(UBO_index0 * 4 + 240, asuint(float2(4.0f, 4.0f).x));
-    _28.Store(UBO_index0 * 4 + 256, asuint(float2(4.0f, 4.0f).y));
+    _28.Store(UBO_index0 * 4 + 64, asuint(1.0f.x));
+    _28.Store(UBO_index0 * 4 + 80, asuint(1.0f.xxxx.y));
+    _28.Store(UBO_index0 * 4 + 96, asuint(1.0f.xxxx.z));
+    _28.Store(UBO_index0 * 4 + 112, asuint(1.0f.xxxx.w));
+    _28.Store(UBO_index0 * 4 + 144, asuint(2.0f.x));
+    _28.Store(UBO_index0 * 4 + 152, asuint(2.0f.xx.y));
+    _28.Store(UBO_index0 * 4 + 192, asuint(3.0f.x));
+    _28.Store(UBO_index0 * 4 + 200, asuint(3.0f.xxx.y));
+    _28.Store(UBO_index0 * 4 + 208, asuint(3.0f.xxx.z));
+    _28.Store(UBO_index0 * 4 + 240, asuint(4.0f.x));
+    _28.Store(UBO_index0 * 4 + 256, asuint(4.0f.xx.y));
     _28.Store(UBO_index0 * 16 + UBO_index1 * 4 + 0, asuint(1.0f));
     _28.Store(UBO_index0 * 8 + UBO_index1 * 4 + 128, asuint(2.0f));
     _28.Store(UBO_index0 * 16 + UBO_index1 * 4 + 160, asuint(3.0f));
     _28.Store(UBO_index0 * 8 + UBO_index1 * 4 + 216, asuint(4.0f));
-    _28.Store4(UBO_index0 * 16 + 0, asuint(float4(1.0f, 1.0f, 1.0f, 1.0f)));
-    _28.Store2(UBO_index0 * 8 + 128, asuint(float2(2.0f, 2.0f)));
-    _28.Store3(UBO_index0 * 16 + 160, asuint(float3(3.0f, 3.0f, 3.0f)));
-    _28.Store2(UBO_index0 * 8 + 216, asuint(float2(4.0f, 4.0f)));
+    _28.Store4(UBO_index0 * 16 + 0, asuint(1.0f.xxxx));
+    _28.Store2(UBO_index0 * 8 + 128, asuint(2.0f.xx));
+    _28.Store3(UBO_index0 * 16 + 160, asuint(3.0f.xxx));
+    _28.Store2(UBO_index0 * 8 + 216, asuint(4.0f.xx));
 }
 
 [numthreads(1, 1, 1)]

--- a/reference/opt/shaders-hlsl/frag/combined-texture-sampler-parameter.frag
+++ b/reference/opt/shaders-hlsl/frag/combined-texture-sampler-parameter.frag
@@ -12,7 +12,7 @@ struct SPIRV_Cross_Output
 
 void frag_main()
 {
-    FragColor = (uSampler.Sample(_uSampler_sampler, float2(1.0f, 1.0f)) + uSampler.Load(int3(int2(10, 10), 0))).x + uSamplerShadow.SampleCmp(_uSamplerShadow_sampler, float3(1.0f, 1.0f, 1.0f).xy, 1.0f);
+    FragColor = (uSampler.Sample(_uSampler_sampler, 1.0f.xx) + uSampler.Load(int3(int2(10, 10), 0))).x + uSamplerShadow.SampleCmp(_uSamplerShadow_sampler, 1.0f.xxx.xy, 1.0f);
 }
 
 SPIRV_Cross_Output main()

--- a/reference/opt/shaders-hlsl/frag/combined-texture-sampler-shadow.frag
+++ b/reference/opt/shaders-hlsl/frag/combined-texture-sampler-shadow.frag
@@ -11,7 +11,7 @@ struct SPIRV_Cross_Output
 
 void frag_main()
 {
-    FragColor = uDepth.SampleCmp(uSampler, float3(1.0f, 1.0f, 1.0f).xy, 1.0f) + uDepth.Sample(uSampler1, float2(1.0f, 1.0f)).x;
+    FragColor = uDepth.SampleCmp(uSampler, 1.0f.xxx.xy, 1.0f) + uDepth.Sample(uSampler1, 1.0f.xx).x;
 }
 
 SPIRV_Cross_Output main()

--- a/reference/opt/shaders-hlsl/frag/mrt.frag
+++ b/reference/opt/shaders-hlsl/frag/mrt.frag
@@ -13,10 +13,10 @@ struct SPIRV_Cross_Output
 
 void frag_main()
 {
-    RT0 = float4(1.0f, 1.0f, 1.0f, 1.0f);
-    RT1 = float4(2.0f, 2.0f, 2.0f, 2.0f);
-    RT2 = float4(3.0f, 3.0f, 3.0f, 3.0f);
-    RT3 = float4(4.0f, 4.0f, 4.0f, 4.0f);
+    RT0 = 1.0f.xxxx;
+    RT1 = 2.0f.xxxx;
+    RT2 = 3.0f.xxxx;
+    RT3 = 4.0f.xxxx;
 }
 
 SPIRV_Cross_Output main()

--- a/reference/opt/shaders-hlsl/frag/swizzle-scalar.frag
+++ b/reference/opt/shaders-hlsl/frag/swizzle-scalar.frag
@@ -1,0 +1,41 @@
+static float4 Float;
+static float vFloat;
+static int4 Int;
+static int vInt;
+static float4 Float2;
+static int4 Int2;
+
+struct SPIRV_Cross_Input
+{
+    nointerpolation float vFloat : TEXCOORD0;
+    nointerpolation int vInt : TEXCOORD1;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 Float : SV_Target0;
+    int4 Int : SV_Target1;
+    float4 Float2 : SV_Target2;
+    int4 Int2 : SV_Target3;
+};
+
+void frag_main()
+{
+    Float = vFloat.xxxx * 2.0f;
+    Int = vInt.xxxx * int4(2, 2, 2, 2);
+    Float2 = 10.0f.xxxx;
+    Int2 = int4(10, 10, 10, 10);
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    vFloat = stage_input.vFloat;
+    vInt = stage_input.vInt;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.Float = Float;
+    stage_output.Int = Int;
+    stage_output.Float2 = Float2;
+    stage_output.Int2 = Int2;
+    return stage_output;
+}

--- a/reference/opt/shaders-hlsl/frag/various-glsl-ops.frag
+++ b/reference/opt/shaders-hlsl/frag/various-glsl-ops.frag
@@ -13,7 +13,7 @@ struct SPIRV_Cross_Output
 
 void frag_main()
 {
-    FragColor = float4(0.0f, 0.0f, 0.0f, EvaluateAttributeSnapped(interpolant, float2(0.100000001490116119384765625f, 0.100000001490116119384765625f)).x) + float4(0.0f, 0.0f, 0.0f, ddx_coarse(interpolant.x));
+    FragColor = float4(0.0f, 0.0f, 0.0f, EvaluateAttributeSnapped(interpolant, 0.100000001490116119384765625f.xx).x) + float4(0.0f, 0.0f, 0.0f, ddx_coarse(interpolant.x));
 }
 
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)

--- a/reference/opt/shaders-hlsl/vert/locations.vert
+++ b/reference/opt/shaders-hlsl/vert/locations.vert
@@ -44,21 +44,21 @@ Foo _70;
 
 void vert_main()
 {
-    gl_Position = ((float4(1.0f, 1.0f, 1.0f, 1.0f) + Input2) + Input4) + Input0;
+    gl_Position = ((1.0f.xxxx + Input2) + Input4) + Input0;
     vLocation0 = 0.0f;
     vLocation1 = 1.0f;
     vLocation2[0] = 2.0f;
     vLocation2[1] = 2.0f;
     Foo _65 = _70;
-    _65.a = float3(1.0f, 1.0f, 1.0f);
+    _65.a = 1.0f.xxx;
     Foo _67 = _65;
-    _67.b = float3(1.0f, 1.0f, 1.0f);
+    _67.b = 1.0f.xxx;
     Foo _69 = _67;
-    _69.c = float3(1.0f, 1.0f, 1.0f);
+    _69.c = 1.0f.xxx;
     vLocation4 = _69;
     vLocation9 = 9.0f;
-    vout.color = float3(2.0f, 2.0f, 2.0f);
-    vout.foo = float3(4.0f, 4.0f, 4.0f);
+    vout.color = 2.0f.xxx;
+    vout.foo = 4.0f.xxx;
 }
 
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input, out VertexOut stage_outputvout)

--- a/reference/opt/shaders-hlsl/vert/matrix-output.vert
+++ b/reference/opt/shaders-hlsl/vert/matrix-output.vert
@@ -9,7 +9,7 @@ struct SPIRV_Cross_Output
 
 void vert_main()
 {
-    gl_Position = float4(1.0f, 1.0f, 1.0f, 1.0f);
+    gl_Position = 1.0f.xxxx;
     m = float4x4(float4(1.0f, 0.0f, 0.0f, 0.0f), float4(0.0f, 1.0f, 0.0f, 0.0f), float4(0.0f, 0.0f, 1.0f, 0.0f), float4(0.0f, 0.0f, 0.0f, 1.0f));
 }
 

--- a/reference/opt/shaders-hlsl/vert/no-input.vert
+++ b/reference/opt/shaders-hlsl/vert/no-input.vert
@@ -6,7 +6,7 @@ struct SPIRV_Cross_Output
 
 void vert_main()
 {
-    gl_Position = float4(1.0f, 1.0f, 1.0f, 1.0f);
+    gl_Position = 1.0f.xxxx;
 }
 
 SPIRV_Cross_Output main()

--- a/reference/opt/shaders-hlsl/vert/point-size-compat.vert
+++ b/reference/opt/shaders-hlsl/vert/point-size-compat.vert
@@ -7,7 +7,7 @@ struct SPIRV_Cross_Output
 
 void vert_main()
 {
-    gl_Position = float4(1.0f, 1.0f, 1.0f, 1.0f);
+    gl_Position = 1.0f.xxxx;
     gl_PointSize = 10.0f;
 }
 

--- a/reference/opt/shaders-hlsl/vert/qualifiers.vert
+++ b/reference/opt/shaders-hlsl/vert/qualifiers.vert
@@ -25,7 +25,7 @@ struct SPIRV_Cross_Output
 
 void vert_main()
 {
-    gl_Position = float4(1.0f, 1.0f, 1.0f, 1.0f);
+    gl_Position = 1.0f.xxxx;
     vFlat = 0.0f;
     vCentroid = 1.0f;
     vSample = 2.0f;

--- a/reference/shaders-hlsl/comp/rwbuffer-matrix.comp
+++ b/reference/shaders-hlsl/comp/rwbuffer-matrix.comp
@@ -70,17 +70,17 @@ void write_dynamic_index_row()
     _28.Store(UBO_index0 * 4 + UBO_index1 * 8 + 144, asuint(2.0f));
     _28.Store(UBO_index0 * 4 + UBO_index1 * 8 + 192, asuint(3.0f));
     _28.Store(UBO_index0 * 4 + UBO_index1 * 16 + 240, asuint(4.0f));
-    _28.Store(UBO_index0 * 4 + 64, asuint(float4(1.0f, 1.0f, 1.0f, 1.0f).x));
-    _28.Store(UBO_index0 * 4 + 80, asuint(float4(1.0f, 1.0f, 1.0f, 1.0f).y));
-    _28.Store(UBO_index0 * 4 + 96, asuint(float4(1.0f, 1.0f, 1.0f, 1.0f).z));
-    _28.Store(UBO_index0 * 4 + 112, asuint(float4(1.0f, 1.0f, 1.0f, 1.0f).w));
-    _28.Store(UBO_index0 * 4 + 144, asuint(float2(2.0f, 2.0f).x));
-    _28.Store(UBO_index0 * 4 + 152, asuint(float2(2.0f, 2.0f).y));
-    _28.Store(UBO_index0 * 4 + 192, asuint(float3(3.0f, 3.0f, 3.0f).x));
-    _28.Store(UBO_index0 * 4 + 200, asuint(float3(3.0f, 3.0f, 3.0f).y));
-    _28.Store(UBO_index0 * 4 + 208, asuint(float3(3.0f, 3.0f, 3.0f).z));
-    _28.Store(UBO_index0 * 4 + 240, asuint(float2(4.0f, 4.0f).x));
-    _28.Store(UBO_index0 * 4 + 256, asuint(float2(4.0f, 4.0f).y));
+    _28.Store(UBO_index0 * 4 + 64, asuint(1.0f.x));
+    _28.Store(UBO_index0 * 4 + 80, asuint(1.0f.xxxx.y));
+    _28.Store(UBO_index0 * 4 + 96, asuint(1.0f.xxxx.z));
+    _28.Store(UBO_index0 * 4 + 112, asuint(1.0f.xxxx.w));
+    _28.Store(UBO_index0 * 4 + 144, asuint(2.0f.x));
+    _28.Store(UBO_index0 * 4 + 152, asuint(2.0f.xx.y));
+    _28.Store(UBO_index0 * 4 + 192, asuint(3.0f.x));
+    _28.Store(UBO_index0 * 4 + 200, asuint(3.0f.xxx.y));
+    _28.Store(UBO_index0 * 4 + 208, asuint(3.0f.xxx.z));
+    _28.Store(UBO_index0 * 4 + 240, asuint(4.0f.x));
+    _28.Store(UBO_index0 * 4 + 256, asuint(4.0f.xx.y));
 }
 
 void write_dynamic_index_col()
@@ -89,10 +89,10 @@ void write_dynamic_index_col()
     _28.Store(UBO_index0 * 8 + UBO_index1 * 4 + 128, asuint(2.0f));
     _28.Store(UBO_index0 * 16 + UBO_index1 * 4 + 160, asuint(3.0f));
     _28.Store(UBO_index0 * 8 + UBO_index1 * 4 + 216, asuint(4.0f));
-    _28.Store4(UBO_index0 * 16 + 0, asuint(float4(1.0f, 1.0f, 1.0f, 1.0f)));
-    _28.Store2(UBO_index0 * 8 + 128, asuint(float2(2.0f, 2.0f)));
-    _28.Store3(UBO_index0 * 16 + 160, asuint(float3(3.0f, 3.0f, 3.0f)));
-    _28.Store2(UBO_index0 * 8 + 216, asuint(float2(4.0f, 4.0f)));
+    _28.Store4(UBO_index0 * 16 + 0, asuint(1.0f.xxxx));
+    _28.Store2(UBO_index0 * 8 + 128, asuint(2.0f.xx));
+    _28.Store3(UBO_index0 * 16 + 160, asuint(3.0f.xxx));
+    _28.Store2(UBO_index0 * 8 + 216, asuint(4.0f.xx));
 }
 
 void read_dynamic_index_row()

--- a/reference/shaders-hlsl/frag/combined-texture-sampler-parameter.frag
+++ b/reference/shaders-hlsl/frag/combined-texture-sampler-parameter.frag
@@ -12,7 +12,7 @@ struct SPIRV_Cross_Output
 
 float4 samp2(Texture2D<float4> s, SamplerState _s_sampler)
 {
-    return s.Sample(_s_sampler, float2(1.0f, 1.0f)) + s.Load(int3(int2(10, 10), 0));
+    return s.Sample(_s_sampler, 1.0f.xx) + s.Load(int3(int2(10, 10), 0));
 }
 
 float4 samp3(Texture2D<float4> s, SamplerState _s_sampler)
@@ -22,7 +22,7 @@ float4 samp3(Texture2D<float4> s, SamplerState _s_sampler)
 
 float samp4(Texture2D<float4> s, SamplerComparisonState _s_sampler)
 {
-    return s.SampleCmp(_s_sampler, float3(1.0f, 1.0f, 1.0f).xy, float3(1.0f, 1.0f, 1.0f).z);
+    return s.SampleCmp(_s_sampler, 1.0f.xxx.xy, 1.0f.xxx.z);
 }
 
 float samp(Texture2D<float4> s0, SamplerState _s0_sampler, Texture2D<float4> s1, SamplerComparisonState _s1_sampler)

--- a/reference/shaders-hlsl/frag/combined-texture-sampler-shadow.frag
+++ b/reference/shaders-hlsl/frag/combined-texture-sampler-shadow.frag
@@ -11,12 +11,12 @@ struct SPIRV_Cross_Output
 
 float samp2(Texture2D<float4> t, SamplerComparisonState s)
 {
-    return t.SampleCmp(s, float3(1.0f, 1.0f, 1.0f).xy, float3(1.0f, 1.0f, 1.0f).z);
+    return t.SampleCmp(s, 1.0f.xxx.xy, 1.0f.xxx.z);
 }
 
 float samp3(Texture2D<float4> t, SamplerState s)
 {
-    return t.Sample(s, float2(1.0f, 1.0f)).x;
+    return t.Sample(s, 1.0f.xx).x;
 }
 
 float samp(Texture2D<float4> t, SamplerComparisonState s, SamplerState s1)

--- a/reference/shaders-hlsl/frag/mrt.frag
+++ b/reference/shaders-hlsl/frag/mrt.frag
@@ -13,10 +13,10 @@ struct SPIRV_Cross_Output
 
 void frag_main()
 {
-    RT0 = float4(1.0f, 1.0f, 1.0f, 1.0f);
-    RT1 = float4(2.0f, 2.0f, 2.0f, 2.0f);
-    RT2 = float4(3.0f, 3.0f, 3.0f, 3.0f);
-    RT3 = float4(4.0f, 4.0f, 4.0f, 4.0f);
+    RT0 = 1.0f.xxxx;
+    RT1 = 2.0f.xxxx;
+    RT2 = 3.0f.xxxx;
+    RT3 = 4.0f.xxxx;
 }
 
 SPIRV_Cross_Output main()

--- a/reference/shaders-hlsl/frag/partial-write-preserve.frag
+++ b/reference/shaders-hlsl/frag/partial-write-preserve.frag
@@ -16,7 +16,7 @@ void partial_inout(inout float4 x)
 
 void complete_inout(out float4 x)
 {
-    x = float4(50.0f, 50.0f, 50.0f, 50.0f);
+    x = 50.0f.xxxx;
 }
 
 void branchy_inout(inout float4 v)
@@ -24,7 +24,7 @@ void branchy_inout(inout float4 v)
     v.y = 20.0f;
     if (UBO_some_value == 20)
     {
-        v = float4(50.0f, 50.0f, 50.0f, 50.0f);
+        v = 50.0f.xxxx;
     }
 }
 
@@ -32,11 +32,11 @@ void branchy_inout_2(out float4 v)
 {
     if (UBO_some_value == 20)
     {
-        v = float4(50.0f, 50.0f, 50.0f, 50.0f);
+        v = 50.0f.xxxx;
     }
     else
     {
-        v = float4(70.0f, 70.0f, 70.0f, 70.0f);
+        v = 70.0f.xxxx;
     }
     v.y = 20.0f;
 }
@@ -48,7 +48,7 @@ void partial_inout(inout B b)
 
 void frag_main()
 {
-    float4 a = float4(10.0f, 10.0f, 10.0f, 10.0f);
+    float4 a = 10.0f.xxxx;
     float4 param = a;
     partial_inout(param);
     a = param;

--- a/reference/shaders-hlsl/frag/swizzle-scalar.frag
+++ b/reference/shaders-hlsl/frag/swizzle-scalar.frag
@@ -1,0 +1,41 @@
+static float4 Float;
+static float vFloat;
+static int4 Int;
+static int vInt;
+static float4 Float2;
+static int4 Int2;
+
+struct SPIRV_Cross_Input
+{
+    nointerpolation float vFloat : TEXCOORD0;
+    nointerpolation int vInt : TEXCOORD1;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 Float : SV_Target0;
+    int4 Int : SV_Target1;
+    float4 Float2 : SV_Target2;
+    int4 Int2 : SV_Target3;
+};
+
+void frag_main()
+{
+    Float = vFloat.xxxx * 2.0f;
+    Int = vInt.xxxx * int4(2, 2, 2, 2);
+    Float2 = 10.0f.xxxx;
+    Int2 = int4(10, 10, 10, 10);
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    vFloat = stage_input.vFloat;
+    vInt = stage_input.vInt;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.Float = Float;
+    stage_output.Int = Int;
+    stage_output.Float2 = Float2;
+    stage_output.Int2 = Int2;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/frag/various-glsl-ops.frag
+++ b/reference/shaders-hlsl/frag/various-glsl-ops.frag
@@ -13,7 +13,7 @@ struct SPIRV_Cross_Output
 
 void frag_main()
 {
-    float4 color = float4(0.0f, 0.0f, 0.0f, EvaluateAttributeSnapped(interpolant, float2(0.100000001490116119384765625f, 0.100000001490116119384765625f)).x);
+    float4 color = float4(0.0f, 0.0f, 0.0f, EvaluateAttributeSnapped(interpolant, 0.100000001490116119384765625f.xx).x);
     color += float4(0.0f, 0.0f, 0.0f, ddx_coarse(interpolant.x));
     FragColor = color;
 }

--- a/reference/shaders-hlsl/vert/locations.vert
+++ b/reference/shaders-hlsl/vert/locations.vert
@@ -42,19 +42,19 @@ struct SPIRV_Cross_Output
 
 void vert_main()
 {
-    gl_Position = ((float4(1.0f, 1.0f, 1.0f, 1.0f) + Input2) + Input4) + Input0;
+    gl_Position = ((1.0f.xxxx + Input2) + Input4) + Input0;
     vLocation0 = 0.0f;
     vLocation1 = 1.0f;
     vLocation2[0] = 2.0f;
     vLocation2[1] = 2.0f;
     Foo foo;
-    foo.a = float3(1.0f, 1.0f, 1.0f);
-    foo.b = float3(1.0f, 1.0f, 1.0f);
-    foo.c = float3(1.0f, 1.0f, 1.0f);
+    foo.a = 1.0f.xxx;
+    foo.b = 1.0f.xxx;
+    foo.c = 1.0f.xxx;
     vLocation4 = foo;
     vLocation9 = 9.0f;
-    vout.color = float3(2.0f, 2.0f, 2.0f);
-    vout.foo = float3(4.0f, 4.0f, 4.0f);
+    vout.color = 2.0f.xxx;
+    vout.foo = 4.0f.xxx;
 }
 
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input, out VertexOut stage_outputvout)

--- a/reference/shaders-hlsl/vert/matrix-output.vert
+++ b/reference/shaders-hlsl/vert/matrix-output.vert
@@ -9,7 +9,7 @@ struct SPIRV_Cross_Output
 
 void vert_main()
 {
-    gl_Position = float4(1.0f, 1.0f, 1.0f, 1.0f);
+    gl_Position = 1.0f.xxxx;
     m = float4x4(float4(1.0f, 0.0f, 0.0f, 0.0f), float4(0.0f, 1.0f, 0.0f, 0.0f), float4(0.0f, 0.0f, 1.0f, 0.0f), float4(0.0f, 0.0f, 0.0f, 1.0f));
 }
 

--- a/reference/shaders-hlsl/vert/no-input.vert
+++ b/reference/shaders-hlsl/vert/no-input.vert
@@ -6,7 +6,7 @@ struct SPIRV_Cross_Output
 
 void vert_main()
 {
-    gl_Position = float4(1.0f, 1.0f, 1.0f, 1.0f);
+    gl_Position = 1.0f.xxxx;
 }
 
 SPIRV_Cross_Output main()

--- a/reference/shaders-hlsl/vert/point-size-compat.vert
+++ b/reference/shaders-hlsl/vert/point-size-compat.vert
@@ -7,7 +7,7 @@ struct SPIRV_Cross_Output
 
 void vert_main()
 {
-    gl_Position = float4(1.0f, 1.0f, 1.0f, 1.0f);
+    gl_Position = 1.0f.xxxx;
     gl_PointSize = 10.0f;
 }
 

--- a/reference/shaders-hlsl/vert/qualifiers.vert
+++ b/reference/shaders-hlsl/vert/qualifiers.vert
@@ -25,7 +25,7 @@ struct SPIRV_Cross_Output
 
 void vert_main()
 {
-    gl_Position = float4(1.0f, 1.0f, 1.0f, 1.0f);
+    gl_Position = 1.0f.xxxx;
     vFlat = 0.0f;
     vCentroid = 1.0f;
     vSample = 2.0f;

--- a/shaders-hlsl/frag/swizzle-scalar.frag
+++ b/shaders-hlsl/frag/swizzle-scalar.frag
@@ -1,0 +1,16 @@
+#version 450
+
+layout(location = 0) flat in float vFloat;
+layout(location = 1) flat in int vInt;
+layout(location = 0) out vec4 Float;
+layout(location = 1) out ivec4 Int;
+layout(location = 2) out vec4 Float2;
+layout(location = 3) out ivec4 Int2;
+
+void main()
+{
+	Float = vec4(vFloat) * 2.0;
+	Int = ivec4(vInt) * 2;
+	Float2 = vec4(10.0);
+	Int2 = ivec4(10);
+}

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -2769,6 +2769,7 @@ void CompilerHLSL::write_access_chain(const SPIRAccessChain &chain, uint32_t val
 				store_expr += ".";
 				store_expr += index_to_swizzle(r);
 			}
+			remove_duplicate_swizzle(store_expr);
 
 			auto bitcast_op = bitcast_glsl_op(target_type, type);
 			if (!bitcast_op.empty())
@@ -2815,6 +2816,7 @@ void CompilerHLSL::write_access_chain(const SPIRAccessChain &chain, uint32_t val
 			for (uint32_t c = 0; c < type.columns; c++)
 			{
 				auto store_expr = join(to_enclosed_expression(value), "[", c, "].", index_to_swizzle(r));
+				remove_duplicate_swizzle(store_expr);
 				auto bitcast_op = bitcast_glsl_op(target_type, type);
 				if (!bitcast_op.empty())
 					store_expr = join(bitcast_op, "(", store_expr, ")");


### PR DESCRIPTION
Add scalar swizzling to constant composites as well.

Fixes #371.