### PR TITLE
fix typo in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ macro(spirv_cross_add_library name config_name)
       PUBLIC_HEADER DESTINATION include/spirv_cross)
   install(FILES ${hdrs} DESTINATION include/spirv_cross)
   install(EXPORT ${config_name}Config DESTINATION share/${config_name}/cmake)
-  export(TARGETS ${targets} FILE ${config_name}Config.cmake)
+  export(TARGETS ${name} FILE ${config_name}Config.cmake)
 endmacro()
 
 


### PR DESCRIPTION
Variable `targets` is not defined. It should be variable`name` to make library targets exported.

This bug prevents cmake based projects directly use SPIRV-Cross libraries by using `FetchContent` module, `add_subdirectory(...)` and `target_link_libraries(...)`.