### PR TITLE
Support OpTypeImage with depth == 2 (unknown) properly.

### DIFF
--- a/reference/opt/shaders-hlsl/asm/frag/unknown-depth-state.asm.frag
+++ b/reference/opt/shaders-hlsl/asm/frag/unknown-depth-state.asm.frag
@@ -1,0 +1,31 @@
+Texture2D<float4> uShadow : register(t0);
+SamplerComparisonState _uShadow_sampler : register(s0);
+Texture2D<float4> uTexture : register(t1);
+SamplerComparisonState uSampler : register(s2);
+
+static float3 vUV;
+static float FragColor;
+
+struct SPIRV_Cross_Input
+{
+    float3 vUV : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    FragColor = uShadow.SampleCmp(_uShadow_sampler, vUV.xy, vUV.z) + uTexture.SampleCmp(uSampler, vUV.xy, vUV.z);
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    vUV = stage_input.vUV;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/opt/shaders-msl/asm/frag/unknown-depth-state.asm.frag
+++ b/reference/opt/shaders-msl/asm/frag/unknown-depth-state.asm.frag
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 vUV [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], depth2d<float> uShadow [[texture(0)]], depth2d<float> uTexture [[texture(1)]], sampler uShadowSmplr [[sampler(0)]], sampler uSampler [[sampler(2)]])
+{
+    main0_out out = {};
+    out.FragColor = uShadow.sample_compare(uShadowSmplr, in.vUV.xy, in.vUV.z) + uTexture.sample_compare(uSampler, in.vUV.xy, in.vUV.z);
+    return out;
+}
+

--- a/reference/opt/shaders/asm/frag/unknown-depth-state.asm.vk.frag
+++ b/reference/opt/shaders/asm/frag/unknown-depth-state.asm.vk.frag
@@ -1,0 +1,13 @@
+#version 450
+
+layout(binding = 0) uniform sampler2DShadow uShadow;
+uniform sampler2DShadow SPIRV_Cross_CombineduTextureuSampler;
+
+layout(location = 0) in vec3 vUV;
+layout(location = 0) out float FragColor;
+
+void main()
+{
+    FragColor = texture(uShadow, vec3(vUV.xy, vUV.z)) + texture(SPIRV_Cross_CombineduTextureuSampler, vec3(vUV.xy, vUV.z));
+}
+

--- a/reference/opt/shaders/asm/frag/unknown-depth-state.asm.vk.frag.vk
+++ b/reference/opt/shaders/asm/frag/unknown-depth-state.asm.vk.frag.vk
@@ -1,0 +1,14 @@
+#version 450
+
+layout(set = 0, binding = 0) uniform sampler2DShadow uShadow;
+layout(set = 0, binding = 1) uniform texture2D uTexture;
+layout(set = 0, binding = 2) uniform samplerShadow uSampler;
+
+layout(location = 0) in vec3 vUV;
+layout(location = 0) out float FragColor;
+
+void main()
+{
+    FragColor = texture(uShadow, vec3(vUV.xy, vUV.z)) + texture(sampler2DShadow(uTexture, uSampler), vec3(vUV.xy, vUV.z));
+}
+

--- a/reference/shaders-hlsl/asm/frag/unknown-depth-state.asm.frag
+++ b/reference/shaders-hlsl/asm/frag/unknown-depth-state.asm.frag
@@ -1,0 +1,41 @@
+Texture2D<float4> uShadow : register(t0);
+SamplerComparisonState _uShadow_sampler : register(s0);
+Texture2D<float4> uTexture : register(t1);
+SamplerComparisonState uSampler : register(s2);
+
+static float3 vUV;
+static float FragColor;
+
+struct SPIRV_Cross_Input
+{
+    float3 vUV : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float FragColor : SV_Target0;
+};
+
+float sample_combined()
+{
+    return uShadow.SampleCmp(_uShadow_sampler, vUV.xy, vUV.z);
+}
+
+float sample_separate()
+{
+    return uTexture.SampleCmp(uSampler, vUV.xy, vUV.z);
+}
+
+void frag_main()
+{
+    FragColor = sample_combined() + sample_separate();
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    vUV = stage_input.vUV;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-msl/asm/frag/unknown-depth-state.asm.frag
+++ b/reference/shaders-msl/asm/frag/unknown-depth-state.asm.frag
@@ -1,0 +1,34 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 vUV [[user(locn0)]];
+};
+
+float sample_combined(thread float3& vUV, thread depth2d<float> uShadow, thread const sampler uShadowSmplr)
+{
+    return uShadow.sample_compare(uShadowSmplr, vUV.xy, vUV.z);
+}
+
+float sample_separate(thread float3& vUV, thread depth2d<float> uTexture, thread sampler uSampler)
+{
+    return uTexture.sample_compare(uSampler, vUV.xy, vUV.z);
+}
+
+fragment main0_out main0(main0_in in [[stage_in]], depth2d<float> uShadow [[texture(0)]], depth2d<float> uTexture [[texture(1)]], sampler uShadowSmplr [[sampler(0)]], sampler uSampler [[sampler(2)]])
+{
+    main0_out out = {};
+    out.FragColor = sample_combined(in.vUV, uShadow, uShadowSmplr) + sample_separate(in.vUV, uTexture, uSampler);
+    return out;
+}
+

--- a/reference/shaders/asm/frag/unknown-depth-state.asm.vk.frag
+++ b/reference/shaders/asm/frag/unknown-depth-state.asm.vk.frag
@@ -1,0 +1,23 @@
+#version 450
+
+layout(binding = 0) uniform sampler2DShadow uShadow;
+uniform sampler2DShadow SPIRV_Cross_CombineduTextureuSampler;
+
+layout(location = 0) in vec3 vUV;
+layout(location = 0) out float FragColor;
+
+float sample_combined()
+{
+    return texture(uShadow, vec3(vUV.xy, vUV.z));
+}
+
+float sample_separate()
+{
+    return texture(SPIRV_Cross_CombineduTextureuSampler, vec3(vUV.xy, vUV.z));
+}
+
+void main()
+{
+    FragColor = sample_combined() + sample_separate();
+}
+

--- a/reference/shaders/asm/frag/unknown-depth-state.asm.vk.frag.vk
+++ b/reference/shaders/asm/frag/unknown-depth-state.asm.vk.frag.vk
@@ -1,0 +1,24 @@
+#version 450
+
+layout(set = 0, binding = 0) uniform sampler2DShadow uShadow;
+layout(set = 0, binding = 1) uniform texture2D uTexture;
+layout(set = 0, binding = 2) uniform samplerShadow uSampler;
+
+layout(location = 0) in vec3 vUV;
+layout(location = 0) out float FragColor;
+
+float sample_combined()
+{
+    return texture(uShadow, vec3(vUV.xy, vUV.z));
+}
+
+float sample_separate()
+{
+    return texture(sampler2DShadow(uTexture, uSampler), vec3(vUV.xy, vUV.z));
+}
+
+void main()
+{
+    FragColor = sample_combined() + sample_separate();
+}
+

--- a/shaders-hlsl/asm/frag/unknown-depth-state.asm.frag
+++ b/shaders-hlsl/asm/frag/unknown-depth-state.asm.frag
@@ -1,0 +1,71 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 6
+; Bound: 44
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %vUV %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %sample_combined_ "sample_combined("
+               OpName %sample_separate_ "sample_separate("
+               OpName %uShadow "uShadow"
+               OpName %vUV "vUV"
+               OpName %uTexture "uTexture"
+               OpName %uSampler "uSampler"
+               OpName %FragColor "FragColor"
+               OpDecorate %uShadow DescriptorSet 0
+               OpDecorate %uShadow Binding 0
+               OpDecorate %vUV Location 0
+               OpDecorate %uTexture DescriptorSet 0
+               OpDecorate %uTexture Binding 1
+               OpDecorate %uSampler DescriptorSet 0
+               OpDecorate %uSampler Binding 2
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+          %7 = OpTypeFunction %float
+         %12 = OpTypeImage %float 2D 2 0 0 1 Unknown
+         %13 = OpTypeSampledImage %12
+%_ptr_UniformConstant_13 = OpTypePointer UniformConstant %13
+    %uShadow = OpVariable %_ptr_UniformConstant_13 UniformConstant
+    %v3float = OpTypeVector %float 3
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+        %vUV = OpVariable %_ptr_Input_v3float Input
+%_ptr_UniformConstant_25 = OpTypePointer UniformConstant %12
+   %uTexture = OpVariable %_ptr_UniformConstant_25 UniformConstant
+         %29 = OpTypeSampler
+%_ptr_UniformConstant_29 = OpTypePointer UniformConstant %29
+   %uSampler = OpVariable %_ptr_UniformConstant_29 UniformConstant
+%_ptr_Output_float = OpTypePointer Output %float
+  %FragColor = OpVariable %_ptr_Output_float Output
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %41 = OpFunctionCall %float %sample_combined_
+         %42 = OpFunctionCall %float %sample_separate_
+         %43 = OpFAdd %float %41 %42
+               OpStore %FragColor %43
+               OpReturn
+               OpFunctionEnd
+%sample_combined_ = OpFunction %float None %7
+          %9 = OpLabel
+         %16 = OpLoad %13 %uShadow
+         %20 = OpLoad %v3float %vUV
+         %21 = OpCompositeExtract %float %20 2
+         %22 = OpImageSampleDrefImplicitLod %float %16 %20 %21
+               OpReturnValue %22
+               OpFunctionEnd
+%sample_separate_ = OpFunction %float None %7
+         %11 = OpLabel
+         %28 = OpLoad %12 %uTexture
+         %32 = OpLoad %29 %uSampler
+         %33 = OpSampledImage %13 %28 %32
+         %34 = OpLoad %v3float %vUV
+         %35 = OpCompositeExtract %float %34 2
+         %36 = OpImageSampleDrefImplicitLod %float %33 %34 %35
+               OpReturnValue %36
+               OpFunctionEnd

--- a/shaders-msl/asm/frag/unknown-depth-state.asm.frag
+++ b/shaders-msl/asm/frag/unknown-depth-state.asm.frag
@@ -1,0 +1,71 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 6
+; Bound: 44
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %vUV %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %sample_combined_ "sample_combined("
+               OpName %sample_separate_ "sample_separate("
+               OpName %uShadow "uShadow"
+               OpName %vUV "vUV"
+               OpName %uTexture "uTexture"
+               OpName %uSampler "uSampler"
+               OpName %FragColor "FragColor"
+               OpDecorate %uShadow DescriptorSet 0
+               OpDecorate %uShadow Binding 0
+               OpDecorate %vUV Location 0
+               OpDecorate %uTexture DescriptorSet 0
+               OpDecorate %uTexture Binding 1
+               OpDecorate %uSampler DescriptorSet 0
+               OpDecorate %uSampler Binding 2
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+          %7 = OpTypeFunction %float
+         %12 = OpTypeImage %float 2D 2 0 0 1 Unknown
+         %13 = OpTypeSampledImage %12
+%_ptr_UniformConstant_13 = OpTypePointer UniformConstant %13
+    %uShadow = OpVariable %_ptr_UniformConstant_13 UniformConstant
+    %v3float = OpTypeVector %float 3
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+        %vUV = OpVariable %_ptr_Input_v3float Input
+%_ptr_UniformConstant_25 = OpTypePointer UniformConstant %12
+   %uTexture = OpVariable %_ptr_UniformConstant_25 UniformConstant
+         %29 = OpTypeSampler
+%_ptr_UniformConstant_29 = OpTypePointer UniformConstant %29
+   %uSampler = OpVariable %_ptr_UniformConstant_29 UniformConstant
+%_ptr_Output_float = OpTypePointer Output %float
+  %FragColor = OpVariable %_ptr_Output_float Output
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %41 = OpFunctionCall %float %sample_combined_
+         %42 = OpFunctionCall %float %sample_separate_
+         %43 = OpFAdd %float %41 %42
+               OpStore %FragColor %43
+               OpReturn
+               OpFunctionEnd
+%sample_combined_ = OpFunction %float None %7
+          %9 = OpLabel
+         %16 = OpLoad %13 %uShadow
+         %20 = OpLoad %v3float %vUV
+         %21 = OpCompositeExtract %float %20 2
+         %22 = OpImageSampleDrefImplicitLod %float %16 %20 %21
+               OpReturnValue %22
+               OpFunctionEnd
+%sample_separate_ = OpFunction %float None %7
+         %11 = OpLabel
+         %28 = OpLoad %12 %uTexture
+         %32 = OpLoad %29 %uSampler
+         %33 = OpSampledImage %13 %28 %32
+         %34 = OpLoad %v3float %vUV
+         %35 = OpCompositeExtract %float %34 2
+         %36 = OpImageSampleDrefImplicitLod %float %33 %34 %35
+               OpReturnValue %36
+               OpFunctionEnd

--- a/shaders/asm/frag/unknown-depth-state.asm.vk.frag
+++ b/shaders/asm/frag/unknown-depth-state.asm.vk.frag
@@ -1,0 +1,71 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 6
+; Bound: 44
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %vUV %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %sample_combined_ "sample_combined("
+               OpName %sample_separate_ "sample_separate("
+               OpName %uShadow "uShadow"
+               OpName %vUV "vUV"
+               OpName %uTexture "uTexture"
+               OpName %uSampler "uSampler"
+               OpName %FragColor "FragColor"
+               OpDecorate %uShadow DescriptorSet 0
+               OpDecorate %uShadow Binding 0
+               OpDecorate %vUV Location 0
+               OpDecorate %uTexture DescriptorSet 0
+               OpDecorate %uTexture Binding 1
+               OpDecorate %uSampler DescriptorSet 0
+               OpDecorate %uSampler Binding 2
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+          %7 = OpTypeFunction %float
+         %12 = OpTypeImage %float 2D 2 0 0 1 Unknown
+         %13 = OpTypeSampledImage %12
+%_ptr_UniformConstant_13 = OpTypePointer UniformConstant %13
+    %uShadow = OpVariable %_ptr_UniformConstant_13 UniformConstant
+    %v3float = OpTypeVector %float 3
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+        %vUV = OpVariable %_ptr_Input_v3float Input
+%_ptr_UniformConstant_25 = OpTypePointer UniformConstant %12
+   %uTexture = OpVariable %_ptr_UniformConstant_25 UniformConstant
+         %29 = OpTypeSampler
+%_ptr_UniformConstant_29 = OpTypePointer UniformConstant %29
+   %uSampler = OpVariable %_ptr_UniformConstant_29 UniformConstant
+%_ptr_Output_float = OpTypePointer Output %float
+  %FragColor = OpVariable %_ptr_Output_float Output
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %41 = OpFunctionCall %float %sample_combined_
+         %42 = OpFunctionCall %float %sample_separate_
+         %43 = OpFAdd %float %41 %42
+               OpStore %FragColor %43
+               OpReturn
+               OpFunctionEnd
+%sample_combined_ = OpFunction %float None %7
+          %9 = OpLabel
+         %16 = OpLoad %13 %uShadow
+         %20 = OpLoad %v3float %vUV
+         %21 = OpCompositeExtract %float %20 2
+         %22 = OpImageSampleDrefImplicitLod %float %16 %20 %21
+               OpReturnValue %22
+               OpFunctionEnd
+%sample_separate_ = OpFunction %float None %7
+         %11 = OpLabel
+         %28 = OpLoad %12 %uTexture
+         %32 = OpLoad %29 %uSampler
+         %33 = OpSampledImage %13 %28 %32
+         %34 = OpLoad %v3float %vUV
+         %35 = OpCompositeExtract %float %34 2
+         %36 = OpImageSampleDrefImplicitLod %float %33 %34 %35
+               OpReturnValue %36
+               OpFunctionEnd

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -826,8 +826,7 @@ protected:
 	// There might be unrelated IDs found in this set which do not correspond to actual variables.
 	// This set should only be queried for the existence of samplers which are already known to be variables or parameter IDs.
 	// Similar is implemented for images, as well as if subpass inputs are needed.
-	std::unordered_set<uint32_t> comparison_samplers;
-	std::unordered_set<uint32_t> comparison_images;
+	std::unordered_set<uint32_t> comparison_ids;
 	bool need_subpass_input = false;
 
 	// In certain backends, we will need to use a dummy sampler to be able to emit code.
@@ -836,23 +835,37 @@ protected:
 	uint32_t dummy_sampler_id = 0;
 
 	void analyze_image_and_sampler_usage();
+
+	struct CombinedImageSamplerDrefHandler : OpcodeHandler
+	{
+		CombinedImageSamplerDrefHandler(Compiler &compiler_)
+		    : compiler(compiler_)
+		{
+		}
+		bool handle(spv::Op opcode, const uint32_t *args, uint32_t length) override;
+
+		Compiler &compiler;
+		std::unordered_set<uint32_t> dref_combined_samplers;
+	};
+
 	struct CombinedImageSamplerUsageHandler : OpcodeHandler
 	{
-		CombinedImageSamplerUsageHandler(Compiler &compiler_)
+		CombinedImageSamplerUsageHandler(Compiler &compiler_,
+		                                 const std::unordered_set<uint32_t> &dref_combined_samplers_)
 		    : compiler(compiler_)
+		    , dref_combined_samplers(dref_combined_samplers_)
 		{
 		}
 
 		bool begin_function_scope(const uint32_t *args, uint32_t length) override;
 		bool handle(spv::Op opcode, const uint32_t *args, uint32_t length) override;
 		Compiler &compiler;
+		const std::unordered_set<uint32_t> &dref_combined_samplers;
 
 		std::unordered_map<uint32_t, std::unordered_set<uint32_t>> dependency_hierarchy;
-		std::unordered_set<uint32_t> comparison_images;
-		std::unordered_set<uint32_t> comparison_samplers;
+		std::unordered_set<uint32_t> comparison_ids;
 
-		void add_hierarchy_to_comparison_samplers(uint32_t sampler);
-		void add_hierarchy_to_comparison_images(uint32_t sampler);
+		void add_hierarchy_to_comparison_ids(uint32_t ids);
 		bool need_subpass_input = false;
 	};
 
@@ -867,6 +880,8 @@ protected:
 
 	Bitset combined_decoration_for_member(const SPIRType &type, uint32_t index) const;
 	static bool is_desktop_only_format(spv::ImageFormat format);
+
+	bool image_is_comparison(const SPIRType &type, uint32_t id) const;
 
 private:
 	// Used only to implement the old deprecated get_entry_point() interface.

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -491,7 +491,7 @@ protected:
 	void replace_fragment_output(SPIRVariable &var);
 	void replace_fragment_outputs();
 	bool check_explicit_lod_allowed(uint32_t lod);
-	std::string legacy_tex_op(const std::string &op, const SPIRType &imgtype, uint32_t lod);
+	std::string legacy_tex_op(const std::string &op, const SPIRType &imgtype, uint32_t lod, uint32_t id);
 
 	uint32_t indent = 0;
 

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -118,9 +118,9 @@ public:
 
 private:
 	std::string type_to_glsl(const SPIRType &type, uint32_t id = 0) override;
-	std::string image_type_hlsl(const SPIRType &type);
-	std::string image_type_hlsl_modern(const SPIRType &type);
-	std::string image_type_hlsl_legacy(const SPIRType &type);
+	std::string image_type_hlsl(const SPIRType &type, uint32_t id);
+	std::string image_type_hlsl_modern(const SPIRType &type, uint32_t id);
+	std::string image_type_hlsl_legacy(const SPIRType &type, uint32_t id);
 	void emit_function_prototype(SPIRFunction &func, const Bitset &return_flags) override;
 	void emit_hlsl_entry_point();
 	void emit_header() override;

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -3633,9 +3633,7 @@ string CompilerMSL::image_type_glsl(const SPIRType &type, uint32_t id)
 
 	// Bypass pointers because we need the real image struct
 	auto &img_type = get<SPIRType>(type.self).image;
-	bool shadow_image = comparison_images.count(id) != 0;
-
-	if (img_type.depth || shadow_image)
+	if (image_is_comparison(type, id))
 	{
 		switch (img_type.dim)
 		{


### PR DESCRIPTION
Track which OpSampledImages are ever used with Dref opcodes.

Fix #631.