### PR TITLE
Do not declare constant composites inline in HLSL.

### DIFF
--- a/reference/opt/shaders-hlsl/frag/constant-composites.frag
+++ b/reference/opt/shaders-hlsl/frag/constant-composites.frag
@@ -1,0 +1,43 @@
+struct Foo
+{
+    float a;
+    float b;
+};
+
+static const float _16[4] = { 1.0f, 4.0f, 3.0f, 2.0f };
+static const Foo _24 = { 10.0f, 20.0f };
+static const Foo _27 = { 30.0f, 40.0f };
+static const Foo _28[2] = { { 10.0f, 20.0f }, { 30.0f, 40.0f } };
+
+static float4 FragColor;
+static int _line;
+
+struct SPIRV_Cross_Input
+{
+    nointerpolation int _line : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+static float lut[4];
+static Foo foos[2];
+
+void frag_main()
+{
+    lut = _16;
+    foos = _28;
+    FragColor = lut[_line].xxxx;
+    FragColor += (foos[_line].a * (foos[1 - _line].a)).xxxx;
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    _line = stage_input._line;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/opt/shaders-msl/frag/constant-composites.frag
+++ b/reference/opt/shaders-msl/frag/constant-composites.frag
@@ -1,0 +1,31 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Foo
+{
+    float a;
+    float b;
+};
+
+struct main0_in
+{
+    int line [[user(locn0)]];
+};
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    float lut[4] = {1.0, 4.0, 3.0, 2.0};
+    Foo foos[2] = {{10.0, 20.0}, {30.0, 40.0}};
+    out.FragColor = float4(lut[in.line]);
+    out.FragColor += float4(foos[in.line].a * (foos[1 - in.line].a));
+    return out;
+}
+

--- a/reference/opt/shaders/frag/constant-composites.frag
+++ b/reference/opt/shaders/frag/constant-composites.frag
@@ -1,0 +1,23 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+struct Foo
+{
+    float a;
+    float b;
+};
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) flat in mediump int _line;
+float lut[4];
+Foo foos[2];
+
+void main()
+{
+    lut = float[](1.0, 4.0, 3.0, 2.0);
+    foos = Foo[](Foo(10.0, 20.0), Foo(30.0, 40.0));
+    FragColor = vec4(lut[_line]);
+    FragColor += vec4(foos[_line].a * (foos[1 - _line].a));
+}
+

--- a/reference/shaders-hlsl/frag/constant-composites.frag
+++ b/reference/shaders-hlsl/frag/constant-composites.frag
@@ -1,0 +1,43 @@
+struct Foo
+{
+    float a;
+    float b;
+};
+
+static const float _16[4] = { 1.0f, 4.0f, 3.0f, 2.0f };
+static const Foo _24 = { 10.0f, 20.0f };
+static const Foo _27 = { 30.0f, 40.0f };
+static const Foo _28[2] = { { 10.0f, 20.0f }, { 30.0f, 40.0f } };
+
+static float4 FragColor;
+static int _line;
+
+struct SPIRV_Cross_Input
+{
+    nointerpolation int _line : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+static float lut[4];
+static Foo foos[2];
+
+void frag_main()
+{
+    lut = _16;
+    foos = _28;
+    FragColor = lut[_line].xxxx;
+    FragColor += (foos[_line].a * (foos[1 - _line].a)).xxxx;
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    _line = stage_input._line;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/frag/partial-write-preserve.frag
+++ b/reference/shaders-hlsl/frag/partial-write-preserve.frag
@@ -4,6 +4,8 @@ struct B
     float b;
 };
 
+static const B _80 = { 10.0f, 20.0f };
+
 cbuffer _42 : register(b0)
 {
     int _42_some_value : packoffset(c0);
@@ -61,7 +63,7 @@ void frag_main()
     float4 param_3;
     branchy_inout_2(param_3);
     a = param_3;
-    B b = { 10.0f, 20.0f };
+    B b = _80;
     B param_4 = b;
     partial_inout(param_4);
     b = param_4;

--- a/reference/shaders-msl/frag/constant-composites.frag
+++ b/reference/shaders-msl/frag/constant-composites.frag
@@ -1,0 +1,31 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Foo
+{
+    float a;
+    float b;
+};
+
+struct main0_in
+{
+    int line [[user(locn0)]];
+};
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    float lut[4] = {1.0, 4.0, 3.0, 2.0};
+    Foo foos[2] = {{10.0, 20.0}, {30.0, 40.0}};
+    out.FragColor = float4(lut[in.line]);
+    out.FragColor += float4(foos[in.line].a * (foos[1 - in.line].a));
+    return out;
+}
+

--- a/reference/shaders/frag/constant-composites.frag
+++ b/reference/shaders/frag/constant-composites.frag
@@ -1,0 +1,23 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+struct Foo
+{
+    float a;
+    float b;
+};
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) flat in mediump int _line;
+float lut[4];
+Foo foos[2];
+
+void main()
+{
+    lut = float[](1.0, 4.0, 3.0, 2.0);
+    foos = Foo[](Foo(10.0, 20.0), Foo(30.0, 40.0));
+    FragColor = vec4(lut[_line]);
+    FragColor += vec4(foos[_line].a * (foos[1 - _line].a));
+}
+

--- a/shaders-hlsl/frag/constant-composites.frag
+++ b/shaders-hlsl/frag/constant-composites.frag
@@ -1,0 +1,20 @@
+#version 310 es
+precision mediump float;
+
+float lut[4] = float[](1.0, 4.0, 3.0, 2.0);
+
+struct Foo
+{
+	float a;
+	float b;
+};
+Foo foos[2] = Foo[](Foo(10.0, 20.0), Foo(30.0, 40.0));
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) flat in int line;
+
+void main()
+{	
+   FragColor = vec4(lut[line]);
+   FragColor += foos[line].a * foos[1 - line].a;
+}

--- a/shaders-msl/frag/constant-composites.frag
+++ b/shaders-msl/frag/constant-composites.frag
@@ -1,0 +1,20 @@
+#version 310 es
+precision mediump float;
+
+float lut[4] = float[](1.0, 4.0, 3.0, 2.0);
+
+struct Foo
+{
+	float a;
+	float b;
+};
+Foo foos[2] = Foo[](Foo(10.0, 20.0), Foo(30.0, 40.0));
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) flat in int line;
+
+void main()
+{	
+   FragColor = vec4(lut[line]);
+   FragColor += foos[line].a * foos[1 - line].a;
+}

--- a/shaders/frag/constant-composites.frag
+++ b/shaders/frag/constant-composites.frag
@@ -1,0 +1,20 @@
+#version 310 es
+precision mediump float;
+
+float lut[4] = float[](1.0, 4.0, 3.0, 2.0);
+
+struct Foo
+{
+	float a;
+	float b;
+};
+Foo foos[2] = Foo[](Foo(10.0, 20.0), Foo(30.0, 40.0));
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) flat in int line;
+
+void main()
+{	
+   FragColor = vec4(lut[line]);
+   FragColor += foos[line].a * foos[1 - line].a;
+}

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -323,6 +323,7 @@ protected:
 		bool use_initializer_list = false;
 		bool use_typed_initializer_list = false;
 		bool can_declare_struct_inline = true;
+		bool can_declare_arrays_inline = true;
 		bool native_row_major_matrix = true;
 		bool use_constructor_splatting = true;
 		bool boolean_mix_support = true;

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -91,6 +91,7 @@ private:
 	void emit_modern_uniform(const SPIRVariable &var);
 	void emit_legacy_uniform(const SPIRVariable &var);
 	void emit_specialization_constants();
+	void emit_composite_constants();
 	void emit_fixup() override;
 	std::string builtin_to_glsl(spv::BuiltIn builtin, spv::StorageClass storage) override;
 	std::string layout_for_member(const SPIRType &type, uint32_t index) override;


### PR DESCRIPTION
Move arrays and structs out to their own global static constants.

Also, replace illegal names in HLSL as well.

Fix #425.