### PR TITLE
MSL: textureQueryLod() is not supported.

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -2039,6 +2039,9 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		break;
 	}
 
+	case OpImageQueryLod:
+		SPIRV_CROSS_THROW("MSL does not support textureQueryLod().");
+
 #define MSL_ImgQry(qrytype)                                                                 \
 	do                                                                                      \
 	{                                                                                       \


### PR DESCRIPTION
Don't bother with hacky workaround unless required.

Fix #694.