### PR TITLE
Add disable_for_loops to CompilerGLSL options

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -8652,7 +8652,7 @@ void CompilerGLSL::emit_block_chain(SPIRBlock &block)
 		get<SPIRVariable>(var).loop_variable_enable = true;
 
 	// This is the older loop behavior in glslang which branches to loop body directly from the loop header.
-	if (block_is_loop_candidate(block, SPIRBlock::MergeToSelectForLoop))
+	if (!options.disable_for_loops && block_is_loop_candidate(block, SPIRBlock::MergeToSelectForLoop))
 	{
 		flush_undeclared_variables(block);
 		if (attempt_emit_loop_header(block, SPIRBlock::MergeToSelectForLoop))
@@ -8664,7 +8664,7 @@ void CompilerGLSL::emit_block_chain(SPIRBlock &block)
 	}
 	// This is the newer loop behavior in glslang which branches from Loop header directly to
 	// a new block, which in turn has a OpBranchSelection without a selection merge.
-	else if (block_is_loop_candidate(block, SPIRBlock::MergeToDirectForLoop))
+	else if (!options.disable_for_loops && block_is_loop_candidate(block, SPIRBlock::MergeToDirectForLoop))
 	{
 		flush_undeclared_variables(block);
 		if (attempt_emit_loop_header(block, SPIRBlock::MergeToDirectForLoop))

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -88,6 +88,12 @@ public:
 		// If disabled on older targets, binding decorations will be stripped.
 		bool enable_420pack_extension = true;
 
+		// If true, complex for-style loops are no longer generated; instead, for (;;) and break/continue are used
+		// Optimization passes in SPIRV-Tools can merge the entire loop body block into the continue block.
+		// This results in shaders that are very hard to read; this flag works around the problem.
+		// Note that setting this to true can break compatibility with older GLSL versions.
+		bool disable_for_loops = false;
+
 		enum Precision
 		{
 			DontCare,


### PR DESCRIPTION
Optimization passes in SPIRV-Tools can merge the entire loop body block
into the continue block. This results in shaders that are very hard to read;
this flag works around the problem.