### PR TITLE
Null crash fix in OpCopyMemory.

### DIFF
--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -3244,7 +3244,7 @@ void Compiler::analyze_variable_scope(SPIRFunction &entry)
 					accessed_variables_to_block[var->self].insert(current_block->self);
 
 				// If we store through an access chain, we have a partial write.
-				if (var->self == lhs)
+				if (var && var->self == lhs)
 					complete_write_variables_to_block[var->self].insert(current_block->self);
 
 				var = compiler.maybe_get_backing_variable(rhs);


### PR DESCRIPTION
I found a crash in OpCopyMemory where it assumed that var wasn't null. This looked like a small oversight as the lines directly above and below do the null check.

I attached a dissassembly file that caused this crash.
[TestDissassembly.txt](https://github.com/KhronosGroup/SPIRV-Cross/files/1725213/TestDissassembly.txt)

