### PR TITLE
Add support for inheriting bindings for combined image samplers.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -483,6 +483,7 @@ struct CLIArguments
 	bool flatten_multidimensional_arrays = false;
 	bool use_420pack_extension = true;
 	bool remove_unused = false;
+	bool combined_samplers_inherit_bindings = false;
 };
 
 static void print_help()
@@ -522,6 +523,7 @@ static void print_help()
 	                "\t[--rename-interface-variable <in|out> <location> <new_variable_name>]\n"
 	                "\t[--set-hlsl-vertex-input-semantic <location> <semantic>]\n"
 	                "\t[--rename-entry-point <old> <new> <stage>]\n"
+	                "\t[--combined-samplers-inherit-bindings]"
 	                "\n");
 }
 
@@ -727,6 +729,7 @@ static int main_inner(int argc, char *argv[])
 	});
 
 	cbs.add("--remove-unused-variables", [&args](CLIParser &) { args.remove_unused = true; });
+	cbs.add("--combined-samplers-inherit-bindings", [&args](CLIParser &) { args.combined_samplers_inherit_bindings = true; });
 
 	cbs.default_handler = [&args](const char *value) { args.input = value; };
 	cbs.error_handler = [] { print_help(); };
@@ -985,6 +988,9 @@ static int main_inner(int argc, char *argv[])
 	if (combined_image_samplers)
 	{
 		compiler->build_combined_image_samplers();
+		if (args.combined_samplers_inherit_bindings)
+			spirv_cross_util::inherit_combined_sampler_bindings(*compiler);
+
 		// Give the remapped combined samplers new names.
 		for (auto &remap : compiler->get_combined_image_samplers())
 		{

--- a/spirv_cross_util.cpp
+++ b/spirv_cross_util.cpp
@@ -48,4 +48,23 @@ void rename_interface_variable(spirv_cross::Compiler &compiler, const std::vecto
 		compiler.set_name(v.id, name);
 	}
 }
+
+void inherit_combined_sampler_bindings(spirv_cross::Compiler &compiler)
+{
+	auto &samplers = compiler.get_combined_image_samplers();
+	for (auto &s : samplers)
+	{
+		if (compiler.has_decoration(s.image_id, spv::DecorationDescriptorSet))
+		{
+			uint32_t set = compiler.get_decoration(s.image_id, spv::DecorationDescriptorSet);
+			compiler.set_decoration(s.combined_id, spv::DecorationDescriptorSet, set);
+		}
+
+		if (compiler.has_decoration(s.image_id, spv::DecorationBinding))
+		{
+			uint32_t binding = compiler.get_decoration(s.image_id, spv::DecorationBinding);
+			compiler.set_decoration(s.combined_id, spv::DecorationBinding, binding);
+		}
+	}
+}
 } // namespace spirv_cross_util

--- a/spirv_cross_util.hpp
+++ b/spirv_cross_util.hpp
@@ -23,6 +23,7 @@ namespace spirv_cross_util
 {
 void rename_interface_variable(spirv_cross::Compiler &compiler, const std::vector<spirv_cross::Resource> &resources,
                                uint32_t location, const std::string &name);
+void inherit_combined_sampler_bindings(spirv_cross::Compiler &compiler);
 }
 
 #endif


### PR DESCRIPTION
Fix #584.