### PR TITLE
Deal with fake overloads when using combined image samplers.

### DIFF
--- a/reference/opt/shaders/vulkan/frag/separate-combined-fake-overload.vk.frag
+++ b/reference/opt/shaders/vulkan/frag/separate-combined-fake-overload.vk.frag
@@ -1,0 +1,12 @@
+#version 450
+
+layout(binding = 0) uniform sampler2D uSamp;
+uniform sampler2D SPIRV_Cross_CombineduTuS;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    FragColor = texture(uSamp, vec2(0.5)) + texture(SPIRV_Cross_CombineduTuS, vec2(0.5));
+}
+

--- a/reference/opt/shaders/vulkan/frag/separate-combined-fake-overload.vk.frag.vk
+++ b/reference/opt/shaders/vulkan/frag/separate-combined-fake-overload.vk.frag.vk
@@ -1,0 +1,13 @@
+#version 450
+
+layout(set = 0, binding = 0) uniform sampler2D uSamp;
+layout(set = 0, binding = 1) uniform texture2D uT;
+layout(set = 0, binding = 2) uniform sampler uS;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    FragColor = texture(uSamp, vec2(0.5)) + texture(sampler2D(uT, uS), vec2(0.5));
+}
+

--- a/reference/shaders/vulkan/frag/separate-combined-fake-overload.vk.frag
+++ b/reference/shaders/vulkan/frag/separate-combined-fake-overload.vk.frag
@@ -1,0 +1,22 @@
+#version 450
+
+layout(binding = 0) uniform sampler2D uSamp;
+uniform sampler2D SPIRV_Cross_CombineduTuS;
+
+layout(location = 0) out vec4 FragColor;
+
+vec4 samp(sampler2D uSamp_1)
+{
+    return texture(uSamp_1, vec2(0.5));
+}
+
+vec4 samp_1(sampler2D SPIRV_Cross_CombinedTS)
+{
+    return texture(SPIRV_Cross_CombinedTS, vec2(0.5));
+}
+
+void main()
+{
+    FragColor = samp(uSamp) + samp_1(SPIRV_Cross_CombineduTuS);
+}
+

--- a/reference/shaders/vulkan/frag/separate-combined-fake-overload.vk.frag.vk
+++ b/reference/shaders/vulkan/frag/separate-combined-fake-overload.vk.frag.vk
@@ -1,0 +1,23 @@
+#version 450
+
+layout(set = 0, binding = 0) uniform sampler2D uSamp;
+layout(set = 0, binding = 1) uniform texture2D uT;
+layout(set = 0, binding = 2) uniform sampler uS;
+
+layout(location = 0) out vec4 FragColor;
+
+vec4 samp(sampler2D uSamp_1)
+{
+    return texture(uSamp_1, vec2(0.5));
+}
+
+vec4 samp(texture2D T, sampler S)
+{
+    return texture(sampler2D(T, S), vec2(0.5));
+}
+
+void main()
+{
+    FragColor = samp(uSamp) + samp(uT, uS);
+}
+

--- a/shaders/vulkan/frag/separate-combined-fake-overload.vk.frag
+++ b/shaders/vulkan/frag/separate-combined-fake-overload.vk.frag
@@ -1,0 +1,21 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+layout(binding = 0) uniform sampler2D uSamp;
+layout(binding = 1) uniform texture2D uT;
+layout(binding = 2) uniform sampler uS;
+
+vec4 samp(sampler2D uSamp)
+{
+	return texture(uSamp, vec2(0.5));
+}
+
+vec4 samp(texture2D T, sampler S)
+{
+	return texture(sampler2D(T, S), vec2(0.5));
+}
+
+void main()
+{
+	FragColor = samp(uSamp) + samp(uT, uS);
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -8616,6 +8616,21 @@ void CompilerGLSL::add_function_overload(const SPIRFunction &func)
 			type_id = type->parent_type;
 			type = &get<SPIRType>(type_id);
 		}
+
+		if (!combined_image_samplers.empty())
+		{
+			// If we have combined image samplers, we cannot really trust the image and sampler arguments
+			// we pass down to callees, because they may be shuffled around.
+			// Ignore these arguments, to make sure that functions need to differ in some other way
+			// to be considered different overloads.
+			if (type->basetype == SPIRType::SampledImage ||
+			    (type->basetype == SPIRType::Image && type->image.sampled == 1) ||
+			    type->basetype == SPIRType::Sampler)
+			{
+				continue;
+			}
+		}
+
 		hasher.u32(type_id);
 	}
 	uint64_t types_hash = hasher.get();


### PR DESCRIPTION
Fix #557.