### PR TITLE
Handle overloaded functions which share the same OpName.

### DIFF
--- a/reference/opt/shaders-hlsl/asm/frag/function-overload-alias.asm.frag
+++ b/reference/opt/shaders-hlsl/asm/frag/function-overload-alias.asm.frag
@@ -1,0 +1,19 @@
+static float4 FragColor;
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    FragColor = (((1.0f.xxxx + 1.0f.xxxx) + (1.0f.xxx.xyzz + 1.0f.xxxx)) + (1.0f.xxxx + 2.0f.xxxx)) + (1.0f.xx.xyxy + 2.0f.xxxx);
+}
+
+SPIRV_Cross_Output main()
+{
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/opt/shaders-msl/asm/frag/function-overload-alias.asm.frag
+++ b/reference/opt/shaders-msl/asm/frag/function-overload-alias.asm.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0()
+{
+    main0_out out = {};
+    out.FragColor = (((float4(1.0) + float4(1.0)) + (float3(1.0).xyzz + float4(1.0))) + (float4(1.0) + float4(2.0))) + (float2(1.0).xyxy + float4(2.0));
+    return out;
+}
+

--- a/reference/opt/shaders/asm/frag/function-overload-alias.asm.frag
+++ b/reference/opt/shaders/asm/frag/function-overload-alias.asm.frag
@@ -1,0 +1,11 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    FragColor = (((vec4(1.0) + vec4(1.0)) + (vec3(1.0).xyzz + vec4(1.0))) + (vec4(1.0) + vec4(2.0))) + (vec2(1.0).xyxy + vec4(2.0));
+}
+

--- a/reference/shaders-hlsl/asm/frag/function-overload-alias.asm.frag
+++ b/reference/shaders-hlsl/asm/frag/function-overload-alias.asm.frag
@@ -1,0 +1,47 @@
+static float4 FragColor;
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+float4 foo(float4 foo_1)
+{
+    return foo_1 + 1.0f.xxxx;
+}
+
+float4 foo(float3 foo_1)
+{
+    return foo_1.xyzz + 1.0f.xxxx;
+}
+
+float4 foo_1(float4 foo_2)
+{
+    return foo_2 + 2.0f.xxxx;
+}
+
+float4 foo(float2 foo_2)
+{
+    return foo_2.xyxy + 2.0f.xxxx;
+}
+
+void frag_main()
+{
+    float4 foo_3 = 1.0f.xxxx;
+    float4 foo_2 = foo(foo_3);
+    float3 foo_5 = 1.0f.xxx;
+    float4 foo_4 = foo(foo_5);
+    float4 foo_7 = 1.0f.xxxx;
+    float4 foo_6 = foo_1(foo_7);
+    float2 foo_9 = 1.0f.xx;
+    float4 foo_8 = foo(foo_9);
+    FragColor = ((foo_2 + foo_4) + foo_6) + foo_8;
+}
+
+SPIRV_Cross_Output main()
+{
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-msl/asm/frag/function-overload-alias.asm.frag
+++ b/reference/shaders-msl/asm/frag/function-overload-alias.asm.frag
@@ -1,0 +1,47 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+float4 foo(thread const float4& foo_1)
+{
+    return foo_1 + float4(1.0);
+}
+
+float4 foo(thread const float3& foo_1)
+{
+    return foo_1.xyzz + float4(1.0);
+}
+
+float4 foo_1(thread const float4& foo_2)
+{
+    return foo_2 + float4(2.0);
+}
+
+float4 foo(thread const float2& foo_2)
+{
+    return foo_2.xyxy + float4(2.0);
+}
+
+fragment main0_out main0()
+{
+    main0_out out = {};
+    float4 foo_3 = float4(1.0);
+    float4 foo_2 = foo(foo_3);
+    float3 foo_5 = float3(1.0);
+    float4 foo_4 = foo(foo_5);
+    float4 foo_7 = float4(1.0);
+    float4 foo_6 = foo_1(foo_7);
+    float2 foo_9 = float2(1.0);
+    float4 foo_8 = foo(foo_9);
+    out.FragColor = ((foo_2 + foo_4) + foo_6) + foo_8;
+    return out;
+}
+

--- a/reference/shaders/asm/frag/function-overload-alias.asm.frag
+++ b/reference/shaders/asm/frag/function-overload-alias.asm.frag
@@ -1,0 +1,39 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+layout(location = 0) out vec4 FragColor;
+
+vec4 foo(vec4 foo_1)
+{
+    return foo_1 + vec4(1.0);
+}
+
+vec4 foo(vec3 foo_1)
+{
+    return foo_1.xyzz + vec4(1.0);
+}
+
+vec4 foo_1(vec4 foo_2)
+{
+    return foo_2 + vec4(2.0);
+}
+
+vec4 foo(vec2 foo_2)
+{
+    return foo_2.xyxy + vec4(2.0);
+}
+
+void main()
+{
+    highp vec4 foo_3 = vec4(1.0);
+    vec4 foo_2 = foo(foo_3);
+    highp vec3 foo_5 = vec3(1.0);
+    vec4 foo_4 = foo(foo_5);
+    highp vec4 foo_7 = vec4(1.0);
+    vec4 foo_6 = foo_1(foo_7);
+    highp vec2 foo_9 = vec2(1.0);
+    vec4 foo_8 = foo(foo_9);
+    FragColor = ((foo_2 + foo_4) + foo_6) + foo_8;
+}
+

--- a/shaders-hlsl/asm/frag/function-overload-alias.asm.frag
+++ b/shaders-hlsl/asm/frag/function-overload-alias.asm.frag
@@ -1,0 +1,153 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 3
+; Bound: 76
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource ESSL 310
+               OpName %main "main"
+               OpName %foobar_vf4_ "foo"
+               OpName %a "foo"
+               OpName %foobar_vf3_ "foo"
+               OpName %a_0 "foo"
+               OpName %foobaz_vf4_ "foo"
+               OpName %a_1 "foo"
+               OpName %foobaz_vf2_ "foo"
+               OpName %a_2 "foo"
+               OpName %a_3 "foo"
+               OpName %param "foo"
+               OpName %b "foo"
+               OpName %param_0 "foo"
+               OpName %c "foo"
+               OpName %param_1 "foo"
+               OpName %d "foo"
+               OpName %param_2 "foo"
+               OpName %FragColor "FragColor"
+               OpDecorate %foobar_vf4_ RelaxedPrecision
+               OpDecorate %a RelaxedPrecision
+               OpDecorate %foobar_vf3_ RelaxedPrecision
+               OpDecorate %a_0 RelaxedPrecision
+               OpDecorate %foobaz_vf4_ RelaxedPrecision
+               OpDecorate %a_1 RelaxedPrecision
+               OpDecorate %foobaz_vf2_ RelaxedPrecision
+               OpDecorate %a_2 RelaxedPrecision
+               OpDecorate %28 RelaxedPrecision
+               OpDecorate %30 RelaxedPrecision
+               OpDecorate %31 RelaxedPrecision
+               OpDecorate %34 RelaxedPrecision
+               OpDecorate %35 RelaxedPrecision
+               OpDecorate %36 RelaxedPrecision
+               OpDecorate %37 RelaxedPrecision
+               OpDecorate %40 RelaxedPrecision
+               OpDecorate %42 RelaxedPrecision
+               OpDecorate %43 RelaxedPrecision
+               OpDecorate %46 RelaxedPrecision
+               OpDecorate %47 RelaxedPrecision
+               OpDecorate %48 RelaxedPrecision
+               OpDecorate %49 RelaxedPrecision
+               OpDecorate %a_3 RelaxedPrecision
+               OpDecorate %55 RelaxedPrecision
+               OpDecorate %b RelaxedPrecision
+               OpDecorate %59 RelaxedPrecision
+               OpDecorate %c RelaxedPrecision
+               OpDecorate %62 RelaxedPrecision
+               OpDecorate %d RelaxedPrecision
+               OpDecorate %66 RelaxedPrecision
+               OpDecorate %FragColor RelaxedPrecision
+               OpDecorate %FragColor Location 0
+               OpDecorate %69 RelaxedPrecision
+               OpDecorate %70 RelaxedPrecision
+               OpDecorate %71 RelaxedPrecision
+               OpDecorate %72 RelaxedPrecision
+               OpDecorate %73 RelaxedPrecision
+               OpDecorate %74 RelaxedPrecision
+               OpDecorate %75 RelaxedPrecision
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+          %9 = OpTypeFunction %v4float %_ptr_Function_v4float
+    %v3float = OpTypeVector %float 3
+%_ptr_Function_v3float = OpTypePointer Function %v3float
+         %15 = OpTypeFunction %v4float %_ptr_Function_v3float
+    %v2float = OpTypeVector %float 2
+%_ptr_Function_v2float = OpTypePointer Function %v2float
+         %24 = OpTypeFunction %v4float %_ptr_Function_v2float
+    %float_1 = OpConstant %float 1
+    %float_2 = OpConstant %float 2
+         %53 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
+         %57 = OpConstantComposite %v3float %float_1 %float_1 %float_1
+         %64 = OpConstantComposite %v2float %float_1 %float_1
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+        %a_3 = OpVariable %_ptr_Function_v4float Function
+      %param = OpVariable %_ptr_Function_v4float Function
+          %b = OpVariable %_ptr_Function_v4float Function
+    %param_0 = OpVariable %_ptr_Function_v3float Function
+          %c = OpVariable %_ptr_Function_v4float Function
+    %param_1 = OpVariable %_ptr_Function_v4float Function
+          %d = OpVariable %_ptr_Function_v4float Function
+    %param_2 = OpVariable %_ptr_Function_v2float Function
+               OpStore %param %53
+         %55 = OpFunctionCall %v4float %foobar_vf4_ %param
+               OpStore %a_3 %55
+               OpStore %param_0 %57
+         %59 = OpFunctionCall %v4float %foobar_vf3_ %param_0
+               OpStore %b %59
+               OpStore %param_1 %53
+         %62 = OpFunctionCall %v4float %foobaz_vf4_ %param_1
+               OpStore %c %62
+               OpStore %param_2 %64
+         %66 = OpFunctionCall %v4float %foobaz_vf2_ %param_2
+               OpStore %d %66
+         %69 = OpLoad %v4float %a_3
+         %70 = OpLoad %v4float %b
+         %71 = OpFAdd %v4float %69 %70
+         %72 = OpLoad %v4float %c
+         %73 = OpFAdd %v4float %71 %72
+         %74 = OpLoad %v4float %d
+         %75 = OpFAdd %v4float %73 %74
+               OpStore %FragColor %75
+               OpReturn
+               OpFunctionEnd
+%foobar_vf4_ = OpFunction %v4float None %9
+          %a = OpFunctionParameter %_ptr_Function_v4float
+         %12 = OpLabel
+         %28 = OpLoad %v4float %a
+         %30 = OpCompositeConstruct %v4float %float_1 %float_1 %float_1 %float_1
+         %31 = OpFAdd %v4float %28 %30
+               OpReturnValue %31
+               OpFunctionEnd
+%foobar_vf3_ = OpFunction %v4float None %15
+        %a_0 = OpFunctionParameter %_ptr_Function_v3float
+         %18 = OpLabel
+         %34 = OpLoad %v3float %a_0
+         %35 = OpVectorShuffle %v4float %34 %34 0 1 2 2
+         %36 = OpCompositeConstruct %v4float %float_1 %float_1 %float_1 %float_1
+         %37 = OpFAdd %v4float %35 %36
+               OpReturnValue %37
+               OpFunctionEnd
+%foobaz_vf4_ = OpFunction %v4float None %9
+        %a_1 = OpFunctionParameter %_ptr_Function_v4float
+         %21 = OpLabel
+         %40 = OpLoad %v4float %a_1
+         %42 = OpCompositeConstruct %v4float %float_2 %float_2 %float_2 %float_2
+         %43 = OpFAdd %v4float %40 %42
+               OpReturnValue %43
+               OpFunctionEnd
+%foobaz_vf2_ = OpFunction %v4float None %24
+        %a_2 = OpFunctionParameter %_ptr_Function_v2float
+         %27 = OpLabel
+         %46 = OpLoad %v2float %a_2
+         %47 = OpVectorShuffle %v4float %46 %46 0 1 0 1
+         %48 = OpCompositeConstruct %v4float %float_2 %float_2 %float_2 %float_2
+         %49 = OpFAdd %v4float %47 %48
+               OpReturnValue %49
+               OpFunctionEnd

--- a/shaders-msl/asm/frag/function-overload-alias.asm.frag
+++ b/shaders-msl/asm/frag/function-overload-alias.asm.frag
@@ -1,0 +1,153 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 3
+; Bound: 76
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource ESSL 310
+               OpName %main "main"
+               OpName %foobar_vf4_ "foo"
+               OpName %a "foo"
+               OpName %foobar_vf3_ "foo"
+               OpName %a_0 "foo"
+               OpName %foobaz_vf4_ "foo"
+               OpName %a_1 "foo"
+               OpName %foobaz_vf2_ "foo"
+               OpName %a_2 "foo"
+               OpName %a_3 "foo"
+               OpName %param "foo"
+               OpName %b "foo"
+               OpName %param_0 "foo"
+               OpName %c "foo"
+               OpName %param_1 "foo"
+               OpName %d "foo"
+               OpName %param_2 "foo"
+               OpName %FragColor "FragColor"
+               OpDecorate %foobar_vf4_ RelaxedPrecision
+               OpDecorate %a RelaxedPrecision
+               OpDecorate %foobar_vf3_ RelaxedPrecision
+               OpDecorate %a_0 RelaxedPrecision
+               OpDecorate %foobaz_vf4_ RelaxedPrecision
+               OpDecorate %a_1 RelaxedPrecision
+               OpDecorate %foobaz_vf2_ RelaxedPrecision
+               OpDecorate %a_2 RelaxedPrecision
+               OpDecorate %28 RelaxedPrecision
+               OpDecorate %30 RelaxedPrecision
+               OpDecorate %31 RelaxedPrecision
+               OpDecorate %34 RelaxedPrecision
+               OpDecorate %35 RelaxedPrecision
+               OpDecorate %36 RelaxedPrecision
+               OpDecorate %37 RelaxedPrecision
+               OpDecorate %40 RelaxedPrecision
+               OpDecorate %42 RelaxedPrecision
+               OpDecorate %43 RelaxedPrecision
+               OpDecorate %46 RelaxedPrecision
+               OpDecorate %47 RelaxedPrecision
+               OpDecorate %48 RelaxedPrecision
+               OpDecorate %49 RelaxedPrecision
+               OpDecorate %a_3 RelaxedPrecision
+               OpDecorate %55 RelaxedPrecision
+               OpDecorate %b RelaxedPrecision
+               OpDecorate %59 RelaxedPrecision
+               OpDecorate %c RelaxedPrecision
+               OpDecorate %62 RelaxedPrecision
+               OpDecorate %d RelaxedPrecision
+               OpDecorate %66 RelaxedPrecision
+               OpDecorate %FragColor RelaxedPrecision
+               OpDecorate %FragColor Location 0
+               OpDecorate %69 RelaxedPrecision
+               OpDecorate %70 RelaxedPrecision
+               OpDecorate %71 RelaxedPrecision
+               OpDecorate %72 RelaxedPrecision
+               OpDecorate %73 RelaxedPrecision
+               OpDecorate %74 RelaxedPrecision
+               OpDecorate %75 RelaxedPrecision
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+          %9 = OpTypeFunction %v4float %_ptr_Function_v4float
+    %v3float = OpTypeVector %float 3
+%_ptr_Function_v3float = OpTypePointer Function %v3float
+         %15 = OpTypeFunction %v4float %_ptr_Function_v3float
+    %v2float = OpTypeVector %float 2
+%_ptr_Function_v2float = OpTypePointer Function %v2float
+         %24 = OpTypeFunction %v4float %_ptr_Function_v2float
+    %float_1 = OpConstant %float 1
+    %float_2 = OpConstant %float 2
+         %53 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
+         %57 = OpConstantComposite %v3float %float_1 %float_1 %float_1
+         %64 = OpConstantComposite %v2float %float_1 %float_1
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+        %a_3 = OpVariable %_ptr_Function_v4float Function
+      %param = OpVariable %_ptr_Function_v4float Function
+          %b = OpVariable %_ptr_Function_v4float Function
+    %param_0 = OpVariable %_ptr_Function_v3float Function
+          %c = OpVariable %_ptr_Function_v4float Function
+    %param_1 = OpVariable %_ptr_Function_v4float Function
+          %d = OpVariable %_ptr_Function_v4float Function
+    %param_2 = OpVariable %_ptr_Function_v2float Function
+               OpStore %param %53
+         %55 = OpFunctionCall %v4float %foobar_vf4_ %param
+               OpStore %a_3 %55
+               OpStore %param_0 %57
+         %59 = OpFunctionCall %v4float %foobar_vf3_ %param_0
+               OpStore %b %59
+               OpStore %param_1 %53
+         %62 = OpFunctionCall %v4float %foobaz_vf4_ %param_1
+               OpStore %c %62
+               OpStore %param_2 %64
+         %66 = OpFunctionCall %v4float %foobaz_vf2_ %param_2
+               OpStore %d %66
+         %69 = OpLoad %v4float %a_3
+         %70 = OpLoad %v4float %b
+         %71 = OpFAdd %v4float %69 %70
+         %72 = OpLoad %v4float %c
+         %73 = OpFAdd %v4float %71 %72
+         %74 = OpLoad %v4float %d
+         %75 = OpFAdd %v4float %73 %74
+               OpStore %FragColor %75
+               OpReturn
+               OpFunctionEnd
+%foobar_vf4_ = OpFunction %v4float None %9
+          %a = OpFunctionParameter %_ptr_Function_v4float
+         %12 = OpLabel
+         %28 = OpLoad %v4float %a
+         %30 = OpCompositeConstruct %v4float %float_1 %float_1 %float_1 %float_1
+         %31 = OpFAdd %v4float %28 %30
+               OpReturnValue %31
+               OpFunctionEnd
+%foobar_vf3_ = OpFunction %v4float None %15
+        %a_0 = OpFunctionParameter %_ptr_Function_v3float
+         %18 = OpLabel
+         %34 = OpLoad %v3float %a_0
+         %35 = OpVectorShuffle %v4float %34 %34 0 1 2 2
+         %36 = OpCompositeConstruct %v4float %float_1 %float_1 %float_1 %float_1
+         %37 = OpFAdd %v4float %35 %36
+               OpReturnValue %37
+               OpFunctionEnd
+%foobaz_vf4_ = OpFunction %v4float None %9
+        %a_1 = OpFunctionParameter %_ptr_Function_v4float
+         %21 = OpLabel
+         %40 = OpLoad %v4float %a_1
+         %42 = OpCompositeConstruct %v4float %float_2 %float_2 %float_2 %float_2
+         %43 = OpFAdd %v4float %40 %42
+               OpReturnValue %43
+               OpFunctionEnd
+%foobaz_vf2_ = OpFunction %v4float None %24
+        %a_2 = OpFunctionParameter %_ptr_Function_v2float
+         %27 = OpLabel
+         %46 = OpLoad %v2float %a_2
+         %47 = OpVectorShuffle %v4float %46 %46 0 1 0 1
+         %48 = OpCompositeConstruct %v4float %float_2 %float_2 %float_2 %float_2
+         %49 = OpFAdd %v4float %47 %48
+               OpReturnValue %49
+               OpFunctionEnd

--- a/shaders/asm/frag/function-overload-alias.asm.frag
+++ b/shaders/asm/frag/function-overload-alias.asm.frag
@@ -1,0 +1,153 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 3
+; Bound: 76
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource ESSL 310
+               OpName %main "main"
+               OpName %foobar_vf4_ "foo"
+               OpName %a "foo"
+               OpName %foobar_vf3_ "foo"
+               OpName %a_0 "foo"
+               OpName %foobaz_vf4_ "foo"
+               OpName %a_1 "foo"
+               OpName %foobaz_vf2_ "foo"
+               OpName %a_2 "foo"
+               OpName %a_3 "foo"
+               OpName %param "foo"
+               OpName %b "foo"
+               OpName %param_0 "foo"
+               OpName %c "foo"
+               OpName %param_1 "foo"
+               OpName %d "foo"
+               OpName %param_2 "foo"
+               OpName %FragColor "FragColor"
+               OpDecorate %foobar_vf4_ RelaxedPrecision
+               OpDecorate %a RelaxedPrecision
+               OpDecorate %foobar_vf3_ RelaxedPrecision
+               OpDecorate %a_0 RelaxedPrecision
+               OpDecorate %foobaz_vf4_ RelaxedPrecision
+               OpDecorate %a_1 RelaxedPrecision
+               OpDecorate %foobaz_vf2_ RelaxedPrecision
+               OpDecorate %a_2 RelaxedPrecision
+               OpDecorate %28 RelaxedPrecision
+               OpDecorate %30 RelaxedPrecision
+               OpDecorate %31 RelaxedPrecision
+               OpDecorate %34 RelaxedPrecision
+               OpDecorate %35 RelaxedPrecision
+               OpDecorate %36 RelaxedPrecision
+               OpDecorate %37 RelaxedPrecision
+               OpDecorate %40 RelaxedPrecision
+               OpDecorate %42 RelaxedPrecision
+               OpDecorate %43 RelaxedPrecision
+               OpDecorate %46 RelaxedPrecision
+               OpDecorate %47 RelaxedPrecision
+               OpDecorate %48 RelaxedPrecision
+               OpDecorate %49 RelaxedPrecision
+               OpDecorate %a_3 RelaxedPrecision
+               OpDecorate %55 RelaxedPrecision
+               OpDecorate %b RelaxedPrecision
+               OpDecorate %59 RelaxedPrecision
+               OpDecorate %c RelaxedPrecision
+               OpDecorate %62 RelaxedPrecision
+               OpDecorate %d RelaxedPrecision
+               OpDecorate %66 RelaxedPrecision
+               OpDecorate %FragColor RelaxedPrecision
+               OpDecorate %FragColor Location 0
+               OpDecorate %69 RelaxedPrecision
+               OpDecorate %70 RelaxedPrecision
+               OpDecorate %71 RelaxedPrecision
+               OpDecorate %72 RelaxedPrecision
+               OpDecorate %73 RelaxedPrecision
+               OpDecorate %74 RelaxedPrecision
+               OpDecorate %75 RelaxedPrecision
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+          %9 = OpTypeFunction %v4float %_ptr_Function_v4float
+    %v3float = OpTypeVector %float 3
+%_ptr_Function_v3float = OpTypePointer Function %v3float
+         %15 = OpTypeFunction %v4float %_ptr_Function_v3float
+    %v2float = OpTypeVector %float 2
+%_ptr_Function_v2float = OpTypePointer Function %v2float
+         %24 = OpTypeFunction %v4float %_ptr_Function_v2float
+    %float_1 = OpConstant %float 1
+    %float_2 = OpConstant %float 2
+         %53 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
+         %57 = OpConstantComposite %v3float %float_1 %float_1 %float_1
+         %64 = OpConstantComposite %v2float %float_1 %float_1
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+        %a_3 = OpVariable %_ptr_Function_v4float Function
+      %param = OpVariable %_ptr_Function_v4float Function
+          %b = OpVariable %_ptr_Function_v4float Function
+    %param_0 = OpVariable %_ptr_Function_v3float Function
+          %c = OpVariable %_ptr_Function_v4float Function
+    %param_1 = OpVariable %_ptr_Function_v4float Function
+          %d = OpVariable %_ptr_Function_v4float Function
+    %param_2 = OpVariable %_ptr_Function_v2float Function
+               OpStore %param %53
+         %55 = OpFunctionCall %v4float %foobar_vf4_ %param
+               OpStore %a_3 %55
+               OpStore %param_0 %57
+         %59 = OpFunctionCall %v4float %foobar_vf3_ %param_0
+               OpStore %b %59
+               OpStore %param_1 %53
+         %62 = OpFunctionCall %v4float %foobaz_vf4_ %param_1
+               OpStore %c %62
+               OpStore %param_2 %64
+         %66 = OpFunctionCall %v4float %foobaz_vf2_ %param_2
+               OpStore %d %66
+         %69 = OpLoad %v4float %a_3
+         %70 = OpLoad %v4float %b
+         %71 = OpFAdd %v4float %69 %70
+         %72 = OpLoad %v4float %c
+         %73 = OpFAdd %v4float %71 %72
+         %74 = OpLoad %v4float %d
+         %75 = OpFAdd %v4float %73 %74
+               OpStore %FragColor %75
+               OpReturn
+               OpFunctionEnd
+%foobar_vf4_ = OpFunction %v4float None %9
+          %a = OpFunctionParameter %_ptr_Function_v4float
+         %12 = OpLabel
+         %28 = OpLoad %v4float %a
+         %30 = OpCompositeConstruct %v4float %float_1 %float_1 %float_1 %float_1
+         %31 = OpFAdd %v4float %28 %30
+               OpReturnValue %31
+               OpFunctionEnd
+%foobar_vf3_ = OpFunction %v4float None %15
+        %a_0 = OpFunctionParameter %_ptr_Function_v3float
+         %18 = OpLabel
+         %34 = OpLoad %v3float %a_0
+         %35 = OpVectorShuffle %v4float %34 %34 0 1 2 2
+         %36 = OpCompositeConstruct %v4float %float_1 %float_1 %float_1 %float_1
+         %37 = OpFAdd %v4float %35 %36
+               OpReturnValue %37
+               OpFunctionEnd
+%foobaz_vf4_ = OpFunction %v4float None %9
+        %a_1 = OpFunctionParameter %_ptr_Function_v4float
+         %21 = OpLabel
+         %40 = OpLoad %v4float %a_1
+         %42 = OpCompositeConstruct %v4float %float_2 %float_2 %float_2 %float_2
+         %43 = OpFAdd %v4float %40 %42
+               OpReturnValue %43
+               OpFunctionEnd
+%foobaz_vf2_ = OpFunction %v4float None %24
+        %a_2 = OpFunctionParameter %_ptr_Function_v2float
+         %27 = OpLabel
+         %46 = OpLoad %v2float %a_2
+         %47 = OpVectorShuffle %v4float %46 %46 0 1 0 1
+         %48 = OpCompositeConstruct %v4float %float_2 %float_2 %float_2 %float_2
+         %49 = OpFAdd %v4float %47 %48
+               OpReturnValue %49
+               OpFunctionEnd

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -1037,6 +1037,23 @@ public:
 private:
 	std::locale old;
 };
+
+class Hasher
+{
+public:
+	inline void u32(uint32_t value)
+	{
+		h = (h * 0x100000001b3ull) ^ value;
+	}
+
+	inline uint64_t get() const
+	{
+		return h;
+	}
+
+private:
+	uint64_t h = 0xcbf29ce484222325ull;
+};
 }
 
 #endif

--- a/spirv_cpp.cpp
+++ b/spirv_cpp.cpp
@@ -375,6 +375,9 @@ void CompilerCPP::emit_c_linkage()
 
 void CompilerCPP::emit_function_prototype(SPIRFunction &func, uint64_t)
 {
+	if (func.self != entry_point)
+		add_function_overload(func);
+
 	local_variable_names = resource_names;
 	string decl;
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -295,6 +295,7 @@ protected:
 	void add_local_variable_name(uint32_t id);
 	void add_resource_name(uint32_t id);
 	void add_member_name(SPIRType &type, uint32_t name);
+	void add_function_overload(const SPIRFunction &func);
 
 	virtual bool is_non_native_row_major_matrix(uint32_t id);
 	virtual bool member_is_non_native_row_major_matrix(const SPIRType &type, uint32_t index);
@@ -303,6 +304,7 @@ protected:
 
 	std::unordered_set<std::string> local_variable_names;
 	std::unordered_set<std::string> resource_names;
+	std::unordered_map<std::string, std::unordered_set<uint64_t>> function_overloads;
 
 	bool processing_entry_point = false;
 

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1746,6 +1746,9 @@ string CompilerHLSL::to_func_call_arg(uint32_t id)
 
 void CompilerHLSL::emit_function_prototype(SPIRFunction &func, uint64_t return_flags)
 {
+	if (func.self != entry_point)
+		add_function_overload(func);
+
 	auto &execution = get_entry_point();
 	// Avoid shadow declarations.
 	local_variable_names = resource_names;

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -2133,6 +2133,9 @@ void CompilerMSL::emit_interface_block(uint32_t ib_var_id)
 // If this is the entry point function, Metal-specific return value and function arguments are added.
 void CompilerMSL::emit_function_prototype(SPIRFunction &func, uint64_t)
 {
+	if (func.self != entry_point)
+		add_function_overload(func);
+
 	local_variable_names = resource_names;
 	string decl;
 


### PR DESCRIPTION
Awkward, but legal SPIR-V.

Fix #454.