### PR TITLE
CompilerMSL vertex entry point return void when rasterization disabled.

### DIFF
--- a/reference/opt/shaders-msl/vert/no_stage_out.vert
+++ b/reference/opt/shaders-msl/vert/no_stage_out.vert
@@ -1,0 +1,20 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct _10
+{
+    uint4 _m0[1024];
+};
+
+struct main0_in
+{
+    uint4 m_19 [[attribute(0)]];
+};
+
+vertex void main0(main0_in in [[stage_in]], device _10& _12 [[buffer(0)]], uint gl_VertexIndex [[vertex_id]])
+{
+    _12._m0[gl_VertexIndex] = in.m_19;
+}
+

--- a/reference/opt/shaders-msl/vert/no_stage_out.write_tex.vert
+++ b/reference/opt/shaders-msl/vert/no_stage_out.write_tex.vert
@@ -1,0 +1,27 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 m_17 [[attribute(0)]];
+};
+
+vertex void main0(main0_in in [[stage_in]], texture1d<uint> _37 [[texture(0)]], texture1d<uint, access::write> _34 [[texture(1)]])
+{
+    main0_out out = {};
+    out.gl_Position = in.m_17;
+    for (int _45 = 0; _45 < 128; )
+    {
+        _34.write(_37.read(uint(_45)), uint(_45));
+        _45++;
+        continue;
+    }
+}
+

--- a/reference/shaders-msl/vert/no_stage_out.vert
+++ b/reference/shaders-msl/vert/no_stage_out.vert
@@ -1,0 +1,20 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct _10
+{
+    uint4 _m0[1024];
+};
+
+struct main0_in
+{
+    uint4 m_19 [[attribute(0)]];
+};
+
+vertex void main0(main0_in in [[stage_in]], device _10& _12 [[buffer(0)]], uint gl_VertexIndex [[vertex_id]])
+{
+    _12._m0[gl_VertexIndex] = in.m_19;
+}
+

--- a/reference/shaders-msl/vert/no_stage_out.write_tex.vert
+++ b/reference/shaders-msl/vert/no_stage_out.write_tex.vert
@@ -1,0 +1,25 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 m_17 [[attribute(0)]];
+};
+
+vertex void main0(main0_in in [[stage_in]], texture1d<uint> _37 [[texture(0)]], texture1d<uint, access::write> _34 [[texture(1)]])
+{
+    main0_out out = {};
+    out.gl_Position = in.m_17;
+    for (int _22 = 0; _22 < 128; _22++)
+    {
+        _34.write(_37.read(uint(_22)), uint(_22));
+    }
+}
+

--- a/shaders-msl/vert/no_stage_out.vert
+++ b/shaders-msl/vert/no_stage_out.vert
@@ -1,0 +1,14 @@
+#version 450
+
+layout(binding = 0, std430) writeonly buffer _10_12
+{
+	uvec4 _m0[1024];
+} _12;
+
+layout(location = 0) in uvec4 _19;
+
+void main()
+{
+	_12._m0[gl_VertexIndex] = _19;
+}
+

--- a/shaders-msl/vert/no_stage_out.write_tex.vert
+++ b/shaders-msl/vert/no_stage_out.write_tex.vert
@@ -1,0 +1,16 @@
+#version 450
+
+layout(binding = 1, r32ui) uniform writeonly uimage1D _32;
+layout(binding = 0, r32ui) uniform readonly uimage1D _35;
+
+layout(location = 0) in vec4 _14;
+
+void main()
+{
+	gl_Position = _14;
+	for (int _19 = 0; _19 < 128; _19++)
+	{
+		imageStore(_32, _19, imageLoad(_35, _19));
+	}
+}
+

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -153,6 +153,7 @@ public:
 		uint32_t msl_version = make_msl_version(1, 2);
 		uint32_t texel_buffer_texture_width = 4096; // Width of 2D Metal textures used as 1D texel buffers
 		bool enable_point_size_builtin = true;
+		bool disable_rasterization = false; // Used as both input and output
 		bool resolve_specialized_array_lengths = true;
 
 		bool is_ios()
@@ -399,6 +400,7 @@ protected:
 		std::unordered_map<uint32_t, uint32_t> result_types;
 		bool suppress_missing_prototypes = false;
 		bool uses_atomics = false;
+		bool uses_image_write = false;
 	};
 
 	// Sorts the members of a SPIRType and associated Meta info based on a settable sorting


### PR DESCRIPTION
Add CompilerMSL::Options::disable_rasterization input/output API flag.
Disable rasterization via API flag or when writing to textures.
Disable rasterization when shader declares no output.
Add test shaders for vertex no output and write texture forcing void output.

Metal has an IFF relationship between pipeline rasterization and vertex shader void return.

Metal requires that vertex shaders have a void return on any of:
- rasterization is disabled on the pipeline
- writing to textures
- writing to buffers
- no output variables are declared

Furthermore...when a void return is declared by the shader for any of the above reasons, the runtime pipeline must disable rasterization...requiring feedback through the API of the void return.