### PR TITLE
MSL: Support global I/O block and struct Input/Output usage.

### DIFF
--- a/reference/opt/shaders-msl/asm/frag/interpolation-qualifiers-struct.asm.frag
+++ b/reference/opt/shaders-msl/asm/frag/interpolation-qualifiers-struct.asm.frag
@@ -33,7 +33,15 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
-    out.FragColor = float4(in.Input_v0.x + in.Input_v1.y, in.Input_v2.xy, ((in.Input_v3.w * in.Input_v4) + in.Input_v5) - in.Input_v6);
+    Input inp = {};
+    inp.v0 = in.Input_v0;
+    inp.v1 = in.Input_v1;
+    inp.v2 = in.Input_v2;
+    inp.v3 = in.Input_v3;
+    inp.v4 = in.Input_v4;
+    inp.v5 = in.Input_v5;
+    inp.v6 = in.Input_v6;
+    out.FragColor = float4(inp.v0.x + inp.v1.y, inp.v2.xy, ((inp.v3.w * inp.v4) + inp.v5) - inp.v6);
     return out;
 }
 

--- a/reference/opt/shaders-msl/asm/frag/vector-shuffle-oom.asm.frag
+++ b/reference/opt/shaders-msl/asm/frag/vector-shuffle-oom.asm.frag
@@ -3,11 +3,6 @@
 
 using namespace metal;
 
-struct _28
-{
-    float4 _m0;
-};
-
 struct _6
 {
     float4 _m0;
@@ -86,6 +81,11 @@ struct _18
     float3 _m36;
     float4x4 _m37[2];
     float4 _m38[2];
+};
+
+struct _28
+{
+    float4 _m0;
 };
 
 constant _28 _74 = {};

--- a/reference/opt/shaders-msl/frag/in_block.frag
+++ b/reference/opt/shaders-msl/frag/in_block.frag
@@ -3,6 +3,12 @@
 
 using namespace metal;
 
+struct VertexOut
+{
+    float4 color;
+    float4 color2;
+};
+
 struct main0_out
 {
     float4 FragColor [[color(0)]];
@@ -17,7 +23,10 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
-    out.FragColor = in.VertexOut_color + in.VertexOut_color2;
+    VertexOut inputs = {};
+    inputs.color = in.VertexOut_color;
+    inputs.color2 = in.VertexOut_color2;
+    out.FragColor = inputs.color + inputs.color2;
     return out;
 }
 

--- a/reference/opt/shaders-msl/frag/interpolation-qualifiers-block.frag
+++ b/reference/opt/shaders-msl/frag/interpolation-qualifiers-block.frag
@@ -33,7 +33,15 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
-    out.FragColor = float4(in.Input_v0.x + in.Input_v1.y, in.Input_v2.xy, ((in.Input_v3.w * in.Input_v4) + in.Input_v5) - in.Input_v6);
+    Input inp = {};
+    inp.v0 = in.Input_v0;
+    inp.v1 = in.Input_v1;
+    inp.v2 = in.Input_v2;
+    inp.v3 = in.Input_v3;
+    inp.v4 = in.Input_v4;
+    inp.v5 = in.Input_v5;
+    inp.v6 = in.Input_v6;
+    out.FragColor = float4(inp.v0.x + inp.v1.y, inp.v2.xy, ((inp.v3.w * inp.v4) + inp.v5) - inp.v6);
     return out;
 }
 

--- a/reference/opt/shaders-msl/vert/interpolation-qualifiers-block.vert
+++ b/reference/opt/shaders-msl/vert/interpolation-qualifiers-block.vert
@@ -34,14 +34,22 @@ struct main0_in
 vertex main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
-    out.Output_v0 = in.Position.xy;
-    out.Output_v1 = in.Position.zw;
-    out.Output_v2 = float3(in.Position.x, in.Position.z * in.Position.y, in.Position.x);
-    out.Output_v3 = in.Position.xxyy;
-    out.Output_v4 = in.Position.w;
-    out.Output_v5 = in.Position.y;
-    out.Output_v6 = in.Position.x * in.Position.w;
+    Output outp = {};
+    outp.v0 = in.Position.xy;
+    outp.v1 = in.Position.zw;
+    outp.v2 = float3(in.Position.x, in.Position.z * in.Position.y, in.Position.x);
+    outp.v3 = in.Position.xxyy;
+    outp.v4 = in.Position.w;
+    outp.v5 = in.Position.y;
+    outp.v6 = in.Position.x * in.Position.w;
     out.gl_Position = in.Position;
+    out.Output_v0 = outp.v0;
+    out.Output_v1 = outp.v1;
+    out.Output_v2 = outp.v2;
+    out.Output_v3 = outp.v3;
+    out.Output_v4 = outp.v4;
+    out.Output_v5 = outp.v5;
+    out.Output_v6 = outp.v6;
     return out;
 }
 

--- a/reference/opt/shaders-msl/vert/out_block.vert
+++ b/reference/opt/shaders-msl/vert/out_block.vert
@@ -8,6 +8,12 @@ struct Transform
     float4x4 transform;
 };
 
+struct VertexOut
+{
+    float4 color;
+    float4 color2;
+};
+
 struct main0_out
 {
     float4 VertexOut_color [[user(locn2)]];
@@ -24,9 +30,12 @@ struct main0_in
 vertex main0_out main0(main0_in in [[stage_in]], constant Transform& block [[buffer(0)]])
 {
     main0_out out = {};
+    VertexOut outputs = {};
     out.gl_Position = block.transform * float4(in.position, 1.0);
-    out.VertexOut_color = in.color;
-    out.VertexOut_color2 = in.color + float4(1.0);
+    outputs.color = in.color;
+    outputs.color2 = in.color + float4(1.0);
+    out.VertexOut_color = outputs.color;
+    out.VertexOut_color2 = outputs.color2;
     return out;
 }
 

--- a/reference/shaders-msl-no-opt/asm/frag/inliner-dominator-inside-loop.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/inliner-dominator-inside-loop.asm.frag
@@ -59,14 +59,14 @@ struct Globals
     float4 ShadowMatrix2;
 };
 
-struct Params
-{
-    float4 LqmatFarTilingFactor;
-};
-
 struct CB0
 {
     Globals CB0;
+};
+
+struct Params
+{
+    float4 LqmatFarTilingFactor;
 };
 
 struct CB2

--- a/reference/shaders-msl-no-opt/frag/in_block_assign.frag
+++ b/reference/shaders-msl-no-opt/frag/in_block_assign.frag
@@ -23,8 +23,7 @@ fragment main0_out main0(main0_in in [[stage_in]])
     main0_out out = {};
     VOUT Clip = {};
     Clip.a = in.VOUT_a;
-    VOUT tmp;
-    tmp.a = _13.a;
+    VOUT tmp = Clip;
     tmp.a += float4(1.0);
     out.FragColor = tmp.a;
     return out;

--- a/reference/shaders-msl-no-opt/frag/in_block_assign.frag
+++ b/reference/shaders-msl-no-opt/frag/in_block_assign.frag
@@ -21,8 +21,10 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
+    VOUT Clip = {};
+    Clip.a = in.VOUT_a;
     VOUT tmp;
-    tmp.a = in.VOUT_a;
+    tmp.a = _13.a;
     tmp.a += float4(1.0);
     out.FragColor = tmp.a;
     return out;

--- a/reference/shaders-msl/asm/frag/interpolation-qualifiers-struct.asm.frag
+++ b/reference/shaders-msl/asm/frag/interpolation-qualifiers-struct.asm.frag
@@ -33,7 +33,15 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
-    out.FragColor = float4(in.Input_v0.x + in.Input_v1.y, in.Input_v2.xy, ((in.Input_v3.w * in.Input_v4) + in.Input_v5) - in.Input_v6);
+    Input inp = {};
+    inp.v0 = in.Input_v0;
+    inp.v1 = in.Input_v1;
+    inp.v2 = in.Input_v2;
+    inp.v3 = in.Input_v3;
+    inp.v4 = in.Input_v4;
+    inp.v5 = in.Input_v5;
+    inp.v6 = in.Input_v6;
+    out.FragColor = float4(inp.v0.x + inp.v1.y, inp.v2.xy, ((inp.v3.w * inp.v4) + inp.v5) - inp.v6);
     return out;
 }
 

--- a/reference/shaders-msl/asm/frag/vector-shuffle-oom.asm.frag
+++ b/reference/shaders-msl/asm/frag/vector-shuffle-oom.asm.frag
@@ -3,11 +3,6 @@
 
 using namespace metal;
 
-struct _28
-{
-    float4 _m0;
-};
-
 struct _6
 {
     float4 _m0;
@@ -86,6 +81,41 @@ struct _18
     float3 _m36;
     float4x4 _m37[2];
     float4 _m38[2];
+};
+
+struct _20
+{
+    float4 _m0;
+    float4 _m1;
+    float2 _m2;
+    float2 _m3;
+    float3 _m4;
+    float _m5;
+    float3 _m6;
+    float _m7;
+    float4 _m8;
+    float4 _m9;
+    float4 _m10;
+    float3 _m11;
+    float _m12;
+    float3 _m13;
+    float _m14;
+    float3 _m15;
+    float4 _m16;
+    float3 _m17;
+    float _m18;
+    float3 _m19;
+    float2 _m20;
+};
+
+struct _21
+{
+    float4 _m0;
+};
+
+struct _28
+{
+    float4 _m0;
 };
 
 constant _28 _74 = {};

--- a/reference/shaders-msl/frag/in_block.frag
+++ b/reference/shaders-msl/frag/in_block.frag
@@ -3,6 +3,12 @@
 
 using namespace metal;
 
+struct VertexOut
+{
+    float4 color;
+    float4 color2;
+};
+
 struct main0_out
 {
     float4 FragColor [[color(0)]];
@@ -17,7 +23,10 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
-    out.FragColor = in.VertexOut_color + in.VertexOut_color2;
+    VertexOut inputs = {};
+    inputs.color = in.VertexOut_color;
+    inputs.color2 = in.VertexOut_color2;
+    out.FragColor = inputs.color + inputs.color2;
     return out;
 }
 

--- a/reference/shaders-msl/frag/interpolation-qualifiers-block.frag
+++ b/reference/shaders-msl/frag/interpolation-qualifiers-block.frag
@@ -33,7 +33,15 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
-    out.FragColor = float4(in.Input_v0.x + in.Input_v1.y, in.Input_v2.xy, ((in.Input_v3.w * in.Input_v4) + in.Input_v5) - in.Input_v6);
+    Input inp = {};
+    inp.v0 = in.Input_v0;
+    inp.v1 = in.Input_v1;
+    inp.v2 = in.Input_v2;
+    inp.v3 = in.Input_v3;
+    inp.v4 = in.Input_v4;
+    inp.v5 = in.Input_v5;
+    inp.v6 = in.Input_v6;
+    out.FragColor = float4(inp.v0.x + inp.v1.y, inp.v2.xy, ((inp.v3.w * inp.v4) + inp.v5) - inp.v6);
     return out;
 }
 

--- a/reference/shaders-msl/vert/interpolation-qualifiers-block.vert
+++ b/reference/shaders-msl/vert/interpolation-qualifiers-block.vert
@@ -34,14 +34,22 @@ struct main0_in
 vertex main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
-    out.Output_v0 = in.Position.xy;
-    out.Output_v1 = in.Position.zw;
-    out.Output_v2 = float3(in.Position.x, in.Position.z * in.Position.y, in.Position.x);
-    out.Output_v3 = in.Position.xxyy;
-    out.Output_v4 = in.Position.w;
-    out.Output_v5 = in.Position.y;
-    out.Output_v6 = in.Position.x * in.Position.w;
+    Output outp = {};
+    outp.v0 = in.Position.xy;
+    outp.v1 = in.Position.zw;
+    outp.v2 = float3(in.Position.x, in.Position.z * in.Position.y, in.Position.x);
+    outp.v3 = in.Position.xxyy;
+    outp.v4 = in.Position.w;
+    outp.v5 = in.Position.y;
+    outp.v6 = in.Position.x * in.Position.w;
     out.gl_Position = in.Position;
+    out.Output_v0 = outp.v0;
+    out.Output_v1 = outp.v1;
+    out.Output_v2 = outp.v2;
+    out.Output_v3 = outp.v3;
+    out.Output_v4 = outp.v4;
+    out.Output_v5 = outp.v5;
+    out.Output_v6 = outp.v6;
     return out;
 }
 

--- a/reference/shaders-msl/vert/out_block.vert
+++ b/reference/shaders-msl/vert/out_block.vert
@@ -8,6 +8,12 @@ struct Transform
     float4x4 transform;
 };
 
+struct VertexOut
+{
+    float4 color;
+    float4 color2;
+};
+
 struct main0_out
 {
     float4 VertexOut_color [[user(locn2)]];
@@ -24,9 +30,12 @@ struct main0_in
 vertex main0_out main0(main0_in in [[stage_in]], constant Transform& block [[buffer(0)]])
 {
     main0_out out = {};
+    VertexOut outputs = {};
     out.gl_Position = block.transform * float4(in.position, 1.0);
-    out.VertexOut_color = in.color;
-    out.VertexOut_color2 = in.color + float4(1.0);
+    outputs.color = in.color;
+    outputs.color2 = in.color + float4(1.0);
+    out.VertexOut_color = outputs.color;
+    out.VertexOut_color2 = outputs.color2;
     return out;
 }
 

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -755,11 +755,13 @@ struct SPIRFunction : IVariant
 
 	// Statements to be emitted when the function returns.
 	// Mostly used for lowering internal data structures onto flattened structures.
-	std::vector<std::string> fixup_statements_out;
+	// Need to defer the statements, because they might rely on things which change during compilation.
+	std::vector<std::function<std::string()>> fixup_statements_out;
 
 	// Statements to be emitted when the function begins.
 	// Mostly used for populating internal data structures from flattened structures.
-	std::vector<std::string> fixup_statements_in;
+	// Need to defer the statements, because they might rely on things which change during compilation.
+	std::vector<std::function<std::string()>> fixup_statements_in;
 
 	bool active = false;
 	bool flush_undeclared = true;

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -753,15 +753,15 @@ struct SPIRFunction : IVariant
 		arguments.push_back({ parameter_type, id, 0u, 0u, alias_global_variable });
 	}
 
-	// Statements to be emitted when the function returns.
+	// Hooks to be run when the function returns.
 	// Mostly used for lowering internal data structures onto flattened structures.
-	// Need to defer the statements, because they might rely on things which change during compilation.
-	std::vector<std::function<std::string()>> fixup_statements_out;
+	// Need to defer this, because they might rely on things which change during compilation.
+	std::vector<std::function<void()>> fixup_hooks_out;
 
-	// Statements to be emitted when the function begins.
+	// Hooks to be run when the function begins.
 	// Mostly used for populating internal data structures from flattened structures.
-	// Need to defer the statements, because they might rely on things which change during compilation.
-	std::vector<std::function<std::string()>> fixup_statements_in;
+	// Need to defer this, because they might rely on things which change during compilation.
+	std::vector<std::function<void()>> fixup_hooks_in;
 
 	bool active = false;
 	bool flush_undeclared = true;

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -487,17 +487,22 @@ bool Compiler::is_hidden_variable(const SPIRVariable &var, bool include_builtins
 	return hidden;
 }
 
-bool Compiler::is_builtin_variable(const SPIRVariable &var) const
+bool Compiler::is_builtin_type(const SPIRType &type) const
 {
-	if (var.compat_builtin || meta[var.self].decoration.builtin)
-		return true;
-
 	// We can have builtin structs as well. If one member of a struct is builtin, the struct must also be builtin.
-	for (auto &m : meta[get<SPIRType>(var.basetype).self].members)
+	for (auto &m : meta[type.self].members)
 		if (m.builtin)
 			return true;
 
 	return false;
+}
+
+bool Compiler::is_builtin_variable(const SPIRVariable &var) const
+{
+	if (var.compat_builtin || meta[var.self].decoration.builtin)
+		return true;
+	else
+		return is_builtin_type(get<SPIRType>(var.basetype));
 }
 
 bool Compiler::is_member_builtin(const SPIRType &type, uint32_t index, BuiltIn *builtin) const

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -602,6 +602,7 @@ protected:
 
 	virtual std::string to_name(uint32_t id, bool allow_alias = true) const;
 	bool is_builtin_variable(const SPIRVariable &var) const;
+	bool is_builtin_type(const SPIRType &type) const;
 	bool is_hidden_variable(const SPIRVariable &var, bool include_builtins = false) const;
 	bool is_immutable(uint32_t id) const;
 	bool is_member_builtin(const SPIRType &type, uint32_t index, spv::BuiltIn *builtin) const;

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -9114,8 +9114,8 @@ void CompilerGLSL::emit_function(SPIRFunction &func, const Bitset &return_flags)
 			var.deferred_declaration = false;
 	}
 
-	for (auto &line : current_function->fixup_statements_in)
-		statement(line());
+	for (auto &line : current_function->fixup_hooks_in)
+		line();
 
 	entry_block.loop_dominator = SPIRBlock::NoDominator;
 	emit_block_chain(entry_block);
@@ -9896,8 +9896,8 @@ void CompilerGLSL::emit_block_chain(SPIRBlock &block)
 	}
 
 	case SPIRBlock::Return:
-		for (auto &line : current_function->fixup_statements_out)
-			statement(line());
+		for (auto &line : current_function->fixup_hooks_out)
+			line();
 
 		if (processing_entry_point)
 			emit_fixup();

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -9115,7 +9115,7 @@ void CompilerGLSL::emit_function(SPIRFunction &func, const Bitset &return_flags)
 	}
 
 	for (auto &line : current_function->fixup_statements_in)
-		statement(line);
+		statement(line());
 
 	entry_block.loop_dominator = SPIRBlock::NoDominator;
 	emit_block_chain(entry_block);
@@ -9897,7 +9897,7 @@ void CompilerGLSL::emit_block_chain(SPIRBlock &block)
 
 	case SPIRBlock::Return:
 		for (auto &line : current_function->fixup_statements_out)
-			statement(line);
+			statement(line());
 
 		if (processing_entry_point)
 			emit_fixup();

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -798,16 +798,16 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage)
 						switch (storage)
 						{
 						case StorageClassInput:
-							entry_func.fixup_statements_in.push_back([=]() -> string {
-								return join(to_name(p_var->self), ".", to_member_name(type, mbr_idx), " = ",
-								            qual_var_name, ";");
+							entry_func.fixup_hooks_in.push_back([=]() {
+								statement(to_name(p_var->self), ".", to_member_name(type, mbr_idx), " = ",
+								          qual_var_name, ";");
 							});
 							break;
 
 						case StorageClassOutput:
-							entry_func.fixup_statements_out.push_back([=]() -> string {
-								return join(qual_var_name, " = ", to_name(p_var->self), ".",
-								            to_member_name(type, mbr_idx), ";");
+							entry_func.fixup_hooks_out.push_back([=]() {
+								statement(qual_var_name, " = ", to_name(p_var->self), ".",
+								          to_member_name(type, mbr_idx), ";");
 							});
 							break;
 
@@ -942,14 +942,14 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage)
 						switch (storage)
 						{
 						case StorageClassInput:
-							entry_func.fixup_statements_in.push_back([=]() -> string {
-								return join(to_name(p_var->self), "[", i, "] = ", ib_var_ref, ".", mbr_name, ";");
+							entry_func.fixup_hooks_in.push_back([=]() {
+								statement(to_name(p_var->self), "[", i, "] = ", ib_var_ref, ".", mbr_name, ";");
 							});
 							break;
 
 						case StorageClassOutput:
-							entry_func.fixup_statements_out.push_back([=]() -> string {
-								return join(ib_var_ref, ".", mbr_name, " = ", to_name(p_var->self), "[", i, "];");
+							entry_func.fixup_hooks_out.push_back([=]() {
+								statement(ib_var_ref, ".", mbr_name, " = ", to_name(p_var->self), "[", i, "];");
 							});
 							break;
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1643,7 +1643,6 @@ void CompilerMSL::emit_resources()
 	declare_undefined_values();
 
 	// Emit the special [[stage_in]] and [[stage_out]] interface blocks which we created.
-	// If these contain built
 	emit_interface_block(stage_out_var_id);
 	emit_interface_block(stage_in_var_id);
 }

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -340,7 +340,6 @@ protected:
 	void emit_resources();
 	void emit_specialization_constants();
 	void emit_interface_block(uint32_t ib_var_id);
-	bool maybe_emit_input_struct_assignment(uint32_t id_lhs, uint32_t id_rhs);
 	bool maybe_emit_array_assignment(uint32_t id_lhs, uint32_t id_rhs);
 	void add_convert_row_major_matrix_function(uint32_t cols, uint32_t rows);
 

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -389,14 +389,12 @@ protected:
 	MSLResourceBinding next_metal_resource_index;
 	uint32_t stage_in_var_id = 0;
 	uint32_t stage_out_var_id = 0;
-	uint32_t stage_uniforms_var_id = 0;
 	bool needs_vertex_idx_arg = false;
 	bool needs_instance_idx_arg = false;
 	bool is_rasterization_disabled = false;
 	std::string qual_pos_var_name;
 	std::string stage_in_var_name = "in";
 	std::string stage_out_var_name = "out";
-	std::string stage_uniform_var_name = "uniforms";
 	std::string sampler_name_suffix = "Smplr";
 	spv::Op previous_instruction_opcode = spv::OpNop;
 


### PR DESCRIPTION
Implement this by flattening outputs and unflattening inputs explicitly.
This allows us to pass down a single struct instead of dealing with the
insanity that would be passing down each flattened member separately.

Remove stage_uniforms_var_id.
Seems to be dead code. Naked uniforms do not exist in SPIR-V for Vulkan,
which this seems to have been intended for. It was also unused elsewhere.

Fix: #695.