### PR TITLE
Refactor MSL to use SPIRCombinedImageSampler.

### DIFF
--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -1236,8 +1236,6 @@ struct Meta
 
 	Decoration decoration;
 	std::vector<Decoration> members;
-	uint32_t sampler = 0;
-	uint32_t image = 0;
 
 	std::unordered_map<uint32_t, uint32_t> decoration_word_offset;
 

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -3933,10 +3933,21 @@ void CompilerHLSL::emit_instruction(const Instruction &instruction)
 		uint32_t result_type = ops[0];
 		uint32_t id = ops[1];
 		auto *combined = maybe_get<SPIRCombinedImageSampler>(ops[2]);
+
 		if (combined)
-			emit_op(result_type, id, to_expression(combined->image), true, true);
+		{
+			auto &e = emit_op(result_type, id, to_expression(combined->image), true, true);
+			auto *var = maybe_get_backing_variable(combined->image);
+			if (var)
+				e.loaded_from = var->self;
+		}
 		else
-			emit_op(result_type, id, to_expression(ops[2]), true, true);
+		{
+			auto &e = emit_op(result_type, id, to_expression(ops[2]), true, true);
+			auto *var = maybe_get_backing_variable(ops[2]);
+			if (var)
+				e.loaded_from = var->self;
+		}
 		break;
 	}
 


### PR DESCRIPTION
Avoids special "meta" data to express this type.
Makes MSL implementation in line with HLSL.
Fix #720.