### PR TITLE
Unpack expressions when used in functions on MSL.

### DIFF
--- a/reference/opt/shaders-msl/frag/binary-func-unpack-pack-arguments.frag
+++ b/reference/opt/shaders-msl/frag/binary-func-unpack-pack-arguments.frag
@@ -1,0 +1,28 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBO
+{
+    packed_float3 color;
+    float v;
+};
+
+struct main0_in
+{
+    float3 vIn [[user(locn0)]];
+};
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant UBO& _15 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.FragColor = dot(in.vIn, float3(_15.color));
+    return out;
+}
+

--- a/reference/shaders-msl/frag/binary-func-unpack-pack-arguments.frag
+++ b/reference/shaders-msl/frag/binary-func-unpack-pack-arguments.frag
@@ -1,0 +1,28 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBO
+{
+    packed_float3 color;
+    float v;
+};
+
+struct main0_in
+{
+    float3 vIn [[user(locn0)]];
+};
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant UBO& _15 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.FragColor = dot(in.vIn, float3(_15.color));
+    return out;
+}
+

--- a/shaders-msl/frag/binary-func-unpack-pack-arguments.frag
+++ b/shaders-msl/frag/binary-func-unpack-pack-arguments.frag
@@ -1,0 +1,15 @@
+#version 450
+layout(location = 0) out float FragColor;
+
+layout(binding = 0, std140) uniform UBO
+{
+	vec3 color;
+	float v;
+};
+
+layout(location = 0) in vec3 vIn;
+
+void main()
+{
+	FragColor = dot(vIn, color);
+}

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -436,6 +436,8 @@ protected:
 	void append_global_func_args(const SPIRFunction &func, uint32_t index, std::vector<std::string> &arglist);
 	std::string to_expression(uint32_t id);
 	std::string to_enclosed_expression(uint32_t id);
+	std::string to_unpacked_expression(uint32_t id);
+	std::string to_enclosed_unpacked_expression(uint32_t id);
 	std::string to_extract_component_expression(uint32_t id, uint32_t index);
 	std::string enclose_expression(const std::string &expr);
 	void strip_enclosed_expression(std::string &expr);


### PR DESCRIPTION
OSX 10.14 broke (?) how overload resolution works,
so overloading e.g. dot(float3, packed_float3) no longer works.

Fix this by unpacking expressions before various func ops.
This fix might need to be applied elsewhere, but do so later if needed.

Fix #603.