### PR TITLE
CompilerMSL remove incorrect packing of non-interface type-aliased structs.

### DIFF
--- a/reference/opt/shaders-msl/comp/struct-nested.comp
+++ b/reference/opt/shaders-msl/comp/struct-nested.comp
@@ -1,0 +1,29 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct s1
+{
+    int a;
+};
+
+struct s2
+{
+    s1 b;
+};
+
+struct dstbuffer
+{
+    s2 test[1];
+};
+
+constant s2 _31 = {};
+
+kernel void main0(device dstbuffer& _19 [[buffer(0)]])
+{
+    s2 _30 = _31;
+    _30.b.a = 0;
+    _19.test[0].b.a = _30.b.a;
+}
+

--- a/reference/shaders-msl/comp/struct-nested.comp
+++ b/reference/shaders-msl/comp/struct-nested.comp
@@ -1,0 +1,27 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct s1
+{
+    int a;
+};
+
+struct s2
+{
+    s1 b;
+};
+
+struct dstbuffer
+{
+    s2 test[1];
+};
+
+kernel void main0(device dstbuffer& _19 [[buffer(0)]])
+{
+    s2 testVal;
+    testVal.b.a = 0;
+    _19.test[0].b.a = testVal.b.a;
+}
+

--- a/shaders-msl/comp/struct-nested.comp
+++ b/shaders-msl/comp/struct-nested.comp
@@ -1,0 +1,20 @@
+#version 450
+				   
+struct s1
+{
+	int a;
+};
+
+struct s2
+{
+	s1 b;
+};
+
+layout(std430, binding = 1) buffer dstbuffer{ s2 test[]; };
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+void main()
+{
+	s2 testVal;
+	testVal.b.a = 0;
+	test[0] = testVal;
+}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -438,11 +438,6 @@ void CompilerMSL::mark_as_packable(SPIRType &type)
 			uint32_t mbr_type_id = type.member_types[mbr_idx];
 			auto &mbr_type = get<SPIRType>(mbr_type_id);
 			mark_as_packable(mbr_type);
-			if (mbr_type.type_alias)
-			{
-				auto &mbr_type_alias = get<SPIRType>(mbr_type.type_alias);
-				mark_as_packable(mbr_type_alias);
-			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes issue #457.