### PR TITLE
Add CompilerMSL::get_is_rasterization_disabled() to manage rasterization status.

### DIFF
--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -153,7 +153,7 @@ public:
 		uint32_t msl_version = make_msl_version(1, 2);
 		uint32_t texel_buffer_texture_width = 4096; // Width of 2D Metal textures used as 1D texel buffers
 		bool enable_point_size_builtin = true;
-		bool disable_rasterization = false; // Used as both input and output
+		bool disable_rasterization = false;
 		bool resolve_specialized_array_lengths = true;
 
 		bool is_ios()
@@ -202,6 +202,13 @@ public:
 	void set_msl_options(const Options &opts)
 	{
 		msl_options = opts;
+	}
+
+	// Provide feedback to calling API to allow runtime to disable pipeline
+	// rasterization if vertex shader requires rasterization to be disabled.
+	bool get_is_rasterization_disabled() const
+	{
+		return is_rasterization_disabled && (get_entry_point().model == spv::ExecutionModelVertex);
 	}
 
 	// An enum of SPIR-V functions that are implemented in additional
@@ -376,6 +383,7 @@ protected:
 	uint32_t stage_uniforms_var_id = 0;
 	bool needs_vertex_idx_arg = false;
 	bool needs_instance_idx_arg = false;
+	bool is_rasterization_disabled = false;
 	std::string qual_pos_var_name;
 	std::string stage_in_var_name = "in";
 	std::string stage_out_var_name = "out";


### PR DESCRIPTION
Simplification refactor of PR #644.