### PR TITLE
 CompilerMSL support matrices & arrays in stage-in & stage-out.

### DIFF
--- a/reference/opt/shaders-msl/asm/frag/combined-sampler-reuse.asm.frag
+++ b/reference/opt/shaders-msl/asm/frag/combined-sampler-reuse.asm.frag
@@ -3,14 +3,14 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float2 vUV [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float2 vUV [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> uTex [[texture(1)]], sampler uSampler [[sampler(0)]])

--- a/reference/opt/shaders-msl/asm/frag/frem.asm.frag
+++ b/reference/opt/shaders-msl/asm/frag/frem.asm.frag
@@ -3,15 +3,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 vB [[user(locn1)]];
-    float4 vA [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vA [[user(locn0)]];
+    float4 vB [[user(locn1)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/reference/opt/shaders-msl/asm/frag/implicit-read-dep-phi.asm.frag
+++ b/reference/opt/shaders-msl/asm/frag/implicit-read-dep-phi.asm.frag
@@ -3,14 +3,14 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 v0 [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 v0 [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> uImage [[texture(0)]], sampler uImageSmplr [[sampler(0)]])

--- a/reference/opt/shaders-msl/asm/frag/srem.asm.frag
+++ b/reference/opt/shaders-msl/asm/frag/srem.asm.frag
@@ -3,15 +3,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    int4 vB [[user(locn1)]];
-    int4 vA [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    int4 vA [[user(locn0)]];
+    int4 vB [[user(locn1)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/reference/opt/shaders-msl/asm/frag/unreachable.asm.frag
+++ b/reference/opt/shaders-msl/asm/frag/unreachable.asm.frag
@@ -3,14 +3,14 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    int counter [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    int counter [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/reference/opt/shaders-msl/desktop-only/vert/basic.desktop.sso.vert
+++ b/reference/opt/shaders-msl/desktop-only/vert/basic.desktop.sso.vert
@@ -8,16 +8,16 @@ struct UBO
     float4x4 uMVP;
 };
 
-struct main0_in
-{
-    float3 aNormal [[attribute(1)]];
-    float4 aVertex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float3 vNormal [[user(locn0)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _16 [[buffer(0)]])

--- a/reference/opt/shaders-msl/flatten/basic.flatten.vert
+++ b/reference/opt/shaders-msl/flatten/basic.flatten.vert
@@ -8,16 +8,16 @@ struct UBO
     float4x4 uMVP;
 };
 
-struct main0_in
-{
-    float3 aNormal [[attribute(1)]];
-    float4 aVertex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float3 vNormal [[user(locn0)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _16 [[buffer(0)]])

--- a/reference/opt/shaders-msl/flatten/multiindex.flatten.vert
+++ b/reference/opt/shaders-msl/flatten/multiindex.flatten.vert
@@ -8,14 +8,14 @@ struct UBO
     float4 Data[3][5];
 };
 
-struct main0_in
-{
-    int2 aIndex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    int2 aIndex [[attribute(0)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _20 [[buffer(0)]])

--- a/reference/opt/shaders-msl/flatten/push-constant.flatten.vert
+++ b/reference/opt/shaders-msl/flatten/push-constant.flatten.vert
@@ -10,16 +10,16 @@ struct PushMe
     float Arr[4];
 };
 
-struct main0_in
-{
-    float4 Pos [[attribute(1)]];
-    float2 Rot [[attribute(0)]];
-};
-
 struct main0_out
 {
     float2 vRot [[user(locn0)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float2 Rot [[attribute(0)]];
+    float4 Pos [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant PushMe& registers [[buffer(0)]])

--- a/reference/opt/shaders-msl/flatten/rowmajor.flatten.vert
+++ b/reference/opt/shaders-msl/flatten/rowmajor.flatten.vert
@@ -10,14 +10,14 @@ struct UBO
     float2x4 uMVP;
 };
 
-struct main0_in
-{
-    float4 aVertex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _18 [[buffer(0)]])

--- a/reference/opt/shaders-msl/flatten/struct.flatten.vert
+++ b/reference/opt/shaders-msl/flatten/struct.flatten.vert
@@ -16,16 +16,16 @@ struct UBO
     Light light;
 };
 
-struct main0_in
-{
-    float3 aNormal [[attribute(1)]];
-    float4 aVertex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float4 vColor [[user(locn0)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _18 [[buffer(0)]])

--- a/reference/opt/shaders-msl/frag/basic.frag
+++ b/reference/opt/shaders-msl/frag/basic.frag
@@ -3,15 +3,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float2 vTex [[user(locn1)]];
-    float4 vColor [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vColor [[user(locn0)]];
+    float2 vTex [[user(locn1)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> uTex [[texture(0)]], sampler uTexSmplr [[sampler(0)]])

--- a/reference/opt/shaders-msl/frag/binary-func-unpack-pack-arguments.frag
+++ b/reference/opt/shaders-msl/frag/binary-func-unpack-pack-arguments.frag
@@ -9,14 +9,14 @@ struct UBO
     float v;
 };
 
-struct main0_in
-{
-    float3 vIn [[user(locn0)]];
-};
-
 struct main0_out
 {
     float FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 vIn [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], constant UBO& _15 [[buffer(0)]])

--- a/reference/opt/shaders-msl/frag/binary-unpack-pack-arguments.frag
+++ b/reference/opt/shaders-msl/frag/binary-unpack-pack-arguments.frag
@@ -9,14 +9,14 @@ struct UBO
     float v;
 };
 
-struct main0_in
-{
-    float3 vIn [[user(locn0)]];
-};
-
 struct main0_out
 {
     float3 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 vIn [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], constant UBO& _15 [[buffer(0)]])

--- a/reference/opt/shaders-msl/frag/bitcasting.frag
+++ b/reference/opt/shaders-msl/frag/bitcasting.frag
@@ -3,15 +3,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 VertGeom [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor0 [[color(0)]];
     float4 FragColor1 [[color(1)]];
+};
+
+struct main0_in
+{
+    float4 VertGeom [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> TextureBase [[texture(0)]], texture2d<float> TextureDetail [[texture(1)]], sampler TextureBaseSmplr [[sampler(0)]], sampler TextureDetailSmplr [[sampler(1)]])

--- a/reference/opt/shaders-msl/frag/builtins.frag
+++ b/reference/opt/shaders-msl/frag/builtins.frag
@@ -3,15 +3,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 vColor [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
     float gl_FragDepth [[depth(any)]];
+};
+
+struct main0_in
+{
+    float4 vColor [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], float4 gl_FragCoord [[position]])

--- a/reference/opt/shaders-msl/frag/composite-extract-forced-temporary.frag
+++ b/reference/opt/shaders-msl/frag/composite-extract-forced-temporary.frag
@@ -3,14 +3,14 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float2 vTexCoord [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float2 vTexCoord [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> Texture [[texture(0)]], sampler TextureSmplr [[sampler(0)]])

--- a/reference/opt/shaders-msl/frag/constant-array.frag
+++ b/reference/opt/shaders-msl/frag/constant-array.frag
@@ -17,14 +17,14 @@ constant float4 _54[2] = {float4(8.0), float4(10.0)};
 constant float4 _55[2][2] = {{float4(1.0), float4(2.0)}, {float4(8.0), float4(10.0)}};
 constant Foobar _75[2] = {{10.0, 40.0}, {90.0, 70.0}};
 
-struct main0_in
-{
-    int index [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    int index [[user(locn0)]];
 };
 
 // Implementation of an array copy function to cover GLSL's ability to copy an array via assignment.

--- a/reference/opt/shaders-msl/frag/constant-composites.frag
+++ b/reference/opt/shaders-msl/frag/constant-composites.frag
@@ -14,14 +14,14 @@ struct Foo
 constant float _16[4] = {1.0, 4.0, 3.0, 2.0};
 constant Foo _28[2] = {{10.0, 20.0}, {30.0, 40.0}};
 
-struct main0_in
-{
-    int line [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    int line [[user(locn0)]];
 };
 
 // Implementation of an array copy function to cover GLSL's ability to copy an array via assignment.

--- a/reference/opt/shaders-msl/frag/control-dependent-in-branch.desktop.frag
+++ b/reference/opt/shaders-msl/frag/control-dependent-in-branch.desktop.frag
@@ -3,14 +3,14 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 vInput [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vInput [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> uSampler [[texture(0)]], sampler uSamplerSmplr [[sampler(0)]])

--- a/reference/opt/shaders-msl/frag/false-loop-init.frag
+++ b/reference/opt/shaders-msl/frag/false-loop-init.frag
@@ -3,14 +3,14 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 accum [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 result [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 accum [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/reference/opt/shaders-msl/frag/fp16-packing.frag
+++ b/reference/opt/shaders-msl/frag/fp16-packing.frag
@@ -3,16 +3,16 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float2 FP32 [[user(locn1)]];
-    uint FP16 [[user(locn0)]];
-};
-
 struct main0_out
 {
     float2 FP32Out [[color(0)]];
     uint FP16Out [[color(1)]];
+};
+
+struct main0_in
+{
+    uint FP16 [[user(locn0)]];
+    float2 FP32 [[user(locn1)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/reference/opt/shaders-msl/frag/front-facing.frag
+++ b/reference/opt/shaders-msl/frag/front-facing.frag
@@ -3,15 +3,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 vB [[user(locn1)]];
-    float4 vA [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vA [[user(locn0)]];
+    float4 vB [[user(locn1)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], bool gl_FrontFacing [[front_facing]])

--- a/reference/opt/shaders-msl/frag/gather-dref.frag
+++ b/reference/opt/shaders-msl/frag/gather-dref.frag
@@ -3,14 +3,14 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float3 vUV [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 vUV [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], depth2d<float> uT [[texture(0)]], sampler uTSmplr [[sampler(0)]])

--- a/reference/opt/shaders-msl/frag/in_block.frag
+++ b/reference/opt/shaders-msl/frag/in_block.frag
@@ -3,15 +3,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 VertexOut_color2 [[user(locn3)]];
-    float4 VertexOut_color [[user(locn2)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 VertexOut_color [[user(locn2)]];
+    float4 VertexOut_color2 [[user(locn3)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/reference/opt/shaders-msl/frag/in_mat.frag
+++ b/reference/opt/shaders-msl/frag/in_mat.frag
@@ -1,0 +1,37 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 outFragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 inPos [[user(locn0)]];
+    float3 inNormal [[user(locn1)]];
+    float4 inInvModelView_0 [[user(locn2)]];
+    float4 inInvModelView_1 [[user(locn3)]];
+    float4 inInvModelView_2 [[user(locn4)]];
+    float4 inInvModelView_3 [[user(locn5)]];
+    float inLodBias [[user(locn6)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], texturecube<float> samplerColor [[texture(1)]], sampler samplerColorSmplr [[sampler(1)]])
+{
+    main0_out out = {};
+    float4x4 inInvModelView = {};
+    inInvModelView[0] = in.inInvModelView_0;
+    inInvModelView[1] = in.inInvModelView_1;
+    inInvModelView[2] = in.inInvModelView_2;
+    inInvModelView[3] = in.inInvModelView_3;
+    float4 _31 = inInvModelView * float4(reflect(normalize(in.inPos), normalize(in.inNormal)), 0.0);
+    float _33 = _31.x;
+    float3 _60 = float3(_33, _31.yz);
+    _60.x = _33 * (-1.0);
+    out.outFragColor = samplerColor.sample(samplerColorSmplr, _60, bias(in.inLodBias));
+    return out;
+}
+

--- a/reference/opt/shaders-msl/frag/mix.frag
+++ b/reference/opt/shaders-msl/frag/mix.frag
@@ -3,17 +3,17 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float vIn3 [[user(locn3)]];
-    float vIn2 [[user(locn2)]];
-    float4 vIn1 [[user(locn1)]];
-    float4 vIn0 [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vIn0 [[user(locn0)]];
+    float4 vIn1 [[user(locn1)]];
+    float vIn2 [[user(locn2)]];
+    float vIn3 [[user(locn3)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/reference/opt/shaders-msl/frag/mrt-array.frag
+++ b/reference/opt/shaders-msl/frag/mrt-array.frag
@@ -5,18 +5,18 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 vB [[user(locn1)]];
-    float4 vA [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor_0 [[color(0)]];
     float4 FragColor_1 [[color(1)]];
     float4 FragColor_2 [[color(2)]];
     float4 FragColor_3 [[color(3)]];
+};
+
+struct main0_in
+{
+    float4 vA [[user(locn0)]];
+    float4 vB [[user(locn1)]];
 };
 
 // Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
@@ -29,7 +29,7 @@ Tx mod(Tx x, Ty y)
 fragment main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
-    float4 FragColor[4];
+    float4 FragColor[4] = {};
     FragColor[0] = mod(in.vA, in.vB);
     FragColor[1] = in.vA + in.vB;
     FragColor[2] = in.vA - in.vB;

--- a/reference/opt/shaders-msl/frag/pls.frag
+++ b/reference/opt/shaders-msl/frag/pls.frag
@@ -3,20 +3,20 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 PLSIn3 [[user(locn3)]];
-    float4 PLSIn2 [[user(locn2)]];
-    float4 PLSIn1 [[user(locn1)]];
-    float4 PLSIn0 [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 PLSOut0 [[color(0)]];
     float4 PLSOut1 [[color(1)]];
     float4 PLSOut2 [[color(2)]];
     float4 PLSOut3 [[color(3)]];
+};
+
+struct main0_in
+{
+    float4 PLSIn0 [[user(locn0)]];
+    float4 PLSIn1 [[user(locn1)]];
+    float4 PLSIn2 [[user(locn2)]];
+    float4 PLSIn3 [[user(locn3)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/reference/opt/shaders-msl/frag/sampler-1d-lod.frag
+++ b/reference/opt/shaders-msl/frag/sampler-1d-lod.frag
@@ -3,14 +3,14 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float vTex [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float vTex [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], texture1d<float> uSampler [[texture(0)]], sampler uSamplerSmplr [[sampler(0)]])

--- a/reference/opt/shaders-msl/frag/sampler-image-arrays.msl2.frag
+++ b/reference/opt/shaders-msl/frag/sampler-image-arrays.msl2.frag
@@ -3,15 +3,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    int vIndex [[user(locn1)]];
-    float2 vTex [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float2 vTex [[user(locn0)]];
+    int vIndex [[user(locn1)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], array<texture2d<float>, 4> uSampler [[texture(0)]], array<texture2d<float>, 4> uTextures [[texture(8)]], array<sampler, 4> uSamplerSmplr [[sampler(0)]], array<sampler, 4> uSamplers [[sampler(4)]])

--- a/reference/opt/shaders-msl/frag/sampler.frag
+++ b/reference/opt/shaders-msl/frag/sampler.frag
@@ -3,15 +3,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float2 vTex [[user(locn1)]];
-    float4 vColor [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vColor [[user(locn0)]];
+    float2 vTex [[user(locn1)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> uTex [[texture(0)]], sampler uTexSmplr [[sampler(0)]])

--- a/reference/opt/shaders-msl/frag/shadow-compare-global-alias.frag
+++ b/reference/opt/shaders-msl/frag/shadow-compare-global-alias.frag
@@ -3,14 +3,14 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float3 vUV [[user(locn0)]];
-};
-
 struct main0_out
 {
     float FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 vUV [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], depth2d<float> uSampler [[texture(0)]], depth2d<float> uTex [[texture(1)]], sampler uSamplerSmplr [[sampler(0)]], sampler uSamp [[sampler(2)]])

--- a/reference/opt/shaders-msl/frag/spec-constant-block-size.frag
+++ b/reference/opt/shaders-msl/frag/spec-constant-block-size.frag
@@ -8,14 +8,14 @@ struct SpecConstArray
     float4 samples[2];
 };
 
-struct main0_in
-{
-    int Index [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    int Index [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], constant SpecConstArray& _15 [[buffer(0)]])

--- a/reference/opt/shaders-msl/frag/swizzle.frag
+++ b/reference/opt/shaders-msl/frag/swizzle.frag
@@ -3,15 +3,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float2 vUV [[user(locn2)]];
-    float3 vNormal [[user(locn1)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 vNormal [[user(locn1)]];
+    float2 vUV [[user(locn2)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> samp [[texture(0)]], sampler sampSmplr [[sampler(0)]])

--- a/reference/opt/shaders-msl/frag/texture-proj-shadow.frag
+++ b/reference/opt/shaders-msl/frag/texture-proj-shadow.frag
@@ -3,16 +3,16 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float2 vClip2 [[user(locn2)]];
-    float4 vClip4 [[user(locn1)]];
-    float3 vClip3 [[user(locn0)]];
-};
-
 struct main0_out
 {
     float FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 vClip3 [[user(locn0)]];
+    float4 vClip4 [[user(locn1)]];
+    float2 vClip2 [[user(locn2)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], depth2d<float> uShadow2D [[texture(1)]], texture1d<float> uSampler1D [[texture(2)]], texture2d<float> uSampler2D [[texture(3)]], texture3d<float> uSampler3D [[texture(4)]], sampler uShadow2DSmplr [[sampler(1)]], sampler uSampler1DSmplr [[sampler(2)]], sampler uSampler2DSmplr [[sampler(3)]], sampler uSampler3DSmplr [[sampler(4)]])

--- a/reference/opt/shaders-msl/frag/unary-enclose.frag
+++ b/reference/opt/shaders-msl/frag/unary-enclose.frag
@@ -3,14 +3,14 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 vIn [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vIn [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/reference/opt/shaders-msl/legacy/vert/transpose.legacy.vert
+++ b/reference/opt/shaders-msl/legacy/vert/transpose.legacy.vert
@@ -10,14 +10,14 @@ struct Buffer
     float4x4 M;
 };
 
-struct main0_in
-{
-    float4 Position [[attribute(0)]];
-};
-
 struct main0_out
 {
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 Position [[attribute(0)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant Buffer& _13 [[buffer(0)]])

--- a/reference/opt/shaders-msl/vert/basic.vert
+++ b/reference/opt/shaders-msl/vert/basic.vert
@@ -8,16 +8,16 @@ struct UBO
     float4x4 uMVP;
 };
 
-struct main0_in
-{
-    float3 aNormal [[attribute(1)]];
-    float4 aVertex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float3 vNormal [[user(locn0)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _16 [[buffer(0)]])

--- a/reference/opt/shaders-msl/vert/copy.flatten.vert
+++ b/reference/opt/shaders-msl/vert/copy.flatten.vert
@@ -16,16 +16,16 @@ struct UBO
     Light lights[4];
 };
 
-struct main0_in
-{
-    float3 aNormal [[attribute(1)]];
-    float4 aVertex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float4 vColor [[user(locn0)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _21 [[buffer(0)]])

--- a/reference/opt/shaders-msl/vert/dynamic.flatten.vert
+++ b/reference/opt/shaders-msl/vert/dynamic.flatten.vert
@@ -16,16 +16,16 @@ struct UBO
     Light lights[4];
 };
 
-struct main0_in
-{
-    float3 aNormal [[attribute(1)]];
-    float4 aVertex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float4 vColor [[user(locn0)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _21 [[buffer(0)]])

--- a/reference/opt/shaders-msl/vert/functions.vert
+++ b/reference/opt/shaders-msl/vert/functions.vert
@@ -13,12 +13,6 @@ struct UBO
     int2 bits;
 };
 
-struct main0_in
-{
-    float3 aNormal [[attribute(1)]];
-    float4 aVertex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float3 vNormal [[user(locn0)]];
@@ -27,6 +21,12 @@ struct main0_out
     int2 vLSB [[user(locn3)]];
     int2 vMSB [[user(locn4)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
 };
 
 // Implementation of the GLSL radians() function

--- a/reference/opt/shaders-msl/vert/in_out_array_mat.vert
+++ b/reference/opt/shaders-msl/vert/in_out_array_mat.vert
@@ -1,0 +1,67 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBO
+{
+    float4x4 projection;
+    float4x4 model;
+    float lodBias;
+};
+
+struct main0_out
+{
+    float3 outPos [[user(locn0)]];
+    float3 outNormal [[user(locn1)]];
+    float4 outTransModel_0 [[user(locn2)]];
+    float4 outTransModel_1 [[user(locn3)]];
+    float4 outTransModel_2 [[user(locn4)]];
+    float4 outTransModel_3 [[user(locn5)]];
+    float outLodBias [[user(locn6)]];
+    float4 color [[user(locn7)]];
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float3 inPos [[attribute(0)]];
+    float4 colors_0 [[attribute(1)]];
+    float4 colors_1 [[attribute(2)]];
+    float4 colors_2 [[attribute(3)]];
+    float3 inNormal [[attribute(4)]];
+    float4 inViewMat_0 [[attribute(5)]];
+    float4 inViewMat_1 [[attribute(6)]];
+    float4 inViewMat_2 [[attribute(7)]];
+    float4 inViewMat_3 [[attribute(8)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant UBO& ubo [[buffer(0)]])
+{
+    main0_out out = {};
+    float4x4 outTransModel = {};
+    float4 colors[3] = {};
+    float4x4 inViewMat = {};
+    colors[0] = in.colors_0;
+    colors[1] = in.colors_1;
+    colors[2] = in.colors_2;
+    inViewMat[0] = in.inViewMat_0;
+    inViewMat[1] = in.inViewMat_1;
+    inViewMat[2] = in.inViewMat_2;
+    inViewMat[3] = in.inViewMat_3;
+    float4 _64 = float4(in.inPos, 1.0);
+    out.gl_Position = (ubo.projection * ubo.model) * _64;
+    out.outPos = float3((ubo.model * _64).xyz);
+    out.outNormal = float3x3(float3(ubo.model[0].x, ubo.model[0].y, ubo.model[0].z), float3(ubo.model[1].x, ubo.model[1].y, ubo.model[1].z), float3(ubo.model[2].x, ubo.model[2].y, ubo.model[2].z)) * in.inNormal;
+    out.outLodBias = ubo.lodBias;
+    outTransModel = transpose(ubo.model) * inViewMat;
+    outTransModel[2] = float4(in.inNormal, 1.0);
+    outTransModel[1].y = ubo.lodBias;
+    out.color = colors[2];
+    out.outTransModel_0 = outTransModel[0];
+    out.outTransModel_1 = outTransModel[1];
+    out.outTransModel_2 = outTransModel[2];
+    out.outTransModel_3 = outTransModel[3];
+    return out;
+}
+

--- a/reference/opt/shaders-msl/vert/out_block.vert
+++ b/reference/opt/shaders-msl/vert/out_block.vert
@@ -8,17 +8,17 @@ struct Transform
     float4x4 transform;
 };
 
-struct main0_in
-{
-    float4 color [[attribute(1)]];
-    float3 position [[attribute(0)]];
-};
-
 struct main0_out
 {
     float4 VertexOut_color [[user(locn2)]];
     float4 VertexOut_color2 [[user(locn3)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float3 position [[attribute(0)]];
+    float4 color [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant Transform& block [[buffer(0)]])

--- a/reference/opt/shaders-msl/vert/packed_matrix.vert
+++ b/reference/opt/shaders-msl/vert/packed_matrix.vert
@@ -26,15 +26,15 @@ struct _42
     float2 _m9;
 };
 
-struct main0_in
-{
-    float4 m_25 [[attribute(0)]];
-};
-
 struct main0_out
 {
     float3 m_72 [[user(locn0)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 m_25 [[attribute(0)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant _42& _44 [[buffer(12)]], constant _15& _17 [[buffer(13)]])

--- a/reference/opt/shaders-msl/vert/pointsize.vert
+++ b/reference/opt/shaders-msl/vert/pointsize.vert
@@ -9,17 +9,17 @@ struct params
     float psize;
 };
 
-struct main0_in
-{
-    float4 color0 [[attribute(1)]];
-    float4 position [[attribute(0)]];
-};
-
 struct main0_out
 {
     float4 color [[user(locn0)]];
     float4 gl_Position [[position]];
     float gl_PointSize [[point_size]];
+};
+
+struct main0_in
+{
+    float4 position [[attribute(0)]];
+    float4 color0 [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant params& _19 [[buffer(0)]])

--- a/reference/opt/shaders-msl/vert/read-from-row-major-array.vert
+++ b/reference/opt/shaders-msl/vert/read-from-row-major-array.vert
@@ -10,15 +10,15 @@ struct Block
     float2x3 var[3][4];
 };
 
-struct main0_in
-{
-    float4 a_position [[attribute(0)]];
-};
-
 struct main0_out
 {
     float v_vtxResult [[user(locn0)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 a_position [[attribute(0)]];
 };
 
 // Implementation of a conversion of matrix content from RowMajor to ColumnMajor organization.

--- a/reference/opt/shaders-msl/vert/return-array.vert
+++ b/reference/opt/shaders-msl/vert/return-array.vert
@@ -3,14 +3,14 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 vInput1 [[attribute(1)]];
-};
-
 struct main0_out
 {
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 vInput1 [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]])

--- a/reference/opt/shaders-msl/vert/ubo.alignment.vert
+++ b/reference/opt/shaders-msl/vert/ubo.alignment.vert
@@ -12,18 +12,18 @@ struct UBO
     float opacity;
 };
 
-struct main0_in
-{
-    float3 aNormal [[attribute(1)]];
-    float4 aVertex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float3 vNormal [[user(locn0)]];
     float3 vColor [[user(locn1)]];
     float2 vSize [[user(locn2)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _18 [[buffer(0)]])

--- a/reference/opt/shaders-msl/vert/ubo.vert
+++ b/reference/opt/shaders-msl/vert/ubo.vert
@@ -8,16 +8,16 @@ struct UBO
     float4x4 mvp;
 };
 
-struct main0_in
-{
-    float3 aNormal [[attribute(1)]];
-    float4 aVertex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float3 vNormal [[user(locn0)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _16 [[buffer(0)]])

--- a/reference/opt/shaders-msl/vulkan/frag/push-constant.vk.frag
+++ b/reference/opt/shaders-msl/vulkan/frag/push-constant.vk.frag
@@ -9,14 +9,14 @@ struct PushConstants
     float4 value1;
 };
 
-struct main0_in
-{
-    float4 vColor [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vColor [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], constant PushConstants& push [[buffer(0)]])

--- a/reference/shaders-msl-no-opt/asm/frag/inliner-dominator-inside-loop.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/inliner-dominator-inside-loop.asm.frag
@@ -83,22 +83,22 @@ constant float4 _192 = {};
 constant float4 _219 = {};
 constant float4 _297 = {};
 
-struct main0_in
-{
-    float IN_studIndex [[user(locn8)]];
-    float4 IN_PosLightSpace_Reflectance [[user(locn7)]];
-    float3 IN_Tangent [[user(locn6)]];
-    float4 IN_Normal_SpecPower [[user(locn5)]];
-    float4 IN_View_Depth [[user(locn4)]];
-    float4 IN_LightPosition_Fog [[user(locn3)]];
-    float4 IN_Color [[user(locn2)]];
-    float4 IN_UvStuds_EdgeDistance2 [[user(locn1)]];
-    float4 IN_Uv_EdgeDistance1 [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 _entryPointOutput [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 IN_Uv_EdgeDistance1 [[user(locn0)]];
+    float4 IN_UvStuds_EdgeDistance2 [[user(locn1)]];
+    float4 IN_Color [[user(locn2)]];
+    float4 IN_LightPosition_Fog [[user(locn3)]];
+    float4 IN_View_Depth [[user(locn4)]];
+    float4 IN_Normal_SpecPower [[user(locn5)]];
+    float3 IN_Tangent [[user(locn6)]];
+    float4 IN_PosLightSpace_Reflectance [[user(locn7)]];
+    float IN_studIndex [[user(locn8)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], constant CB0& _19 [[buffer(0)]], texture2d<float> StudsMapTexture [[texture(0)]], texture2d<float> ShadowMapTexture [[texture(1)]], texturecube<float> EnvironmentMapTexture [[texture(2)]], texture2d<float> DiffuseMapTexture [[texture(3)]], texture2d<float> NormalMapTexture [[texture(4)]], texture2d<float> SpecularMapTexture [[texture(5)]], texture3d<float> LightMapTexture [[texture(6)]], texture2d<float> NormalDetailMapTexture [[texture(8)]], sampler StudsMapSampler [[sampler(0)]], sampler ShadowMapSampler [[sampler(1)]], sampler EnvironmentMapSampler [[sampler(2)]], sampler DiffuseMapSampler [[sampler(3)]], sampler NormalMapSampler [[sampler(4)]], sampler SpecularMapSampler [[sampler(5)]], sampler LightMapSampler [[sampler(6)]], sampler NormalDetailMapSampler [[sampler(8)]], float4 gl_FragCoord [[position]])

--- a/reference/shaders-msl-no-opt/frag/in_block_assign.frag
+++ b/reference/shaders-msl-no-opt/frag/in_block_assign.frag
@@ -8,14 +8,14 @@ struct VOUT
     float4 a;
 };
 
-struct main0_in
-{
-    float4 VOUT_a [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 VOUT_a [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/reference/shaders-msl/asm/frag/combined-sampler-reuse.asm.frag
+++ b/reference/shaders-msl/asm/frag/combined-sampler-reuse.asm.frag
@@ -3,14 +3,14 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float2 vUV [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float2 vUV [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> uTex [[texture(1)]], sampler uSampler [[sampler(0)]])

--- a/reference/shaders-msl/asm/frag/frem.asm.frag
+++ b/reference/shaders-msl/asm/frag/frem.asm.frag
@@ -3,15 +3,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 vB [[user(locn1)]];
-    float4 vA [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vA [[user(locn0)]];
+    float4 vB [[user(locn1)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/reference/shaders-msl/asm/frag/implicit-read-dep-phi.asm.frag
+++ b/reference/shaders-msl/asm/frag/implicit-read-dep-phi.asm.frag
@@ -3,14 +3,14 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 v0 [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 v0 [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> uImage [[texture(0)]], sampler uImageSmplr [[sampler(0)]])

--- a/reference/shaders-msl/asm/frag/srem.asm.frag
+++ b/reference/shaders-msl/asm/frag/srem.asm.frag
@@ -3,15 +3,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    int4 vB [[user(locn1)]];
-    int4 vA [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    int4 vA [[user(locn0)]];
+    int4 vB [[user(locn1)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/reference/shaders-msl/asm/frag/unreachable.asm.frag
+++ b/reference/shaders-msl/asm/frag/unreachable.asm.frag
@@ -5,14 +5,14 @@ using namespace metal;
 
 constant float4 _21 = {};
 
-struct main0_in
-{
-    int counter [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    int counter [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/reference/shaders-msl/desktop-only/vert/basic.desktop.sso.vert
+++ b/reference/shaders-msl/desktop-only/vert/basic.desktop.sso.vert
@@ -8,16 +8,16 @@ struct UBO
     float4x4 uMVP;
 };
 
-struct main0_in
-{
-    float3 aNormal [[attribute(1)]];
-    float4 aVertex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float3 vNormal [[user(locn0)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _16 [[buffer(0)]])

--- a/reference/shaders-msl/flatten/basic.flatten.vert
+++ b/reference/shaders-msl/flatten/basic.flatten.vert
@@ -8,16 +8,16 @@ struct UBO
     float4x4 uMVP;
 };
 
-struct main0_in
-{
-    float3 aNormal [[attribute(1)]];
-    float4 aVertex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float3 vNormal [[user(locn0)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _16 [[buffer(0)]])

--- a/reference/shaders-msl/flatten/multiindex.flatten.vert
+++ b/reference/shaders-msl/flatten/multiindex.flatten.vert
@@ -8,14 +8,14 @@ struct UBO
     float4 Data[3][5];
 };
 
-struct main0_in
-{
-    int2 aIndex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    int2 aIndex [[attribute(0)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _20 [[buffer(0)]])

--- a/reference/shaders-msl/flatten/push-constant.flatten.vert
+++ b/reference/shaders-msl/flatten/push-constant.flatten.vert
@@ -10,16 +10,16 @@ struct PushMe
     float Arr[4];
 };
 
-struct main0_in
-{
-    float4 Pos [[attribute(1)]];
-    float2 Rot [[attribute(0)]];
-};
-
 struct main0_out
 {
     float2 vRot [[user(locn0)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float2 Rot [[attribute(0)]];
+    float4 Pos [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant PushMe& registers [[buffer(0)]])

--- a/reference/shaders-msl/flatten/rowmajor.flatten.vert
+++ b/reference/shaders-msl/flatten/rowmajor.flatten.vert
@@ -12,14 +12,14 @@ struct UBO
     float2x4 uMVP;
 };
 
-struct main0_in
-{
-    float4 aVertex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
 };
 
 // Implementation of a conversion of matrix content from RowMajor to ColumnMajor organization.

--- a/reference/shaders-msl/flatten/struct.flatten.vert
+++ b/reference/shaders-msl/flatten/struct.flatten.vert
@@ -16,16 +16,16 @@ struct UBO
     Light light;
 };
 
-struct main0_in
-{
-    float3 aNormal [[attribute(1)]];
-    float4 aVertex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float4 vColor [[user(locn0)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _18 [[buffer(0)]])

--- a/reference/shaders-msl/frag/basic.frag
+++ b/reference/shaders-msl/frag/basic.frag
@@ -3,15 +3,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float2 vTex [[user(locn1)]];
-    float4 vColor [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vColor [[user(locn0)]];
+    float2 vTex [[user(locn1)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> uTex [[texture(0)]], sampler uTexSmplr [[sampler(0)]])

--- a/reference/shaders-msl/frag/binary-func-unpack-pack-arguments.frag
+++ b/reference/shaders-msl/frag/binary-func-unpack-pack-arguments.frag
@@ -9,14 +9,14 @@ struct UBO
     float v;
 };
 
-struct main0_in
-{
-    float3 vIn [[user(locn0)]];
-};
-
 struct main0_out
 {
     float FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 vIn [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], constant UBO& _15 [[buffer(0)]])

--- a/reference/shaders-msl/frag/binary-unpack-pack-arguments.frag
+++ b/reference/shaders-msl/frag/binary-unpack-pack-arguments.frag
@@ -9,14 +9,14 @@ struct UBO
     float v;
 };
 
-struct main0_in
-{
-    float3 vIn [[user(locn0)]];
-};
-
 struct main0_out
 {
     float3 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 vIn [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], constant UBO& _15 [[buffer(0)]])

--- a/reference/shaders-msl/frag/bitcasting.frag
+++ b/reference/shaders-msl/frag/bitcasting.frag
@@ -3,15 +3,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 VertGeom [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor0 [[color(0)]];
     float4 FragColor1 [[color(1)]];
+};
+
+struct main0_in
+{
+    float4 VertGeom [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> TextureBase [[texture(0)]], texture2d<float> TextureDetail [[texture(1)]], sampler TextureBaseSmplr [[sampler(0)]], sampler TextureDetailSmplr [[sampler(1)]])

--- a/reference/shaders-msl/frag/builtins.frag
+++ b/reference/shaders-msl/frag/builtins.frag
@@ -3,15 +3,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 vColor [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
     float gl_FragDepth [[depth(any)]];
+};
+
+struct main0_in
+{
+    float4 vColor [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], float4 gl_FragCoord [[position]])

--- a/reference/shaders-msl/frag/composite-extract-forced-temporary.frag
+++ b/reference/shaders-msl/frag/composite-extract-forced-temporary.frag
@@ -3,14 +3,14 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float2 vTexCoord [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float2 vTexCoord [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> Texture [[texture(0)]], sampler TextureSmplr [[sampler(0)]])

--- a/reference/shaders-msl/frag/constant-array.frag
+++ b/reference/shaders-msl/frag/constant-array.frag
@@ -17,14 +17,14 @@ constant float4 _54[2] = {float4(8.0), float4(10.0)};
 constant float4 _55[2][2] = {{float4(1.0), float4(2.0)}, {float4(8.0), float4(10.0)}};
 constant Foobar _75[2] = {{10.0, 40.0}, {90.0, 70.0}};
 
-struct main0_in
-{
-    int index [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    int index [[user(locn0)]];
 };
 
 // Implementation of an array copy function to cover GLSL's ability to copy an array via assignment.

--- a/reference/shaders-msl/frag/constant-composites.frag
+++ b/reference/shaders-msl/frag/constant-composites.frag
@@ -14,14 +14,14 @@ struct Foo
 constant float _16[4] = {1.0, 4.0, 3.0, 2.0};
 constant Foo _28[2] = {{10.0, 20.0}, {30.0, 40.0}};
 
-struct main0_in
-{
-    int line [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    int line [[user(locn0)]];
 };
 
 // Implementation of an array copy function to cover GLSL's ability to copy an array via assignment.

--- a/reference/shaders-msl/frag/control-dependent-in-branch.desktop.frag
+++ b/reference/shaders-msl/frag/control-dependent-in-branch.desktop.frag
@@ -3,14 +3,14 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 vInput [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vInput [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> uSampler [[texture(0)]], sampler uSamplerSmplr [[sampler(0)]])

--- a/reference/shaders-msl/frag/false-loop-init.frag
+++ b/reference/shaders-msl/frag/false-loop-init.frag
@@ -3,14 +3,14 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 accum [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 result [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 accum [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/reference/shaders-msl/frag/fp16-packing.frag
+++ b/reference/shaders-msl/frag/fp16-packing.frag
@@ -3,16 +3,16 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float2 FP32 [[user(locn1)]];
-    uint FP16 [[user(locn0)]];
-};
-
 struct main0_out
 {
     float2 FP32Out [[color(0)]];
     uint FP16Out [[color(1)]];
+};
+
+struct main0_in
+{
+    uint FP16 [[user(locn0)]];
+    float2 FP32 [[user(locn1)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/reference/shaders-msl/frag/fp16.desktop.frag
+++ b/reference/shaders-msl/frag/fp16.desktop.frag
@@ -13,10 +13,10 @@ struct ResType
 
 struct main0_in
 {
-    half4 v4 [[user(locn3)]];
-    half3 v3 [[user(locn2)]];
-    half2 v2 [[user(locn1)]];
     half v1 [[user(locn0)]];
+    half2 v2 [[user(locn1)]];
+    half3 v3 [[user(locn2)]];
+    half4 v4 [[user(locn3)]];
 };
 
 // Implementation of the GLSL mod() function, which is slightly different than Metal fmod()

--- a/reference/shaders-msl/frag/front-facing.frag
+++ b/reference/shaders-msl/frag/front-facing.frag
@@ -3,15 +3,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 vB [[user(locn1)]];
-    float4 vA [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vA [[user(locn0)]];
+    float4 vB [[user(locn1)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], bool gl_FrontFacing [[front_facing]])

--- a/reference/shaders-msl/frag/gather-dref.frag
+++ b/reference/shaders-msl/frag/gather-dref.frag
@@ -3,14 +3,14 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float3 vUV [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 vUV [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], depth2d<float> uT [[texture(0)]], sampler uTSmplr [[sampler(0)]])

--- a/reference/shaders-msl/frag/in_block.frag
+++ b/reference/shaders-msl/frag/in_block.frag
@@ -3,15 +3,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 VertexOut_color2 [[user(locn3)]];
-    float4 VertexOut_color [[user(locn2)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 VertexOut_color [[user(locn2)]];
+    float4 VertexOut_color2 [[user(locn3)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/reference/shaders-msl/frag/in_mat.frag
+++ b/reference/shaders-msl/frag/in_mat.frag
@@ -1,0 +1,37 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 outFragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 inPos [[user(locn0)]];
+    float3 inNormal [[user(locn1)]];
+    float4 inInvModelView_0 [[user(locn2)]];
+    float4 inInvModelView_1 [[user(locn3)]];
+    float4 inInvModelView_2 [[user(locn4)]];
+    float4 inInvModelView_3 [[user(locn5)]];
+    float inLodBias [[user(locn6)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], texturecube<float> samplerColor [[texture(1)]], sampler samplerColorSmplr [[sampler(1)]])
+{
+    main0_out out = {};
+    float4x4 inInvModelView = {};
+    inInvModelView[0] = in.inInvModelView_0;
+    inInvModelView[1] = in.inInvModelView_1;
+    inInvModelView[2] = in.inInvModelView_2;
+    inInvModelView[3] = in.inInvModelView_3;
+    float3 cI = normalize(in.inPos);
+    float3 cR = reflect(cI, normalize(in.inNormal));
+    cR = float3((inInvModelView * float4(cR, 0.0)).xyz);
+    cR.x *= (-1.0);
+    out.outFragColor = samplerColor.sample(samplerColorSmplr, cR, bias(in.inLodBias));
+    return out;
+}
+

--- a/reference/shaders-msl/frag/mix.frag
+++ b/reference/shaders-msl/frag/mix.frag
@@ -3,17 +3,17 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float vIn3 [[user(locn3)]];
-    float vIn2 [[user(locn2)]];
-    float4 vIn1 [[user(locn1)]];
-    float4 vIn0 [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vIn0 [[user(locn0)]];
+    float4 vIn1 [[user(locn1)]];
+    float vIn2 [[user(locn2)]];
+    float vIn3 [[user(locn3)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/reference/shaders-msl/frag/mrt-array.frag
+++ b/reference/shaders-msl/frag/mrt-array.frag
@@ -5,18 +5,18 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 vB [[user(locn1)]];
-    float4 vA [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor_0 [[color(0)]];
     float4 FragColor_1 [[color(1)]];
     float4 FragColor_2 [[color(2)]];
     float4 FragColor_3 [[color(3)]];
+};
+
+struct main0_in
+{
+    float4 vA [[user(locn0)]];
+    float4 vB [[user(locn1)]];
 };
 
 // Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
@@ -40,7 +40,7 @@ void write_in_function(thread float4 (&FragColor)[4], thread float4& vA, thread 
 fragment main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
-    float4 FragColor[4];
+    float4 FragColor[4] = {};
     FragColor[0] = mod(in.vA, in.vB);
     FragColor[1] = in.vA + in.vB;
     write_in_function(FragColor, in.vA, in.vB);

--- a/reference/shaders-msl/frag/pls.frag
+++ b/reference/shaders-msl/frag/pls.frag
@@ -3,20 +3,20 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float4 PLSIn3 [[user(locn3)]];
-    float4 PLSIn2 [[user(locn2)]];
-    float4 PLSIn1 [[user(locn1)]];
-    float4 PLSIn0 [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 PLSOut0 [[color(0)]];
     float4 PLSOut1 [[color(1)]];
     float4 PLSOut2 [[color(2)]];
     float4 PLSOut3 [[color(3)]];
+};
+
+struct main0_in
+{
+    float4 PLSIn0 [[user(locn0)]];
+    float4 PLSIn1 [[user(locn1)]];
+    float4 PLSIn2 [[user(locn2)]];
+    float4 PLSIn3 [[user(locn3)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/reference/shaders-msl/frag/sampler-1d-lod.frag
+++ b/reference/shaders-msl/frag/sampler-1d-lod.frag
@@ -3,14 +3,14 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float vTex [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float vTex [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], texture1d<float> uSampler [[texture(0)]], sampler uSamplerSmplr [[sampler(0)]])

--- a/reference/shaders-msl/frag/sampler-image-arrays.msl2.frag
+++ b/reference/shaders-msl/frag/sampler-image-arrays.msl2.frag
@@ -5,15 +5,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    int vIndex [[user(locn1)]];
-    float2 vTex [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float2 vTex [[user(locn0)]];
+    int vIndex [[user(locn1)]];
 };
 
 float4 sample_from_global(thread int& vIndex, thread float2& vTex, thread const array<texture2d<float>, 4> uSampler, thread const array<sampler, 4> uSamplerSmplr)

--- a/reference/shaders-msl/frag/sampler.frag
+++ b/reference/shaders-msl/frag/sampler.frag
@@ -5,15 +5,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float2 vTex [[user(locn1)]];
-    float4 vColor [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vColor [[user(locn0)]];
+    float2 vTex [[user(locn1)]];
 };
 
 float4 sample_texture(thread const texture2d<float> tex, thread const sampler texSmplr, thread const float2& uv)

--- a/reference/shaders-msl/frag/shadow-compare-global-alias.frag
+++ b/reference/shaders-msl/frag/shadow-compare-global-alias.frag
@@ -5,14 +5,14 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float3 vUV [[user(locn0)]];
-};
-
 struct main0_out
 {
     float FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 vUV [[user(locn0)]];
 };
 
 float Samp(thread const float3& uv, thread depth2d<float> uTex, thread sampler uSamp)

--- a/reference/shaders-msl/frag/spec-constant-block-size.frag
+++ b/reference/shaders-msl/frag/spec-constant-block-size.frag
@@ -8,14 +8,14 @@ struct SpecConstArray
     float4 samples[2];
 };
 
-struct main0_in
-{
-    int Index [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    int Index [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], constant SpecConstArray& _15 [[buffer(0)]])

--- a/reference/shaders-msl/frag/swizzle.frag
+++ b/reference/shaders-msl/frag/swizzle.frag
@@ -3,15 +3,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float2 vUV [[user(locn2)]];
-    float3 vNormal [[user(locn1)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 vNormal [[user(locn1)]];
+    float2 vUV [[user(locn2)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> samp [[texture(0)]], sampler sampSmplr [[sampler(0)]])

--- a/reference/shaders-msl/frag/texture-proj-shadow.frag
+++ b/reference/shaders-msl/frag/texture-proj-shadow.frag
@@ -3,16 +3,16 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    float2 vClip2 [[user(locn2)]];
-    float4 vClip4 [[user(locn1)]];
-    float3 vClip3 [[user(locn0)]];
-};
-
 struct main0_out
 {
     float FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 vClip3 [[user(locn0)]];
+    float4 vClip4 [[user(locn1)]];
+    float2 vClip2 [[user(locn2)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], depth2d<float> uShadow2D [[texture(1)]], texture1d<float> uSampler1D [[texture(2)]], texture2d<float> uSampler2D [[texture(3)]], texture3d<float> uSampler3D [[texture(4)]], sampler uShadow2DSmplr [[sampler(1)]], sampler uSampler1DSmplr [[sampler(2)]], sampler uSampler2DSmplr [[sampler(3)]], sampler uSampler3DSmplr [[sampler(4)]])

--- a/reference/shaders-msl/frag/unary-enclose.frag
+++ b/reference/shaders-msl/frag/unary-enclose.frag
@@ -3,15 +3,15 @@
 
 using namespace metal;
 
-struct main0_in
-{
-    int4 vIn1 [[user(locn1)]];
-    float4 vIn [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vIn [[user(locn0)]];
+    int4 vIn1 [[user(locn1)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/reference/shaders-msl/legacy/vert/transpose.legacy.vert
+++ b/reference/shaders-msl/legacy/vert/transpose.legacy.vert
@@ -10,14 +10,14 @@ struct Buffer
     float4x4 M;
 };
 
-struct main0_in
-{
-    float4 Position [[attribute(0)]];
-};
-
 struct main0_out
 {
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 Position [[attribute(0)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant Buffer& _13 [[buffer(0)]])

--- a/reference/shaders-msl/vert/basic.vert
+++ b/reference/shaders-msl/vert/basic.vert
@@ -8,16 +8,16 @@ struct UBO
     float4x4 uMVP;
 };
 
-struct main0_in
-{
-    float3 aNormal [[attribute(1)]];
-    float4 aVertex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float3 vNormal [[user(locn0)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _16 [[buffer(0)]])

--- a/reference/shaders-msl/vert/copy.flatten.vert
+++ b/reference/shaders-msl/vert/copy.flatten.vert
@@ -23,16 +23,16 @@ struct Light_1
     float4 Color;
 };
 
-struct main0_in
-{
-    float3 aNormal [[attribute(1)]];
-    float4 aVertex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float4 vColor [[user(locn0)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _21 [[buffer(0)]])

--- a/reference/shaders-msl/vert/dynamic.flatten.vert
+++ b/reference/shaders-msl/vert/dynamic.flatten.vert
@@ -16,16 +16,16 @@ struct UBO
     Light lights[4];
 };
 
-struct main0_in
-{
-    float3 aNormal [[attribute(1)]];
-    float4 aVertex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float4 vColor [[user(locn0)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _21 [[buffer(0)]])

--- a/reference/shaders-msl/vert/functions.vert
+++ b/reference/shaders-msl/vert/functions.vert
@@ -13,12 +13,6 @@ struct UBO
     int2 bits;
 };
 
-struct main0_in
-{
-    float3 aNormal [[attribute(1)]];
-    float4 aVertex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float3 vNormal [[user(locn0)]];
@@ -27,6 +21,12 @@ struct main0_out
     int2 vLSB [[user(locn3)]];
     int2 vMSB [[user(locn4)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
 };
 
 // Implementation of the GLSL radians() function

--- a/reference/shaders-msl/vert/in_out_array_mat.vert
+++ b/reference/shaders-msl/vert/in_out_array_mat.vert
@@ -1,0 +1,78 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBO
+{
+    float4x4 projection;
+    float4x4 model;
+    float lodBias;
+};
+
+struct main0_out
+{
+    float3 outPos [[user(locn0)]];
+    float3 outNormal [[user(locn1)]];
+    float4 outTransModel_0 [[user(locn2)]];
+    float4 outTransModel_1 [[user(locn3)]];
+    float4 outTransModel_2 [[user(locn4)]];
+    float4 outTransModel_3 [[user(locn5)]];
+    float outLodBias [[user(locn6)]];
+    float4 color [[user(locn7)]];
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float3 inPos [[attribute(0)]];
+    float4 colors_0 [[attribute(1)]];
+    float4 colors_1 [[attribute(2)]];
+    float4 colors_2 [[attribute(3)]];
+    float3 inNormal [[attribute(4)]];
+    float4 inViewMat_0 [[attribute(5)]];
+    float4 inViewMat_1 [[attribute(6)]];
+    float4 inViewMat_2 [[attribute(7)]];
+    float4 inViewMat_3 [[attribute(8)]];
+};
+
+void write_deeper_in_function(thread float4x4& outTransModel, constant UBO& ubo, thread float4& color, thread float4 (&colors)[3])
+{
+    outTransModel[1].y = ubo.lodBias;
+    color = colors[2];
+}
+
+void write_in_function(thread float4x4& outTransModel, constant UBO& ubo, thread float4& color, thread float4 (&colors)[3], thread float3& inNormal)
+{
+    outTransModel[2] = float4(inNormal, 1.0);
+    write_deeper_in_function(outTransModel, ubo, color, colors);
+}
+
+vertex main0_out main0(main0_in in [[stage_in]], constant UBO& ubo [[buffer(0)]])
+{
+    main0_out out = {};
+    float4x4 outTransModel = {};
+    float4 colors[3] = {};
+    float4x4 inViewMat = {};
+    colors[0] = in.colors_0;
+    colors[1] = in.colors_1;
+    colors[2] = in.colors_2;
+    inViewMat[0] = in.inViewMat_0;
+    inViewMat[1] = in.inViewMat_1;
+    inViewMat[2] = in.inViewMat_2;
+    inViewMat[3] = in.inViewMat_3;
+    out.gl_Position = (ubo.projection * ubo.model) * float4(in.inPos, 1.0);
+    out.outPos = float3((ubo.model * float4(in.inPos, 1.0)).xyz);
+    out.outNormal = float3x3(float3(float3(ubo.model[0].x, ubo.model[0].y, ubo.model[0].z)), float3(float3(ubo.model[1].x, ubo.model[1].y, ubo.model[1].z)), float3(float3(ubo.model[2].x, ubo.model[2].y, ubo.model[2].z))) * in.inNormal;
+    out.outLodBias = ubo.lodBias;
+    outTransModel = transpose(ubo.model) * inViewMat;
+    write_in_function(outTransModel, ubo, out.color, colors, in.inNormal);
+    out.outTransModel_0 = outTransModel[0];
+    out.outTransModel_1 = outTransModel[1];
+    out.outTransModel_2 = outTransModel[2];
+    out.outTransModel_3 = outTransModel[3];
+    return out;
+}
+

--- a/reference/shaders-msl/vert/out_block.vert
+++ b/reference/shaders-msl/vert/out_block.vert
@@ -8,17 +8,17 @@ struct Transform
     float4x4 transform;
 };
 
-struct main0_in
-{
-    float4 color [[attribute(1)]];
-    float3 position [[attribute(0)]];
-};
-
 struct main0_out
 {
     float4 VertexOut_color [[user(locn2)]];
     float4 VertexOut_color2 [[user(locn3)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float3 position [[attribute(0)]];
+    float4 color [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant Transform& block [[buffer(0)]])

--- a/reference/shaders-msl/vert/packed_matrix.vert
+++ b/reference/shaders-msl/vert/packed_matrix.vert
@@ -26,15 +26,15 @@ struct _42
     float2 _m9;
 };
 
-struct main0_in
-{
-    float4 m_25 [[attribute(0)]];
-};
-
 struct main0_out
 {
     float3 m_72 [[user(locn0)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 m_25 [[attribute(0)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant _42& _44 [[buffer(12)]], constant _15& _17 [[buffer(13)]])

--- a/reference/shaders-msl/vert/pointsize.vert
+++ b/reference/shaders-msl/vert/pointsize.vert
@@ -9,17 +9,17 @@ struct params
     float psize;
 };
 
-struct main0_in
-{
-    float4 color0 [[attribute(1)]];
-    float4 position [[attribute(0)]];
-};
-
 struct main0_out
 {
     float4 color [[user(locn0)]];
     float4 gl_Position [[position]];
     float gl_PointSize [[point_size]];
+};
+
+struct main0_in
+{
+    float4 position [[attribute(0)]];
+    float4 color0 [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant params& _19 [[buffer(0)]])

--- a/reference/shaders-msl/vert/read-from-row-major-array.vert
+++ b/reference/shaders-msl/vert/read-from-row-major-array.vert
@@ -10,15 +10,15 @@ struct Block
     float2x3 var[3][4];
 };
 
-struct main0_in
-{
-    float4 a_position [[attribute(0)]];
-};
-
 struct main0_out
 {
     float v_vtxResult [[user(locn0)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 a_position [[attribute(0)]];
 };
 
 // Implementation of a conversion of matrix content from RowMajor to ColumnMajor organization.

--- a/reference/shaders-msl/vert/return-array.vert
+++ b/reference/shaders-msl/vert/return-array.vert
@@ -7,15 +7,15 @@ using namespace metal;
 
 constant float4 _20[2] = {float4(10.0), float4(20.0)};
 
-struct main0_in
-{
-    float4 vInput1 [[attribute(1)]];
-    float4 vInput0 [[attribute(0)]];
-};
-
 struct main0_out
 {
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 vInput0 [[attribute(0)]];
+    float4 vInput1 [[attribute(1)]];
 };
 
 // Implementation of an array copy function to cover GLSL's ability to copy an array via assignment.

--- a/reference/shaders-msl/vert/ubo.alignment.vert
+++ b/reference/shaders-msl/vert/ubo.alignment.vert
@@ -12,18 +12,18 @@ struct UBO
     float opacity;
 };
 
-struct main0_in
-{
-    float3 aNormal [[attribute(1)]];
-    float4 aVertex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float3 vNormal [[user(locn0)]];
     float3 vColor [[user(locn1)]];
     float2 vSize [[user(locn2)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _18 [[buffer(0)]])

--- a/reference/shaders-msl/vert/ubo.vert
+++ b/reference/shaders-msl/vert/ubo.vert
@@ -8,16 +8,16 @@ struct UBO
     float4x4 mvp;
 };
 
-struct main0_in
-{
-    float3 aNormal [[attribute(1)]];
-    float4 aVertex [[attribute(0)]];
-};
-
 struct main0_out
 {
     float3 vNormal [[user(locn0)]];
     float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+    float3 aNormal [[attribute(1)]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _16 [[buffer(0)]])

--- a/reference/shaders-msl/vulkan/frag/push-constant.vk.frag
+++ b/reference/shaders-msl/vulkan/frag/push-constant.vk.frag
@@ -9,14 +9,14 @@ struct PushConstants
     float4 value1;
 };
 
-struct main0_in
-{
-    float4 vColor [[user(locn0)]];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vColor [[user(locn0)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], constant PushConstants& push [[buffer(0)]])

--- a/shaders-msl/frag/in_mat.frag
+++ b/shaders-msl/frag/in_mat.frag
@@ -1,0 +1,19 @@
+#version 450
+
+layout(binding = 1) uniform samplerCube samplerColor;
+
+layout(location = 0) in vec3 inPos;
+layout(location = 1) in vec3 inNormal;
+layout(location = 2) in mat4 inInvModelView;
+layout(location = 6) in float inLodBias;
+layout(location = 0) out vec4 outFragColor;
+
+void main()
+{
+	vec3 cI = normalize(inPos);
+	vec3 cR = reflect(cI, normalize(inNormal));
+	cR = vec3((inInvModelView * vec4(cR, 0.0)).xyz);
+	cR.x *= (-1.0);
+	outFragColor = texture(samplerColor, cR, inLodBias);
+}
+

--- a/shaders-msl/vert/in_out_array_mat.vert
+++ b/shaders-msl/vert/in_out_array_mat.vert
@@ -1,0 +1,41 @@
+#version 450
+
+layout(binding = 0, std140) uniform UBO
+{
+	mat4 projection;
+	mat4 model;
+	float lodBias;
+} ubo;
+
+layout(location = 0) in vec3 inPos;
+layout(location = 1) in vec4 colors[3];
+layout(location = 4) in vec3 inNormal;
+layout(location = 5) in mat4 inViewMat;
+layout(location = 0) out vec3 outPos;
+layout(location = 1) out vec3 outNormal;
+layout(location = 2) out mat4 outTransModel;
+layout(location = 6) out float outLodBias;
+layout(location = 7) out vec4 color;
+
+void write_deeper_in_function()
+{
+	outTransModel[1][1] = ubo.lodBias;
+	color = colors[2];
+}
+
+void write_in_function()
+{
+	outTransModel[2] = vec4(inNormal, 1.0);
+	write_deeper_in_function();
+}
+
+void main()
+{
+	gl_Position = (ubo.projection * ubo.model) * vec4(inPos, 1.0);
+	outPos = vec3((ubo.model * vec4(inPos, 1.0)).xyz);
+	outNormal = mat3(vec3(ubo.model[0].x, ubo.model[0].y, ubo.model[0].z), vec3(ubo.model[1].x, ubo.model[1].y, ubo.model[1].z), vec3(ubo.model[2].x, ubo.model[2].y, ubo.model[2].z)) * inNormal;
+	outLodBias = ubo.lodBias;
+	outTransModel = transpose(ubo.model) * inViewMat;
+	write_in_function();
+}
+

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -745,7 +745,11 @@ struct SPIRFunction : IVariant
 
 	// Statements to be emitted when the function returns.
 	// Mostly used for lowering internal data structures onto flattened structures.
-	std::vector<std::string> fixup_statements;
+	std::vector<std::string> fixup_statements_out;
+
+	// Statements to be emitted when the function begins.
+	// Mostly used for populating internal data structures from flattened structures.
+	std::vector<std::string> fixup_statements_in;
 
 	bool active = false;
 	bool flush_undeclared = true;

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -8952,6 +8952,9 @@ void CompilerGLSL::emit_function(SPIRFunction &func, const Bitset &return_flags)
 			var.deferred_declaration = false;
 	}
 
+	for (auto &line : current_function->fixup_statements_in)
+		statement(line);
+
 	entry_block.loop_dominator = SPIRBlock::NoDominator;
 	emit_block_chain(entry_block);
 
@@ -9681,8 +9684,9 @@ void CompilerGLSL::emit_block_chain(SPIRBlock &block)
 	}
 
 	case SPIRBlock::Return:
-		for (auto &line : current_function->fixup_statements)
+		for (auto &line : current_function->fixup_statements_out)
 			statement(line);
+
 		if (processing_entry_point)
 			emit_fixup();
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -278,7 +278,6 @@ string CompilerMSL::compile()
 
 	replace_illegal_names();
 
-	non_stage_in_input_var_ids.clear();
 	struct_member_padding.clear();
 
 	update_active_builtins();
@@ -292,10 +291,11 @@ string CompilerMSL::compile()
 	// Preprocess OpCodes to extract the need to output additional header content
 	preprocess_op_codes();
 
-	// Create structs to hold input, output and uniform variables
+	// Create structs to hold input, output and uniform variables.
+	// Do output first to ensure out. is declared at top of entry function.
 	qual_pos_var_name = "";
-	stage_in_var_id = add_interface_block(StorageClassInput);
 	stage_out_var_id = add_interface_block(StorageClassOutput);
+	stage_in_var_id = add_interface_block(StorageClassInput);
 	stage_uniforms_var_id = add_interface_block(StorageClassUniformConstant);
 
 	// Convert the use of global variables to recursively-passed function parameters
@@ -423,9 +423,9 @@ void CompilerMSL::extract_global_variables_from_functions()
 		if (id.get_type() == TypeVariable)
 		{
 			auto &var = id.get<SPIRVariable>();
-			if (var.storage == StorageClassInput || var.storage == StorageClassUniform ||
-			    var.storage == StorageClassUniformConstant || var.storage == StorageClassPushConstant ||
-			    var.storage == StorageClassStorageBuffer)
+			if (var.storage == StorageClassInput || var.storage == StorageClassOutput ||
+			    var.storage == StorageClassUniform || var.storage == StorageClassUniformConstant ||
+			    var.storage == StorageClassPushConstant || var.storage == StorageClassStorageBuffer)
 			{
 				global_var_ids.insert(var.self);
 			}
@@ -664,9 +664,9 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage)
 	{
 		ib_var_ref = stage_out_var_name;
 
-		// Add the output interface struct as a local variable to the entry function,
-		// and force the entry function to return the output interface struct from
-		// any blocks that perform a function return.
+		// Add the output interface struct as a local variable to the entry function, force
+		// the entry function to return the output interface struct from any blocks that perform
+		// a function return, and indicate the output var requires early initialization
 		auto &entry_func = get<SPIRFunction>(entry_point);
 		entry_func.add_local_variable(ib_var_id);
 		for (auto &blk_id : entry_func.blocks)
@@ -675,6 +675,7 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage)
 			if (blk.terminator == SPIRBlock::Return)
 				blk.return_value = ib_var_id;
 		}
+		vars_needing_early_declaration.push_back(ib_var_id);
 		break;
 	}
 
@@ -689,7 +690,7 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage)
 		break;
 	}
 
-	set_name(ib_type_id, get_entry_point_name() + "_" + ib_var_ref);
+	set_name(ib_type_id, to_name(entry_point) + "_" + ib_var_ref);
 	set_name(ib_var_id, ib_var_ref);
 
 	for (auto p_var : vars)
@@ -705,11 +706,7 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage)
 				BuiltIn builtin;
 				bool is_builtin = is_member_builtin(type, mbr_idx, &builtin);
 
-				if (should_move_to_input_buffer(mbr_type_id, is_builtin, storage))
-				{
-					move_member_to_input_buffer(type, mbr_idx);
-				}
-				else if (!is_builtin || has_active_builtin(builtin, storage))
+				if (!is_builtin || has_active_builtin(builtin, storage))
 				{
 					// Add a reference to the member to the interface struct.
 					uint32_t ib_mbr_idx = uint32_t(ib_type.member_types.size());
@@ -760,34 +757,45 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage)
 			bool is_builtin = is_builtin_variable(*p_var);
 			BuiltIn builtin = BuiltIn(get_decoration(p_var->self, DecorationBuiltIn));
 
-			if (should_move_to_input_buffer(type_id, is_builtin, storage))
+			if (!is_builtin || has_active_builtin(builtin, storage))
 			{
-				move_to_input_buffer(*p_var);
-			}
-			else if (!is_builtin || has_active_builtin(builtin, storage))
-			{
-				// Arrays of MRT output is not allowed in MSL, so need to handle it specially.
-				if (!is_builtin && storage == StorageClassOutput && get_entry_point().model == ExecutionModelFragment &&
-				    !type.array.empty())
+				// MSL does not allow matrices or arrays in input or output variables, so need to handle it specially.
+				if (!is_builtin && (storage == StorageClassInput || storage == StorageClassOutput) &&
+				    (is_matrix(type) || is_array(type)))
 				{
-					if (type.array.size() != 1)
-						SPIRV_CROSS_THROW("Cannot emit arrays-of-arrays with MRT.");
+					uint32_t elem_cnt = 0;
 
-					uint32_t num_mrts = type.array_size_literal.back() ? type.array.back() :
-					                                                     get<SPIRConstant>(type.array.back()).scalar();
+					if (is_matrix(type))
+					{
+						if (is_array(type))
+							SPIRV_CROSS_THROW("MSL cannot emit arrays-of-matrices in input and output variables.");
 
-					auto *no_array_type = &type;
-					while (!no_array_type->array.empty())
-						no_array_type = &get<SPIRType>(no_array_type->parent_type);
+						elem_cnt = type.columns;
+					}
+					else if (is_array(type))
+					{
+						if (type.array.size() != 1)
+							SPIRV_CROSS_THROW("MSL cannot emit arrays-of-arrays in input and output variables.");
+
+						elem_cnt = type.array_size_literal.back() ? type.array.back() :
+						                                            get<SPIRConstant>(type.array.back()).scalar();
+					}
+
+					auto *usable_type = &type;
+					while (is_array(*usable_type) || is_matrix(*usable_type))
+						usable_type = &get<SPIRType>(usable_type->parent_type);
 
 					auto &entry_func = get<SPIRFunction>(entry_point);
 					entry_func.add_local_variable(p_var->self);
 
-					for (uint32_t i = 0; i < num_mrts; i++)
+					// We need to declare the variable early and at entry-point scope.
+					vars_needing_early_declaration.push_back(p_var->self);
+
+					for (uint32_t i = 0; i < elem_cnt; i++)
 					{
 						// Add a reference to the variable type to the interface struct.
 						uint32_t ib_mbr_idx = uint32_t(ib_type.member_types.size());
-						ib_type.member_types.push_back(no_array_type->self);
+						ib_type.member_types.push_back(usable_type->self);
 
 						// Give the member a name
 						string mbr_name = ensure_valid_name(join(to_expression(p_var->self), "_", i), "m");
@@ -807,9 +815,21 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage)
 							set_member_decoration(ib_type_id, ib_mbr_idx, DecorationIndex, index);
 						}
 
-						// Lower the internal array to flattened output when entry point returns.
-						entry_func.fixup_statements.push_back(
-						    join(ib_var_ref, ".", mbr_name, " = ", to_name(p_var->self), "[", i, "];"));
+						switch (storage)
+						{
+						case StorageClassInput:
+							entry_func.fixup_statements_in.push_back(
+							    join(to_name(p_var->self), "[", i, "] = ", ib_var_ref, ".", mbr_name, ";"));
+							break;
+
+						case StorageClassOutput:
+							entry_func.fixup_statements_out.push_back(
+							    join(ib_var_ref, ".", mbr_name, " = ", to_name(p_var->self), "[", i, "];"));
+							break;
+
+						default:
+							break;
+						}
 					}
 				}
 				else
@@ -855,155 +875,9 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage)
 	}
 
 	// Sort the members of the structure by their locations.
-	// Oddly, Metal handles inputs better if they are sorted in reverse order.
-	MemberSorter::SortAspect sort_aspect =
-	    (storage == StorageClassInput) ? MemberSorter::LocationReverse : MemberSorter::Location;
-	MemberSorter member_sorter(ib_type, meta[ib_type_id], sort_aspect);
+	MemberSorter member_sorter(ib_type, meta[ib_type_id], MemberSorter::Location);
 	member_sorter.sort();
 
-	return ib_var_id;
-}
-
-// Returns whether a variable of type and storage class should be moved from an interface
-// block to a secondary input buffer block.
-// This is the case for matrixes and arrays that appear in the stage_in interface block
-// of a vertex function, and true is returned.
-// Other types do not need to move, and false is returned.
-// Matrices and arrays are not permitted in the output of a vertex function or the input
-// or output of a fragment function, and in those cases, an exception is thrown.
-bool CompilerMSL::should_move_to_input_buffer(uint32_t type_id, bool is_builtin, StorageClass storage)
-{
-	auto &type = get<SPIRType>(type_id);
-
-	if ((is_matrix(type) || is_array(type)) && !is_builtin)
-	{
-		auto &execution = get_entry_point();
-
-		if (execution.model == ExecutionModelVertex)
-		{
-			if (storage == StorageClassInput)
-				return true;
-
-			if (storage == StorageClassOutput)
-				SPIRV_CROSS_THROW("The vertex function output structure may not include a matrix or array.");
-		}
-		else if (execution.model == ExecutionModelFragment)
-		{
-			if (storage == StorageClassInput)
-				SPIRV_CROSS_THROW("The fragment function stage_in structure may not include a matrix or array.");
-
-			//if (storage == StorageClassOutput)
-			//	SPIRV_CROSS_THROW("The fragment function output structure may not include a matrix or array.");
-		}
-	}
-
-	return false;
-}
-
-// Excludes the specified variable from an interface block structure.
-// Instead, for the variable is added to a block variable corresponding to a secondary MSL buffer.
-// The use case for this is when a vertex stage_in variable contains a matrix or array.
-void CompilerMSL::move_to_input_buffer(SPIRVariable &var)
-{
-	uint32_t var_id = var.self;
-
-	if (!has_decoration(var_id, DecorationLocation))
-		return;
-
-	uint32_t mbr_type_id = var.basetype;
-	string mbr_name = ensure_valid_name(to_expression(var_id), "m");
-	uint32_t mbr_locn = get_decoration(var_id, DecorationLocation);
-	meta[var_id].decoration.qualified_alias = add_input_buffer_block_member(mbr_type_id, mbr_name, mbr_locn);
-}
-
-// Excludes the specified type member from the stage_in block structure.
-// Instead, for the variable is added to a block variable corresponding to a secondary MSL buffer.
-// The use case for this is when a vertex stage_in variable contains a matrix or array.
-void CompilerMSL::move_member_to_input_buffer(const SPIRType &type, uint32_t index)
-{
-	uint32_t type_id = type.self;
-
-	if (!has_member_decoration(type_id, index, DecorationLocation))
-		return;
-
-	uint32_t mbr_type_id = type.member_types[index];
-	string mbr_name = ensure_valid_name(to_qualified_member_name(type, index), "m");
-	uint32_t mbr_locn = get_member_decoration(type_id, index, DecorationLocation);
-	string qual_name = add_input_buffer_block_member(mbr_type_id, mbr_name, mbr_locn);
-	set_member_qualified_name(type_id, index, qual_name);
-}
-
-// Adds a member to the input buffer block that corresponds to the MTLBuffer used by an attribute location
-string CompilerMSL::add_input_buffer_block_member(uint32_t mbr_type_id, string mbr_name, uint32_t mbr_locn)
-{
-	mark_location_as_used_by_shader(mbr_locn, StorageClassInput);
-
-	MSLVertexAttr *p_va = vtx_attrs_by_location[mbr_locn];
-	if (!p_va)
-		return "";
-
-	if (p_va->per_instance)
-		needs_instance_idx_arg = true;
-	else
-		needs_vertex_idx_arg = true;
-
-	// The variable that is the block struct.
-	// Record the stride of this struct in its offset decoration.
-	uint32_t ib_var_id = get_input_buffer_block_var_id(p_va->msl_buffer);
-	auto &ib_var = get<SPIRVariable>(ib_var_id);
-	uint32_t ib_type_id = ib_var.basetype;
-	auto &ib_type = get<SPIRType>(ib_type_id);
-	set_decoration(ib_type_id, DecorationOffset, p_va->msl_stride);
-
-	// Add a reference to the variable type to the interface struct.
-	uint32_t ib_mbr_idx = uint32_t(ib_type.member_types.size());
-	ib_type.member_types.push_back(mbr_type_id);
-
-	// Give the member a name
-	set_member_name(ib_type_id, ib_mbr_idx, mbr_name);
-
-	// Set MSL buffer and offset decorations, and indicate no valid attribute location
-	set_member_decoration(ib_type_id, ib_mbr_idx, DecorationBinding, p_va->msl_buffer);
-	set_member_decoration(ib_type_id, ib_mbr_idx, DecorationOffset, p_va->msl_offset);
-	set_member_decoration(ib_type_id, ib_mbr_idx, DecorationLocation, k_unknown_location);
-
-	// Update the original variable reference to include the structure and index reference
-	string idx_var_name =
-	    builtin_to_glsl(p_va->per_instance ? BuiltInInstanceIndex : BuiltInVertexIndex, StorageClassInput);
-	return get_name(ib_var_id) + "[" + idx_var_name + "]." + mbr_name;
-}
-
-// Returns the ID of the input block that will use the specified MSL buffer index,
-// lazily creating an input block variable and type if needed.
-//
-// The use of this block applies only to input variables that have been excluded from the stage_in
-// block, which typically only occurs if an attempt to pass a matrix in the stage_in block.
-uint32_t CompilerMSL::get_input_buffer_block_var_id(uint32_t msl_buffer)
-{
-	uint32_t ib_var_id = non_stage_in_input_var_ids[msl_buffer];
-	if (!ib_var_id)
-	{
-		// No interface block exists yet. Create a new typed variable for this interface block.
-		// The initializer expression is allocated here, but populated when the function
-		// declaraion is emitted, because it is cleared after each compilation pass.
-		uint32_t next_id = increase_bound_by(3);
-		uint32_t ib_type_id = next_id++;
-		auto &ib_type = set<SPIRType>(ib_type_id);
-		ib_type.basetype = SPIRType::Struct;
-		ib_type.storage = StorageClassInput;
-		set_decoration(ib_type_id, DecorationBlock);
-
-		ib_var_id = next_id++;
-		auto &var = set<SPIRVariable>(ib_var_id, ib_type_id, StorageClassInput, 0);
-		var.initializer = next_id++;
-
-		string ib_var_name = stage_in_var_name + convert_to_string(msl_buffer);
-		set_name(ib_var_id, ib_var_name);
-		set_name(ib_type_id, get_entry_point_name() + "_" + ib_var_name);
-
-		// Add the variable to the map of buffer blocks, accessed by the Metal buffer index.
-		non_stage_in_input_var_ids[msl_buffer] = ib_var_id;
-	}
 	return ib_var_id;
 }
 
@@ -1560,11 +1434,8 @@ void CompilerMSL::emit_resources()
 	declare_undefined_values();
 
 	// Output interface structs.
-	emit_interface_block(stage_in_var_id);
-	for (auto &nsi_var : non_stage_in_input_var_ids)
-		emit_interface_block(nsi_var.second);
-
 	emit_interface_block(stage_out_var_id);
+	emit_interface_block(stage_in_var_id);
 	emit_interface_block(stage_uniforms_var_id);
 }
 
@@ -2447,14 +2318,17 @@ void CompilerMSL::emit_function_prototype(SPIRFunction &func, const Bitset &)
 	{
 		decl += entry_point_args(!func.arguments.empty());
 
-		// If entry point function has a output interface struct, set its initializer.
-		// This is done at this late stage because the initialization expression is
-		// cleared after each compilation pass.
-		if (stage_out_var_id)
+		// If entry point function has variables that require early declaration,
+		// ensure they each have an empty initializer, creating one if needed.
+		// This is done at this late stage because the initialization expression
+		// is cleared after each compilation pass.
+		for (auto var_id : vars_needing_early_declaration)
 		{
-			auto &so_var = get<SPIRVariable>(stage_out_var_id);
-			auto &so_type = get<SPIRType>(so_var.basetype);
-			set<SPIRExpression>(so_var.initializer, "{}", so_type.self, true);
+			auto &ed_var = get<SPIRVariable>(var_id);
+			if (!ed_var.initializer)
+				ed_var.initializer = increase_bound_by(1);
+
+			set<SPIRExpression>(ed_var.initializer, "{}", ed_var.basetype, true);
 		}
 	}
 
@@ -3247,19 +3121,6 @@ string CompilerMSL::entry_point_args(bool append_comma)
 		ep_args += type_to_glsl(type) + " " + to_name(var.self) + " [[stage_in]]";
 	}
 
-	// Non-stage-in vertex attribute structures
-	for (auto &nsi_var : non_stage_in_input_var_ids)
-	{
-		auto &var = get<SPIRVariable>(nsi_var.second);
-		auto &type = get<SPIRType>(var.basetype);
-
-		if (!ep_args.empty())
-			ep_args += ", ";
-
-		ep_args += "device " + type_to_glsl(type) + "* " + to_name(var.self) + " [[buffer(" +
-		           convert_to_string(nsi_var.first) + ")]]";
-	}
-
 	// Output resources, sorted by resource index & type
 	// We need to sort to work around a bug on macOS 10.13 with NVidia drivers where switching between shaders
 	// with different order of buffers can result in issues with buffer assignments inside the driver.
@@ -3443,12 +3304,6 @@ uint32_t CompilerMSL::get_metal_resource_index(SPIRVariable &var, SPIRType::Base
 		break;
 	}
 	return resource_index;
-}
-
-// Returns the name of the entry point of this shader
-string CompilerMSL::get_entry_point_name()
-{
-	return to_name(entry_point);
 }
 
 string CompilerMSL::argument_decl(const SPIRFunction::Parameter &arg)

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -327,7 +327,6 @@ protected:
 
 	std::string func_type_decl(SPIRType &type);
 	std::string entry_point_args(bool append_comma);
-	std::string get_entry_point_name();
 	std::string to_qualified_member_name(const SPIRType &type, uint32_t index);
 	std::string ensure_valid_name(std::string name, std::string pfx);
 	std::string to_sampler_expression(uint32_t id);
@@ -341,11 +340,6 @@ protected:
 	uint32_t get_ordered_member_location(uint32_t type_id, uint32_t index);
 	size_t get_declared_struct_member_alignment(const SPIRType &struct_type, uint32_t index) const;
 	std::string to_component_argument(uint32_t id);
-	bool should_move_to_input_buffer(uint32_t type_id, bool is_builtin, spv::StorageClass storage);
-	void move_to_input_buffer(SPIRVariable &var);
-	void move_member_to_input_buffer(const SPIRType &type, uint32_t index);
-	std::string add_input_buffer_block_member(uint32_t mbr_type_id, std::string mbr_name, uint32_t mbr_locn);
-	uint32_t get_input_buffer_block_var_id(uint32_t msl_buffer);
 	void align_struct(SPIRType &ib_type);
 	bool is_member_packable(SPIRType &ib_type, uint32_t index);
 	MSLStructMemberKey get_struct_member_key(uint32_t type_id, uint32_t index);
@@ -365,10 +359,10 @@ protected:
 	Options msl_options;
 	std::set<SPVFuncImpl> spv_function_implementations;
 	std::unordered_map<uint32_t, MSLVertexAttr *> vtx_attrs_by_location;
-	std::map<uint32_t, uint32_t> non_stage_in_input_var_ids;
 	std::unordered_map<MSLStructMemberKey, uint32_t> struct_member_padding;
 	std::set<std::string> pragma_lines;
 	std::set<std::string> typedef_lines;
+	std::vector<uint32_t> vars_needing_early_declaration;
 	std::vector<MSLResourceBinding *> resource_bindings;
 	MSLResourceBinding next_metal_resource_index;
 	uint32_t stage_in_var_id = 0;


### PR DESCRIPTION
Support matrices and arrays as both input and output variables for both fragment and vertex shaders.

This extends the previous support for MRT array output in fragment shaders to the general case for arrays and matrices, both input and output, in both fragment and vertex shaders.

Adds the enhancement requested and discussed in issue #602.