### PR TITLE
MSL: Support unordered relational operators.

### DIFF
--- a/reference/shaders-msl/asm/frag/unord-relational-op.asm.frag
+++ b/reference/shaders-msl/asm/frag/unord-relational-op.asm.frag
@@ -13,17 +13,45 @@ struct main0_out
     float4 FragColor [[color(0)]];
 };
 
-fragment main0_out main0()
+struct main0_in
+{
+    float2 c [[user(locn2)]];
+    float2 d [[user(locn3)]];
+    float3 e [[user(locn4)]];
+    float3 f [[user(locn5)]];
+    float4 g [[user(locn6)]];
+    float4 h [[user(locn7)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
     float t0 = a;
     float t1 = b;
-    bool c21 = (isunordered(a, b) || a == b);
-    bool c22 = (isunordered(a, b) || a != b);
-    bool c23 = (isunordered(a, b) || a < b);
-    bool c25 = (isunordered(a, b) || a > b);
-    bool c27 = (isunordered(a, b) || a <= b);
-    bool c29 = (isunordered(a, b) || a >= b);
+    bool c1 = (isunordered(a, b) || a == b);
+    bool c2 = (isunordered(a, b) || a != b);
+    bool c3 = (isunordered(a, b) || a < b);
+    bool c4 = (isunordered(a, b) || a > b);
+    bool c5 = (isunordered(a, b) || a <= b);
+    bool c6 = (isunordered(a, b) || a >= b);
+    bool2 c7 = (isunordered(in.c, in.d) || in.c == in.d);
+    bool2 c8 = (isunordered(in.c, in.d) || in.c != in.d);
+    bool2 c9 = (isunordered(in.c, in.d) || in.c < in.d);
+    bool2 c10 = (isunordered(in.c, in.d) || in.c > in.d);
+    bool2 c11 = (isunordered(in.c, in.d) || in.c <= in.d);
+    bool2 c12 = (isunordered(in.c, in.d) || in.c >= in.d);
+    bool3 c13 = (isunordered(in.e, in.f) || in.e == in.f);
+    bool3 c14 = (isunordered(in.e, in.f) || in.e != in.f);
+    bool3 c15 = (isunordered(in.e, in.f) || in.e < in.f);
+    bool3 c16 = (isunordered(in.e, in.f) || in.e > in.f);
+    bool3 c17 = (isunordered(in.e, in.f) || in.e <= in.f);
+    bool3 c18 = (isunordered(in.e, in.f) || in.e >= in.f);
+    bool4 c19 = (isunordered(in.g, in.h) || in.g == in.h);
+    bool4 c20 = (isunordered(in.g, in.h) || in.g != in.h);
+    bool4 c21 = (isunordered(in.g, in.h) || in.g < in.h);
+    bool4 c22 = (isunordered(in.g, in.h) || in.g > in.h);
+    bool4 c23 = (isunordered(in.g, in.h) || in.g <= in.h);
+    bool4 c24 = (isunordered(in.g, in.h) || in.g >= in.h);
     out.FragColor = float4(t0 + t1);
     return out;
 }

--- a/reference/shaders-msl/asm/frag/unord-relational-op.asm.frag
+++ b/reference/shaders-msl/asm/frag/unord-relational-op.asm.frag
@@ -1,0 +1,30 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+constant float a_tmp [[function_constant(1)]];
+constant float a = is_function_constant_defined(a_tmp) ? a_tmp : 1.0;
+constant float b_tmp [[function_constant(2)]];
+constant float b = is_function_constant_defined(b_tmp) ? b_tmp : 2.0;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0()
+{
+    main0_out out = {};
+    float t0 = a;
+    float t1 = b;
+    bool c21 = (isunordered(a, b) || a == b);
+    bool c22 = (isunordered(a, b) || a != b);
+    bool c23 = (isunordered(a, b) || a < b);
+    bool c25 = (isunordered(a, b) || a > b);
+    bool c27 = (isunordered(a, b) || a <= b);
+    bool c29 = (isunordered(a, b) || a >= b);
+    out.FragColor = float4(t0 + t1);
+    return out;
+}
+

--- a/shaders-msl/asm/frag/unord-relational-op.asm.frag
+++ b/shaders-msl/asm/frag/unord-relational-op.asm.frag
@@ -1,38 +1,59 @@
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Khronos Glslang Reference Front End; 7
-; Bound: 33
+; Bound: 122
 ; Schema: 0
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
-               OpEntryPoint Fragment %main "main" %FragColor
+               OpEntryPoint Fragment %main "main" %c %d %e %f %g %h %FragColor
                OpExecutionMode %main OriginUpperLeft
-               OpSource ESSL 310
+               OpSource GLSL 460
                OpName %main "main"
                OpName %t0 "t0"
                OpName %a "a"
                OpName %t1 "t1"
                OpName %b "b"
+               OpName %c1 "c1"
+               OpName %c2 "c2"
+               OpName %c3 "c3"
+               OpName %c4 "c4"
+               OpName %c5 "c5"
+               OpName %c6 "c6"
+               OpName %c7 "c7"
+               OpName %c "c"
+               OpName %d "d"
+               OpName %c8 "c8"
+               OpName %c9 "c9"
+               OpName %c10 "c10"
+               OpName %c11 "c11"
+               OpName %c12 "c12"
+               OpName %c13 "c13"
+               OpName %e "e"
+               OpName %f "f"
+               OpName %c14 "c14"
+               OpName %c15 "c15"
+               OpName %c16 "c16"
+               OpName %c17 "c17"
+               OpName %c18 "c18"
+               OpName %c19 "c19"
+               OpName %g "g"
+               OpName %h "h"
+               OpName %c20 "c20"
                OpName %c21 "c21"
                OpName %c22 "c22"
                OpName %c23 "c23"
-               OpName %c25 "c25"
-               OpName %c27 "c27"
-               OpName %c29 "c29"
+               OpName %c24 "c24"
                OpName %FragColor "FragColor"
-               OpDecorate %t0 RelaxedPrecision
-               OpDecorate %a RelaxedPrecision
                OpDecorate %a SpecId 1
-               OpDecorate %t1 RelaxedPrecision
-               OpDecorate %b RelaxedPrecision
                OpDecorate %b SpecId 2
-               OpDecorate %FragColor RelaxedPrecision
+               OpDecorate %c Location 2
+               OpDecorate %d Location 3
+               OpDecorate %e Location 4
+               OpDecorate %f Location 5
+               OpDecorate %g Location 6
+               OpDecorate %h Location 7
                OpDecorate %FragColor Location 0
-               OpDecorate %29 RelaxedPrecision
-               OpDecorate %30 RelaxedPrecision
-               OpDecorate %31 RelaxedPrecision
-               OpDecorate %32 RelaxedPrecision
        %void = OpTypeVoid
           %3 = OpTypeFunction %void
       %float = OpTypeFloat 32
@@ -41,37 +62,144 @@
           %b = OpSpecConstant %float 2
        %bool = OpTypeBool
 %_ptr_Function_bool = OpTypePointer Function %bool
+     %v2bool = OpTypeVector %bool 2
+%_ptr_Function_v2bool = OpTypePointer Function %v2bool
+    %v2float = OpTypeVector %float 2
+%_ptr_Input_v2float = OpTypePointer Input %v2float
+          %c = OpVariable %_ptr_Input_v2float Input
+          %d = OpVariable %_ptr_Input_v2float Input
+     %v3bool = OpTypeVector %bool 3
+%_ptr_Function_v3bool = OpTypePointer Function %v3bool
+    %v3float = OpTypeVector %float 3
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+          %e = OpVariable %_ptr_Input_v3float Input
+          %f = OpVariable %_ptr_Input_v3float Input
+     %v4bool = OpTypeVector %bool 4
+%_ptr_Function_v4bool = OpTypePointer Function %v4bool
     %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+          %g = OpVariable %_ptr_Input_v4float Input
+          %h = OpVariable %_ptr_Input_v4float Input
 %_ptr_Output_v4float = OpTypePointer Output %v4float
   %FragColor = OpVariable %_ptr_Output_v4float Output
        %main = OpFunction %void None %3
           %5 = OpLabel
          %t0 = OpVariable %_ptr_Function_float Function
          %t1 = OpVariable %_ptr_Function_float Function
-        %c21 = OpVariable %_ptr_Function_bool Function
-        %c22 = OpVariable %_ptr_Function_bool Function
-        %c23 = OpVariable %_ptr_Function_bool Function
-        %c25 = OpVariable %_ptr_Function_bool Function
-        %c27 = OpVariable %_ptr_Function_bool Function
-        %c29 = OpVariable %_ptr_Function_bool Function
+         %c1 = OpVariable %_ptr_Function_bool Function
+         %c2 = OpVariable %_ptr_Function_bool Function
+         %c3 = OpVariable %_ptr_Function_bool Function
+         %c4 = OpVariable %_ptr_Function_bool Function
+         %c5 = OpVariable %_ptr_Function_bool Function
+         %c6 = OpVariable %_ptr_Function_bool Function
+         %c7 = OpVariable %_ptr_Function_v2bool Function
+         %c8 = OpVariable %_ptr_Function_v2bool Function
+         %c9 = OpVariable %_ptr_Function_v2bool Function
+        %c10 = OpVariable %_ptr_Function_v2bool Function
+        %c11 = OpVariable %_ptr_Function_v2bool Function
+        %c12 = OpVariable %_ptr_Function_v2bool Function
+        %c13 = OpVariable %_ptr_Function_v3bool Function
+        %c14 = OpVariable %_ptr_Function_v3bool Function
+        %c15 = OpVariable %_ptr_Function_v3bool Function
+        %c16 = OpVariable %_ptr_Function_v3bool Function
+        %c17 = OpVariable %_ptr_Function_v3bool Function
+        %c18 = OpVariable %_ptr_Function_v3bool Function
+        %c19 = OpVariable %_ptr_Function_v4bool Function
+        %c20 = OpVariable %_ptr_Function_v4bool Function
+        %c21 = OpVariable %_ptr_Function_v4bool Function
+        %c22 = OpVariable %_ptr_Function_v4bool Function
+        %c23 = OpVariable %_ptr_Function_v4bool Function
+        %c24 = OpVariable %_ptr_Function_v4bool Function
                OpStore %t0 %a
                OpStore %t1 %b
          %15 = OpFUnordEqual %bool %a %b
-               OpStore %c21 %15
+               OpStore %c1 %15
          %17 = OpFUnordNotEqual %bool %a %b
-               OpStore %c22 %17
+               OpStore %c2 %17
          %19 = OpFUnordLessThan %bool %a %b
-               OpStore %c23 %19
+               OpStore %c3 %19
          %21 = OpFUnordGreaterThan %bool %a %b
-               OpStore %c25 %21
+               OpStore %c4 %21
          %23 = OpFUnordLessThanEqual %bool %a %b
-               OpStore %c27 %23
+               OpStore %c5 %23
          %25 = OpFUnordGreaterThanEqual %bool %a %b
-               OpStore %c29 %25
-         %29 = OpLoad %float %t0
-         %30 = OpLoad %float %t1
-         %31 = OpFAdd %float %29 %30
-         %32 = OpCompositeConstruct %v4float %31 %31 %31 %31
-               OpStore %FragColor %32
+               OpStore %c6 %25
+         %32 = OpLoad %v2float %c
+         %34 = OpLoad %v2float %d
+         %35 = OpFUnordEqual %v2bool %32 %34
+               OpStore %c7 %35
+         %37 = OpLoad %v2float %c
+         %38 = OpLoad %v2float %d
+         %39 = OpFUnordNotEqual %v2bool %37 %38
+               OpStore %c8 %39
+         %41 = OpLoad %v2float %c
+         %42 = OpLoad %v2float %d
+         %43 = OpFUnordLessThan %v2bool %41 %42
+               OpStore %c9 %43
+         %45 = OpLoad %v2float %c
+         %46 = OpLoad %v2float %d
+         %47 = OpFUnordGreaterThan %v2bool %45 %46
+               OpStore %c10 %47
+         %49 = OpLoad %v2float %c
+         %50 = OpLoad %v2float %d
+         %51 = OpFUnordLessThanEqual %v2bool %49 %50
+               OpStore %c11 %51
+         %53 = OpLoad %v2float %c
+         %54 = OpLoad %v2float %d
+         %55 = OpFUnordGreaterThanEqual %v2bool %53 %54
+               OpStore %c12 %55
+         %62 = OpLoad %v3float %e
+         %64 = OpLoad %v3float %f
+         %65 = OpFUnordEqual %v3bool %62 %64
+               OpStore %c13 %65
+         %67 = OpLoad %v3float %e
+         %68 = OpLoad %v3float %f
+         %69 = OpFUnordNotEqual %v3bool %67 %68
+               OpStore %c14 %69
+         %71 = OpLoad %v3float %e
+         %72 = OpLoad %v3float %f
+         %73 = OpFUnordLessThan %v3bool %71 %72
+               OpStore %c15 %73
+         %75 = OpLoad %v3float %e
+         %76 = OpLoad %v3float %f
+         %77 = OpFUnordGreaterThan %v3bool %75 %76
+               OpStore %c16 %77
+         %79 = OpLoad %v3float %e
+         %80 = OpLoad %v3float %f
+         %81 = OpFUnordLessThanEqual %v3bool %79 %80
+               OpStore %c17 %81
+         %83 = OpLoad %v3float %e
+         %84 = OpLoad %v3float %f
+         %85 = OpFUnordGreaterThanEqual %v3bool %83 %84
+               OpStore %c18 %85
+         %92 = OpLoad %v4float %g
+         %94 = OpLoad %v4float %h
+         %95 = OpFUnordEqual %v4bool %92 %94
+               OpStore %c19 %95
+         %97 = OpLoad %v4float %g
+         %98 = OpLoad %v4float %h
+         %99 = OpFUnordNotEqual %v4bool %97 %98
+               OpStore %c20 %99
+        %101 = OpLoad %v4float %g
+        %102 = OpLoad %v4float %h
+        %103 = OpFUnordLessThan %v4bool %101 %102
+               OpStore %c21 %103
+        %105 = OpLoad %v4float %g
+        %106 = OpLoad %v4float %h
+        %107 = OpFUnordGreaterThan %v4bool %105 %106
+               OpStore %c22 %107
+        %109 = OpLoad %v4float %g
+        %110 = OpLoad %v4float %h
+        %111 = OpFUnordLessThanEqual %v4bool %109 %110
+               OpStore %c23 %111
+        %113 = OpLoad %v4float %g
+        %114 = OpLoad %v4float %h
+        %115 = OpFUnordGreaterThanEqual %v4bool %113 %114
+               OpStore %c24 %115
+        %118 = OpLoad %float %t0
+        %119 = OpLoad %float %t1
+        %120 = OpFAdd %float %118 %119
+        %121 = OpCompositeConstruct %v4float %120 %120 %120 %120
+               OpStore %FragColor %121
                OpReturn
                OpFunctionEnd

--- a/shaders-msl/asm/frag/unord-relational-op.asm.frag
+++ b/shaders-msl/asm/frag/unord-relational-op.asm.frag
@@ -1,0 +1,77 @@
+; SPIR-V
+; Version: 1.3
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 33
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource ESSL 310
+               OpName %main "main"
+               OpName %t0 "t0"
+               OpName %a "a"
+               OpName %t1 "t1"
+               OpName %b "b"
+               OpName %c21 "c21"
+               OpName %c22 "c22"
+               OpName %c23 "c23"
+               OpName %c25 "c25"
+               OpName %c27 "c27"
+               OpName %c29 "c29"
+               OpName %FragColor "FragColor"
+               OpDecorate %t0 RelaxedPrecision
+               OpDecorate %a RelaxedPrecision
+               OpDecorate %a SpecId 1
+               OpDecorate %t1 RelaxedPrecision
+               OpDecorate %b RelaxedPrecision
+               OpDecorate %b SpecId 2
+               OpDecorate %FragColor RelaxedPrecision
+               OpDecorate %FragColor Location 0
+               OpDecorate %29 RelaxedPrecision
+               OpDecorate %30 RelaxedPrecision
+               OpDecorate %31 RelaxedPrecision
+               OpDecorate %32 RelaxedPrecision
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_ptr_Function_float = OpTypePointer Function %float
+          %a = OpSpecConstant %float 1
+          %b = OpSpecConstant %float 2
+       %bool = OpTypeBool
+%_ptr_Function_bool = OpTypePointer Function %bool
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %t0 = OpVariable %_ptr_Function_float Function
+         %t1 = OpVariable %_ptr_Function_float Function
+        %c21 = OpVariable %_ptr_Function_bool Function
+        %c22 = OpVariable %_ptr_Function_bool Function
+        %c23 = OpVariable %_ptr_Function_bool Function
+        %c25 = OpVariable %_ptr_Function_bool Function
+        %c27 = OpVariable %_ptr_Function_bool Function
+        %c29 = OpVariable %_ptr_Function_bool Function
+               OpStore %t0 %a
+               OpStore %t1 %b
+         %15 = OpFUnordEqual %bool %a %b
+               OpStore %c21 %15
+         %17 = OpFUnordNotEqual %bool %a %b
+               OpStore %c22 %17
+         %19 = OpFUnordLessThan %bool %a %b
+               OpStore %c23 %19
+         %21 = OpFUnordGreaterThan %bool %a %b
+               OpStore %c25 %21
+         %23 = OpFUnordLessThanEqual %bool %a %b
+               OpStore %c27 %23
+         %25 = OpFUnordGreaterThanEqual %bool %a %b
+               OpStore %c29 %25
+         %29 = OpLoad %float %t0
+         %30 = OpLoad %float %t1
+         %31 = OpFAdd %float %29 %30
+         %32 = OpCompositeConstruct %v4float %31 %31 %31 %31
+               OpStore %FragColor %32
+               OpReturn
+               OpFunctionEnd

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -276,6 +276,7 @@ public:
 	void remap_constexpr_sampler(uint32_t id, const MSLConstexprSampler &sampler);
 
 protected:
+	void emit_binary_unord_op(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, const char *op);
 	void emit_instruction(const Instruction &instr) override;
 	void emit_glsl_op(uint32_t result_type, uint32_t result_id, uint32_t op, const uint32_t *args,
 	                  uint32_t count) override;


### PR DESCRIPTION
The SPIR-V spec says that these check if the operands either are
unordered or satisfy the given condition. So that's just what we'll do,
using Metal's `isunordered()` stdlib function. Apple's optimizers ought
to be able to collapse that to a single unordered compare.