### PR TITLE
Various maintenance fixes.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -122,7 +122,7 @@ struct CLIParser
 			THROW("Tried to parse uint, but nothing left in arguments");
 		}
 
-		uint32_t val = stoul(*argv);
+		uint64_t val = stoul(*argv);
 		if (val > numeric_limits<uint32_t>::max())
 		{
 			THROW("next_uint() out of range");
@@ -131,7 +131,7 @@ struct CLIParser
 		argc--;
 		argv++;
 
-		return val;
+		return uint32_t(val);
 	}
 
 	double next_double()
@@ -212,7 +212,6 @@ static void print_resources(const Compiler &compiler, const char *tag, const vec
 	for (auto &res : resources)
 	{
 		auto &type = compiler.get_type(res.type_id);
-		auto &mask = compiler.get_decoration_bitset(res.id);
 
 		if (print_ssbo && compiler.buffer_is_hlsl_counter_buffer(res.id))
 			continue;
@@ -230,6 +229,12 @@ static void print_resources(const Compiler &compiler, const char *tag, const vec
 		uint32_t block_size = 0;
 		if (is_sized_block)
 			block_size = uint32_t(compiler.get_declared_struct_size(compiler.get_type(res.base_type_id)));
+
+		Bitset mask;
+		if (print_ssbo)
+			mask = compiler.get_buffer_block_flags(res.id);
+		else
+			mask = compiler.get_decoration_bitset(res.id);
 
 		string array;
 		for (auto arr : type.array)

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -4078,7 +4078,12 @@ void Compiler::analyze_variable_scope(SPIRFunction &entry)
 	}
 }
 
-Bitset Compiler::get_buffer_block_flags(const SPIRVariable &var)
+Bitset Compiler::get_buffer_block_flags(uint32_t id) const
+{
+	return get_buffer_block_flags(get<SPIRVariable>(id));
+}
+
+Bitset Compiler::get_buffer_block_flags(const SPIRVariable &var) const
 {
 	auto &type = get<SPIRType>(var.basetype);
 	assert(type.basetype == SPIRType::Struct);

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -483,6 +483,12 @@ public:
 	// ID is the name of a variable as returned by Resource::id, and must be a variable with a Block-like type.
 	std::string get_remapped_declared_block_name(uint32_t id) const;
 
+	// For buffer block variables, get the decorations for that variable.
+	// Sometimes, decorations for buffer blocks are found in member decorations instead
+	// of direct decorations on the variable itself.
+	// The most common use here is to check if a buffer is readonly or writeonly.
+	Bitset get_buffer_block_flags(uint32_t id) const;
+
 protected:
 	const uint32_t *stream(const Instruction &instr) const
 	{
@@ -784,7 +790,7 @@ protected:
 
 	VariableTypeRemapCallback variable_remap_callback;
 
-	Bitset get_buffer_block_flags(const SPIRVariable &var);
+	Bitset get_buffer_block_flags(const SPIRVariable &var) const;
 	bool get_common_basic_type(const SPIRType &type, SPIRType::BaseType &base_type);
 
 	std::unordered_set<uint32_t> forced_temporaries;

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1265,11 +1265,11 @@ string CompilerGLSL::layout_for_variable(const SPIRVariable &var)
 	if (flags.get(DecorationIndex))
 		attr.push_back(join("index = ", dec.index));
 
-	// set = 0 is the default. Do not emit set = decoration in regular GLSL output, but
-	// we should preserve it in Vulkan GLSL mode.
+	// Do not emit set = decoration in regular GLSL output, but
+	// we need to preserve it in Vulkan GLSL mode.
 	if (var.storage != StorageClassPushConstant)
 	{
-		if (flags.get(DecorationDescriptorSet) && (dec.set != 0 || options.vulkan_semantics))
+		if (flags.get(DecorationDescriptorSet) && options.vulkan_semantics)
 			attr.push_back(join("set = ", dec.set));
 	}
 


### PR DESCRIPTION
- Do not emit set = in GLSL, even when non-zero.
- Fix warning on tautological comparison.
- Expose get_buffer_block_flags as mentioned in reflection guide.

Fix #595 
Fix #596 
Fix #592