### PR TITLE
Strip location qualifier on in/out blocks below GLSL 4.40

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1151,7 +1151,7 @@ bool CompilerGLSL::can_use_io_location(StorageClass storage)
 	if ((get_execution_model() != ExecutionModelVertex && storage == StorageClassInput) ||
 	    (get_execution_model() != ExecutionModelFragment && storage == StorageClassOutput))
 	{
-		if (!options.es && options.version < 410 && !options.separate_shader_objects)
+		if (!options.es && options.version < 440 && !options.separate_shader_objects)
 			return false;
 		else if (options.es && options.version < 310)
 			return false;


### PR DESCRIPTION
It seems location qualifier for in/out blocks became core in GLSL 4.40, or can be used with the extension `GL_ARB_enhanced_layouts`.
I am also unsure if `GL_ARB_separate_shader_objects` is relevant for this check.