### PR TITLE
Implement subpassLoad in HLSL and MSL.

### DIFF
--- a/reference/opt/shaders-hlsl/frag/input-attachment-ms.frag
+++ b/reference/opt/shaders-hlsl/frag/input-attachment-ms.frag
@@ -1,0 +1,32 @@
+Texture2DMS<float4> uSubpass0 : register(t0);
+Texture2DMS<float4> uSubpass1 : register(t1);
+
+static float4 gl_FragCoord;
+static int gl_SampleID;
+static float4 FragColor;
+
+struct SPIRV_Cross_Input
+{
+    float4 gl_FragCoord : SV_Position;
+    uint gl_SampleID : SV_SampleIndex;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    FragColor = (uSubpass0.Load(int2(gl_FragCoord.xy), 1) + uSubpass1.Load(int2(gl_FragCoord.xy), 2)) + uSubpass0.Load(int2(gl_FragCoord.xy), gl_SampleID);
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    gl_FragCoord = stage_input.gl_FragCoord;
+    gl_SampleID = stage_input.gl_SampleID;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/opt/shaders-hlsl/frag/input-attachment.frag
+++ b/reference/opt/shaders-hlsl/frag/input-attachment.frag
@@ -1,0 +1,29 @@
+Texture2D<float4> uSubpass0 : register(t0);
+Texture2D<float4> uSubpass1 : register(t1);
+
+static float4 gl_FragCoord;
+static float4 FragColor;
+
+struct SPIRV_Cross_Input
+{
+    float4 gl_FragCoord : SV_Position;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    FragColor = uSubpass0.Load(int3(int2(gl_FragCoord.xy), 0)) + uSubpass1.Load(int3(int2(gl_FragCoord.xy), 0));
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    gl_FragCoord = stage_input.gl_FragCoord;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/opt/shaders-msl/frag/input-attachment-ms.frag
+++ b/reference/opt/shaders-msl/frag/input-attachment-ms.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(texture2d_ms<float> uSubpass0 [[texture(0)]], texture2d_ms<float> uSubpass1 [[texture(1)]], uint gl_SampleID [[sample_id]], float4 gl_FragCoord [[position]])
+{
+    main0_out out = {};
+    out.FragColor = (uSubpass0.read(uint2(gl_FragCoord.xy), 1) + uSubpass1.read(uint2(gl_FragCoord.xy), 2)) + uSubpass0.read(uint2(gl_FragCoord.xy), gl_SampleID);
+    return out;
+}
+

--- a/reference/opt/shaders-msl/frag/input-attachment.frag
+++ b/reference/opt/shaders-msl/frag/input-attachment.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(texture2d<float> uSubpass0 [[texture(0)]], texture2d<float> uSubpass1 [[texture(1)]], float4 gl_FragCoord [[position]])
+{
+    main0_out out = {};
+    out.FragColor = uSubpass0.read(uint2(gl_FragCoord.xy), 0) + uSubpass1.read(uint2(gl_FragCoord.xy), 0);
+    return out;
+}
+

--- a/reference/opt/shaders-msl/frag/sample-depth-separate-image-sampler.frag
+++ b/reference/opt/shaders-msl/frag/sample-depth-separate-image-sampler.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+fragment main0_out main0(depth2d<float> uDepth [[texture(0)]], texture2d<float> uColor [[texture(1)]], sampler uSamplerShadow [[sampler(0)]], sampler uSampler [[sampler(1)]])
+{
+    main0_out out = {};
+    out.FragColor = uDepth.sample_compare(uSamplerShadow, float3(0.5).xy, 0.5) + uColor.sample(uSampler, float2(0.5)).x;
+    return out;
+}
+

--- a/reference/shaders-hlsl/frag/input-attachment-ms.frag
+++ b/reference/shaders-hlsl/frag/input-attachment-ms.frag
@@ -1,0 +1,37 @@
+Texture2DMS<float4> uSubpass0 : register(t0);
+Texture2DMS<float4> uSubpass1 : register(t1);
+
+static float4 gl_FragCoord;
+static int gl_SampleID;
+static float4 FragColor;
+
+struct SPIRV_Cross_Input
+{
+    float4 gl_FragCoord : SV_Position;
+    uint gl_SampleID : SV_SampleIndex;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+float4 load_subpasses(Texture2DMS<float4> uInput)
+{
+    return uInput.Load(int2(gl_FragCoord.xy), gl_SampleID);
+}
+
+void frag_main()
+{
+    FragColor = (uSubpass0.Load(int2(gl_FragCoord.xy), 1) + uSubpass1.Load(int2(gl_FragCoord.xy), 2)) + load_subpasses(uSubpass0);
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    gl_FragCoord = stage_input.gl_FragCoord;
+    gl_SampleID = stage_input.gl_SampleID;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/frag/input-attachment.frag
+++ b/reference/shaders-hlsl/frag/input-attachment.frag
@@ -1,0 +1,34 @@
+Texture2D<float4> uSubpass0 : register(t0);
+Texture2D<float4> uSubpass1 : register(t1);
+
+static float4 gl_FragCoord;
+static float4 FragColor;
+
+struct SPIRV_Cross_Input
+{
+    float4 gl_FragCoord : SV_Position;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+float4 load_subpasses(Texture2D<float4> uInput)
+{
+    return uInput.Load(int3(int2(gl_FragCoord.xy), 0));
+}
+
+void frag_main()
+{
+    FragColor = uSubpass0.Load(int3(int2(gl_FragCoord.xy), 0)) + load_subpasses(uSubpass1);
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    gl_FragCoord = stage_input.gl_FragCoord;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-msl/frag/input-attachment-ms.frag
+++ b/reference/shaders-msl/frag/input-attachment-ms.frag
@@ -1,0 +1,24 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+float4 load_subpasses(thread const texture2d_ms<float> uInput, thread uint& gl_SampleID, thread float4& gl_FragCoord)
+{
+    return uInput.read(uint2(gl_FragCoord.xy), gl_SampleID);
+}
+
+fragment main0_out main0(texture2d_ms<float> uSubpass0 [[texture(0)]], texture2d_ms<float> uSubpass1 [[texture(1)]], uint gl_SampleID [[sample_id]], float4 gl_FragCoord [[position]])
+{
+    main0_out out = {};
+    out.FragColor = (uSubpass0.read(uint2(gl_FragCoord.xy), 1) + uSubpass1.read(uint2(gl_FragCoord.xy), 2)) + load_subpasses(uSubpass0, gl_SampleID, gl_FragCoord);
+    return out;
+}
+

--- a/reference/shaders-msl/frag/input-attachment.frag
+++ b/reference/shaders-msl/frag/input-attachment.frag
@@ -1,0 +1,24 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+float4 load_subpasses(thread const texture2d<float> uInput, thread float4& gl_FragCoord)
+{
+    return uInput.read(uint2(gl_FragCoord.xy), 0);
+}
+
+fragment main0_out main0(texture2d<float> uSubpass0 [[texture(0)]], texture2d<float> uSubpass1 [[texture(1)]], float4 gl_FragCoord [[position]])
+{
+    main0_out out = {};
+    out.FragColor = uSubpass0.read(uint2(gl_FragCoord.xy), 0) + load_subpasses(uSubpass1, gl_FragCoord);
+    return out;
+}
+

--- a/reference/shaders-msl/frag/sample-depth-separate-image-sampler.frag
+++ b/reference/shaders-msl/frag/sample-depth-separate-image-sampler.frag
@@ -1,0 +1,29 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+float sample_depth_from_function(thread const depth2d<float> uT, thread const sampler uS)
+{
+    return uT.sample_compare(uS, float3(0.5).xy, float3(0.5).z);
+}
+
+float sample_color_from_function(thread const texture2d<float> uT, thread const sampler uS)
+{
+    return uT.sample(uS, float2(0.5)).x;
+}
+
+fragment main0_out main0(depth2d<float> uDepth [[texture(0)]], texture2d<float> uColor [[texture(1)]], sampler uSamplerShadow [[sampler(0)]], sampler uSampler [[sampler(1)]])
+{
+    main0_out out = {};
+    out.FragColor = sample_depth_from_function(uDepth, uSamplerShadow) + sample_color_from_function(uColor, uSampler);
+    return out;
+}
+

--- a/shaders-hlsl/frag/input-attachment-ms.frag
+++ b/shaders-hlsl/frag/input-attachment-ms.frag
@@ -1,0 +1,15 @@
+#version 450
+
+layout(input_attachment_index = 0, set = 0, binding = 0) uniform subpassInputMS uSubpass0;
+layout(input_attachment_index = 1, set = 0, binding = 1) uniform subpassInputMS uSubpass1;
+layout(location = 0) out vec4 FragColor;
+
+vec4 load_subpasses(mediump subpassInputMS uInput)
+{
+	return subpassLoad(uInput, gl_SampleID);
+}
+
+void main()
+{
+    FragColor = subpassLoad(uSubpass0, 1) + subpassLoad(uSubpass1, 2) + load_subpasses(uSubpass0);
+}

--- a/shaders-hlsl/frag/input-attachment.frag
+++ b/shaders-hlsl/frag/input-attachment.frag
@@ -1,0 +1,16 @@
+#version 310 es
+precision mediump float;
+
+layout(input_attachment_index = 0, set = 0, binding = 0) uniform mediump subpassInput uSubpass0;
+layout(input_attachment_index = 1, set = 0, binding = 1) uniform mediump subpassInput uSubpass1;
+layout(location = 0) out vec4 FragColor;
+
+vec4 load_subpasses(mediump subpassInput uInput)
+{
+	return subpassLoad(uInput);
+}
+
+void main()
+{
+    FragColor = subpassLoad(uSubpass0) + load_subpasses(uSubpass1);
+}

--- a/shaders-msl/frag/input-attachment-ms.frag
+++ b/shaders-msl/frag/input-attachment-ms.frag
@@ -1,0 +1,15 @@
+#version 450
+
+layout(input_attachment_index = 0, set = 0, binding = 0) uniform subpassInputMS uSubpass0;
+layout(input_attachment_index = 1, set = 0, binding = 1) uniform subpassInputMS uSubpass1;
+layout(location = 0) out vec4 FragColor;
+
+vec4 load_subpasses(mediump subpassInputMS uInput)
+{
+	return subpassLoad(uInput, gl_SampleID);
+}
+
+void main()
+{
+    FragColor = subpassLoad(uSubpass0, 1) + subpassLoad(uSubpass1, 2) + load_subpasses(uSubpass0);
+}

--- a/shaders-msl/frag/input-attachment.frag
+++ b/shaders-msl/frag/input-attachment.frag
@@ -1,0 +1,16 @@
+#version 310 es
+precision mediump float;
+
+layout(input_attachment_index = 0, set = 0, binding = 0) uniform mediump subpassInput uSubpass0;
+layout(input_attachment_index = 1, set = 0, binding = 1) uniform mediump subpassInput uSubpass1;
+layout(location = 0) out vec4 FragColor;
+
+vec4 load_subpasses(mediump subpassInput uInput)
+{
+	return subpassLoad(uInput);
+}
+
+void main()
+{
+    FragColor = subpassLoad(uSubpass0) + load_subpasses(uSubpass1);
+}

--- a/shaders-msl/frag/sample-depth-separate-image-sampler.frag
+++ b/shaders-msl/frag/sample-depth-separate-image-sampler.frag
@@ -1,0 +1,22 @@
+#version 450
+
+layout(set = 0, binding = 0) uniform texture2D uDepth;
+layout(set = 0, binding = 1) uniform texture2D uColor;
+layout(set = 0, binding = 2) uniform sampler uSampler;
+layout(set = 0, binding = 3) uniform samplerShadow uSamplerShadow;
+layout(location = 0) out float FragColor;
+
+float sample_depth_from_function(texture2D uT, samplerShadow uS)
+{
+	return texture(sampler2DShadow(uT, uS), vec3(0.5));
+}
+
+float sample_color_from_function(texture2D uT, sampler uS)
+{
+	return texture(sampler2D(uT, uS), vec2(0.5)).x;
+}
+
+void main()
+{
+	FragColor = sample_depth_from_function(uDepth, uSamplerShadow) + sample_color_from_function(uColor, uSampler);
+}

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -3752,11 +3752,13 @@ bool Compiler::has_active_builtin(BuiltIn builtin, StorageClass storage)
 	return flags & (1ull << builtin);
 }
 
-void Compiler::analyze_sampler_comparison_states()
+void Compiler::analyze_image_and_sampler_usage()
 {
 	CombinedImageSamplerUsageHandler handler(*this);
 	traverse_all_reachable_opcodes(get<SPIRFunction>(entry_point), handler);
 	comparison_samplers = move(handler.comparison_samplers);
+	comparison_images = move(handler.comparison_images);
+	need_subpass_input = handler.need_subpass_input;
 }
 
 bool Compiler::CombinedImageSamplerUsageHandler::begin_function_scope(const uint32_t *args, uint32_t length)
@@ -3775,6 +3777,14 @@ bool Compiler::CombinedImageSamplerUsageHandler::begin_function_scope(const uint
 	}
 
 	return true;
+}
+
+void Compiler::CombinedImageSamplerUsageHandler::add_hierarchy_to_comparison_images(uint32_t image)
+{
+	// Traverse the variable dependency hierarchy and tag everything in its path with comparison samplers.
+	comparison_images.insert(image);
+	for (auto &img : dependency_hierarchy[image])
+		add_hierarchy_to_comparison_samplers(img);
 }
 
 void Compiler::CombinedImageSamplerUsageHandler::add_hierarchy_to_comparison_samplers(uint32_t sampler)
@@ -3796,6 +3806,12 @@ bool Compiler::CombinedImageSamplerUsageHandler::handle(Op opcode, const uint32_
 		if (length < 3)
 			return false;
 		dependency_hierarchy[args[1]].insert(args[2]);
+
+		// Ideally defer this to OpImageRead, but then we'd need to track loaded IDs.
+		// If we load an image, we're going to use it and there is little harm in declaring an unused gl_FragCoord.
+		auto &type = compiler.get<SPIRType>(args[0]);
+		if (type.image.dim == DimSubpassData)
+			need_subpass_input = true;
 		break;
 	}
 
@@ -3808,6 +3824,10 @@ bool Compiler::CombinedImageSamplerUsageHandler::handle(Op opcode, const uint32_
 		auto &type = compiler.get<SPIRType>(result_type);
 		if (type.image.depth)
 		{
+			// This image must be a depth image.
+			uint32_t image = args[2];
+			add_hierarchy_to_comparison_images(image);
+
 			// This sampler must be a SamplerComparisionState, and not a regular SamplerState.
 			uint32_t sampler = args[3];
 			add_hierarchy_to_comparison_samplers(sampler);

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -3781,10 +3781,10 @@ bool Compiler::CombinedImageSamplerUsageHandler::begin_function_scope(const uint
 
 void Compiler::CombinedImageSamplerUsageHandler::add_hierarchy_to_comparison_images(uint32_t image)
 {
-	// Traverse the variable dependency hierarchy and tag everything in its path with comparison samplers.
+	// Traverse the variable dependency hierarchy and tag everything in its path with comparison images.
 	comparison_images.insert(image);
 	for (auto &img : dependency_hierarchy[image])
-		add_hierarchy_to_comparison_samplers(img);
+		add_hierarchy_to_comparison_images(img);
 }
 
 void Compiler::CombinedImageSamplerUsageHandler::add_hierarchy_to_comparison_samplers(uint32_t sampler)

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -720,8 +720,12 @@ protected:
 	// SPIR-V does not support this distinction, so we must keep track of this information outside the type system.
 	// There might be unrelated IDs found in this set which do not correspond to actual variables.
 	// This set should only be queried for the existence of samplers which are already known to be variables or parameter IDs.
+	// Similar is implemented for images, as well as if subpass inputs are needed.
 	std::unordered_set<uint32_t> comparison_samplers;
-	void analyze_sampler_comparison_states();
+	std::unordered_set<uint32_t> comparison_images;
+	bool need_subpass_input = false;
+
+	void analyze_image_and_sampler_usage();
 	struct CombinedImageSamplerUsageHandler : OpcodeHandler
 	{
 		CombinedImageSamplerUsageHandler(Compiler &compiler_)
@@ -734,9 +738,12 @@ protected:
 		Compiler &compiler;
 
 		std::unordered_map<uint32_t, std::unordered_set<uint32_t>> dependency_hierarchy;
+		std::unordered_set<uint32_t> comparison_images;
 		std::unordered_set<uint32_t> comparison_samplers;
 
 		void add_hierarchy_to_comparison_samplers(uint32_t sampler);
+		void add_hierarchy_to_comparison_images(uint32_t sampler);
+		bool need_subpass_input = false;
 	};
 
 	void make_constant_null(uint32_t id, uint32_t type);

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -376,7 +376,7 @@ string CompilerGLSL::compile()
 	find_static_extensions();
 	fixup_image_load_store_access();
 	update_active_builtins();
-	analyze_sampler_comparison_states();
+	analyze_image_and_sampler_usage();
 
 	uint32_t pass_count = 0;
 	do

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -7419,7 +7419,9 @@ string CompilerGLSL::image_type_glsl(const SPIRType &type, uint32_t /* id */)
 			require_extension("GL_EXT_texture_array");
 		res += "Array";
 	}
-	if (type.image.depth)
+
+	// "Shadow" state in GLSL only exists for samplers and combined image samplers.
+	if (((type.basetype == SPIRType::SampledImage) || (type.basetype == SPIRType::Sampler)) && type.image.depth)
 		res += "Shadow";
 
 	return res;

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -337,7 +337,7 @@ void CompilerMSL::extract_global_variables_from_function(uint32_t func_id, std::
 					added_arg_ids.insert(base_id);
 
 				auto &type = get<SPIRType>(ops[0]);
-				if (type.image.dim == DimSubpassData)
+				if (type.basetype == SPIRType::Image && type.image.dim == DimSubpassData)
 				{
 					// Implicitly reads gl_FragCoord.
 					assert(builtin_frag_coord_id != 0);

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -3237,8 +3237,9 @@ string CompilerMSL::image_type_glsl(const SPIRType &type, uint32_t id)
 
 	// Bypass pointers because we need the real image struct
 	auto &img_type = get<SPIRType>(type.self).image;
+	bool shadow_image = comparison_images.count(id) != 0;
 
-	if (img_type.depth)
+	if (img_type.depth || shadow_image)
 	{
 		switch (img_type.dim)
 		{

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -52,6 +52,55 @@ CompilerMSL::CompilerMSL(const uint32_t *ir, size_t word_count, MSLVertexAttr *p
 			resource_bindings.push_back(&p_res_bindings[i]);
 }
 
+void CompilerMSL::build_implicit_builtins()
+{
+	if (need_subpass_input)
+	{
+		bool has_frag_coord = false;
+
+		for (auto &id : ids)
+		{
+			if (id.get_type() != TypeVariable)
+				continue;
+
+			auto &var = id.get<SPIRVariable>();
+
+			if (var.storage == StorageClassInput &&
+			    meta[var.self].decoration.builtin &&
+			    meta[var.self].decoration.builtin_type == BuiltInFragCoord)
+			{
+				has_frag_coord = true;
+				break;
+			}
+		}
+
+		if (!has_frag_coord)
+		{
+			uint32_t offset = increase_bound_by(3);
+			uint32_t type_id = offset;
+			uint32_t type_ptr_id = offset + 1;
+			uint32_t var_id = offset + 2;
+
+			// Create gl_FragCoord.
+			SPIRType vec4_type;
+			vec4_type.basetype = SPIRType::Float;
+			vec4_type.vecsize = 4;
+			set<SPIRType>(type_id, vec4_type);
+
+			SPIRType vec4_type_ptr;
+			vec4_type_ptr = vec4_type;
+			vec4_type_ptr.pointer = true;
+			vec4_type_ptr.parent_type = type_id;
+			vec4_type_ptr.storage = StorageClassInput;
+			auto &ptr_type = set<SPIRType>(type_ptr_id, vec4_type_ptr);
+			ptr_type.self = offset;
+
+			set<SPIRVariable>(var_id, type_ptr_id, StorageClassInput);
+			set_decoration(var_id, DecorationBuiltIn, BuiltInFragCoord);
+		}
+	}
+}
+
 string CompilerMSL::compile()
 {
 	// Force a classic "C" locale, reverts when function returns
@@ -60,7 +109,7 @@ string CompilerMSL::compile()
 	// Do not deal with GLES-isms like precision, older extensions and such.
 	CompilerGLSL::options.vulkan_semantics = true;
 	CompilerGLSL::options.es = false;
-	CompilerGLSL::options.version = 120;
+	CompilerGLSL::options.version = 450;
 	backend.float_literal_suffix = false;
 	backend.uint32_t_literal_suffix = true;
 	backend.basic_int_type = "int";
@@ -81,6 +130,9 @@ string CompilerMSL::compile()
 	struct_member_padding.clear();
 
 	update_active_builtins();
+	analyze_image_and_sampler_usage();
+	build_implicit_builtins();
+
 	fixup_image_load_store_access();
 
 	set_enabled_interface_variables(get_active_interface_variables());
@@ -273,6 +325,7 @@ void CompilerMSL::extract_global_variables_from_function(uint32_t func_id, std::
 			switch (op)
 			{
 			case OpLoad:
+			case OpInBoundsAccessChain:
 			case OpAccessChain:
 			{
 				uint32_t base_id = ops[2];
@@ -1462,11 +1515,15 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 	{
 		// Mark that this shader reads from this image
 		uint32_t img_id = ops[2];
-		auto *p_var = maybe_get_backing_variable(img_id);
-		if (p_var && has_decoration(p_var->self, DecorationNonReadable))
+		auto &type = expression_type(img_id);
+		if (type.image.dim != DimSubpassData)
 		{
-			unset_decoration(p_var->self, DecorationNonReadable);
-			force_recompile = true;
+			auto *p_var = maybe_get_backing_variable(img_id);
+			if (p_var && has_decoration(p_var->self, DecorationNonReadable))
+			{
+				unset_decoration(p_var->self, DecorationNonReadable);
+				force_recompile = true;
+			}
 		}
 
 		emit_texture_op(instruction);
@@ -2139,6 +2196,13 @@ string CompilerMSL::to_function_args(uint32_t img, const SPIRType &imgtype, bool
 
 		alt_coord = ".y";
 
+		break;
+
+	case DimSubpassData:
+		if (imgtype.image.ms)
+			tex_coords = "uint2(gl_FragCoord.xy)";
+		else
+			tex_coords = join("uint2(gl_FragCoord.xy), 0");
 		break;
 
 	case Dim2D:
@@ -3192,6 +3256,7 @@ string CompilerMSL::image_type_glsl(const SPIRType &type, uint32_t id)
 			break;
 		case DimBuffer:
 		case Dim2D:
+		case DimSubpassData:
 			img_type_name += (img_type.ms ? "texture2d_ms" : (img_type.arrayed ? "texture2d_array" : "texture2d"));
 			break;
 		case Dim3D:
@@ -3213,7 +3278,7 @@ string CompilerMSL::image_type_glsl(const SPIRType &type, uint32_t id)
 	// For unsampled images, append the sample/read/write access qualifier.
 	// For kernel images, the access qualifier my be supplied directly by SPIR-V.
 	// Otherwise it may be set based on whether the image is read from or written to within the shader.
-	if (type.basetype == SPIRType::Image && type.image.sampled == 2)
+	if (type.basetype == SPIRType::Image && type.image.sampled == 2 && type.image.dim != DimSubpassData)
 	{
 		switch (img_type.access)
 		{

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -268,6 +268,7 @@ protected:
 	void emit_barrier(uint32_t id_exe_scope, uint32_t id_mem_scope, uint32_t id_mem_sem);
 	void emit_array_copy(const std::string &lhs, uint32_t rhs_id) override;
 	void build_implicit_builtins();
+	uint32_t builtin_frag_coord_id = 0;
 
 	Options options;
 	std::set<SPVFuncImpl> spv_function_implementations;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -267,6 +267,7 @@ protected:
 	void add_pragma_line(const std::string &line);
 	void emit_barrier(uint32_t id_exe_scope, uint32_t id_mem_scope, uint32_t id_mem_sem);
 	void emit_array_copy(const std::string &lhs, uint32_t rhs_id) override;
+	void build_implicit_builtins();
 
 	Options options;
 	std::set<SPVFuncImpl> spv_function_implementations;


### PR DESCRIPTION
Fix #435.
Fix #439.

There might be a way to exploit on-tile storage in Metal, but I have no idea how that would map into subpasses in SPIR-V.