### PR TITLE
Move `rename_interface_variable` to util

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,12 +101,17 @@ spirv_cross_add_library(spirv-cross-hlsl spirv_cross_hlsl STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/spirv_hlsl.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/spirv_hlsl.cpp)
 
+spirv_cross_add_library(spirv-cross-util spirv_cross_util STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross_util.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross_util.cpp)
+
 add_executable(spirv-cross main.cpp)
 target_compile_options(spirv-cross PRIVATE ${spirv-compiler-options})
 target_compile_definitions(spirv-cross PRIVATE ${spirv-compiler-defines})
 
 install(TARGETS spirv-cross RUNTIME DESTINATION bin)
-target_link_libraries(spirv-cross spirv-cross-glsl spirv-cross-hlsl spirv-cross-cpp spirv-cross-msl spirv-cross-core)
+target_link_libraries(spirv-cross spirv-cross-glsl spirv-cross-hlsl spirv-cross-cpp spirv-cross-msl spirv-cross-util spirv-cross-core)
+target_link_libraries(spirv-cross-util spirv-cross-core)
 target_link_libraries(spirv-cross-glsl spirv-cross-core)
 target_link_libraries(spirv-cross-msl spirv-cross-glsl)
 target_link_libraries(spirv-cross-hlsl spirv-cross-glsl)

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -4,7 +4,7 @@ include $(CLEAR_VARS)
 
 LOCAL_CFLAGS += -std=c++11 -Wall -Wextra
 LOCAL_MODULE := spirv-cross
-LOCAL_SRC_FILES := ../spirv_cfg.cpp ../spirv_cross.cpp ../spirv_glsl.cpp ../spirv_msl.cpp ../spirv_cpp.cpp
+LOCAL_SRC_FILES := ../spirv_cfg.cpp ../spirv_cross.cpp ../spirv_cross_util.cpp ../spirv_glsl.cpp ../spirv_hlsl.cpp ../spirv_msl.cpp ../spirv_cpp.cpp
 LOCAL_CPP_FEATURES := exceptions
 LOCAL_ARM_MODE := arm
 LOCAL_CFLAGS := -D__STDC_LIMIT_MACROS

--- a/msvc/SPIRV-Cross.vcxproj
+++ b/msvc/SPIRV-Cross.vcxproj
@@ -130,6 +130,7 @@
     <ClCompile Include="..\spirv_hlsl.cpp" />
     <ClCompile Include="..\spirv_msl.cpp" />
     <ClCompile Include="..\spirv_cfg.cpp" />
+    <ClCompile Include="..\spirv_cross_util.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\GLSL.std.450.h" />
@@ -141,6 +142,7 @@
     <ClInclude Include="..\spirv_hlsl.hpp" />
     <ClInclude Include="..\spirv_msl.hpp" />
     <ClInclude Include="..\spirv_cfg.hpp" />
+    <ClInclude Include="..\spirv_cross_util.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/msvc/SPIRV-Cross.vcxproj.filters
+++ b/msvc/SPIRV-Cross.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClCompile Include="..\spirv_hlsl.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\spirv_cross_util.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\GLSL.std.450.h">
@@ -63,6 +66,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\spirv_hlsl.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\spirv_cross_util.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/spirv_cross_util.cpp
+++ b/spirv_cross_util.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015-2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "spirv_cross_util.hpp"
+#include "spirv_common.hpp"
+
+using namespace spv;
+using namespace spirv_cross;
+
+namespace spirv_cross_util
+{
+void rename_interface_variable(spirv_cross::Compiler &compiler, const std::vector<spirv_cross::Resource> &resources,
+                               uint32_t location, const std::string &name)
+{
+	for (auto &v : resources)
+	{
+		if (!compiler.has_decoration(v.id, spv::DecorationLocation))
+			continue;
+
+		auto loc = compiler.get_decoration(v.id, spv::DecorationLocation);
+		if (loc != location)
+			continue;
+
+		auto &type = compiler.get_type(v.base_type_id);
+
+		// This is more of a friendly variant. If we need to rename interface variables, we might have to rename
+		// structs as well and make sure all the names match up.
+		if (type.basetype == SPIRType::Struct)
+		{
+			compiler.set_name(v.base_type_id, join("SPIRV_Cross_Interface_Location", location));
+			for (uint32_t i = 0; i < uint32_t(type.member_types.size()); i++)
+				compiler.set_member_name(v.base_type_id, i, join("InterfaceMember", i));
+		}
+
+		compiler.set_name(v.id, name);
+	}
+}
+}

--- a/spirv_cross_util.hpp
+++ b/spirv_cross_util.hpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015-2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SPIRV_CROSS_UTIL_HPP
+#define SPIRV_CROSS_UTIL_HPP
+
+#include "spirv_cross.hpp"
+
+namespace spirv_cross_util
+{
+void rename_interface_variable(spirv_cross::Compiler &compiler, const std::vector<spirv_cross::Resource> &resources,
+                               uint32_t location, const std::string &name);
+}
+
+#endif


### PR DESCRIPTION
Fixes #467.

I noticed that in #210 the choice was made to explicitly move this method into `main.cpp`, but it would be useful to expose as part of the reflection API if possible (I'd prefer not to re-implement it myself).

Let me know if it's still too specific or belongs on another class. Thanks!