### PR TITLE
Use HLSL barriers that better match SPIR-V semantics

### DIFF
--- a/reference/opt/shaders-hlsl/comp/shared.comp
+++ b/reference/opt/shaders-hlsl/comp/shared.comp
@@ -18,6 +18,12 @@ void comp_main()
     sShared[gl_LocalInvocationIndex] = asfloat(_22.Load(gl_GlobalInvocationID.x * 4 + 0));
     GroupMemoryBarrierWithGroupSync();
     _44.Store(gl_GlobalInvocationID.x * 4 + 0, asuint(sShared[(4u - gl_LocalInvocationIndex) - 1u]));
+    GroupMemoryBarrierWithGroupSync();
+    AllMemoryBarrier();
+    DeviceMemoryBarrier();
+    DeviceMemoryBarrier();
+    GroupMemoryBarrier();
+    AllMemoryBarrier();
 }
 
 [numthreads(4, 1, 1)]

--- a/reference/shaders-hlsl/comp/shared.comp
+++ b/reference/shaders-hlsl/comp/shared.comp
@@ -20,6 +20,12 @@ void comp_main()
     sShared[gl_LocalInvocationIndex] = idata;
     GroupMemoryBarrierWithGroupSync();
     _44.Store(ident * 4 + 0, asuint(sShared[(4u - gl_LocalInvocationIndex) - 1u]));
+    GroupMemoryBarrierWithGroupSync();
+    AllMemoryBarrier();
+    DeviceMemoryBarrier();
+    DeviceMemoryBarrier();
+    GroupMemoryBarrier();
+    AllMemoryBarrier();
 }
 
 [numthreads(4, 1, 1)]

--- a/shaders-hlsl/comp/shared.comp
+++ b/shaders-hlsl/comp/shared.comp
@@ -23,5 +23,12 @@ void main()
     barrier();
 
     out_data[ident] = sShared[gl_WorkGroupSize.x - gl_LocalInvocationIndex - 1u];
+
+    barrier();
+    memoryBarrier();
+    memoryBarrierBuffer();
+    memoryBarrierImage();
+    memoryBarrierShared();
+    groupMemoryBarrier();
 }
 


### PR DESCRIPTION
We noticed one of our upscaler compute shaders was producing artifacts in recent builds of mpv (see mpv-player/mpv#5353):

![image](https://user-images.githubusercontent.com/162837/34635872-f444d116-f2e9-11e7-8663-0049699b12a1.png)

I narrowed this down to the recent barrier changes in glslang. Our upscaler uses the following barriers:
```glsl
groupMemoryBarrier();
barrier();
```

KhronosGroup/glslang@070aaeafcdc0 (before the barrier changes) emits the following SPIR-V (parameters translated for easier reading):
```
OpMemoryBarrier Device CrossWorkgroup|Relaxed
OpControlBarrier Workgroup Device Relaxed
```

The current version of SPIRV-Cross translates them to the following HLSL. This worked in mpv:
```hlsl
DeviceMemoryBarrier();
GroupMemoryBarrierWithGroupSync();
```

KhronosGroup/glslang@2505057af8f4 (after the changes) emits different SPIR-V memory semantics:
```
OpMemoryBarrier Workgroup Uniform|Workgroup|AtomicCounter|Image|AcquireRelease
OpControlBarrier Workgroup Workgroup WorkgroupMemory|AcquireRelease
```

SPIRV-Cross, without this patch, translates the new semantics to the following HLSL, which results in the above artifacts in mpv:
```hlsl
DeviceMemoryBarrier();
DeviceMemoryBarrierWithGroupSync();
```

The new HLSL seems wrong because as far as I can tell, DeviceMemoryBarrier doesn't enforce memory ordering for accesses to workgroup memory. Since SPIRV-Cross currently uses equality to check for MemorySemanticsWorkgroupMemoryMask rather than treating the memory argument as a bitfield, adding the AcquireRelease flag will make it incorrectly emit a DeviceMemoryBarrierWithGroupSync.

To try and figure out the proper semantics, I had a look at the SPIR-V generated by glslang for GLSL and HLSL intrinsics and the SPIR-V generated by Microsoft's DirectXShaderCompiler for HLSL intrinsics. The results are below:

| GLSL intrinsic             | HLSL intrinsic                   | Opcode         | Execution scope | Memory scope    | Storage        | Memory order   |
| -------------------------- | -------------------------------- | -------------- | --------------- | --------------- | -------------- | -------------- |
| memoryBarrier              | AllMemoryBarrier                 | MemoryBarrier  |                 | Device          | All            | AcquireRelease |
| -                          | AllMemoryBarrierWithGroupSync    | ControlBarrier | Workgroup       | Device          | All            | AcquireRelease |
| -                          | DeviceMemoryBarrier              | MemoryBarrier  |                 | Device          | Uniform\|Image | AcquireRelease |
| -                          | DeviceMemoryBarrierWithGroupSync | ControlBarrier | Workgroup       | Device          | Uniform\|Image | AcquireRelease |
| -                          | GroupMemoryBarrier               | MemoryBarrier  |                 | Workgroup       | Workgroup      | AcquireRelease |
| barrier                    | GroupMemoryBarrierWithGroupSync  | ControlBarrier | Workgroup       | Workgroup       | Workgroup      | AcquireRelease |
| memoryBarrierAtomicCounter | -                                | MemoryBarrier  |                 | Device          | AtomicCounter  | AcquireRelease |
| memoryBarrierBuffer        | -                                | MemoryBarrier  |                 | Device          | Uniform        | AcquireRelease |
| memoryBarrierImage         | -                                | MemoryBarrier  |                 | Device          | Image          | AcquireRelease |
| memoryBarrierShared        | -                                | MemoryBarrier  |                 | Device          | Workgroup      | AcquireRelease |
| groupMemoryBarrier         | -                                | MemoryBarrier  |                 | Workgroup       | All            | AcquireRelease |

As far as I understand, SPIRV-Cross should emit the least restrictive HLSL barrier intrinsic that still provides the semantics in the table above. I've done my best to implement this, though I'm not too familar with compute shader memory models, so I might have made some incorrect assumptions. I ignored the memory scope argument because spirv_glsl.cpp does as well and I didn't understand what it meant for memoryBarrierShared to operate at Device scope.

With these changes, SPIRV-Cross generates the following HLSL, which fixes the bug in mpv:
```hlsl
AllMemoryBarrier();
GroupMemoryBarrierWithGroupSync();
```

I also updated the tests with expected translations from GLSL to HLSL. **Edit:** I just noticed that Travis fails because its glslang is pinned to an older commit that generates different barriers. Testing the other shaders with the new glslang fails. I'm not sure what to do about this.