### PR TITLE
Add version check for explicit uniform locations

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1164,6 +1164,14 @@ bool CompilerGLSL::can_use_io_location(StorageClass storage)
 			return false;
 	}
 
+	if(storage == StorageClassUniformConstant)
+	{
+		if (options.es && options.version < 310)
+			return false;
+		else if (!options.es && options.version < 430)
+			return false;
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
When generating GLSL for versions below 4.30 on OpenGL and below 3.10 on OpenGL ES, explicit uniform locations should not be available, but were being generated.

This change uses the versions present in the GLSL (ES) documents, but does not check for extensions.