### PR TITLE
Fix depth-compare sampling in MSL when used as global alias argument.

### DIFF
--- a/reference/opt/shaders-msl/frag/shadow-compare-global-alias.frag
+++ b/reference/opt/shaders-msl/frag/shadow-compare-global-alias.frag
@@ -1,0 +1,27 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_in
+{
+    float3 vUV [[user(locn0)]];
+};
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], depth2d<float> uSampler [[texture(0)]], depth2d<float> uTex [[texture(1)]], sampler uSamplerSmplr [[sampler(0)]], sampler uSamp [[sampler(2)]])
+{
+    main0_out out = {};
+    out.FragColor = uSampler.sample_compare(uSamplerSmplr, in.vUV.xy, in.vUV.z);
+    out.FragColor += uTex.sample_compare(uSamp, in.vUV.xy, in.vUV.z);
+    out.FragColor += uTex.sample_compare(uSamp, in.vUV.xy, in.vUV.z);
+    out.FragColor += uSampler.sample_compare(uSamplerSmplr, in.vUV.xy, in.vUV.z);
+    out.FragColor += uTex.sample_compare(uSamp, in.vUV.xy, in.vUV.z);
+    out.FragColor += uSampler.sample_compare(uSamplerSmplr, in.vUV.xy, in.vUV.z);
+    return out;
+}
+

--- a/reference/shaders-msl/frag/shadow-compare-global-alias.frag
+++ b/reference/shaders-msl/frag/shadow-compare-global-alias.frag
@@ -1,0 +1,53 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_in
+{
+    float3 vUV [[user(locn0)]];
+};
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+float Samp(thread const float3& uv, thread depth2d<float> uTex, thread sampler uSamp)
+{
+    return uTex.sample_compare(uSamp, uv.xy, uv.z);
+}
+
+float Samp2(thread const float3& uv, thread depth2d<float> uSampler, thread const sampler uSamplerSmplr, thread float3& vUV)
+{
+    return uSampler.sample_compare(uSamplerSmplr, vUV.xy, vUV.z);
+}
+
+float Samp3(thread const depth2d<float> uT, thread const sampler uS, thread const float3& uv, thread float3& vUV)
+{
+    return uT.sample_compare(uS, vUV.xy, vUV.z);
+}
+
+float Samp4(thread const depth2d<float> uS, thread const sampler uSSmplr, thread const float3& uv, thread float3& vUV)
+{
+    return uS.sample_compare(uSSmplr, vUV.xy, vUV.z);
+}
+
+fragment main0_out main0(main0_in in [[stage_in]], depth2d<float> uSampler [[texture(0)]], depth2d<float> uTex [[texture(1)]], sampler uSamplerSmplr [[sampler(0)]], sampler uSamp [[sampler(2)]])
+{
+    main0_out out = {};
+    out.FragColor = uSampler.sample_compare(uSamplerSmplr, in.vUV.xy, in.vUV.z);
+    out.FragColor += uTex.sample_compare(uSamp, in.vUV.xy, in.vUV.z);
+    float3 param = in.vUV;
+    out.FragColor += Samp(param, uTex, uSamp);
+    float3 param_1 = in.vUV;
+    out.FragColor += Samp2(param_1, uSampler, uSamplerSmplr, in.vUV);
+    float3 param_2 = in.vUV;
+    out.FragColor += Samp3(uTex, uSamp, param_2, in.vUV);
+    float3 param_3 = in.vUV;
+    out.FragColor += Samp4(uSampler, uSamplerSmplr, param_3, in.vUV);
+    return out;
+}
+

--- a/shaders-msl/frag/shadow-compare-global-alias.frag
+++ b/shaders-msl/frag/shadow-compare-global-alias.frag
@@ -1,0 +1,38 @@
+#version 450
+
+layout(location = 0) out float FragColor;
+layout(binding = 0) uniform sampler2DShadow uSampler;
+layout(location = 0) in vec3 vUV;
+
+layout(binding = 1) uniform texture2D uTex;
+layout(binding = 2) uniform samplerShadow uSamp;
+
+float Samp(vec3 uv)
+{
+	return texture(sampler2DShadow(uTex, uSamp), uv);
+}
+
+float Samp2(vec3 uv)
+{
+	return texture(uSampler, vUV);
+}
+
+float Samp3(texture2D uT, samplerShadow uS, vec3 uv)
+{
+	return texture(sampler2DShadow(uT, uS), vUV);
+}
+
+float Samp4(sampler2DShadow uS, vec3 uv)
+{
+	return texture(uS, vUV);
+}
+
+void main()
+{
+	FragColor = texture(uSampler, vUV);
+	FragColor += texture(sampler2DShadow(uTex, uSamp), vUV);
+	FragColor += Samp(vUV);
+	FragColor += Samp2(vUV);
+	FragColor += Samp3(uTex, uSamp, vUV);
+	FragColor += Samp4(uSampler, vUV);
+}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -3493,6 +3493,14 @@ std::string CompilerMSL::sampler_type(const SPIRType &type)
 // Returns an MSL string describing  the SPIR-V image type
 string CompilerMSL::image_type_glsl(const SPIRType &type, uint32_t id)
 {
+	auto *var = maybe_get<SPIRVariable>(id);
+	if (var && var->basevariable)
+	{
+		// For comparison images, check against the base variable,
+		// and not the fake ID which might have been generated for this variable.
+		id = var->basevariable;
+	}
+
 	if (!type.array.empty())
 	{
 		if (!msl_options.supports_msl_version(2))

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -2860,7 +2860,8 @@ string CompilerMSL::member_attribute_qualifier(const SPIRType &type, uint32_t in
 		}
 		uint32_t locn = get_ordered_member_location(type.self, index);
 		if (locn != k_unknown_location && has_member_decoration(type.self, index, DecorationIndex))
-			return join(" [[color(", locn, "), index(", get_member_decoration(type.self, index, DecorationIndex), ")]]");
+			return join(" [[color(", locn, "), index(", get_member_decoration(type.self, index, DecorationIndex),
+			            ")]]");
 		else if (locn != k_unknown_location)
 			return join(" [[color(", locn, ")]]");
 		else if (has_member_decoration(type.self, index, DecorationIndex))
@@ -3321,11 +3322,7 @@ void CompilerMSL::replace_illegal_names()
 	// FIXME: MSL and GLSL are doing two different things here.
 	// Agree on convention and remove this override.
 	static const unordered_set<string> keywords = {
-		"kernel",
-		"vertex",
-		"fragment",
-		"compute",
-		"bias",
+		"kernel", "vertex", "fragment", "compute", "bias",
 	};
 
 	static const unordered_set<string> illegal_func_names = {


### PR DESCRIPTION
Fix #529.