### PR TITLE
CompilerMSL disable rasterization on buffer writes in vertex shader.

### DIFF
--- a/reference/opt/shaders-msl/vert/no_stage_out.write_buff.vert
+++ b/reference/opt/shaders-msl/vert/no_stage_out.write_buff.vert
@@ -1,0 +1,37 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct _35
+{
+    uint4 _m0[1024];
+};
+
+struct _40
+{
+    uint4 _m0[1024];
+};
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 m_17 [[attribute(0)]];
+};
+
+vertex void main0(main0_in in [[stage_in]], constant _40& _42 [[buffer(0)]], device _35& _37 [[buffer(1)]])
+{
+    main0_out out = {};
+    out.gl_Position = in.m_17;
+    for (int _51 = 0; _51 < 1024; )
+    {
+        _37._m0[_51] = _42._m0[_51];
+        _51++;
+        continue;
+    }
+}
+

--- a/reference/opt/shaders-msl/vert/no_stage_out.write_buff_atomic.vert
+++ b/reference/opt/shaders-msl/vert/no_stage_out.write_buff_atomic.vert
@@ -1,0 +1,30 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct _23
+{
+    uint _m0;
+};
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 m_17 [[attribute(0)]];
+};
+
+vertex void main0(main0_in in [[stage_in]], device _23& _25 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = in.m_17;
+    uint _29 = atomic_fetch_add_explicit((volatile device atomic_uint*)&_25._m0, 1u, memory_order_relaxed);
+}
+

--- a/reference/shaders-msl/vert/no_stage_out.write_buff.vert
+++ b/reference/shaders-msl/vert/no_stage_out.write_buff.vert
@@ -1,0 +1,35 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct _35
+{
+    uint4 _m0[1024];
+};
+
+struct _40
+{
+    uint4 _m0[1024];
+};
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 m_17 [[attribute(0)]];
+};
+
+vertex void main0(main0_in in [[stage_in]], constant _40& _42 [[buffer(0)]], device _35& _37 [[buffer(1)]])
+{
+    main0_out out = {};
+    out.gl_Position = in.m_17;
+    for (int _22 = 0; _22 < 1024; _22++)
+    {
+        _37._m0[_22] = _42._m0[_22];
+    }
+}
+

--- a/reference/shaders-msl/vert/no_stage_out.write_buff_atomic.vert
+++ b/reference/shaders-msl/vert/no_stage_out.write_buff_atomic.vert
@@ -1,0 +1,31 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct _23
+{
+    uint _m0;
+};
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 m_17 [[attribute(0)]];
+};
+
+vertex void main0(main0_in in [[stage_in]], device _23& _25 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = in.m_17;
+    uint _29 = atomic_fetch_add_explicit((volatile device atomic_uint*)&_25._m0, 1u, memory_order_relaxed);
+    uint _22 = _29;
+}
+

--- a/shaders-msl/vert/no_stage_out.write_buff.vert
+++ b/shaders-msl/vert/no_stage_out.write_buff.vert
@@ -1,0 +1,23 @@
+#version 450
+
+layout(binding = 1, std430) writeonly buffer _33_35
+{
+	uvec4 _m0[1024];
+} _35;
+
+layout(binding = 0, std140) uniform _38_40
+{
+	uvec4 _m0[1024];
+} _40;
+
+layout(location = 0) in vec4 _14;
+
+void main()
+{
+	gl_Position = _14;
+	for (int _19 = 0; _19 < 1024; _19++)
+	{
+		_35._m0[_19] = _40._m0[_19];
+	}
+}
+

--- a/shaders-msl/vert/no_stage_out.write_buff_atomic.vert
+++ b/shaders-msl/vert/no_stage_out.write_buff_atomic.vert
@@ -1,0 +1,15 @@
+#version 450
+
+layout(binding = 0, std430) coherent buffer _19_21
+{
+	uint _m0;
+} _21;
+
+layout(location = 0) in vec4 _14;
+
+void main()
+{
+	gl_Position = _14;
+	uint _26 = atomicAdd(_21._m0, 1u);
+}
+

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -403,12 +403,13 @@ protected:
 
 		bool handle(spv::Op opcode, const uint32_t *args, uint32_t length) override;
 		CompilerMSL::SPVFuncImpl get_spv_func_impl(spv::Op opcode, const uint32_t *args);
+		void check_resource_write(uint32_t var_id);
 
 		CompilerMSL &compiler;
 		std::unordered_map<uint32_t, uint32_t> result_types;
 		bool suppress_missing_prototypes = false;
 		bool uses_atomics = false;
-		bool uses_image_write = false;
+		bool uses_resource_write = false;
 	};
 
 	// Sorts the members of a SPIRType and associated Meta info based on a settable sorting


### PR DESCRIPTION
Continues from PRs #644 & #646 to include writes and atomic writes to buffers from vertex shaders. 