### PR TITLE
Added generation of the textureXYZGrad() legacy GLSL instruction

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -3384,6 +3384,8 @@ string CompilerGLSL::legacy_tex_op(const std::string &op, const SPIRType &imgtyp
 	}
 	else if (op == "textureProj")
 		return join("texture", type, "Proj");
+	else if (op == "textureGrad")
+		return join("texture", type, "Grad");
 	else if (op == "textureProjLod")
 	{
 		if (use_explicit_lod)


### PR DESCRIPTION
Nothing super exciting, but I ran into this issue and I figured I would try and upstream my fix. Basically it adds support for emitting the textureXYZGrad() GLSL instruction for legacy GLSL generation.

I'm not sure if this is the proper way to go about creating a pull request, so apologies if I screwed something up.