### PR TITLE
Support the shader_draw_parameters extension.

### DIFF
--- a/reference/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
+++ b/reference/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
@@ -1,0 +1,23 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    uint gl_BaseVertex;
+    uint gl_BaseInstance;
+};
+
+vertex main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    out.gl_Position = float4(in.gl_BaseVertex, in.gl_BaseInstance, 0, 1);
+    return out;
+}
+

--- a/reference/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
+++ b/reference/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
@@ -8,16 +8,10 @@ struct main0_out
     float4 gl_Position [[position]];
 };
 
-struct main0_in
-{
-    uint gl_BaseVertex [[base_vertex]];
-    uint gl_BaseInstance [[base_instance]];
-};
-
-vertex main0_out main0(main0_in in [[stage_in]])
+vertex main0_out main0(uint gl_BaseVertex [[base_vertex]], uint gl_BaseInstance [[base_instance]])
 {
     main0_out out = {};
-    out.gl_Position = float4(float(in.gl_BaseVertex), float(in.gl_BaseInstance), 0.0f, 1.0f);
+    out.gl_Position = float4(float(gl_BaseVertex), float(gl_BaseInstance), 0.0, 1.0);
     return out;
 }
 

--- a/reference/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
+++ b/reference/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
@@ -17,7 +17,7 @@ struct main0_in
 vertex main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
-    out.gl_Position = float4(float(in.gl_BaseVertex), float(in.gl_BaseInstance), 0, 1);
+    out.gl_Position = float4(float(in.gl_BaseVertex), float(in.gl_BaseInstance), 0.0f, 1.0f);
     return out;
 }
 

--- a/reference/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
+++ b/reference/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
@@ -10,14 +10,14 @@ struct main0_out
 
 struct main0_in
 {
-    uint gl_BaseVertex;
-    uint gl_BaseInstance;
+    uint gl_BaseVertex [[base_vertex]];
+    uint gl_BaseInstance [[base_instance]];
 };
 
 vertex main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
-    out.gl_Position = float4(in.gl_BaseVertex, in.gl_BaseInstance, 0, 1);
+    out.gl_Position = float4(float(in.gl_BaseVertex), float(in.gl_BaseInstance), 0, 1);
     return out;
 }
 

--- a/reference/shaders/desktop-only/vert/shader-draw-parameters-450.desktop.vert
+++ b/reference/shaders/desktop-only/vert/shader-draw-parameters-450.desktop.vert
@@ -1,0 +1,12 @@
+#version 450
+#extension GL_ARB_shader_draw_parameters : enable
+
+out gl_PerVertex
+{
+    vec4 gl_Position;
+};
+
+void main()
+{
+    gl_Position = vec4(float(gl_BaseVertexARB), float(gl_BaseInstanceARB), float(gl_DrawIDARB), 1);
+}

--- a/reference/shaders/desktop-only/vert/shader-draw-parameters-450.desktop.vert
+++ b/reference/shaders/desktop-only/vert/shader-draw-parameters-450.desktop.vert
@@ -3,5 +3,7 @@
 
 void main()
 {
-    gl_Position = vec4(float(gl_BaseVertexARB), float(gl_BaseInstanceARB), float(gl_DrawIDARB), 1);
+    gl_Position = vec4(float(gl_BaseVertexARB), float(gl_BaseInstanceARB), float(gl_DrawIDARB), 1.0);
 }
+
+

--- a/reference/shaders/desktop-only/vert/shader-draw-parameters-450.desktop.vert
+++ b/reference/shaders/desktop-only/vert/shader-draw-parameters-450.desktop.vert
@@ -1,10 +1,5 @@
 #version 450
-#extension GL_ARB_shader_draw_parameters : enable
-
-out gl_PerVertex
-{
-    vec4 gl_Position;
-};
+#extension GL_ARB_shader_draw_parameters : require
 
 void main()
 {

--- a/reference/shaders/desktop-only/vert/shader-draw-parameters-450.desktop.vert
+++ b/reference/shaders/desktop-only/vert/shader-draw-parameters-450.desktop.vert
@@ -6,4 +6,3 @@ void main()
     gl_Position = vec4(float(gl_BaseVertexARB), float(gl_BaseInstanceARB), float(gl_DrawIDARB), 1.0);
 }
 
-

--- a/reference/shaders/desktop-only/vert/shader-draw-parameters.desktop.vert
+++ b/reference/shaders/desktop-only/vert/shader-draw-parameters.desktop.vert
@@ -1,0 +1,12 @@
+#version 450
+#extension GL_ARB_shader_draw_parameters : enable
+
+out gl_PerVertex
+{
+    vec4 gl_Position;
+};
+
+void main()
+{
+    gl_Position = vec4(gl_BaseVertexARB, gl_BaseInstanceARB, gl_DrawIDARB, 1);
+}

--- a/reference/shaders/desktop-only/vert/shader-draw-parameters.desktop.vert
+++ b/reference/shaders/desktop-only/vert/shader-draw-parameters.desktop.vert
@@ -5,4 +5,3 @@ void main()
     gl_Position = vec4(float(gl_BaseVertex), float(gl_BaseInstance), float(gl_DrawID), 1.0);
 }
 
-

--- a/reference/shaders/desktop-only/vert/shader-draw-parameters.desktop.vert
+++ b/reference/shaders/desktop-only/vert/shader-draw-parameters.desktop.vert
@@ -2,5 +2,7 @@
 
 void main()
 {
-    gl_Position = vec4(float(gl_BaseVertex), float(gl_BaseInstance), float(gl_DrawID), 1);
+    gl_Position = vec4(float(gl_BaseVertex), float(gl_BaseInstance), float(gl_DrawID), 1.0);
 }
+
+

--- a/reference/shaders/desktop-only/vert/shader-draw-parameters.desktop.vert
+++ b/reference/shaders/desktop-only/vert/shader-draw-parameters.desktop.vert
@@ -1,5 +1,4 @@
-#version 450
-#extension GL_ARB_shader_draw_parameters : enable
+#version 460
 
 out gl_PerVertex
 {
@@ -8,5 +7,5 @@ out gl_PerVertex
 
 void main()
 {
-    gl_Position = vec4(gl_BaseVertexARB, gl_BaseInstanceARB, gl_DrawIDARB, 1);
+    gl_Position = vec4(float(gl_BaseVertex), float(gl_BaseInstance), float(gl_DrawID), 1);
 }

--- a/reference/shaders/desktop-only/vert/shader-draw-parameters.desktop.vert
+++ b/reference/shaders/desktop-only/vert/shader-draw-parameters.desktop.vert
@@ -1,10 +1,5 @@
 #version 460
 
-out gl_PerVertex
-{
-    vec4 gl_Position;
-};
-
 void main()
 {
     gl_Position = vec4(float(gl_BaseVertex), float(gl_BaseInstance), float(gl_DrawID), 1);

--- a/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
+++ b/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
@@ -1,0 +1,11 @@
+#version 460
+
+out gl_PerVertex
+{
+    vec4 gl_Position;
+};
+
+void main()
+{
+    gl_Position = vec4(gl_BaseVertex, gl_BaseInstance, 0, 1);
+}

--- a/shaders/desktop-only/vert/shader-draw-parameters-450.desktop.vert
+++ b/shaders/desktop-only/vert/shader-draw-parameters-450.desktop.vert
@@ -1,0 +1,12 @@
+#version 450
+#extension GL_ARB_shader_draw_parameters : enable
+
+out gl_PerVertex
+{
+    vec4 gl_Position;
+};
+
+void main()
+{
+    gl_Position = vec4(gl_BaseVertexARB, gl_BaseInstanceARB, gl_DrawIDARB, 1);
+}

--- a/shaders/desktop-only/vert/shader-draw-parameters.desktop.vert
+++ b/shaders/desktop-only/vert/shader-draw-parameters.desktop.vert
@@ -1,0 +1,11 @@
+#version 460
+
+out gl_PerVertex
+{
+    vec4 gl_Position;
+};
+
+void main()
+{
+    gl_Position = vec4(gl_BaseVertex, gl_BaseInstance, gl_DrawID, 1);
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -5066,6 +5066,30 @@ string CompilerGLSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 		return "gl_GlobalInvocationID";
 	case BuiltInLocalInvocationIndex:
 		return "gl_LocalInvocationIndex";
+	case BuiltInBaseVertex:
+		if (options.es)
+			SPIRV_CROSS_THROW("BaseVertex not supported in ES profile.");
+		if (options.version < 460) {
+			require_extension_internal("GL_ARB_shader_draw_parameters");
+			return "gl_BaseVertexARB";
+		}
+		return "gl_BaseVertex";
+	case BuiltInBaseInstance:
+		if (options.es)
+			SPIRV_CROSS_THROW("BaseInstance not supported in ES profile.");
+		if (options.version < 460) {
+			require_extension_internal("GL_ARB_shader_draw_parameters");
+			return "gl_BaseInstanceARB";
+		}
+		return "gl_BaseInstance";
+	case BuiltInDrawIndex:
+		if (options.es)
+			SPIRV_CROSS_THROW("DrawIndex not supported in ES profile.");
+		if (options.version < 460) {
+			require_extension_internal("GL_ARB_shader_draw_parameters");
+			return "gl_DrawIDARB";
+		}
+		return "gl_DrawID";
 
 	case BuiltInSampleId:
 		if (options.es && options.version < 320)
@@ -10020,6 +10044,9 @@ void CompilerGLSL::bitcast_from_builtin_load(uint32_t source_id, std::string &ex
 	case BuiltInVertexId:
 	case BuiltInVertexIndex:
 	case BuiltInSampleId:
+	case BuiltInBaseVertex:
+	case BuiltInBaseInstance:
+	case BuiltInDrawIndex:
 		expected_type = SPIRType::Int;
 		break;
 

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -5069,7 +5069,8 @@ string CompilerGLSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 	case BuiltInBaseVertex:
 		if (options.es)
 			SPIRV_CROSS_THROW("BaseVertex not supported in ES profile.");
-		if (options.version < 460) {
+		if (options.version < 460)
+		{
 			require_extension_internal("GL_ARB_shader_draw_parameters");
 			return "gl_BaseVertexARB";
 		}
@@ -5077,7 +5078,8 @@ string CompilerGLSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 	case BuiltInBaseInstance:
 		if (options.es)
 			SPIRV_CROSS_THROW("BaseInstance not supported in ES profile.");
-		if (options.version < 460) {
+		if (options.version < 460)
+		{
 			require_extension_internal("GL_ARB_shader_draw_parameters");
 			return "gl_BaseInstanceARB";
 		}
@@ -5085,7 +5087,8 @@ string CompilerGLSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 	case BuiltInDrawIndex:
 		if (options.es)
 			SPIRV_CROSS_THROW("DrawIndex not supported in ES profile.");
-		if (options.version < 460) {
+		if (options.version < 460)
+		{
 			require_extension_internal("GL_ARB_shader_draw_parameters");
 			return "gl_DrawIDARB";
 		}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -3891,8 +3891,7 @@ string CompilerMSL::builtin_qualifier(BuiltIn builtin)
 	case BuiltInBaseInstance:
 		return "base_instance";
 	case BuiltInDrawIndex:
-		// FIXME: Metal needs real support for this.
-		return "buffer(15)";
+		SPIRV_CROSS_THROW("DrawIndex is not supported in MSL.");
 
 	// Vertex function out
 	case BuiltInClipDistance:
@@ -3965,7 +3964,7 @@ string CompilerMSL::builtin_type_decl(BuiltIn builtin)
 	case BuiltInBaseInstance:
 		return "uint";
 	case BuiltInDrawIndex:
-		return "device uint *";
+		SPIRV_CROSS_THROW("DrawIndex is not supported in MSL.");
 
 	// Vertex function out
 	case BuiltInClipDistance:

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -2964,8 +2964,10 @@ string CompilerMSL::member_attribute_qualifier(const SPIRType &type, uint32_t in
 			case BuiltInInstanceId:
 			case BuiltInInstanceIndex:
 			case BuiltInBaseInstance:
-			case BuiltInDrawIndex:
 				return string(" [[") + builtin_qualifier(builtin) + "]]";
+
+			case BuiltInDrawIndex:
+				SPIRV_CROSS_THROW("DrawIndex is not supported in MSL.");
 
 			default:
 				return "";
@@ -3847,7 +3849,7 @@ string CompilerMSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 	case BuiltInBaseInstance:
 		return "gl_BaseInstance";
 	case BuiltInDrawIndex:
-		return "gl_DrawID";
+		SPIRV_CROSS_THROW("DrawIndex is not supported in MSL.");
 
 	// When used in the entry function, output builtins are qualified with output struct name.
 	// Test storage class as NOT Input, as output builtins might be part of generic type.

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -2960,8 +2960,11 @@ string CompilerMSL::member_attribute_qualifier(const SPIRType &type, uint32_t in
 			{
 			case BuiltInVertexId:
 			case BuiltInVertexIndex:
+			case BuiltInBaseVertex:
 			case BuiltInInstanceId:
 			case BuiltInInstanceIndex:
+			case BuiltInBaseInstance:
+			case BuiltInDrawIndex:
 				return string(" [[") + builtin_qualifier(builtin) + "]]";
 
 			default:
@@ -3839,6 +3842,12 @@ string CompilerMSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 		return "gl_VertexIndex";
 	case BuiltInInstanceIndex:
 		return "gl_InstanceIndex";
+	case BuiltInBaseVertex:
+		return "gl_BaseVertex";
+	case BuiltInBaseInstance:
+		return "gl_BaseInstance";
+	case BuiltInDrawIndex:
+		return "gl_DrawID";
 
 	// When used in the entry function, output builtins are qualified with output struct name.
 	// Test storage class as NOT Input, as output builtins might be part of generic type.
@@ -3873,10 +3882,17 @@ string CompilerMSL::builtin_qualifier(BuiltIn builtin)
 		return "vertex_id";
 	case BuiltInVertexIndex:
 		return "vertex_id";
+	case BuiltInBaseVertex:
+		return "base_vertex";
 	case BuiltInInstanceId:
 		return "instance_id";
 	case BuiltInInstanceIndex:
 		return "instance_id";
+	case BuiltInBaseInstance:
+		return "base_instance";
+	case BuiltInDrawIndex:
+		// FIXME: Metal needs real support for this.
+		return "buffer(15)";
 
 	// Vertex function out
 	case BuiltInClipDistance:
@@ -3940,10 +3956,16 @@ string CompilerMSL::builtin_type_decl(BuiltIn builtin)
 		return "uint";
 	case BuiltInVertexIndex:
 		return "uint";
+	case BuiltInBaseVertex:
+		return "uint";
 	case BuiltInInstanceId:
 		return "uint";
 	case BuiltInInstanceIndex:
 		return "uint";
+	case BuiltInBaseInstance:
+		return "uint";
+	case BuiltInDrawIndex:
+		return "device uint *";
 
 	// Vertex function out
 	case BuiltInClipDistance:


### PR DESCRIPTION
This adds the builtin uniforms from the `SPV_KHR_shader_draw_parameters` extension, and emits them to GLSL (with `GL_ARB_shader_draw_parameters`) and MSL. Metal doesn't support repeated draws the way Vulkan does, so the `DrawIndex` builtin isn't implemented here.

HLSL isn't added in this PR. I don't know what the corresponding builtin variables are in HLSL.