### PR TITLE
CompilerMSL support gl_SampleMask and convert it to scalar uint from array.

### DIFF
--- a/reference/opt/shaders-msl/frag/sample-mask.frag
+++ b/reference/opt/shaders-msl/frag/sample-mask.frag
@@ -1,0 +1,19 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+    uint gl_SampleMask [[sample_mask]];
+};
+
+fragment main0_out main0()
+{
+    main0_out out = {};
+    out.FragColor = float4(1.0);
+    out.gl_SampleMask = 0;
+    return out;
+}
+

--- a/reference/shaders-msl/frag/sample-mask.frag
+++ b/reference/shaders-msl/frag/sample-mask.frag
@@ -1,0 +1,19 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+    uint gl_SampleMask [[sample_mask]];
+};
+
+fragment main0_out main0()
+{
+    main0_out out = {};
+    out.FragColor = float4(1.0);
+    out.gl_SampleMask = 0;
+    return out;
+}
+

--- a/shaders-msl/frag/sample-mask.frag
+++ b/shaders-msl/frag/sample-mask.frag
@@ -1,0 +1,10 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = vec4(1.0);
+	gl_SampleMask[0] = 0;
+}
+

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -4487,7 +4487,7 @@ string CompilerGLSL::access_chain_internal(uint32_t base, const uint32_t *indice
 			type_id = type->parent_type;
 			type = &get<SPIRType>(type_id);
 		}
-		else
+		else if (!backend.allow_truncated_access_chain)
 			SPIRV_CROSS_THROW("Cannot subdivide a scalar value!");
 	}
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -332,6 +332,7 @@ protected:
 		bool can_swizzle_scalar = false;
 		bool force_gl_in_out_block = false;
 		bool can_return_array = true;
+		bool allow_truncated_access_chain = false;
 	} backend;
 
 	void emit_struct(SPIRType &type);

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -226,6 +226,7 @@ protected:
 	                                            std::unordered_set<uint32_t> &processed_func_ids);
 	uint32_t add_interface_block(spv::StorageClass storage);
 	void mark_location_as_used_by_shader(uint32_t location, spv::StorageClass storage);
+	uint32_t ensure_correct_builtin_type(uint32_t type_id, spv::BuiltIn builtin);
 
 	void emit_custom_functions();
 	void emit_resources();
@@ -251,7 +252,7 @@ protected:
 	uint32_t get_ordered_member_location(uint32_t type_id, uint32_t index);
 	size_t get_declared_struct_member_alignment(const SPIRType &struct_type, uint32_t index) const;
 	std::string to_component_argument(uint32_t id);
-	bool should_move_to_input_buffer(SPIRType &type, bool is_builtin, spv::StorageClass storage);
+	bool should_move_to_input_buffer(uint32_t type_id, bool is_builtin, spv::StorageClass storage);
 	void move_to_input_buffer(SPIRVariable &var);
 	void move_member_to_input_buffer(const SPIRType &type, uint32_t index);
 	std::string add_input_buffer_block_member(uint32_t mbr_type_id, std::string mbr_name, uint32_t mbr_locn);


### PR DESCRIPTION
This is a partial fix for Issue #443. It fixes the original issue reported in the use of `gl_SampleMask.

Issue #443 still requires work that is independent of this PR...and this PR can be added now.