### PR TITLE
Revert to not forcing gl_in/gl_out block for MSL.

### DIFF
--- a/reference/opt/shaders-msl/desktop-only/vert/basic.desktop.sso.vert
+++ b/reference/opt/shaders-msl/desktop-only/vert/basic.desktop.sso.vert
@@ -1,0 +1,30 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBO
+{
+    float4x4 uMVP;
+};
+
+struct main0_in
+{
+    float3 aNormal [[attribute(1)]];
+    float4 aVertex [[attribute(0)]];
+};
+
+struct main0_out
+{
+    float3 vNormal [[user(locn0)]];
+    float4 gl_Position [[position]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _16 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = _16.uMVP * in.aVertex;
+    out.vNormal = in.aNormal;
+    return out;
+}
+

--- a/reference/opt/shaders-msl/desktop-only/vert/clip-cull-distance.desktop.vert
+++ b/reference/opt/shaders-msl/desktop-only/vert/clip-cull-distance.desktop.vert
@@ -1,0 +1,23 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+    float gl_ClipDistance [[clip_distance]] [2];
+    float gl_CullDistance[2];
+};
+
+vertex main0_out main0()
+{
+    main0_out out = {};
+    out.gl_Position = float4(10.0);
+    out.gl_ClipDistance[0] = 1.0;
+    out.gl_ClipDistance[1] = 4.0;
+    out.gl_CullDistance[0] = 4.0;
+    out.gl_CullDistance[1] = 9.0;
+    return out;
+}
+

--- a/reference/shaders-msl/desktop-only/vert/basic.desktop.sso.vert
+++ b/reference/shaders-msl/desktop-only/vert/basic.desktop.sso.vert
@@ -1,0 +1,30 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBO
+{
+    float4x4 uMVP;
+};
+
+struct main0_in
+{
+    float3 aNormal [[attribute(1)]];
+    float4 aVertex [[attribute(0)]];
+};
+
+struct main0_out
+{
+    float3 vNormal [[user(locn0)]];
+    float4 gl_Position [[position]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _16 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = _16.uMVP * in.aVertex;
+    out.vNormal = in.aNormal;
+    return out;
+}
+

--- a/reference/shaders-msl/desktop-only/vert/clip-cull-distance.desktop.vert
+++ b/reference/shaders-msl/desktop-only/vert/clip-cull-distance.desktop.vert
@@ -1,0 +1,23 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+    float gl_ClipDistance [[clip_distance]] [2];
+    float gl_CullDistance[2];
+};
+
+vertex main0_out main0()
+{
+    main0_out out = {};
+    out.gl_Position = float4(10.0);
+    out.gl_ClipDistance[0] = 1.0;
+    out.gl_ClipDistance[1] = 4.0;
+    out.gl_CullDistance[0] = 4.0;
+    out.gl_CullDistance[1] = 9.0;
+    return out;
+}
+

--- a/shaders-msl/desktop-only/vert/basic.desktop.sso.vert
+++ b/shaders-msl/desktop-only/vert/basic.desktop.sso.vert
@@ -1,0 +1,20 @@
+#version 450
+
+out gl_PerVertex
+{
+   vec4 gl_Position;
+};
+
+layout(std140) uniform UBO
+{
+    mat4 uMVP;
+};
+layout(location = 0) in vec4 aVertex;
+layout(location = 1) in vec3 aNormal;
+layout(location = 0) out vec3 vNormal;
+
+void main()
+{
+    gl_Position = uMVP * aVertex;
+    vNormal = aNormal;
+}

--- a/shaders-msl/desktop-only/vert/clip-cull-distance.desktop.vert
+++ b/shaders-msl/desktop-only/vert/clip-cull-distance.desktop.vert
@@ -1,0 +1,10 @@
+#version 450
+
+void main()
+{
+   gl_Position = vec4(10.0);
+   gl_ClipDistance[0] = 1.0;
+   gl_ClipDistance[1] = 4.0;
+   gl_CullDistance[0] = 4.0;
+   gl_CullDistance[1] = 9.0;
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -4305,7 +4305,8 @@ string CompilerGLSL::access_chain_internal(uint32_t base, const uint32_t *indice
 			};
 
 			auto *var = maybe_get<SPIRVariable>(base);
-			if (i == 0 && var && is_builtin_variable(*var) && !has_decoration(type->self, DecorationBlock))
+			if (backend.force_gl_in_out_block && i == 0 && var && is_builtin_variable(*var) &&
+			    !has_decoration(type->self, DecorationBlock))
 			{
 				// This deals with scenarios for tesc/geom where arrays of gl_Position[] are declared.
 				// Normally, these variables live in blocks when compiled from GLSL,

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -322,7 +322,7 @@ protected:
 		bool allow_precision_qualifiers = false;
 		bool can_swizzle_scalar = false;
 		bool force_temp_use_for_two_vector_shuffles = false;
-
+		bool force_gl_in_out_block = true;
 	} backend;
 
 	void emit_struct(SPIRType &type);

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -71,6 +71,7 @@ string CompilerMSL::compile()
 	backend.native_row_major_matrix = false;
 	backend.flexible_member_array_supported = false;
 	backend.force_temp_use_for_two_vector_shuffles = true;
+	backend.force_gl_in_out_block = false;
 
 	replace_illegal_names();
 
@@ -3160,6 +3161,7 @@ string CompilerMSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 	case BuiltInPosition:
 	case BuiltInPointSize:
 	case BuiltInClipDistance:
+	case BuiltInCullDistance:
 	case BuiltInLayer:
 	case BuiltInFragDepth:
 		if (current_function && (current_function->self == entry_point))


### PR DESCRIPTION
The recent change to auto-generate GLSL gl_in/gl_out structs, for HLSL-originated SPIR-V, broke certain MSL use-cases. This PR fixes that.