### PR TITLE
Added support for shadowXY() sample instructions in legacy GLSL

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -3947,7 +3947,7 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 	expr += ")";
 
 	// texture(samplerXShadow) returns float. shadowX() returns vec4. Swizzle here.
-	if (is_legacy() && ((imgtype.basetype == SPIRType::SampledImage) || (imgtype.basetype == SPIRType::Sampler)) && imgtype.image.depth)
+	if (is_legacy() && imgtype.image.depth)
 		expr += ".r";
 
 	emit_op(result_type, id, expr, forward);

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -3542,47 +3542,43 @@ string CompilerGLSL::legacy_tex_op(const std::string &op, const SPIRType &imgtyp
 			require_extension_internal("GL_ARB_shader_texture_lod");
 	}
 
-	// texture
+	std::string type_prefix = imgtype.image.depth ? "shadow" : "texture";
+
 	if (op == "texture")
-		return join("texture", type);
+		return join(type_prefix, type);
 	else if (op == "textureLod")
 	{
 		if (use_explicit_lod)
-			return join("texture", type, is_legacy_es() ? "LodEXT" : "Lod");
+			return join(type_prefix, type, is_legacy_es() ? "LodEXT" : "Lod");
 		else
-			return join("texture", type);
+			return join(type_prefix, type);
 	}
 	else if (op == "textureProj")
-		return join("texture", type, "Proj");
+		return join(type_prefix, type, "Proj");
 	else if (op == "textureGrad")
-		return join("texture", type, is_legacy_es() ? "GradEXT" : is_legacy_desktop() ? "GradARB" : "Grad");
+		return join(type_prefix, type, is_legacy_es() ? "GradEXT" : is_legacy_desktop() ? "GradARB" : "Grad");
 	else if (op == "textureProjLod")
 	{
 		if (use_explicit_lod)
-			return join("texture", type, is_legacy_es() ? "ProjLodEXT" : "ProjLod");
+			return join(type_prefix, type, is_legacy_es() ? "ProjLodEXT" : "ProjLod");
 		else
-			return join("texture", type);
+			return join(type_prefix, type);
 	}
-	// shadow
-	else if (op == "shadow")
-		return join("shadow", type);
-	else if (op == "shadowLodOffset")
+	else if (op == "textureLodOffset")
 	{
 		if (use_explicit_lod)
-			return join("shadow", type, "LodOffset");
+			return join(type_prefix, type, "LodOffset");
 		else
-			return join("shadow", type);
+			return join(type_prefix, type);
 	}
-	else if (op == "shadowProjGrad")
-		return join("shadow", type, "ProjGrad");
-	else if (op == "shadowGrad")
-		return join("shadow", type, "Grad");
-	else if (op == "shadowProjLodOffset")
+	else if (op == "textureProjGrad")
+		return join(type_prefix, type, "ProjGrad");
+	else if (op == "textureProjLodOffset")
 	{
 		if (use_explicit_lod)
-			return join("shadow", type, "ProjLodOffset");
+			return join(type_prefix, type, "ProjLodOffset");
 		else
-			return join("shadow", type);
+			return join(type_prefix, type);
 	}
 	else
 	{
@@ -3994,10 +3990,7 @@ string CompilerGLSL::to_function_name(uint32_t, const SPIRType &imgtype, bool is
 		fname += "texelFetch";
 	else
 	{
-		if (is_legacy() && ((imgtype.basetype == SPIRType::SampledImage) || (imgtype.basetype == SPIRType::Sampler)) && imgtype.image.depth)
-			fname += "shadow";
-		else
-			fname += "texture";
+		fname += "texture";
 
 		if (is_gather)
 			fname += "Gather";

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -3562,7 +3562,7 @@ string CompilerGLSL::legacy_tex_op(const std::string &op, const SPIRType &imgtyp
 		if (use_explicit_lod)
 			return join(type_prefix, type, is_legacy_es() ? "ProjLodEXT" : "ProjLod");
 		else
-			return join(type_prefix, type);
+			return join(type_prefix, type, "Proj");
 	}
 	else if (op == "textureLodOffset")
 	{
@@ -3578,7 +3578,7 @@ string CompilerGLSL::legacy_tex_op(const std::string &op, const SPIRType &imgtyp
 		if (use_explicit_lod)
 			return join(type_prefix, type, "ProjLodOffset");
 		else
-			return join(type_prefix, type);
+			return join(type_prefix, type, "ProjOffset");
 	}
 	else
 	{


### PR DESCRIPTION
Basically what the title says. If you have a shadow sampler up until now SPIRV-Cross would emit a `texture[XY]()` instruction, which works fine on modern GLSL backends but not on legacy backends. 

This adds the emission of  `shadowXY()` instructions. It's not 100% complete but should cover the most used cases, at least to implement CSM. And it's a starting point for others to pile on more variants if necessary.