### PR TITLE
Support spec constant array size in blocks.

### DIFF
--- a/reference/opt/shaders-hlsl/frag/spec-constant-block-size.frag
+++ b/reference/opt/shaders-hlsl/frag/spec-constant-block-size.frag
@@ -1,0 +1,33 @@
+static const int Value = 2;
+
+cbuffer _15 : register(b0)
+{
+    float4 _15_samples[Value] : packoffset(c0);
+};
+
+static float4 FragColor;
+static int Index;
+
+struct SPIRV_Cross_Input
+{
+    nointerpolation int Index : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    FragColor = _15_samples[Index];
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    Index = stage_input.Index;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/opt/shaders-msl/frag/spec-constant-block-size.frag
+++ b/reference/opt/shaders-msl/frag/spec-constant-block-size.frag
@@ -1,0 +1,27 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct SpecConstArray
+{
+    float4 samples[2];
+};
+
+struct main0_in
+{
+    int Index [[user(locn0)]];
+};
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant SpecConstArray& _15 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.FragColor = _15.samples[in.Index];
+    return out;
+}
+

--- a/reference/opt/shaders/vulkan/frag/spec-constant-block-size.vk.frag
+++ b/reference/opt/shaders/vulkan/frag/spec-constant-block-size.vk.frag
@@ -1,0 +1,17 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+layout(binding = 0, std140) uniform SpecConstArray
+{
+    vec4 samples[2];
+} _15;
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) flat in mediump int Index;
+
+void main()
+{
+    FragColor = _15.samples[Index];
+}
+

--- a/reference/opt/shaders/vulkan/frag/spec-constant-block-size.vk.frag.vk
+++ b/reference/opt/shaders/vulkan/frag/spec-constant-block-size.vk.frag.vk
@@ -1,0 +1,19 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+layout(constant_id = 10) const int Value = 2;
+
+layout(set = 0, binding = 0, std140) uniform SpecConstArray
+{
+    vec4 samples[Value];
+} _15;
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) flat in mediump int Index;
+
+void main()
+{
+    FragColor = _15.samples[Index];
+}
+

--- a/reference/shaders-hlsl/frag/spec-constant-block-size.frag
+++ b/reference/shaders-hlsl/frag/spec-constant-block-size.frag
@@ -1,0 +1,33 @@
+static const int Value = 2;
+
+cbuffer _15 : register(b0)
+{
+    float4 _15_samples[Value] : packoffset(c0);
+};
+
+static float4 FragColor;
+static int Index;
+
+struct SPIRV_Cross_Input
+{
+    nointerpolation int Index : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    FragColor = _15_samples[Index];
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    Index = stage_input.Index;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-msl/frag/spec-constant-block-size.frag
+++ b/reference/shaders-msl/frag/spec-constant-block-size.frag
@@ -1,0 +1,27 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct SpecConstArray
+{
+    float4 samples[2];
+};
+
+struct main0_in
+{
+    int Index [[user(locn0)]];
+};
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant SpecConstArray& _15 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.FragColor = _15.samples[in.Index];
+    return out;
+}
+

--- a/reference/shaders/vulkan/frag/spec-constant-block-size.vk.frag
+++ b/reference/shaders/vulkan/frag/spec-constant-block-size.vk.frag
@@ -1,0 +1,17 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+layout(binding = 0, std140) uniform SpecConstArray
+{
+    vec4 samples[2];
+} _15;
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) flat in mediump int Index;
+
+void main()
+{
+    FragColor = _15.samples[Index];
+}
+

--- a/reference/shaders/vulkan/frag/spec-constant-block-size.vk.frag.vk
+++ b/reference/shaders/vulkan/frag/spec-constant-block-size.vk.frag.vk
@@ -1,0 +1,19 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+layout(constant_id = 10) const int Value = 2;
+
+layout(set = 0, binding = 0, std140) uniform SpecConstArray
+{
+    vec4 samples[Value];
+} _15;
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) flat in mediump int Index;
+
+void main()
+{
+    FragColor = _15.samples[Index];
+}
+

--- a/shaders-hlsl/frag/spec-constant-block-size.frag
+++ b/shaders-hlsl/frag/spec-constant-block-size.frag
@@ -1,0 +1,17 @@
+#version 310 es
+precision mediump float;
+
+layout(constant_id = 10) const int Value = 2;
+layout(binding = 0) uniform SpecConstArray
+{
+	vec4 samples[Value];
+};
+
+layout(location = 0) flat in int Index;
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = samples[Index];
+}
+

--- a/shaders-msl/frag/spec-constant-block-size.frag
+++ b/shaders-msl/frag/spec-constant-block-size.frag
@@ -1,0 +1,17 @@
+#version 310 es
+precision mediump float;
+
+layout(constant_id = 10) const int Value = 2;
+layout(binding = 0) uniform SpecConstArray
+{
+	vec4 samples[Value];
+};
+
+layout(location = 0) flat in int Index;
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = samples[Index];
+}
+

--- a/shaders/vulkan/frag/spec-constant-block-size.vk.frag
+++ b/shaders/vulkan/frag/spec-constant-block-size.vk.frag
@@ -1,0 +1,17 @@
+#version 310 es
+precision mediump float;
+
+layout(constant_id = 10) const int Value = 2;
+layout(binding = 0) uniform SpecConstArray
+{
+	vec4 samples[Value];
+};
+
+layout(location = 0) flat in int Index;
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = samples[Index];
+}
+

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -2296,7 +2296,9 @@ size_t Compiler::get_declared_struct_member_size(const SPIRType &struct_type, ui
 	if (!type.array.empty())
 	{
 		// For arrays, we can use ArrayStride to get an easy check.
-		return type_struct_member_array_stride(struct_type, index) * type.array.back();
+		bool array_size_literal = type.array_size_literal.back();
+		uint32_t array_size = array_size_literal ? type.array.back() : get<SPIRConstant>(type.array.back()).scalar();
+		return type_struct_member_array_stride(struct_type, index) * array_size;
 	}
 	else if (type.basetype == SPIRType::Struct)
 	{

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -7472,10 +7472,18 @@ uint32_t CompilerGLSL::to_array_size_literal(const SPIRType &type, uint32_t inde
 {
 	assert(type.array.size() == type.array_size_literal.size());
 
-	if (!type.array_size_literal[index])
-		SPIRV_CROSS_THROW("The array size is not a literal, but a specialization constant or spec constant op.");
-
-	return type.array[index];
+	if (type.array_size_literal[index])
+	{
+		return type.array[index];
+	}
+	else
+	{
+		// Use the default spec constant value.
+		// This is the best we can do.
+		uint32_t array_size_id = type.array[index];
+		uint32_t array_size = get<SPIRConstant>(array_size_id).scalar();
+		return array_size;
+	}
 }
 
 string CompilerGLSL::to_array_size(const SPIRType &type, uint32_t index)

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -3637,7 +3637,12 @@ size_t CompilerMSL::get_declared_struct_member_size(const SPIRType &struct_type,
 		// For arrays, we can use ArrayStride to get an easy check.
 		// Runtime arrays will have zero size so force to min of one.
 		if (!type.array.empty())
-			return type_struct_member_array_stride(struct_type, index) * max(type.array.back(), 1U);
+		{
+			bool array_size_literal = type.array_size_literal.back();
+			uint32_t array_size =
+			    array_size_literal ? type.array.back() : get<SPIRConstant>(type.array.back()).scalar();
+			return type_struct_member_array_stride(struct_type, index) * max(array_size, 1u);
+		}
 
 		if (type.basetype == SPIRType::Struct)
 			return get_declared_struct_size(type);


### PR DESCRIPTION
Won't really be correct if the spec constant is changed outside
SPIRV-Cross, but nothing we can do about that, really.

Fix #459.