### PR TITLE
MSL: Handle the SamplePosition builtin.

### DIFF
--- a/reference/opt/shaders-msl/frag/sample-position-func.frag
+++ b/reference/opt/shaders-msl/frag/sample-position-func.frag
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    int index [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], uint gl_SampleID [[sample_id]])
+{
+    main0_out out = {};
+    out.FragColor = float4(get_sample_position(gl_SampleID), float(in.index), 1.0);
+    return out;
+}
+

--- a/reference/opt/shaders-msl/frag/sample-position.frag
+++ b/reference/opt/shaders-msl/frag/sample-position.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(uint gl_SampleID [[sample_id]])
+{
+    main0_out out = {};
+    out.FragColor = float4(get_sample_position(gl_SampleID), float(gl_SampleID), 1.0);
+    return out;
+}
+

--- a/reference/shaders-msl/frag/sample-position-func.frag
+++ b/reference/shaders-msl/frag/sample-position-func.frag
@@ -1,0 +1,30 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    int index [[user(locn0)]];
+};
+
+float4 getColor(thread const int& i, thread float2 gl_SamplePosition)
+{
+    return float4(gl_SamplePosition, float(i), 1.0);
+}
+
+fragment main0_out main0(main0_in in [[stage_in]], uint gl_SampleID [[sample_id]])
+{
+    main0_out out = {};
+    int param = in.index;
+    out.FragColor = getColor(param, get_sample_position(gl_SampleID));
+    return out;
+}
+

--- a/reference/shaders-msl/frag/sample-position.frag
+++ b/reference/shaders-msl/frag/sample-position.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(uint gl_SampleID [[sample_id]])
+{
+    main0_out out = {};
+    out.FragColor = float4(get_sample_position(gl_SampleID), float(gl_SampleID), 1.0);
+    return out;
+}
+

--- a/shaders-msl/frag/sample-position-func.frag
+++ b/shaders-msl/frag/sample-position-func.frag
@@ -1,0 +1,15 @@
+#version 450
+
+layout(location = 0) in flat int index;
+
+layout(location = 0) out vec4 FragColor;
+
+vec4 getColor(int i)
+{
+	return vec4(gl_SamplePosition, i, 1.0);
+}
+
+void main()
+{
+	FragColor = getColor(index);
+}

--- a/shaders-msl/frag/sample-position.frag
+++ b/shaders-msl/frag/sample-position.frag
@@ -1,0 +1,8 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = vec4(gl_SamplePosition, gl_SampleID, 1.0);
+}

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -374,6 +374,7 @@ protected:
 	void build_implicit_builtins();
 	void emit_entry_point_declarations() override;
 	uint32_t builtin_frag_coord_id = 0;
+	uint32_t builtin_sample_id_id = 0;
 
 	void bitcast_to_builtin_store(uint32_t target_id, std::string &expr, const SPIRType &expr_type) override;
 	void bitcast_from_builtin_load(uint32_t source_id, std::string &expr, const SPIRType &expr_type) override;


### PR DESCRIPTION
This is somewhat tricky, because in MSL this value is obtained through a
function, `get_sample_position()`. Since the call expression is an
rvalue, it can't be passed by reference, so functions get a copy
instead.

This was the last piece preventing us from turning on sample-rate
shading support in MoltenVK.