### PR TITLE
Propagate loop dominator to switch-default block

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -9374,6 +9374,8 @@ void CompilerGLSL::propagate_loop_dominators(const SPIRBlock &block)
 			set_dominator(block.false_block, dominator);
 		if (block.next_block)
 			set_dominator(block.next_block, dominator);
+		if (block.default_block)
+			set_dominator(block.default_block, dominator);
 
 		for (auto &c : block.cases)
 			set_dominator(c.block, dominator);


### PR DESCRIPTION
This is necessary if OpSwitch is inside a loop.