### PR TITLE
CompilerMSL pass builtin struct members into functions.

### DIFF
--- a/reference/opt/shaders-msl/vert/set_builtin_in_func.vert
+++ b/reference/opt/shaders-msl/vert/set_builtin_in_func.vert
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+vertex main0_out main0()
+{
+    main0_out out = {};
+    out.gl_Position = float4(1.0);
+    return out;
+}
+

--- a/reference/opt/shaders-msl/vert/set_builtin_in_func.vert
+++ b/reference/opt/shaders-msl/vert/set_builtin_in_func.vert
@@ -6,12 +6,14 @@ using namespace metal;
 struct main0_out
 {
     float4 gl_Position [[position]];
+    float gl_PointSize [[point_size]];
 };
 
 vertex main0_out main0()
 {
     main0_out out = {};
-    out.gl_Position = float4(1.0);
+    out.gl_PointSize = 1.0;
+    out.gl_Position = float4(out.gl_PointSize);
     return out;
 }
 

--- a/reference/shaders-msl/vert/set_builtin_in_func.vert
+++ b/reference/shaders-msl/vert/set_builtin_in_func.vert
@@ -8,17 +8,19 @@ using namespace metal;
 struct main0_out
 {
     float4 gl_Position [[position]];
+    float gl_PointSize [[point_size]];
 };
 
-void write_position(thread float4& gl_Position)
+void write_outblock(thread float4& gl_Position, thread float& gl_PointSize)
 {
-    gl_Position = float4(1.0);
+    gl_PointSize = 1.0;
+    gl_Position = float4(gl_PointSize);
 }
 
 vertex main0_out main0()
 {
     main0_out out = {};
-    write_position(out.gl_Position);
+    write_outblock(out.gl_Position, out.gl_PointSize);
     return out;
 }
 

--- a/reference/shaders-msl/vert/set_builtin_in_func.vert
+++ b/reference/shaders-msl/vert/set_builtin_in_func.vert
@@ -1,0 +1,24 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+void write_position(thread float4& gl_Position)
+{
+    gl_Position = float4(1.0);
+}
+
+vertex main0_out main0()
+{
+    main0_out out = {};
+    write_position(out.gl_Position);
+    return out;
+}
+

--- a/shaders-msl/vert/set_builtin_in_func.vert
+++ b/shaders-msl/vert/set_builtin_in_func.vert
@@ -1,11 +1,12 @@
 #version 450
 
-void write_position()
+void write_outblock()
 {
-    gl_Position = vec4(1.0);
+	gl_PointSize = 1.0;
+    gl_Position = vec4(gl_PointSize);
 }
 
 void main()
 {
-    write_position();
+    write_outblock();
 }

--- a/shaders-msl/vert/set_builtin_in_func.vert
+++ b/shaders-msl/vert/set_builtin_in_func.vert
@@ -1,0 +1,11 @@
+#version 450
+
+void write_position()
+{
+    gl_Position = vec4(1.0);
+}
+
+void main()
+{
+    write_position();
+}

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -1063,6 +1063,34 @@ const SPIRType &Compiler::get_type_from_variable(uint32_t id) const
 	return get<SPIRType>(get<SPIRVariable>(id).basetype);
 }
 
+uint32_t Compiler::get_non_pointer_type_id(uint32_t type_id) const
+{
+	auto *p_type = &get<SPIRType>(type_id);
+	while (p_type->pointer)
+	{
+		assert(p_type->parent_type);
+		type_id = p_type->parent_type;
+		p_type = &get<SPIRType>(type_id);
+	}
+	return type_id;
+}
+
+const SPIRType &Compiler::get_non_pointer_type(const SPIRType &type) const
+{
+	auto *p_type = &type;
+	while (p_type->pointer)
+	{
+		assert(p_type->parent_type);
+		p_type = &get<SPIRType>(p_type->parent_type);
+	}
+	return *p_type;
+}
+
+const SPIRType &Compiler::get_non_pointer_type(uint32_t type_id) const
+{
+	return get_non_pointer_type(get<SPIRType>(type_id));
+}
+
 void Compiler::set_member_decoration_string(uint32_t id, uint32_t index, spv::Decoration decoration,
                                             const std::string &argument)
 {
@@ -4243,14 +4271,8 @@ bool Compiler::ActiveBuiltinHandler::handle(spv::Op opcode, const uint32_t *args
 		// Required if we access chain into builtins like gl_GlobalInvocationID.
 		add_if_builtin(args[2]);
 
-		auto *type = &compiler.get<SPIRType>(var->basetype);
-
 		// Start traversing type hierarchy at the proper non-pointer types.
-		while (type->pointer)
-		{
-			assert(type->parent_type);
-			type = &compiler.get<SPIRType>(type->parent_type);
-		}
+		auto *type = &compiler.get_non_pointer_type(var->basetype);
 
 		auto &flags =
 		    type->storage == StorageClassInput ? compiler.active_input_builtins : compiler.active_output_builtins;

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -170,6 +170,15 @@ public:
 	// Gets the SPIR-V type of a variable.
 	const SPIRType &get_type_from_variable(uint32_t id) const;
 
+	// Gets the id of SPIR-V type underlying the given type_id, which might be a pointer.
+	uint32_t get_non_pointer_type_id(uint32_t type_id) const;
+
+	// Gets the SPIR-V type underlying the given type, which might be a pointer.
+	const SPIRType &get_non_pointer_type(const SPIRType &type) const;
+
+	// Gets the SPIR-V type underlying the given type_id, which might be a pointer.
+	const SPIRType &get_non_pointer_type(uint32_t type_id) const;
+
 	// Gets the underlying storage class for an OpVariable.
 	spv::StorageClass get_storage_class(uint32_t id) const;
 

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -3524,14 +3524,8 @@ void CompilerHLSL::emit_access_chain(const Instruction &instruction)
 		else
 			base = to_expression(ops[2]);
 
-		auto *basetype = &type;
-
 		// Start traversing type hierarchy at the proper non-pointer types.
-		while (basetype->pointer)
-		{
-			assert(basetype->parent_type);
-			basetype = &get<SPIRType>(basetype->parent_type);
-		}
+		auto *basetype = &get_non_pointer_type(type);
 
 		// Traverse the type hierarchy down to the actual buffer types.
 		for (uint32_t i = 0; i < to_plain_buffer_length; i++)

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -551,7 +551,7 @@ void CompilerMSL::extract_global_variables_from_function(uint32_t func_id, std::
 				{
 					BuiltIn builtin;
 					bool is_builtin = is_member_builtin(*p_type, mbr_idx, &builtin);
-					if (!is_builtin || has_active_builtin(builtin, var.storage))
+					if (is_builtin && has_active_builtin(builtin, var.storage))
 					{
 						// Add a arg variable with the same type and decorations as the member
 						uint32_t next_id = increase_bound_by(1);

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -534,19 +534,44 @@ void CompilerMSL::extract_global_variables_from_function(uint32_t func_id, std::
 	// Add the global variables as arguments to the function
 	if (func_id != entry_point)
 	{
-		uint32_t next_id = increase_bound_by(uint32_t(added_arg_ids.size()));
 		for (uint32_t arg_id : added_arg_ids)
 		{
-			auto var = get<SPIRVariable>(arg_id);
+			auto &var = get<SPIRVariable>(arg_id);
 			uint32_t type_id = var.basetype;
-			func.add_parameter(type_id, next_id, true);
-			set<SPIRVariable>(next_id, type_id, StorageClassFunction, 0, arg_id);
+			auto *p_type = &get<SPIRType>(type_id);
 
-			// Ensure the existing variable has a valid name and the new variable has all the same meta info
-			set_name(arg_id, ensure_valid_name(to_name(arg_id), "v"));
-			meta[next_id] = meta[arg_id];
+			if (is_builtin_variable(var) && p_type->basetype == SPIRType::Struct)
+			{
+				// Get the non-pointer type
+				type_id = get_non_pointer_type_id(type_id);
+				p_type = &get<SPIRType>(type_id);
 
-			next_id++;
+				uint32_t mbr_idx = 0;
+				for (auto &mbr_type_id : p_type->member_types)
+				{
+					BuiltIn builtin;
+					bool is_builtin = is_member_builtin(*p_type, mbr_idx, &builtin);
+					if (!is_builtin || has_active_builtin(builtin, var.storage))
+					{
+						// Add a arg variable with the same type and decorations as the member
+						uint32_t next_id = increase_bound_by(1);
+						func.add_parameter(mbr_type_id, next_id, true);
+						set<SPIRVariable>(next_id, mbr_type_id, StorageClassFunction);
+						meta[next_id].decoration = meta[type_id].members[mbr_idx];
+					}
+					mbr_idx++;
+				}
+			}
+			else
+			{
+				uint32_t next_id = increase_bound_by(1);
+				func.add_parameter(type_id, next_id, true);
+				set<SPIRVariable>(next_id, type_id, StorageClassFunction, 0, arg_id);
+
+				// Ensure the existing variable has a valid name and the new variable has all the same meta info
+				set_name(arg_id, ensure_valid_name(to_name(arg_id), "v"));
+				meta[next_id] = meta[arg_id];
+			}
 		}
 	}
 }
@@ -1703,7 +1728,7 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		break;
 
 	case OpAtomicXor:
-		AFMO (xor);
+		AFMO(xor);
 		break;
 
 	// Images
@@ -3553,17 +3578,13 @@ std::string CompilerMSL::sampler_type(const SPIRType &type)
 			SPIRV_CROSS_THROW("MSL 2.0 or greater is required for arrays of samplers.");
 
 		// Arrays of samplers in MSL must be declared with a special array<T, N> syntax ala C++11 std::array.
-		auto *parent = &type;
-		while (parent->pointer)
-			parent = &get<SPIRType>(parent->parent_type);
-		parent = &get<SPIRType>(parent->parent_type);
-
 		uint32_t array_size =
 		    type.array_size_literal.back() ? type.array.back() : get<SPIRConstant>(type.array.back()).scalar();
-
 		if (array_size == 0)
 			SPIRV_CROSS_THROW("Unsized array of samplers is not supported in MSL.");
-		return join("array<", sampler_type(*parent), ", ", array_size, ">");
+
+		auto &parent = get<SPIRType>(get_non_pointer_type(type).parent_type);
+		return join("array<", sampler_type(parent), ", ", array_size, ">");
 	}
 	else
 		return "sampler";
@@ -3586,16 +3607,13 @@ string CompilerMSL::image_type_glsl(const SPIRType &type, uint32_t id)
 			SPIRV_CROSS_THROW("MSL 2.0 or greater is required for arrays of textures.");
 
 		// Arrays of images in MSL must be declared with a special array<T, N> syntax ala C++11 std::array.
-		auto *parent = &type;
-		while (parent->pointer)
-			parent = &get<SPIRType>(parent->parent_type);
-		parent = &get<SPIRType>(parent->parent_type);
-
 		uint32_t array_size =
 		    type.array_size_literal.back() ? type.array.back() : get<SPIRConstant>(type.array.back()).scalar();
 		if (array_size == 0)
 			SPIRV_CROSS_THROW("Unsized array of images is not supported in MSL.");
-		return join("array<", image_type_glsl(*parent, id), ", ", array_size, ">");
+
+		auto &parent = get<SPIRType>(get_non_pointer_type(type).parent_type);
+		return join("array<", image_type_glsl(parent, id), ", ", array_size, ">");
 	}
 
 	string img_type_name;


### PR DESCRIPTION
Add and use Compiler::get_non_pointer_type() convenience functions.

Fixes issue #610.