### PR TITLE
HLSL: Use same logic as GLSL for picking cbuffer block name.

### DIFF
--- a/reference/opt/shaders-hlsl/asm/frag/cbuffer-stripped.asm.frag
+++ b/reference/opt/shaders-hlsl/asm/frag/cbuffer-stripped.asm.frag
@@ -1,8 +1,9 @@
-cbuffer _5 : register(b0)
+cbuffer _4_5 : register(b0)
 {
     column_major float2x4 _5_m0 : packoffset(c0);
     float4 _5_m1 : packoffset(c4);
 };
+
 
 static float2 _3;
 

--- a/reference/opt/shaders-hlsl/asm/frag/pass-by-value.asm.frag
+++ b/reference/opt/shaders-hlsl/asm/frag/pass-by-value.asm.frag
@@ -1,7 +1,8 @@
-cbuffer registers
+cbuffer Registers
 {
     float registers_foo : packoffset(c0);
 };
+
 
 static float FragColor;
 

--- a/reference/opt/shaders-hlsl/comp/num-workgroups-alone.comp
+++ b/reference/opt/shaders-hlsl/comp/num-workgroups-alone.comp
@@ -1,12 +1,13 @@
 RWByteAddressBuffer _10 : register(u0);
 cbuffer SPIRV_Cross_NumWorkgroups : register(b0)
 {
-    uint3 SPIRV_Cross_NumWorkgroups_count : packoffset(c0);
+    uint3 SPIRV_Cross_NumWorkgroups_1_count : packoffset(c0);
 };
+
 
 void comp_main()
 {
-    _10.Store3(0, SPIRV_Cross_NumWorkgroups_count);
+    _10.Store3(0, SPIRV_Cross_NumWorkgroups_1_count);
 }
 
 [numthreads(1, 1, 1)]

--- a/reference/opt/shaders-hlsl/comp/num-workgroups-with-builtins.comp
+++ b/reference/opt/shaders-hlsl/comp/num-workgroups-with-builtins.comp
@@ -1,8 +1,9 @@
 RWByteAddressBuffer _10 : register(u0);
 cbuffer SPIRV_Cross_NumWorkgroups : register(b0)
 {
-    uint3 SPIRV_Cross_NumWorkgroups_count : packoffset(c0);
+    uint3 SPIRV_Cross_NumWorkgroups_1_count : packoffset(c0);
 };
+
 
 static uint3 gl_WorkGroupID;
 struct SPIRV_Cross_Input
@@ -12,7 +13,7 @@ struct SPIRV_Cross_Input
 
 void comp_main()
 {
-    _10.Store3(0, SPIRV_Cross_NumWorkgroups_count + gl_WorkGroupID);
+    _10.Store3(0, SPIRV_Cross_NumWorkgroups_1_count + gl_WorkGroupID);
 }
 
 [numthreads(1, 1, 1)]

--- a/reference/opt/shaders-hlsl/comp/rwbuffer-matrix.comp
+++ b/reference/opt/shaders-hlsl/comp/rwbuffer-matrix.comp
@@ -1,9 +1,10 @@
 RWByteAddressBuffer _28 : register(u0);
-cbuffer _68 : register(b1)
+cbuffer UBO : register(b1)
 {
     int _68_index0 : packoffset(c0);
     int _68_index1 : packoffset(c0.y);
 };
+
 
 void comp_main()
 {

--- a/reference/opt/shaders-hlsl/frag/constant-buffer-array.invalid.sm51.frag
+++ b/reference/opt/shaders-hlsl/frag/constant-buffer-array.invalid.sm51.frag
@@ -7,13 +7,14 @@ struct CBO_1
 };
 
 ConstantBuffer<CBO_1> cbo[2][4] : register(b4, space0);
-cbuffer push
+cbuffer PushMe
 {
     float4 push_a : packoffset(c0);
     float4 push_b : packoffset(c1);
     float4 push_c : packoffset(c2);
     float4 push_d : packoffset(c3);
 };
+
 
 static float4 FragColor;
 

--- a/reference/opt/shaders-hlsl/frag/resources.frag
+++ b/reference/opt/shaders-hlsl/frag/resources.frag
@@ -1,11 +1,13 @@
-cbuffer cbuf : register(b3)
+cbuffer CBuffer : register(b3)
 {
     float4 cbuf_a : packoffset(c0);
 };
-cbuffer registers
+
+cbuffer PushMe
 {
     float4 registers_d : packoffset(c0);
 };
+
 Texture2D<float4> uSampledImage : register(t4);
 SamplerState _uSampledImage_sampler : register(s4);
 Texture2D<float4> uTexture : register(t5);

--- a/reference/opt/shaders-hlsl/frag/row-major-layout-in-struct.frag
+++ b/reference/opt/shaders-hlsl/frag/row-major-layout-in-struct.frag
@@ -4,10 +4,11 @@ struct Foo
     row_major float4x4 w;
 };
 
-cbuffer _17 : register(b0)
+cbuffer UBO : register(b0)
 {
     Foo _17_foo : packoffset(c0);
 };
+
 
 static float4 FragColor;
 static float4 vUV;

--- a/reference/opt/shaders-hlsl/frag/spec-constant-block-size.frag
+++ b/reference/opt/shaders-hlsl/frag/spec-constant-block-size.frag
@@ -1,9 +1,10 @@
 static const int Value = 2;
 
-cbuffer _15 : register(b0)
+cbuffer SpecConstArray : register(b0)
 {
     float4 _15_samples[Value] : packoffset(c0);
 };
+
 
 static float4 FragColor;
 static int Index;

--- a/reference/opt/shaders-hlsl/vert/basic.vert
+++ b/reference/opt/shaders-hlsl/vert/basic.vert
@@ -1,7 +1,8 @@
-cbuffer _16
+cbuffer UBO
 {
     row_major float4x4 _16_uMVP : packoffset(c0);
 };
+
 
 static float4 gl_Position;
 static float4 aVertex;

--- a/reference/opt/shaders-hlsl/vert/read-from-row-major-array.vert
+++ b/reference/opt/shaders-hlsl/vert/read-from-row-major-array.vert
@@ -1,7 +1,8 @@
-cbuffer _104 : register(b0)
+cbuffer Block : register(b0)
 {
     column_major float2x3 _104_var[3][4] : packoffset(c0);
 };
+
 
 static float4 gl_Position;
 static float4 a_position;

--- a/reference/shaders-hlsl/asm/frag/cbuffer-stripped.asm.frag
+++ b/reference/shaders-hlsl/asm/frag/cbuffer-stripped.asm.frag
@@ -1,8 +1,9 @@
-cbuffer _5 : register(b0)
+cbuffer _4_5 : register(b0)
 {
     column_major float2x4 _5_m0 : packoffset(c0);
     float4 _5_m1 : packoffset(c4);
 };
+
 
 static float2 _3;
 

--- a/reference/shaders-hlsl/asm/frag/pass-by-value.asm.frag
+++ b/reference/shaders-hlsl/asm/frag/pass-by-value.asm.frag
@@ -1,7 +1,8 @@
-cbuffer registers
+cbuffer Registers
 {
     float registers_foo : packoffset(c0);
 };
+
 
 static float FragColor;
 

--- a/reference/shaders-hlsl/comp/num-workgroups-alone.comp
+++ b/reference/shaders-hlsl/comp/num-workgroups-alone.comp
@@ -1,12 +1,13 @@
 RWByteAddressBuffer _10 : register(u0);
 cbuffer SPIRV_Cross_NumWorkgroups : register(b0)
 {
-    uint3 SPIRV_Cross_NumWorkgroups_count : packoffset(c0);
+    uint3 SPIRV_Cross_NumWorkgroups_1_count : packoffset(c0);
 };
+
 
 void comp_main()
 {
-    _10.Store3(0, SPIRV_Cross_NumWorkgroups_count);
+    _10.Store3(0, SPIRV_Cross_NumWorkgroups_1_count);
 }
 
 [numthreads(1, 1, 1)]

--- a/reference/shaders-hlsl/comp/num-workgroups-with-builtins.comp
+++ b/reference/shaders-hlsl/comp/num-workgroups-with-builtins.comp
@@ -1,8 +1,9 @@
 RWByteAddressBuffer _10 : register(u0);
 cbuffer SPIRV_Cross_NumWorkgroups : register(b0)
 {
-    uint3 SPIRV_Cross_NumWorkgroups_count : packoffset(c0);
+    uint3 SPIRV_Cross_NumWorkgroups_1_count : packoffset(c0);
 };
+
 
 static uint3 gl_WorkGroupID;
 struct SPIRV_Cross_Input
@@ -12,7 +13,7 @@ struct SPIRV_Cross_Input
 
 void comp_main()
 {
-    _10.Store3(0, SPIRV_Cross_NumWorkgroups_count + gl_WorkGroupID);
+    _10.Store3(0, SPIRV_Cross_NumWorkgroups_1_count + gl_WorkGroupID);
 }
 
 [numthreads(1, 1, 1)]

--- a/reference/shaders-hlsl/comp/rwbuffer-matrix.comp
+++ b/reference/shaders-hlsl/comp/rwbuffer-matrix.comp
@@ -1,9 +1,10 @@
 RWByteAddressBuffer _28 : register(u0);
-cbuffer _68 : register(b1)
+cbuffer UBO : register(b1)
 {
     int _68_index0 : packoffset(c0);
     int _68_index1 : packoffset(c0.y);
 };
+
 
 void row_to_col()
 {

--- a/reference/shaders-hlsl/frag/constant-buffer-array.invalid.sm51.frag
+++ b/reference/shaders-hlsl/frag/constant-buffer-array.invalid.sm51.frag
@@ -7,13 +7,14 @@ struct CBO_1
 };
 
 ConstantBuffer<CBO_1> cbo[2][4] : register(b4, space0);
-cbuffer push
+cbuffer PushMe
 {
     float4 push_a : packoffset(c0);
     float4 push_b : packoffset(c1);
     float4 push_c : packoffset(c2);
     float4 push_d : packoffset(c3);
 };
+
 
 static float4 FragColor;
 

--- a/reference/shaders-hlsl/frag/partial-write-preserve.frag
+++ b/reference/shaders-hlsl/frag/partial-write-preserve.frag
@@ -6,10 +6,11 @@ struct B
 
 static const B _80 = { 10.0f, 20.0f };
 
-cbuffer _42 : register(b0)
+cbuffer UBO : register(b0)
 {
     int _42_some_value : packoffset(c0);
 };
+
 
 void partial_inout(inout float4 x)
 {

--- a/reference/shaders-hlsl/frag/resources.frag
+++ b/reference/shaders-hlsl/frag/resources.frag
@@ -1,11 +1,13 @@
-cbuffer cbuf : register(b3)
+cbuffer CBuffer : register(b3)
 {
     float4 cbuf_a : packoffset(c0);
 };
-cbuffer registers
+
+cbuffer PushMe
 {
     float4 registers_d : packoffset(c0);
 };
+
 Texture2D<float4> uSampledImage : register(t4);
 SamplerState _uSampledImage_sampler : register(s4);
 Texture2D<float4> uTexture : register(t5);

--- a/reference/shaders-hlsl/frag/row-major-layout-in-struct.frag
+++ b/reference/shaders-hlsl/frag/row-major-layout-in-struct.frag
@@ -10,10 +10,11 @@ struct Foo
     row_major float4x4 w;
 };
 
-cbuffer _17 : register(b0)
+cbuffer UBO : register(b0)
 {
     Foo _17_foo : packoffset(c0);
 };
+
 
 static float4 FragColor;
 static float4 vUV;

--- a/reference/shaders-hlsl/frag/spec-constant-block-size.frag
+++ b/reference/shaders-hlsl/frag/spec-constant-block-size.frag
@@ -1,9 +1,10 @@
 static const int Value = 2;
 
-cbuffer _15 : register(b0)
+cbuffer SpecConstArray : register(b0)
 {
     float4 _15_samples[Value] : packoffset(c0);
 };
+
 
 static float4 FragColor;
 static int Index;

--- a/reference/shaders-hlsl/vert/basic.vert
+++ b/reference/shaders-hlsl/vert/basic.vert
@@ -1,7 +1,8 @@
-cbuffer _16
+cbuffer UBO
 {
     row_major float4x4 _16_uMVP : packoffset(c0);
 };
+
 
 static float4 gl_Position;
 static float4 aVertex;

--- a/reference/shaders-hlsl/vert/read-from-row-major-array.vert
+++ b/reference/shaders-hlsl/vert/read-from-row-major-array.vert
@@ -1,7 +1,8 @@
-cbuffer _104 : register(b0)
+cbuffer Block : register(b0)
 {
     column_major float2x3 _104_var[3][4] : packoffset(c0);
 };
+
 
 static float4 gl_Position;
 static float4 a_position;

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -512,6 +512,8 @@ public:
 	// For other names like remapped names for variables, etc, it's generally enough to query the name of the variables
 	// after compiling, block names are an exception to this rule.
 	// ID is the name of a variable as returned by Resource::id, and must be a variable with a Block-like type.
+	//
+	// This also applies to HLSL cbuffers.
 	std::string get_remapped_declared_block_name(uint32_t id) const;
 
 	// For buffer block variables, get the decorations for that variable.

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1858,9 +1858,25 @@ void CompilerHLSL::emit_buffer_block(const SPIRVariable &var)
 			// this restriction is similar to GLSL where layout(offset) is not possible on sub-structs.
 			flattened_structs.insert(var.self);
 
+			// Prefer the block name if possible.
+			auto buffer_name = to_name(type.self, false);
+			if (ir.meta[type.self].decoration.alias.empty() || resource_names.find(buffer_name) != end(resource_names))
+				buffer_name = get_block_fallback_name(var.self);
+			add_variable(resource_names, buffer_name);
+
+			// If for some reason buffer_name is an illegal name, make a final fallback to a workaround name.
+			// This cannot conflict with anything else, so we're safe now.
+			if (buffer_name.empty())
+				buffer_name = join("_", get<SPIRType>(var.basetype).self, "_", var.self);
+
+			resource_names.insert(buffer_name);
+
+			// Save for post-reflection later.
+			declared_block_names[var.self] = buffer_name;
+
 			type.member_name_cache.clear();
 			add_resource_name(var.self);
-			statement("cbuffer ", to_name(var.self), to_resource_binding(var));
+			statement("cbuffer ", buffer_name, to_resource_binding(var));
 			begin_scope();
 
 			uint32_t i = 0;
@@ -1876,6 +1892,7 @@ void CompilerHLSL::emit_buffer_block(const SPIRVariable &var)
 			}
 
 			end_scope_decl();
+			statement("");
 		}
 		else
 		{


### PR DESCRIPTION
HLSL just picked the variable name which did not work as expected for
some users. Use the same logic as GLSL and set up declared_block_names,
so the actual name can be queried later.

Fix #728.