### PR TITLE
MSL: Account for components when assigning locations to varyings.

### DIFF
--- a/reference/opt/shaders-msl/asm/frag/locations-components.asm.frag
+++ b/reference/opt/shaders-msl/asm/frag/locations-components.asm.frag
@@ -11,10 +11,10 @@ struct main0_out
 struct main0_in
 {
     float2 m_2 [[user(locn1)]];
-    float m_3 [[user(locn1)]];
+    float m_3 [[user(locn1_2)]];
     float m_4 [[user(locn2), flat]];
-    uint m_5 [[user(locn2)]];
-    uint m_6 [[user(locn2)]];
+    uint m_5 [[user(locn2_1)]];
+    uint m_6 [[user(locn2_2)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/reference/shaders-msl/asm/frag/locations-components.asm.frag
+++ b/reference/shaders-msl/asm/frag/locations-components.asm.frag
@@ -11,10 +11,10 @@ struct main0_out
 struct main0_in
 {
     float2 m_2 [[user(locn1)]];
-    float m_3 [[user(locn1)]];
+    float m_3 [[user(locn1_2)]];
     float m_4 [[user(locn2), flat]];
-    uint m_5 [[user(locn2)]];
-    uint m_6 [[user(locn2)]];
+    uint m_5 [[user(locn2_1)]];
+    uint m_6 [[user(locn2_2)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]])

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -1217,6 +1217,7 @@ struct Meta
 		Bitset decoration_flags;
 		spv::BuiltIn builtin_type;
 		uint32_t location = 0;
+		uint32_t component = 0;
 		uint32_t set = 0;
 		uint32_t binding = 0;
 		uint32_t offset = 0;

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -1126,6 +1126,10 @@ void Compiler::set_member_decoration(uint32_t id, uint32_t index, Decoration dec
 		dec.location = argument;
 		break;
 
+	case DecorationComponent:
+		dec.component = argument;
+		break;
+
 	case DecorationBinding:
 		dec.binding = argument;
 		break;
@@ -1212,6 +1216,8 @@ uint32_t Compiler::get_member_decoration(uint32_t id, uint32_t index, Decoration
 		return dec.builtin_type;
 	case DecorationLocation:
 		return dec.location;
+	case DecorationComponent:
+		return dec.component;
 	case DecorationBinding:
 		return dec.binding;
 	case DecorationOffset:
@@ -1266,6 +1272,10 @@ void Compiler::unset_member_decoration(uint32_t id, uint32_t index, Decoration d
 		dec.location = 0;
 		break;
 
+	case DecorationComponent:
+		dec.component = 0;
+		break;
+
 	case DecorationOffset:
 		dec.offset = 0;
 		break;
@@ -1313,6 +1323,10 @@ void Compiler::set_decoration(uint32_t id, Decoration decoration, uint32_t argum
 
 	case DecorationLocation:
 		dec.location = argument;
+		break;
+
+	case DecorationComponent:
+		dec.component = argument;
 		break;
 
 	case DecorationOffset:
@@ -1427,6 +1441,8 @@ uint32_t Compiler::get_decoration(uint32_t id, Decoration decoration) const
 		return dec.builtin_type;
 	case DecorationLocation:
 		return dec.location;
+	case DecorationComponent:
+		return dec.component;
 	case DecorationOffset:
 		return dec.offset;
 	case DecorationBinding:
@@ -1460,6 +1476,10 @@ void Compiler::unset_decoration(uint32_t id, Decoration decoration)
 
 	case DecorationLocation:
 		dec.location = 0;
+		break;
+
+	case DecorationComponent:
+		dec.component = 0;
 		break;
 
 	case DecorationOffset:

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -348,7 +348,7 @@ protected:
 	std::string argument_decl(const SPIRFunction::Parameter &arg);
 	std::string round_fp_tex_coords(std::string tex_coords, bool coord_is_fp);
 	uint32_t get_metal_resource_index(SPIRVariable &var, SPIRType::BaseType basetype);
-	uint32_t get_ordered_member_location(uint32_t type_id, uint32_t index);
+	uint32_t get_ordered_member_location(uint32_t type_id, uint32_t index, uint32_t *comp = nullptr);
 	size_t get_declared_struct_member_alignment(const SPIRType &struct_type, uint32_t index) const;
 	std::string to_component_argument(uint32_t id);
 	void align_struct(SPIRType &ib_type);


### PR DESCRIPTION
Two varyings (vertex outputs/fragment inputs) might have the same
location but be in different components--e.g. the compiler may have
packed what were two different varyings into a single varying vector.
Giving both varyings the same `[[user]]` attribute won't work--it may
yield unexpected results, or flat out fail to link. We could eventually
pack such varyings into a single vector, but that would require us to
handle the case where the varyings are different types--e.g. a `float`
and a `uint` packed into the same vector. For now, it seems most
prudent to give them unique `[[user]]` locations and let Apple's
compiler work out the best way to pack them.