### PR TITLE
Fix textureGrad compilation for legacy targets

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -3452,7 +3452,7 @@ string CompilerGLSL::legacy_tex_op(const std::string &op, const SPIRType &imgtyp
 
 	bool use_explicit_lod = check_explicit_lod_allowed(lod);
 
-	if (op == "textureLod" || op == "textureProjLod")
+	if (op == "textureLod" || op == "textureProjLod" || op == "textureGrad")
 	{
 		if (is_legacy_es())
 		{
@@ -3475,7 +3475,7 @@ string CompilerGLSL::legacy_tex_op(const std::string &op, const SPIRType &imgtyp
 	else if (op == "textureProj")
 		return join("texture", type, "Proj");
 	else if (op == "textureGrad")
-		return join("texture", type, "Grad");
+		return join("texture", type, is_legacy_es() ? "GradEXT" : is_legacy_desktop() ? "GradARB" : "Grad");
 	else if (op == "textureProjLod")
 	{
 		if (use_explicit_lod)


### PR DESCRIPTION
textureGrad isn't part of core GL2 or GLES2. In desktop GL, it's
provided by GL_ARB_shader_texture_lod and is called texture2DGradARB; in
ES, it's provided by GL_EXT_shader_texture_lod and is called
texture2DGradEXT.

This change rewrites textureGrad similarly to textureProj as per above.