### PR TITLE
Fix invalid code generation for HLSL SM 3 when fragment shader output is not a vec4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,7 @@
 *.a
 *.bc
 /external
+.vs/
+*.vcxproj.user
 
 !CMakeLists.txt

--- a/reference/shaders-hlsl/frag/basic-color-3comp.sm30.frag
+++ b/reference/shaders-hlsl/frag/basic-color-3comp.sm30.frag
@@ -1,0 +1,26 @@
+static float3 FragColor;
+static float4 vColor;
+
+struct SPIRV_Cross_Input
+{
+    float4 vColor : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : COLOR0;
+};
+
+void frag_main()
+{
+    FragColor = vColor.xyz;
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    vColor = stage_input.vColor;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = float4(FragColor, 0.0);
+    return stage_output;
+}

--- a/reference/shaders-hlsl/frag/basic-color-3comp.sm50.frag
+++ b/reference/shaders-hlsl/frag/basic-color-3comp.sm50.frag
@@ -1,0 +1,26 @@
+static float3 FragColor;
+static float4 vColor;
+
+struct SPIRV_Cross_Input
+{
+    float4 vColor : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float3 FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    FragColor = vColor.xyz;
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    vColor = stage_input.vColor;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/shaders-hlsl/frag/basic-color-3comp.sm30.frag
+++ b/shaders-hlsl/frag/basic-color-3comp.sm30.frag
@@ -1,0 +1,11 @@
+#version 310 es
+precision mediump float;
+
+layout(location = 0) in vec4 vColor;
+layout(location = 0) out vec3 FragColor;
+
+void main()
+{
+    FragColor = vColor.xyz;
+}
+

--- a/shaders-hlsl/frag/basic-color-3comp.sm50.frag
+++ b/shaders-hlsl/frag/basic-color-3comp.sm50.frag
@@ -1,0 +1,11 @@
+#version 310 es
+precision mediump float;
+
+layout(location = 0) in vec4 vColor;
+layout(location = 0) out vec3 FragColor;
+
+void main()
+{
+    FragColor = vColor.xyz;
+}
+

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -192,8 +192,8 @@ def shader_to_sm(shader):
         return '60'
     elif '.sm51.' in shader:
         return '51'
-    elif '.sm20.' in shader:
-        return '20'
+    elif '.sm30.' in shader:
+        return '30'
     else:
         return '50'
 


### PR DESCRIPTION
The HLSL compiler throws the following error when targeting shader model 3 and an output with the "COLOR" semantic is not a four-component vector:
``` 
error X4529: COLOR0 must be a four-component vector
```
This fixes that by forcing fragment shader outputs to a four-component vector and padding any outputs with less components with zeroes.

Also added some user-specific Visual Studio files to the gitignore for convenience and tests to do future regression checking on the above.