### PR TITLE
MSL: Handle the ViewportIndex builtin.

### DIFF
--- a/reference/opt/shaders-msl/vert/layer.msl11.invalid.vert
+++ b/reference/opt/shaders-msl/vert/layer.msl11.invalid.vert
@@ -18,7 +18,7 @@ vertex main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
     out.gl_Position = in.coord;
-    out.gl_Layer = int(in.coord.z);
+    out.gl_Layer = uint(int(in.coord.z));
     return out;
 }
 

--- a/reference/opt/shaders-msl/vert/layer.msl11.invalid.vert
+++ b/reference/opt/shaders-msl/vert/layer.msl11.invalid.vert
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+    uint gl_Layer [[render_target_array_index]];
+};
+
+struct main0_in
+{
+    float4 coord [[attribute(0)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    out.gl_Position = in.coord;
+    out.gl_Layer = int(in.coord.z);
+    return out;
+}
+

--- a/reference/opt/shaders-msl/vert/viewport-index.msl2.invalid.vert
+++ b/reference/opt/shaders-msl/vert/viewport-index.msl2.invalid.vert
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+    uint gl_ViewportIndex [[viewport_array_index]];
+};
+
+struct main0_in
+{
+    float4 coord [[attribute(0)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    out.gl_Position = in.coord;
+    out.gl_ViewportIndex = int(in.coord.z);
+    return out;
+}
+

--- a/reference/opt/shaders-msl/vert/viewport-index.msl2.invalid.vert
+++ b/reference/opt/shaders-msl/vert/viewport-index.msl2.invalid.vert
@@ -18,7 +18,7 @@ vertex main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
     out.gl_Position = in.coord;
-    out.gl_ViewportIndex = int(in.coord.z);
+    out.gl_ViewportIndex = uint(int(in.coord.z));
     return out;
 }
 

--- a/reference/shaders-msl/vert/layer.msl11.invalid.vert
+++ b/reference/shaders-msl/vert/layer.msl11.invalid.vert
@@ -18,7 +18,7 @@ vertex main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
     out.gl_Position = in.coord;
-    out.gl_Layer = int(in.coord.z);
+    out.gl_Layer = uint(int(in.coord.z));
     return out;
 }
 

--- a/reference/shaders-msl/vert/layer.msl11.invalid.vert
+++ b/reference/shaders-msl/vert/layer.msl11.invalid.vert
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+    uint gl_Layer [[render_target_array_index]];
+};
+
+struct main0_in
+{
+    float4 coord [[attribute(0)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    out.gl_Position = in.coord;
+    out.gl_Layer = int(in.coord.z);
+    return out;
+}
+

--- a/reference/shaders-msl/vert/viewport-index.msl2.invalid.vert
+++ b/reference/shaders-msl/vert/viewport-index.msl2.invalid.vert
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+    uint gl_ViewportIndex [[viewport_array_index]];
+};
+
+struct main0_in
+{
+    float4 coord [[attribute(0)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    out.gl_Position = in.coord;
+    out.gl_ViewportIndex = int(in.coord.z);
+    return out;
+}
+

--- a/reference/shaders-msl/vert/viewport-index.msl2.invalid.vert
+++ b/reference/shaders-msl/vert/viewport-index.msl2.invalid.vert
@@ -18,7 +18,7 @@ vertex main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
     out.gl_Position = in.coord;
-    out.gl_ViewportIndex = int(in.coord.z);
+    out.gl_ViewportIndex = uint(int(in.coord.z));
     return out;
 }
 

--- a/shaders-msl/vert/layer.msl11.invalid.vert
+++ b/shaders-msl/vert/layer.msl11.invalid.vert
@@ -1,0 +1,10 @@
+#version 450
+#extension GL_ARB_shader_viewport_layer_array : require
+
+layout(location = 0) in vec4 coord;
+
+void main()
+{
+	gl_Position = coord;
+	gl_Layer = int(coord.z);
+}

--- a/shaders-msl/vert/viewport-index.msl2.invalid.vert
+++ b/shaders-msl/vert/viewport-index.msl2.invalid.vert
@@ -1,0 +1,10 @@
+#version 450
+#extension GL_ARB_shader_viewport_layer_array : require
+
+layout(location = 0) in vec4 coord;
+
+void main()
+{
+	gl_Position = coord;
+	gl_ViewportIndex = int(coord.z);
+}


### PR DESCRIPTION
This requires MSL 2.0+.

Also, force `ViewportIndex` and `Layer` to be defined as the correct
type, which is always `uint` in MSL.

Since Metal doesn't yet have geometry shaders, the vertex shader (or
tessellation evaluation shader == "post-tessellation vertex shader" in
Metal jargon) is the only kind of shader that can set this output. This
currently requires an extension to Vulkan, which causes validation of
the SPIR-V binaries for the test cases to fail. Therefore, the test
cases are marked "invalid", even though they're actually perfectly valid
SPIR-V--they just won't work without the
`SPV_EXT_shader_viewport_index_layer` extension.