### PR TITLE
Deal with continue blocks which only flush phi variables.

### DIFF
--- a/reference/opt/shaders/asm/frag/for-loop-phi-only-continue.asm.frag
+++ b/reference/opt/shaders/asm/frag/for-loop-phi-only-continue.asm.frag
@@ -1,0 +1,17 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    float _19;
+    _19 = 0.0;
+    for (int _22 = 0; _22 < 16; )
+    {
+        _19 += 1.0;
+        _22++;
+        continue;
+    }
+    FragColor = vec4(_19);
+}
+

--- a/reference/shaders/asm/frag/for-loop-phi-only-continue.asm.frag
+++ b/reference/shaders/asm/frag/for-loop-phi-only-continue.asm.frag
@@ -1,0 +1,19 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    float _19;
+    _19 = 0.0;
+    float _20;
+    int _23;
+    for (int _22 = 0; _22 < 16; _19 = _20, _22 = _23)
+    {
+        _20 = _19 + 1.0;
+        _23 = _22 + 1;
+        continue;
+    }
+    FragColor = vec4(_19);
+}
+

--- a/shaders/asm/frag/for-loop-phi-only-continue.asm.frag
+++ b/shaders/asm/frag/for-loop-phi-only-continue.asm.frag
@@ -1,0 +1,48 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 6
+; Bound: 51
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %FragColor "FragColor"
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %int_16 = OpConstant %int 16
+       %bool = OpTypeBool
+    %float_1 = OpConstant %float 1
+      %int_1 = OpConstant %int 1
+    %float_2 = OpConstant %float 2
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpBranch %14
+         %14 = OpLabel
+         %50 = OpPhi %float %float_0 %5 %25 %15
+         %47 = OpPhi %int %int_0 %5 %28 %15
+         %22 = OpSLessThan %bool %47 %int_16
+               OpLoopMerge %16 %15 None
+               OpBranchConditional %22 %body1 %16
+      %body1 = OpLabel
+         %25 = OpFAdd %float %50 %float_1
+         %28 = OpIAdd %int %47 %int_1
+			   OpBranch %15
+         %15 = OpLabel
+               OpBranch %14
+         %16 = OpLabel
+         %46 = OpCompositeConstruct %v4float %50 %50 %50 %50
+               OpStore %FragColor %46
+               OpReturn
+               OpFunctionEnd

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -2437,7 +2437,13 @@ bool Compiler::execution_is_noop(const SPIRBlock &from, const SPIRBlock &to) con
 		if (!start->ops.empty())
 			return false;
 
-		start = &get<SPIRBlock>(start->next_block);
+		auto &next = get<SPIRBlock>(start->next_block);
+		// Flushing phi variables does not count as noop.
+		for (auto &phi : next.phi_variables)
+			if (phi.parent == start->self)
+				return false;
+
+		start = &next;
 	}
 }
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -549,6 +549,7 @@ protected:
 	void find_static_extensions();
 
 	std::string emit_for_loop_initializers(const SPIRBlock &block);
+	void emit_while_loop_initializers(const SPIRBlock &block);
 	bool for_loop_initializers_are_same_type(const SPIRBlock &block);
 	bool optimize_read_modify_write(const SPIRType &type, const std::string &lhs, const std::string &rhs);
 	void fixup_image_load_store_access();


### PR DESCRIPTION
Need to promote while loops for for-loops in this case.
Also, deal with potential loop variables for other loop types.

Fix #651.