### PR TITLE
Use GL_NV_gpu_shader5 as a fallback for AMD_gpu_shader_half_float.

### DIFF
--- a/reference/opt/shaders/desktop-only/frag/fp16.desktop.frag
+++ b/reference/opt/shaders/desktop-only/frag/fp16.desktop.frag
@@ -1,5 +1,11 @@
 #version 450
+#if defined(GL_AMD_gpu_shader_half_float)
 #extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_NV_gpu_shader5)
+#extension GL_NV_gpu_shader5 : require
+#else
+#error No extension available for FP16.
+#endif
 
 layout(location = 3) in f16vec4 v4;
 

--- a/reference/shaders/desktop-only/frag/fp16.desktop.frag
+++ b/reference/shaders/desktop-only/frag/fp16.desktop.frag
@@ -1,5 +1,11 @@
 #version 450
+#if defined(GL_AMD_gpu_shader_half_float)
 #extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_NV_gpu_shader5)
+#extension GL_NV_gpu_shader5 : require
+#else
+#error No extension available for FP16.
+#endif
 
 struct ResType
 {


### PR DESCRIPTION
Fix #660.