### PR TITLE
Changed OpTypeImage to only flag depth if the op is 1

### DIFF
--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -1842,7 +1842,7 @@ void Compiler::parse(const Instruction &instruction)
 		type.basetype = SPIRType::Image;
 		type.image.type = ops[1];
 		type.image.dim = static_cast<Dim>(ops[2]);
-		type.image.depth = ops[3] != 0;
+		type.image.depth = ops[3] == 1;
 		type.image.arrayed = ops[4] != 0;
 		type.image.ms = ops[5] != 0;
 		type.image.sampled = ops[6];


### PR DESCRIPTION
Based on the SPIR-V spec, `Depth` is only guaranteed if the op is 1. An op of 2 may or may not be depth, which is what DXC outputs for all texture types.

https://www.khronos.org/registry/spir-v/specs/1.0/SPIRV.html#OpTypeImage

https://github.com/Microsoft/DirectXShaderCompiler/blob/master/docs/SPIR-V.rst#textures