### PR TITLE
Strip uniform locations for ESSL < 3.00 and GLSL < 4.30

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1166,6 +1166,14 @@ bool CompilerGLSL::can_use_io_location(StorageClass storage)
 			return false;
 	}
 
+	if (storage == StorageClassUniform || storage == StorageClassUniformConstant)
+	{
+		if (options.es && options.version < 310)
+			return false;
+		else if (!options.es && options.version < 430)
+			return false;
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
Fixes #525 

It might be best to utilize `ARB_explicit_uniform_location` for desktop GLSL, but I'm not sure how exactly to go about that (e.g. do we require it, or do we use it only if the user requests the extension?). So here's a simple solution for now.