### PR TITLE
MSL: Properly support passing parameters by value.

### DIFF
--- a/reference/opt/shaders-hlsl/asm/frag/pass-by-value.asm.frag
+++ b/reference/opt/shaders-hlsl/asm/frag/pass-by-value.asm.frag
@@ -1,0 +1,24 @@
+cbuffer registers
+{
+    float registers_foo : packoffset(c0);
+};
+
+static float FragColor;
+
+struct SPIRV_Cross_Output
+{
+    float FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    FragColor = 10.0f + registers_foo;
+}
+
+SPIRV_Cross_Output main()
+{
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/opt/shaders-msl/asm/frag/pass-by-value.asm.frag
+++ b/reference/opt/shaders-msl/asm/frag/pass-by-value.asm.frag
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Registers
+{
+    float foo;
+};
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+fragment main0_out main0(constant Registers& registers [[buffer(0)]])
+{
+    main0_out out = {};
+    out.FragColor = 10.0 + registers.foo;
+    return out;
+}
+

--- a/reference/opt/shaders/asm/frag/pass-by-value.asm.frag
+++ b/reference/opt/shaders/asm/frag/pass-by-value.asm.frag
@@ -1,0 +1,16 @@
+#version 450
+
+struct Registers
+{
+    float foo;
+};
+
+uniform Registers registers;
+
+layout(location = 0) out float FragColor;
+
+void main()
+{
+    FragColor = 10.0 + registers.foo;
+}
+

--- a/reference/shaders-hlsl/asm/frag/pass-by-value.asm.frag
+++ b/reference/shaders-hlsl/asm/frag/pass-by-value.asm.frag
@@ -1,0 +1,29 @@
+cbuffer registers
+{
+    float registers_foo : packoffset(c0);
+};
+
+static float FragColor;
+
+struct SPIRV_Cross_Output
+{
+    float FragColor : SV_Target0;
+};
+
+float add_value(float v, float w)
+{
+    return v + w;
+}
+
+void frag_main()
+{
+    FragColor = add_value(10.0f, registers_foo);
+}
+
+SPIRV_Cross_Output main()
+{
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-msl/asm/frag/empty-struct.asm.frag
+++ b/reference/shaders-msl/asm/frag/empty-struct.asm.frag
@@ -15,7 +15,7 @@ float GetValue(thread const EmptyStructTest& self)
     return 0.0;
 }
 
-float GetValue_1(thread const EmptyStructTest& self)
+float GetValue_1(EmptyStructTest self)
 {
     return 0.0;
 }

--- a/reference/shaders-msl/asm/frag/pass-by-value.asm.frag
+++ b/reference/shaders-msl/asm/frag/pass-by-value.asm.frag
@@ -1,0 +1,29 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Registers
+{
+    float foo;
+};
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+float add_value(float v, float w)
+{
+    return v + w;
+}
+
+fragment main0_out main0(constant Registers& registers [[buffer(0)]])
+{
+    main0_out out = {};
+    out.FragColor = add_value(10.0, registers.foo);
+    return out;
+}
+

--- a/reference/shaders/asm/frag/pass-by-value.asm.frag
+++ b/reference/shaders/asm/frag/pass-by-value.asm.frag
@@ -1,0 +1,21 @@
+#version 450
+
+struct Registers
+{
+    float foo;
+};
+
+uniform Registers registers;
+
+layout(location = 0) out float FragColor;
+
+float add_value(float v, float w)
+{
+    return v + w;
+}
+
+void main()
+{
+    FragColor = add_value(10.0, registers.foo);
+}
+

--- a/shaders-hlsl/asm/frag/pass-by-value.asm.frag
+++ b/shaders-hlsl/asm/frag/pass-by-value.asm.frag
@@ -1,0 +1,51 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 6
+; Bound: 32
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %add_value_f1_f1_ "add_value(f1;f1;"
+               OpName %v "v"
+               OpName %w "w"
+               OpName %FragColor "FragColor"
+               OpName %Registers "Registers"
+               OpMemberName %Registers 0 "foo"
+               OpName %registers "registers"
+               OpDecorate %FragColor Location 0
+               OpMemberDecorate %Registers 0 Offset 0
+               OpDecorate %Registers Block
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_ptr_Function_float = OpTypePointer Function %float
+          %8 = OpTypeFunction %float %float %float
+%_ptr_Output_float = OpTypePointer Output %float
+  %FragColor = OpVariable %_ptr_Output_float Output
+   %float_10 = OpConstant %float 10
+  %Registers = OpTypeStruct %float
+%_ptr_PushConstant_Registers = OpTypePointer PushConstant %Registers
+  %registers = OpVariable %_ptr_PushConstant_Registers PushConstant
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_PushConstant_float = OpTypePointer PushConstant %float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %29 = OpAccessChain %_ptr_PushConstant_float %registers %int_0
+         %30 = OpLoad %float %29
+         %31 = OpFunctionCall %float %add_value_f1_f1_ %float_10 %30
+               OpStore %FragColor %31
+               OpReturn
+               OpFunctionEnd
+%add_value_f1_f1_ = OpFunction %float None %8
+          %v = OpFunctionParameter %float
+          %w = OpFunctionParameter %float
+         %12 = OpLabel
+         %15 = OpFAdd %float %v %w
+               OpReturnValue %15
+               OpFunctionEnd

--- a/shaders-msl/asm/frag/pass-by-value.asm.frag
+++ b/shaders-msl/asm/frag/pass-by-value.asm.frag
@@ -1,0 +1,51 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 6
+; Bound: 32
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %add_value_f1_f1_ "add_value(f1;f1;"
+               OpName %v "v"
+               OpName %w "w"
+               OpName %FragColor "FragColor"
+               OpName %Registers "Registers"
+               OpMemberName %Registers 0 "foo"
+               OpName %registers "registers"
+               OpDecorate %FragColor Location 0
+               OpMemberDecorate %Registers 0 Offset 0
+               OpDecorate %Registers Block
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_ptr_Function_float = OpTypePointer Function %float
+          %8 = OpTypeFunction %float %float %float
+%_ptr_Output_float = OpTypePointer Output %float
+  %FragColor = OpVariable %_ptr_Output_float Output
+   %float_10 = OpConstant %float 10
+  %Registers = OpTypeStruct %float
+%_ptr_PushConstant_Registers = OpTypePointer PushConstant %Registers
+  %registers = OpVariable %_ptr_PushConstant_Registers PushConstant
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_PushConstant_float = OpTypePointer PushConstant %float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %29 = OpAccessChain %_ptr_PushConstant_float %registers %int_0
+         %30 = OpLoad %float %29
+         %31 = OpFunctionCall %float %add_value_f1_f1_ %float_10 %30
+               OpStore %FragColor %31
+               OpReturn
+               OpFunctionEnd
+%add_value_f1_f1_ = OpFunction %float None %8
+          %v = OpFunctionParameter %float
+          %w = OpFunctionParameter %float
+         %12 = OpLabel
+         %15 = OpFAdd %float %v %w
+               OpReturnValue %15
+               OpFunctionEnd

--- a/shaders/asm/frag/pass-by-value.asm.frag
+++ b/shaders/asm/frag/pass-by-value.asm.frag
@@ -1,0 +1,51 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 6
+; Bound: 32
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %add_value_f1_f1_ "add_value(f1;f1;"
+               OpName %v "v"
+               OpName %w "w"
+               OpName %FragColor "FragColor"
+               OpName %Registers "Registers"
+               OpMemberName %Registers 0 "foo"
+               OpName %registers "registers"
+               OpDecorate %FragColor Location 0
+               OpMemberDecorate %Registers 0 Offset 0
+               OpDecorate %Registers Block
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_ptr_Function_float = OpTypePointer Function %float
+          %8 = OpTypeFunction %float %float %float
+%_ptr_Output_float = OpTypePointer Output %float
+  %FragColor = OpVariable %_ptr_Output_float Output
+   %float_10 = OpConstant %float 10
+  %Registers = OpTypeStruct %float
+%_ptr_PushConstant_Registers = OpTypePointer PushConstant %Registers
+  %registers = OpVariable %_ptr_PushConstant_Registers PushConstant
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_PushConstant_float = OpTypePointer PushConstant %float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %29 = OpAccessChain %_ptr_PushConstant_float %registers %int_0
+         %30 = OpLoad %float %29
+         %31 = OpFunctionCall %float %add_value_f1_f1_ %float_10 %30
+               OpStore %FragColor %31
+               OpReturn
+               OpFunctionEnd
+%add_value_f1_f1_ = OpFunction %float None %8
+          %v = OpFunctionParameter %float
+          %w = OpFunctionParameter %float
+         %12 = OpLabel
+         %15 = OpFAdd %float %v %w
+               OpReturnValue %15
+               OpFunctionEnd


### PR DESCRIPTION
MSL would force thread const& which would not work if the input argument
came from a different storage class.

Emit proper non-reference arguments for such values.

Fix #643.