### PR TITLE
Add support for 8- and 16-bit types to GLSL and MSL.

### DIFF
--- a/reference/opt/shaders-msl/comp/bitcast-16bit-1.invalid.comp
+++ b/reference/opt/shaders-msl/comp/bitcast-16bit-1.invalid.comp
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct SSBO0
+{
+    short4 inputs[1];
+};
+
+struct SSBO1
+{
+    int4 outputs[1];
+};
+
+kernel void main0(device SSBO0& _25 [[buffer(0)]], device SSBO1& _39 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+{
+    _39.outputs[gl_GlobalInvocationID.x].x = int(as_type<uint>(as_type<half2>(_25.inputs[gl_GlobalInvocationID.x].xy) + half2(half(1))));
+    _39.outputs[gl_GlobalInvocationID.x].y = as_type<int>(_25.inputs[gl_GlobalInvocationID.x].zw);
+    _39.outputs[gl_GlobalInvocationID.x].z = int(as_type<uint>(ushort2(_25.inputs[gl_GlobalInvocationID.x].xy)));
+}
+

--- a/reference/opt/shaders-msl/comp/bitcast-16bit-2.invalid.comp
+++ b/reference/opt/shaders-msl/comp/bitcast-16bit-2.invalid.comp
@@ -1,0 +1,28 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct SSBO1
+{
+    short4 outputs[1];
+};
+
+struct SSBO0
+{
+    int4 inputs[1];
+};
+
+struct UBO
+{
+    half4 const0;
+};
+
+kernel void main0(device SSBO0& _29 [[buffer(0)]], device SSBO1& _21 [[buffer(1)]], constant UBO& _40 [[buffer(2)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+{
+    short2 _47 = as_type<short2>(_29.inputs[gl_GlobalInvocationID.x].x) + as_type<short2>(_40.const0.xy);
+    _21.outputs[gl_GlobalInvocationID.x] = short4(_47.x, _47.y, _21.outputs[gl_GlobalInvocationID.x].z, _21.outputs[gl_GlobalInvocationID.x].w);
+    short2 _66 = short2(as_type<ushort2>(uint(_29.inputs[gl_GlobalInvocationID.x].y)) - as_type<ushort2>(_40.const0.zw));
+    _21.outputs[gl_GlobalInvocationID.x] = short4(_21.outputs[gl_GlobalInvocationID.x].x, _21.outputs[gl_GlobalInvocationID.x].y, _66.x, _66.y);
+}
+

--- a/reference/opt/shaders-msl/frag/16bit-constants.frag
+++ b/reference/opt/shaders-msl/frag/16bit-constants.frag
@@ -1,0 +1,21 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    half foo [[color(0)]];
+    short bar [[color(1)]];
+    ushort baz [[color(2)]];
+};
+
+fragment main0_out main0()
+{
+    main0_out out = {};
+    out.foo = 1.0h;
+    out.bar = 2;
+    out.baz = 3u;
+    return out;
+}
+

--- a/reference/opt/shaders-msl/vulkan/vert/small-storage.vk.vert
+++ b/reference/opt/shaders-msl/vulkan/vert/small-storage.vk.vert
@@ -1,0 +1,48 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct block
+{
+    short2 a;
+    ushort2 b;
+    char2 c;
+    uchar2 d;
+    half2 e;
+};
+
+struct storage
+{
+    short3 f;
+    ushort3 g;
+    char3 h;
+    uchar3 i;
+    half3 j;
+};
+
+struct main0_out
+{
+    short4 p [[user(locn0)]];
+    ushort4 q [[user(locn1)]];
+    half4 r [[user(locn2)]];
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    short foo [[attribute(0)]];
+    ushort bar [[attribute(1)]];
+    half baz [[attribute(2)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant block& _26 [[buffer(0)]], const device storage& _53 [[buffer(1)]])
+{
+    main0_out out = {};
+    out.p = short4((int4(int(in.foo)) + int4(int2(_26.a), int2(_26.c))) - int4(int3(_53.f) / int3(_53.h), 1));
+    out.q = ushort4((uint4(uint(in.bar)) + uint4(uint2(_26.b), uint2(_26.d))) - uint4(uint3(_53.g) / uint3(_53.i), 1u));
+    out.r = half4((float4(float(in.baz)) + float4(float2(_26.e), 0.0, 1.0)) - float4(float3(_53.j), 1.0));
+    out.gl_Position = float4(0.0, 0.0, 0.0, 1.0);
+    return out;
+}
+

--- a/reference/opt/shaders/comp/bitcast-16bit-1.invalid.comp
+++ b/reference/opt/shaders/comp/bitcast-16bit-1.invalid.comp
@@ -1,0 +1,38 @@
+#version 450
+#if defined(GL_AMD_gpu_shader_half_float)
+#extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_NV_gpu_shader5)
+#extension GL_NV_gpu_shader5 : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
+#else
+#error No extension available for FP16.
+#endif
+#if defined(GL_AMD_gpu_shader_int16)
+#extension GL_AMD_gpu_shader_int16 : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
+#else
+#error No extension available for Int16.
+#endif
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0, std430) buffer SSBO0
+{
+    i16vec4 inputs[];
+} _25;
+
+layout(binding = 1, std430) buffer SSBO1
+{
+    ivec4 outputs[];
+} _39;
+
+void main()
+{
+    uint ident = gl_GlobalInvocationID.x;
+    f16vec2 a = int16BitsToFloat16(_25.inputs[ident].xy);
+    _39.outputs[ident].x = int(packFloat2x16(a + f16vec2(float16_t(1), float16_t(1))));
+    _39.outputs[ident].y = packInt2x16(_25.inputs[ident].zw);
+    _39.outputs[ident].z = int(packUint2x16(u16vec2(_25.inputs[ident].xy)));
+}
+

--- a/reference/opt/shaders/comp/bitcast-16bit-2.invalid.comp
+++ b/reference/opt/shaders/comp/bitcast-16bit-2.invalid.comp
@@ -1,0 +1,43 @@
+#version 450
+#if defined(GL_AMD_gpu_shader_int16)
+#extension GL_AMD_gpu_shader_int16 : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
+#else
+#error No extension available for Int16.
+#endif
+#if defined(GL_AMD_gpu_shader_half_float)
+#extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_NV_gpu_shader5)
+#extension GL_NV_gpu_shader5 : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
+#else
+#error No extension available for FP16.
+#endif
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 1, std430) buffer SSBO1
+{
+    i16vec4 outputs[];
+} _21;
+
+layout(binding = 0, std430) buffer SSBO0
+{
+    ivec4 inputs[];
+} _29;
+
+layout(binding = 2, std140) uniform UBO
+{
+    f16vec4 const0;
+} _40;
+
+void main()
+{
+    uint ident = gl_GlobalInvocationID.x;
+    i16vec2 _47 = unpackInt2x16(_29.inputs[ident].x) + float16BitsToInt16(_40.const0.xy);
+    _21.outputs[ident] = i16vec4(_47.x, _47.y, _21.outputs[ident].z, _21.outputs[ident].w);
+    i16vec2 _66 = i16vec2(unpackUint2x16(uint(_29.inputs[ident].y)) - float16BitsToUint16(_40.const0.zw));
+    _21.outputs[ident] = i16vec4(_21.outputs[ident].x, _21.outputs[ident].y, _66.x, _66.y);
+}
+

--- a/reference/opt/shaders/desktop-only/frag/fp16.invalid.desktop.frag
+++ b/reference/opt/shaders/desktop-only/frag/fp16.invalid.desktop.frag
@@ -3,6 +3,8 @@
 #extension GL_AMD_gpu_shader_half_float : require
 #elif defined(GL_NV_gpu_shader5)
 #extension GL_NV_gpu_shader5 : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
 #else
 #error No extension available for FP16.
 #endif

--- a/reference/opt/shaders/frag/16bit-constants.frag
+++ b/reference/opt/shaders/frag/16bit-constants.frag
@@ -1,0 +1,29 @@
+#version 450
+#if defined(GL_AMD_gpu_shader_half_float)
+#extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_NV_gpu_shader5)
+#extension GL_NV_gpu_shader5 : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
+#else
+#error No extension available for FP16.
+#endif
+#if defined(GL_AMD_gpu_shader_int16)
+#extension GL_AMD_gpu_shader_int16 : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
+#else
+#error No extension available for Int16.
+#endif
+
+layout(location = 0) out float16_t foo;
+layout(location = 1) out int16_t bar;
+layout(location = 2) out uint16_t baz;
+
+void main()
+{
+    foo = 1.0hf;
+    bar = 2s;
+    baz = 3us;
+}
+

--- a/reference/opt/shaders/vulkan/vert/small-storage.vk.vert
+++ b/reference/opt/shaders/vulkan/vert/small-storage.vk.vert
@@ -19,20 +19,20 @@
 
 layout(binding = 0, std140) uniform block
 {
-    layout(offset = 0) i16vec2 a;
-    layout(offset = 4) u16vec2 b;
-    layout(offset = 8) i8vec2 c;
-    layout(offset = 10) u8vec2 d;
-    layout(offset = 12) f16vec2 e;
+    i16vec2 a;
+    u16vec2 b;
+    i8vec2 c;
+    u8vec2 d;
+    f16vec2 e;
 } _26;
 
-layout(binding = 1, std140) readonly buffer storage
+layout(binding = 1, std430) readonly buffer storage
 {
-    layout(offset = 0) i16vec3 f;
-    layout(offset = 8) u16vec3 g;
-    layout(offset = 16) i8vec3 h;
-    layout(offset = 20) u8vec3 i;
-    layout(offset = 24) f16vec3 j;
+    i16vec3 f;
+    u16vec3 g;
+    i8vec3 h;
+    u8vec3 i;
+    f16vec3 j;
 } _53;
 
 struct pushconst

--- a/reference/opt/shaders/vulkan/vert/small-storage.vk.vert
+++ b/reference/opt/shaders/vulkan/vert/small-storage.vk.vert
@@ -1,0 +1,63 @@
+#version 450
+#if defined(GL_AMD_gpu_shader_int16)
+#extension GL_AMD_gpu_shader_int16 : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
+#else
+#error No extension available for Int16.
+#endif
+#extension GL_EXT_shader_8bit_storage : require
+#if defined(GL_AMD_gpu_shader_half_float)
+#extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_NV_gpu_shader5)
+#extension GL_NV_gpu_shader5 : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
+#else
+#error No extension available for FP16.
+#endif
+
+layout(binding = 0, std140) uniform block
+{
+    layout(offset = 0) i16vec2 a;
+    layout(offset = 4) u16vec2 b;
+    layout(offset = 8) i8vec2 c;
+    layout(offset = 10) u8vec2 d;
+    layout(offset = 12) f16vec2 e;
+} _26;
+
+layout(binding = 1, std140) readonly buffer storage
+{
+    layout(offset = 0) i16vec3 f;
+    layout(offset = 8) u16vec3 g;
+    layout(offset = 16) i8vec3 h;
+    layout(offset = 20) u8vec3 i;
+    layout(offset = 24) f16vec3 j;
+} _53;
+
+struct pushconst
+{
+    i16vec4 k;
+    u16vec4 l;
+    i8vec4 m;
+    u8vec4 n;
+    f16vec4 o;
+};
+
+uniform pushconst _76;
+
+layout(location = 0) out i16vec4 p;
+layout(location = 0, component = 0) in int16_t foo;
+layout(location = 1) out u16vec4 q;
+layout(location = 0, component = 1) in uint16_t bar;
+layout(location = 2) out f16vec4 r;
+layout(location = 1) in float16_t baz;
+
+void main()
+{
+    p = i16vec4((((ivec4(int(foo)) + ivec4(ivec2(_26.a), ivec2(_26.c))) - ivec4(ivec3(_53.f) / ivec3(_53.h), 1)) + ivec4(_76.k)) + ivec4(_76.m));
+    q = u16vec4((((uvec4(uint(bar)) + uvec4(uvec2(_26.b), uvec2(_26.d))) - uvec4(uvec3(_53.g) / uvec3(_53.i), 1u)) + uvec4(_76.l)) + uvec4(_76.n));
+    r = f16vec4(((vec4(float(baz)) + vec4(vec2(_26.e), 0.0, 1.0)) - vec4(vec3(_53.j), 1.0)) + vec4(_76.o));
+    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+}
+

--- a/reference/opt/shaders/vulkan/vert/small-storage.vk.vert.vk
+++ b/reference/opt/shaders/vulkan/vert/small-storage.vk.vert.vk
@@ -17,29 +17,29 @@
 
 layout(set = 0, binding = 0, std140) uniform block
 {
-    layout(offset = 0) i16vec2 a;
-    layout(offset = 4) u16vec2 b;
-    layout(offset = 8) i8vec2 c;
-    layout(offset = 10) u8vec2 d;
-    layout(offset = 12) f16vec2 e;
+    i16vec2 a;
+    u16vec2 b;
+    i8vec2 c;
+    u8vec2 d;
+    f16vec2 e;
 } _26;
 
-layout(set = 0, binding = 1, std140) readonly buffer storage
+layout(set = 0, binding = 1, std430) readonly buffer storage
 {
-    layout(offset = 0) i16vec3 f;
-    layout(offset = 8) u16vec3 g;
-    layout(offset = 16) i8vec3 h;
-    layout(offset = 20) u8vec3 i;
-    layout(offset = 24) f16vec3 j;
+    i16vec3 f;
+    u16vec3 g;
+    i8vec3 h;
+    u8vec3 i;
+    f16vec3 j;
 } _53;
 
-layout(push_constant, std140) uniform pushconst
+layout(push_constant, std430) uniform pushconst
 {
-    layout(offset = 0) i16vec4 k;
-    layout(offset = 8) u16vec4 l;
-    layout(offset = 16) i8vec4 m;
-    layout(offset = 20) u8vec4 n;
-    layout(offset = 24) f16vec4 o;
+    i16vec4 k;
+    u16vec4 l;
+    i8vec4 m;
+    u8vec4 n;
+    f16vec4 o;
 } _76;
 
 layout(location = 0) out i16vec4 p;

--- a/reference/opt/shaders/vulkan/vert/small-storage.vk.vert.vk
+++ b/reference/opt/shaders/vulkan/vert/small-storage.vk.vert.vk
@@ -1,0 +1,59 @@
+#version 450
+#if defined(GL_AMD_gpu_shader_int16)
+#extension GL_AMD_gpu_shader_int16 : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
+#else
+#error No extension available for Int16.
+#endif
+#extension GL_EXT_shader_8bit_storage : require
+#if defined(GL_AMD_gpu_shader_half_float)
+#extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
+#else
+#error No extension available for FP16.
+#endif
+
+layout(set = 0, binding = 0, std140) uniform block
+{
+    layout(offset = 0) i16vec2 a;
+    layout(offset = 4) u16vec2 b;
+    layout(offset = 8) i8vec2 c;
+    layout(offset = 10) u8vec2 d;
+    layout(offset = 12) f16vec2 e;
+} _26;
+
+layout(set = 0, binding = 1, std140) readonly buffer storage
+{
+    layout(offset = 0) i16vec3 f;
+    layout(offset = 8) u16vec3 g;
+    layout(offset = 16) i8vec3 h;
+    layout(offset = 20) u8vec3 i;
+    layout(offset = 24) f16vec3 j;
+} _53;
+
+layout(push_constant, std140) uniform pushconst
+{
+    layout(offset = 0) i16vec4 k;
+    layout(offset = 8) u16vec4 l;
+    layout(offset = 16) i8vec4 m;
+    layout(offset = 20) u8vec4 n;
+    layout(offset = 24) f16vec4 o;
+} _76;
+
+layout(location = 0) out i16vec4 p;
+layout(location = 0, component = 0) in int16_t foo;
+layout(location = 1) out u16vec4 q;
+layout(location = 0, component = 1) in uint16_t bar;
+layout(location = 2) out f16vec4 r;
+layout(location = 1) in float16_t baz;
+
+void main()
+{
+    p = i16vec4((((ivec4(int(foo)) + ivec4(ivec2(_26.a), ivec2(_26.c))) - ivec4(ivec3(_53.f) / ivec3(_53.h), 1)) + ivec4(_76.k)) + ivec4(_76.m));
+    q = u16vec4((((uvec4(uint(bar)) + uvec4(uvec2(_26.b), uvec2(_26.d))) - uvec4(uvec3(_53.g) / uvec3(_53.i), 1u)) + uvec4(_76.l)) + uvec4(_76.n));
+    r = f16vec4(((vec4(float(baz)) + vec4(vec2(_26.e), 0.0, 1.0)) - vec4(vec3(_53.j), 1.0)) + vec4(_76.o));
+    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+}
+

--- a/reference/shaders-msl/comp/bitcast-16bit-1.invalid.comp
+++ b/reference/shaders-msl/comp/bitcast-16bit-1.invalid.comp
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct SSBO0
+{
+    short4 inputs[1];
+};
+
+struct SSBO1
+{
+    int4 outputs[1];
+};
+
+kernel void main0(device SSBO0& _25 [[buffer(0)]], device SSBO1& _39 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+{
+    uint ident = gl_GlobalInvocationID.x;
+    half2 a = as_type<half2>(_25.inputs[ident].xy);
+    _39.outputs[ident].x = int(as_type<uint>(a + half2(half(1), half(1))));
+    _39.outputs[ident].y = as_type<int>(_25.inputs[ident].zw);
+    _39.outputs[ident].z = int(as_type<uint>(ushort2(_25.inputs[ident].xy)));
+}
+

--- a/reference/shaders-msl/comp/bitcast-16bit-2.invalid.comp
+++ b/reference/shaders-msl/comp/bitcast-16bit-2.invalid.comp
@@ -1,0 +1,29 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct SSBO1
+{
+    short4 outputs[1];
+};
+
+struct SSBO0
+{
+    int4 inputs[1];
+};
+
+struct UBO
+{
+    half4 const0;
+};
+
+kernel void main0(device SSBO0& _29 [[buffer(0)]], device SSBO1& _21 [[buffer(1)]], constant UBO& _40 [[buffer(2)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+{
+    uint ident = gl_GlobalInvocationID.x;
+    short2 _47 = as_type<short2>(_29.inputs[ident].x) + as_type<short2>(_40.const0.xy);
+    _21.outputs[ident] = short4(_47.x, _47.y, _21.outputs[ident].z, _21.outputs[ident].w);
+    short2 _66 = short2(as_type<ushort2>(uint(_29.inputs[ident].y)) - as_type<ushort2>(_40.const0.zw));
+    _21.outputs[ident] = short4(_21.outputs[ident].x, _21.outputs[ident].y, _66.x, _66.y);
+}
+

--- a/reference/shaders-msl/frag/16bit-constants.frag
+++ b/reference/shaders-msl/frag/16bit-constants.frag
@@ -1,0 +1,21 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    half foo [[color(0)]];
+    short bar [[color(1)]];
+    ushort baz [[color(2)]];
+};
+
+fragment main0_out main0()
+{
+    main0_out out = {};
+    out.foo = 1.0h;
+    out.bar = 2;
+    out.baz = 3u;
+    return out;
+}
+

--- a/reference/shaders-msl/vulkan/vert/small-storage.vk.vert
+++ b/reference/shaders-msl/vulkan/vert/small-storage.vk.vert
@@ -1,0 +1,48 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct block
+{
+    short2 a;
+    ushort2 b;
+    char2 c;
+    uchar2 d;
+    half2 e;
+};
+
+struct storage
+{
+    short3 f;
+    ushort3 g;
+    char3 h;
+    uchar3 i;
+    half3 j;
+};
+
+struct main0_out
+{
+    short4 p [[user(locn0)]];
+    ushort4 q [[user(locn1)]];
+    half4 r [[user(locn2)]];
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    short foo [[attribute(0)]];
+    ushort bar [[attribute(1)]];
+    half baz [[attribute(2)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant block& _26 [[buffer(0)]], const device storage& _53 [[buffer(1)]])
+{
+    main0_out out = {};
+    out.p = short4((int4(int(in.foo)) + int4(int2(_26.a), int2(_26.c))) - int4(int3(_53.f) / int3(_53.h), 1));
+    out.q = ushort4((uint4(uint(in.bar)) + uint4(uint2(_26.b), uint2(_26.d))) - uint4(uint3(_53.g) / uint3(_53.i), 1u));
+    out.r = half4((float4(float(in.baz)) + float4(float2(_26.e), 0.0, 1.0)) - float4(float3(_53.j), 1.0));
+    out.gl_Position = float4(0.0, 0.0, 0.0, 1.0);
+    return out;
+}
+

--- a/reference/shaders/comp/bitcast-16bit-1.invalid.comp
+++ b/reference/shaders/comp/bitcast-16bit-1.invalid.comp
@@ -1,0 +1,38 @@
+#version 450
+#if defined(GL_AMD_gpu_shader_half_float)
+#extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_NV_gpu_shader5)
+#extension GL_NV_gpu_shader5 : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
+#else
+#error No extension available for FP16.
+#endif
+#if defined(GL_AMD_gpu_shader_int16)
+#extension GL_AMD_gpu_shader_int16 : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
+#else
+#error No extension available for Int16.
+#endif
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0, std430) buffer SSBO0
+{
+    i16vec4 inputs[];
+} _25;
+
+layout(binding = 1, std430) buffer SSBO1
+{
+    ivec4 outputs[];
+} _39;
+
+void main()
+{
+    uint ident = gl_GlobalInvocationID.x;
+    f16vec2 a = int16BitsToFloat16(_25.inputs[ident].xy);
+    _39.outputs[ident].x = int(packFloat2x16(a + f16vec2(float16_t(1), float16_t(1))));
+    _39.outputs[ident].y = packInt2x16(_25.inputs[ident].zw);
+    _39.outputs[ident].z = int(packUint2x16(u16vec2(_25.inputs[ident].xy)));
+}
+

--- a/reference/shaders/comp/bitcast-16bit-2.invalid.comp
+++ b/reference/shaders/comp/bitcast-16bit-2.invalid.comp
@@ -1,0 +1,43 @@
+#version 450
+#if defined(GL_AMD_gpu_shader_int16)
+#extension GL_AMD_gpu_shader_int16 : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
+#else
+#error No extension available for Int16.
+#endif
+#if defined(GL_AMD_gpu_shader_half_float)
+#extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_NV_gpu_shader5)
+#extension GL_NV_gpu_shader5 : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
+#else
+#error No extension available for FP16.
+#endif
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 1, std430) buffer SSBO1
+{
+    i16vec4 outputs[];
+} _21;
+
+layout(binding = 0, std430) buffer SSBO0
+{
+    ivec4 inputs[];
+} _29;
+
+layout(binding = 2, std140) uniform UBO
+{
+    f16vec4 const0;
+} _40;
+
+void main()
+{
+    uint ident = gl_GlobalInvocationID.x;
+    i16vec2 _47 = unpackInt2x16(_29.inputs[ident].x) + float16BitsToInt16(_40.const0.xy);
+    _21.outputs[ident] = i16vec4(_47.x, _47.y, _21.outputs[ident].z, _21.outputs[ident].w);
+    i16vec2 _66 = i16vec2(unpackUint2x16(uint(_29.inputs[ident].y)) - float16BitsToUint16(_40.const0.zw));
+    _21.outputs[ident] = i16vec4(_21.outputs[ident].x, _21.outputs[ident].y, _66.x, _66.y);
+}
+

--- a/reference/shaders/desktop-only/frag/fp16.invalid.desktop.frag
+++ b/reference/shaders/desktop-only/frag/fp16.invalid.desktop.frag
@@ -3,6 +3,8 @@
 #extension GL_AMD_gpu_shader_half_float : require
 #elif defined(GL_NV_gpu_shader5)
 #extension GL_NV_gpu_shader5 : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
 #else
 #error No extension available for FP16.
 #endif

--- a/reference/shaders/frag/16bit-constants.frag
+++ b/reference/shaders/frag/16bit-constants.frag
@@ -1,0 +1,29 @@
+#version 450
+#if defined(GL_AMD_gpu_shader_half_float)
+#extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_NV_gpu_shader5)
+#extension GL_NV_gpu_shader5 : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
+#else
+#error No extension available for FP16.
+#endif
+#if defined(GL_AMD_gpu_shader_int16)
+#extension GL_AMD_gpu_shader_int16 : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
+#else
+#error No extension available for Int16.
+#endif
+
+layout(location = 0) out float16_t foo;
+layout(location = 1) out int16_t bar;
+layout(location = 2) out uint16_t baz;
+
+void main()
+{
+    foo = 1.0hf;
+    bar = 2s;
+    baz = 3us;
+}
+

--- a/reference/shaders/vulkan/vert/small-storage.vk.vert
+++ b/reference/shaders/vulkan/vert/small-storage.vk.vert
@@ -19,20 +19,20 @@
 
 layout(binding = 0, std140) uniform block
 {
-    layout(offset = 0) i16vec2 a;
-    layout(offset = 4) u16vec2 b;
-    layout(offset = 8) i8vec2 c;
-    layout(offset = 10) u8vec2 d;
-    layout(offset = 12) f16vec2 e;
+    i16vec2 a;
+    u16vec2 b;
+    i8vec2 c;
+    u8vec2 d;
+    f16vec2 e;
 } _26;
 
-layout(binding = 1, std140) readonly buffer storage
+layout(binding = 1, std430) readonly buffer storage
 {
-    layout(offset = 0) i16vec3 f;
-    layout(offset = 8) u16vec3 g;
-    layout(offset = 16) i8vec3 h;
-    layout(offset = 20) u8vec3 i;
-    layout(offset = 24) f16vec3 j;
+    i16vec3 f;
+    u16vec3 g;
+    i8vec3 h;
+    u8vec3 i;
+    f16vec3 j;
 } _53;
 
 struct pushconst

--- a/reference/shaders/vulkan/vert/small-storage.vk.vert
+++ b/reference/shaders/vulkan/vert/small-storage.vk.vert
@@ -1,0 +1,63 @@
+#version 450
+#if defined(GL_AMD_gpu_shader_int16)
+#extension GL_AMD_gpu_shader_int16 : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
+#else
+#error No extension available for Int16.
+#endif
+#extension GL_EXT_shader_8bit_storage : require
+#if defined(GL_AMD_gpu_shader_half_float)
+#extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_NV_gpu_shader5)
+#extension GL_NV_gpu_shader5 : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
+#else
+#error No extension available for FP16.
+#endif
+
+layout(binding = 0, std140) uniform block
+{
+    layout(offset = 0) i16vec2 a;
+    layout(offset = 4) u16vec2 b;
+    layout(offset = 8) i8vec2 c;
+    layout(offset = 10) u8vec2 d;
+    layout(offset = 12) f16vec2 e;
+} _26;
+
+layout(binding = 1, std140) readonly buffer storage
+{
+    layout(offset = 0) i16vec3 f;
+    layout(offset = 8) u16vec3 g;
+    layout(offset = 16) i8vec3 h;
+    layout(offset = 20) u8vec3 i;
+    layout(offset = 24) f16vec3 j;
+} _53;
+
+struct pushconst
+{
+    i16vec4 k;
+    u16vec4 l;
+    i8vec4 m;
+    u8vec4 n;
+    f16vec4 o;
+};
+
+uniform pushconst _76;
+
+layout(location = 0) out i16vec4 p;
+layout(location = 0, component = 0) in int16_t foo;
+layout(location = 1) out u16vec4 q;
+layout(location = 0, component = 1) in uint16_t bar;
+layout(location = 2) out f16vec4 r;
+layout(location = 1) in float16_t baz;
+
+void main()
+{
+    p = i16vec4((((ivec4(int(foo)) + ivec4(ivec2(_26.a), ivec2(_26.c))) - ivec4(ivec3(_53.f) / ivec3(_53.h), 1)) + ivec4(_76.k)) + ivec4(_76.m));
+    q = u16vec4((((uvec4(uint(bar)) + uvec4(uvec2(_26.b), uvec2(_26.d))) - uvec4(uvec3(_53.g) / uvec3(_53.i), 1u)) + uvec4(_76.l)) + uvec4(_76.n));
+    r = f16vec4(((vec4(float(baz)) + vec4(vec2(_26.e), 0.0, 1.0)) - vec4(vec3(_53.j), 1.0)) + vec4(_76.o));
+    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+}
+

--- a/reference/shaders/vulkan/vert/small-storage.vk.vert.vk
+++ b/reference/shaders/vulkan/vert/small-storage.vk.vert.vk
@@ -17,29 +17,29 @@
 
 layout(set = 0, binding = 0, std140) uniform block
 {
-    layout(offset = 0) i16vec2 a;
-    layout(offset = 4) u16vec2 b;
-    layout(offset = 8) i8vec2 c;
-    layout(offset = 10) u8vec2 d;
-    layout(offset = 12) f16vec2 e;
+    i16vec2 a;
+    u16vec2 b;
+    i8vec2 c;
+    u8vec2 d;
+    f16vec2 e;
 } _26;
 
-layout(set = 0, binding = 1, std140) readonly buffer storage
+layout(set = 0, binding = 1, std430) readonly buffer storage
 {
-    layout(offset = 0) i16vec3 f;
-    layout(offset = 8) u16vec3 g;
-    layout(offset = 16) i8vec3 h;
-    layout(offset = 20) u8vec3 i;
-    layout(offset = 24) f16vec3 j;
+    i16vec3 f;
+    u16vec3 g;
+    i8vec3 h;
+    u8vec3 i;
+    f16vec3 j;
 } _53;
 
-layout(push_constant, std140) uniform pushconst
+layout(push_constant, std430) uniform pushconst
 {
-    layout(offset = 0) i16vec4 k;
-    layout(offset = 8) u16vec4 l;
-    layout(offset = 16) i8vec4 m;
-    layout(offset = 20) u8vec4 n;
-    layout(offset = 24) f16vec4 o;
+    i16vec4 k;
+    u16vec4 l;
+    i8vec4 m;
+    u8vec4 n;
+    f16vec4 o;
 } _76;
 
 layout(location = 0) out i16vec4 p;

--- a/reference/shaders/vulkan/vert/small-storage.vk.vert.vk
+++ b/reference/shaders/vulkan/vert/small-storage.vk.vert.vk
@@ -1,0 +1,59 @@
+#version 450
+#if defined(GL_AMD_gpu_shader_int16)
+#extension GL_AMD_gpu_shader_int16 : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
+#else
+#error No extension available for Int16.
+#endif
+#extension GL_EXT_shader_8bit_storage : require
+#if defined(GL_AMD_gpu_shader_half_float)
+#extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_16bit_storage : require
+#else
+#error No extension available for FP16.
+#endif
+
+layout(set = 0, binding = 0, std140) uniform block
+{
+    layout(offset = 0) i16vec2 a;
+    layout(offset = 4) u16vec2 b;
+    layout(offset = 8) i8vec2 c;
+    layout(offset = 10) u8vec2 d;
+    layout(offset = 12) f16vec2 e;
+} _26;
+
+layout(set = 0, binding = 1, std140) readonly buffer storage
+{
+    layout(offset = 0) i16vec3 f;
+    layout(offset = 8) u16vec3 g;
+    layout(offset = 16) i8vec3 h;
+    layout(offset = 20) u8vec3 i;
+    layout(offset = 24) f16vec3 j;
+} _53;
+
+layout(push_constant, std140) uniform pushconst
+{
+    layout(offset = 0) i16vec4 k;
+    layout(offset = 8) u16vec4 l;
+    layout(offset = 16) i8vec4 m;
+    layout(offset = 20) u8vec4 n;
+    layout(offset = 24) f16vec4 o;
+} _76;
+
+layout(location = 0) out i16vec4 p;
+layout(location = 0, component = 0) in int16_t foo;
+layout(location = 1) out u16vec4 q;
+layout(location = 0, component = 1) in uint16_t bar;
+layout(location = 2) out f16vec4 r;
+layout(location = 1) in float16_t baz;
+
+void main()
+{
+    p = i16vec4((((ivec4(int(foo)) + ivec4(ivec2(_26.a), ivec2(_26.c))) - ivec4(ivec3(_53.f) / ivec3(_53.h), 1)) + ivec4(_76.k)) + ivec4(_76.m));
+    q = u16vec4((((uvec4(uint(bar)) + uvec4(uvec2(_26.b), uvec2(_26.d))) - uvec4(uvec3(_53.g) / uvec3(_53.i), 1u)) + uvec4(_76.l)) + uvec4(_76.n));
+    r = f16vec4(((vec4(float(baz)) + vec4(vec2(_26.e), 0.0, 1.0)) - vec4(vec3(_53.j), 1.0)) + vec4(_76.o));
+    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+}
+

--- a/shaders-msl/comp/bitcast-16bit-1.invalid.comp
+++ b/shaders-msl/comp/bitcast-16bit-1.invalid.comp
@@ -1,0 +1,23 @@
+#version 450 core
+#extension GL_AMD_gpu_shader_half_float : require
+#extension GL_AMD_gpu_shader_int16 : require
+layout(local_size_x = 1) in;
+
+layout(binding = 0, std430) buffer SSBO0
+{
+   i16vec4 inputs[];
+};
+
+layout(binding = 1, std430) buffer SSBO1
+{
+   ivec4 outputs[];
+};
+
+void main()
+{
+   uint ident = gl_GlobalInvocationID.x;
+   f16vec2 a = int16BitsToFloat16(inputs[ident].xy);
+   outputs[ident].x = int(packFloat2x16(a + f16vec2(1, 1)));
+   outputs[ident].y = packInt2x16(inputs[ident].zw);
+   outputs[ident].z = int(packUint2x16(u16vec2(inputs[ident].xy)));
+}

--- a/shaders-msl/comp/bitcast-16bit-2.invalid.comp
+++ b/shaders-msl/comp/bitcast-16bit-2.invalid.comp
@@ -1,0 +1,26 @@
+#version 450 core
+#extension GL_AMD_gpu_shader_half_float : require
+#extension GL_AMD_gpu_shader_int16 : require
+layout(local_size_x = 1) in;
+
+layout(binding = 0, std430) buffer SSBO0
+{
+   ivec4 inputs[];
+};
+
+layout(binding = 1, std430) buffer SSBO1
+{
+   i16vec4 outputs[];
+};
+
+layout(binding = 2) uniform UBO
+{
+   f16vec4 const0;
+};
+
+void main()
+{
+   uint ident = gl_GlobalInvocationID.x;
+   outputs[ident].xy = unpackInt2x16(inputs[ident].x) + float16BitsToInt16(const0.xy);
+   outputs[ident].zw = i16vec2(unpackUint2x16(uint(inputs[ident].y)) - float16BitsToUint16(const0.zw));
+}

--- a/shaders-msl/frag/16bit-constants.frag
+++ b/shaders-msl/frag/16bit-constants.frag
@@ -1,0 +1,14 @@
+#version 450 core
+
+#extension GL_AMD_gpu_shader_int16 : require
+#extension GL_AMD_gpu_shader_half_float : require
+
+layout(location = 0) out float16_t foo;
+layout(location = 1) out int16_t bar;
+layout(location = 2) out uint16_t baz;
+
+void main() {
+	foo = 1.0hf;
+	bar = 2s;
+	baz = 3us;
+}

--- a/shaders-msl/vulkan/vert/small-storage.vk.vert
+++ b/shaders-msl/vulkan/vert/small-storage.vk.vert
@@ -1,0 +1,38 @@
+#version 450 core
+
+// GL_EXT_shader_16bit_storage doesn't support input/output.
+#extension GL_EXT_shader_8bit_storage : require
+#extension GL_AMD_gpu_shader_int16 : require
+#extension GL_AMD_gpu_shader_half_float : require
+
+layout(location = 0) in int16_t foo;
+layout(location = 1) in uint16_t bar;
+layout(location = 2) in float16_t baz;
+
+layout(binding = 0) uniform block {
+    i16vec2 a;
+    u16vec2 b;
+    i8vec2 c;
+    u8vec2 d;
+    f16vec2 e;
+};
+
+layout(binding = 1) readonly buffer storage {
+    i16vec3 f;
+    u16vec3 g;
+    i8vec3 h;
+    u8vec3 i;
+    f16vec3 j;
+};
+
+layout(location = 0) out i16vec4 p;
+layout(location = 1) out u16vec4 q;
+layout(location = 2) out f16vec4 r;
+
+void main() {
+    p = i16vec4(int(foo) + ivec4(ivec2(a), ivec2(c)) - ivec4(ivec3(f) / ivec3(h), 1));
+    q = u16vec4(uint(bar) + uvec4(uvec2(b), uvec2(d)) - uvec4(uvec3(g) / uvec3(i), 1));
+    r = f16vec4(float(baz) + vec4(vec2(e), 0, 1) - vec4(vec3(j), 1));
+    gl_Position = vec4(0, 0, 0, 1);
+}
+

--- a/shaders/comp/bitcast-16bit-1.invalid.comp
+++ b/shaders/comp/bitcast-16bit-1.invalid.comp
@@ -1,0 +1,23 @@
+#version 450 core
+#extension GL_AMD_gpu_shader_half_float : require
+#extension GL_AMD_gpu_shader_int16 : require
+layout(local_size_x = 1) in;
+
+layout(binding = 0, std430) buffer SSBO0
+{
+   i16vec4 inputs[];
+};
+
+layout(binding = 1, std430) buffer SSBO1
+{
+   ivec4 outputs[];
+};
+
+void main()
+{
+   uint ident = gl_GlobalInvocationID.x;
+   f16vec2 a = int16BitsToFloat16(inputs[ident].xy);
+   outputs[ident].x = int(packFloat2x16(a + f16vec2(1, 1)));
+   outputs[ident].y = packInt2x16(inputs[ident].zw);
+   outputs[ident].z = int(packUint2x16(u16vec2(inputs[ident].xy)));
+}

--- a/shaders/comp/bitcast-16bit-2.invalid.comp
+++ b/shaders/comp/bitcast-16bit-2.invalid.comp
@@ -1,0 +1,26 @@
+#version 450 core
+#extension GL_AMD_gpu_shader_half_float : require
+#extension GL_AMD_gpu_shader_int16 : require
+layout(local_size_x = 1) in;
+
+layout(binding = 0, std430) buffer SSBO0
+{
+   ivec4 inputs[];
+};
+
+layout(binding = 1, std430) buffer SSBO1
+{
+   i16vec4 outputs[];
+};
+
+layout(binding = 2) uniform UBO
+{
+   f16vec4 const0;
+};
+
+void main()
+{
+   uint ident = gl_GlobalInvocationID.x;
+   outputs[ident].xy = unpackInt2x16(inputs[ident].x) + float16BitsToInt16(const0.xy);
+   outputs[ident].zw = i16vec2(unpackUint2x16(uint(inputs[ident].y)) - float16BitsToUint16(const0.zw));
+}

--- a/shaders/frag/16bit-constants.frag
+++ b/shaders/frag/16bit-constants.frag
@@ -1,0 +1,14 @@
+#version 450 core
+
+#extension GL_AMD_gpu_shader_int16 : require
+#extension GL_AMD_gpu_shader_half_float : require
+
+layout(location = 0) out float16_t foo;
+layout(location = 1) out int16_t bar;
+layout(location = 2) out uint16_t baz;
+
+void main() {
+	foo = 1.0hf;
+	bar = 2s;
+	baz = 3us;
+}

--- a/shaders/vulkan/vert/small-storage.vk.vert
+++ b/shaders/vulkan/vert/small-storage.vk.vert
@@ -1,0 +1,46 @@
+#version 450 core
+
+// GL_EXT_shader_16bit_storage doesn't support input/output.
+#extension GL_EXT_shader_8bit_storage : require
+#extension GL_AMD_gpu_shader_int16 : require
+#extension GL_AMD_gpu_shader_half_float : require
+
+layout(location = 0, component = 0) in int16_t foo;
+layout(location = 0, component = 1) in uint16_t bar;
+layout(location = 1) in float16_t baz;
+
+layout(binding = 0) uniform block {
+    i16vec2 a;
+    u16vec2 b;
+    i8vec2 c;
+    u8vec2 d;
+    f16vec2 e;
+};
+
+layout(binding = 1) readonly buffer storage {
+    i16vec3 f;
+    u16vec3 g;
+    i8vec3 h;
+    u8vec3 i;
+    f16vec3 j;
+};
+
+layout(push_constant) uniform pushconst {
+    i16vec4 k;
+    u16vec4 l;
+    i8vec4 m;
+    u8vec4 n;
+    f16vec4 o;
+};
+
+layout(location = 0) out i16vec4 p;
+layout(location = 1) out u16vec4 q;
+layout(location = 2) out f16vec4 r;
+
+void main() {
+    p = i16vec4(int(foo) + ivec4(ivec2(a), ivec2(c)) - ivec4(ivec3(f) / ivec3(h), 1) + ivec4(k) + ivec4(m));
+    q = u16vec4(uint(bar) + uvec4(uvec2(b), uvec2(d)) - uvec4(uvec3(g) / uvec3(i), 1) + uvec4(l) + uvec4(n));
+    r = f16vec4(float(baz) + vec4(vec2(e), 0, 1) - vec4(vec3(j), 1) + vec4(o));
+    gl_Position = vec4(0, 0, 0, 1);
+}
+

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -402,6 +402,10 @@ struct SPIRType : IVariant
 		Void,
 		Boolean,
 		Char,
+		SByte,
+		UByte,
+		Short,
+		UShort,
 		Int,
 		UInt,
 		Int64,
@@ -1010,6 +1014,11 @@ struct SPIRConstant : IVariant
 		return m.c[col].r[row].u32;
 	}
 
+	inline int16_t scalar_i16(uint32_t col = 0, uint32_t row = 0) const
+	{
+		return int16_t(m.c[col].r[row].u32 & 0xffffu);
+	}
+
 	inline uint16_t scalar_u16(uint32_t col = 0, uint32_t row = 0) const
 	{
 		return uint16_t(m.c[col].r[row].u32 & 0xffffu);
@@ -1377,8 +1386,9 @@ static inline bool type_is_floating_point(const SPIRType &type)
 
 static inline bool type_is_integral(const SPIRType &type)
 {
-	return type.basetype == SPIRType::Int || type.basetype == SPIRType::UInt || type.basetype == SPIRType::Int64 ||
-	       type.basetype == SPIRType::UInt64;
+	return type.basetype == SPIRType::SByte || type.basetype == SPIRType::UByte || type.basetype == SPIRType::Short ||
+	       type.basetype == SPIRType::UShort || type.basetype == SPIRType::Int || type.basetype == SPIRType::UInt ||
+	       type.basetype == SPIRType::Int64 || type.basetype == SPIRType::UInt64;
 }
 } // namespace spirv_cross
 

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -3351,6 +3351,72 @@ string CompilerGLSL::constant_expression_vector(const SPIRConstant &c, uint32_t 
 		}
 		break;
 
+	case SPIRType::UShort:
+		if (splat)
+		{
+			res += convert_to_string(c.scalar(vector, 0));
+			if (is_legacy())
+			{
+				// Fake unsigned constant literals with signed ones if possible.
+				// Things like array sizes, etc, tend to be unsigned even though they could just as easily be signed.
+				if (c.scalar_i16(vector, 0) < 0)
+					SPIRV_CROSS_THROW("Tried to convert uint literal into int, but this made the literal negative.");
+			}
+			else if (backend.uint16_t_literal_suffix)
+				res += backend.uint16_t_literal_suffix;
+		}
+		else
+		{
+			for (uint32_t i = 0; i < c.vector_size(); i++)
+			{
+				if (c.vector_size() > 1 && c.specialization_constant_id(vector, i) != 0)
+					res += to_name(c.specialization_constant_id(vector, i));
+				else
+				{
+					res += convert_to_string(c.scalar(vector, i));
+					if (is_legacy())
+					{
+						// Fake unsigned constant literals with signed ones if possible.
+						// Things like array sizes, etc, tend to be unsigned even though they could just as easily be signed.
+						if (c.scalar_i16(vector, i) < 0)
+							SPIRV_CROSS_THROW(
+							    "Tried to convert uint literal into int, but this made the literal negative.");
+					}
+					else if (backend.uint16_t_literal_suffix)
+						res += backend.uint16_t_literal_suffix;
+				}
+
+				if (i + 1 < c.vector_size())
+					res += ", ";
+			}
+		}
+		break;
+
+	case SPIRType::Short:
+		if (splat)
+		{
+			res += convert_to_string(c.scalar_i16(vector, 0));
+			if (backend.int16_t_literal_suffix)
+				res += backend.int16_t_literal_suffix;
+		}
+		else
+		{
+			for (uint32_t i = 0; i < c.vector_size(); i++)
+			{
+				if (c.vector_size() > 1 && c.specialization_constant_id(vector, i) != 0)
+					res += to_name(c.specialization_constant_id(vector, i));
+				else
+				{
+					res += convert_to_string(c.scalar_i16(vector, i));
+					if (backend.int16_t_literal_suffix)
+						res += backend.int16_t_literal_suffix;
+				}
+				if (i + 1 < c.vector_size())
+					res += ", ";
+			}
+		}
+		break;
+
 	case SPIRType::Boolean:
 		if (splat)
 			res += c.scalar(vector, 0) ? "true" : "false";

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1851,20 +1851,22 @@ void CompilerGLSL::replace_illegal_names()
 		"dFdx", "dFdxCoarse", "dFdxFine",
 		"dFdy", "dFdyCoarse", "dFdyFine",
 		"distance", "dot", "EmitStreamVertex", "EmitVertex", "EndPrimitive", "EndStreamPrimitive", "equal", "exp", "exp2",
-		"faceforward", "findLSB", "findMSB", "floatBitsToInt", "floatBitsToUint", "floor", "fma", "fract", "frexp", "fwidth", "fwidthCoarse", "fwidthFine",
+		"faceforward", "findLSB", "findMSB", "float16BitsToInt16", "float16BitsToUint16", "floatBitsToInt", "floatBitsToUint", "floor", "fma", "fract",
+		"frexp", "fwidth", "fwidthCoarse", "fwidthFine",
 		"greaterThan", "greaterThanEqual", "groupMemoryBarrier",
 		"imageAtomicAdd", "imageAtomicAnd", "imageAtomicCompSwap", "imageAtomicExchange", "imageAtomicMax", "imageAtomicMin", "imageAtomicOr", "imageAtomicXor",
-		"imageLoad", "imageSamples", "imageSize", "imageStore", "imulExtended", "intBitsToFloat", "interpolateAtOffset", "interpolateAtCentroid", "interpolateAtSample",
+		"imageLoad", "imageSamples", "imageSize", "imageStore", "imulExtended", "int16BitsToFloat16", "intBitsToFloat", "interpolateAtOffset", "interpolateAtCentroid", "interpolateAtSample",
 		"inverse", "inversesqrt", "isinf", "isnan", "ldexp", "length", "lessThan", "lessThanEqual", "log", "log2",
 		"matrixCompMult", "max", "memoryBarrier", "memoryBarrierAtomicCounter", "memoryBarrierBuffer", "memoryBarrierImage", "memoryBarrierShared",
 		"min", "mix", "mod", "modf", "noise", "noise1", "noise2", "noise3", "noise4", "normalize", "not", "notEqual",
-		"outerProduct", "packDouble2x32", "packHalf2x16", "packSnorm2x16", "packSnorm4x8", "packUnorm2x16", "packUnorm4x8", "pow",
+		"outerProduct", "packDouble2x32", "packHalf2x16", "packInt2x16", "packInt4x16", "packSnorm2x16", "packSnorm4x8",
+		"packUint2x16", "packUint4x16", "packUnorm2x16", "packUnorm4x8", "pow",
 		"radians", "reflect", "refract", "round", "roundEven", "sign", "sin", "sinh", "smoothstep", "sqrt", "step",
 		"tan", "tanh", "texelFetch", "texelFetchOffset", "texture", "textureGather", "textureGatherOffset", "textureGatherOffsets",
 		"textureGrad", "textureGradOffset", "textureLod", "textureLodOffset", "textureOffset", "textureProj", "textureProjGrad",
 		"textureProjGradOffset", "textureProjLod", "textureProjLodOffset", "textureProjOffset", "textureQueryLevels", "textureQueryLod", "textureSamples", "textureSize",
-		"transpose", "trunc", "uaddCarry", "uintBitsToFloat", "umulExtended", "unpackDouble2x32", "unpackHalf2x16", "unpackSnorm2x16", "unpackSnorm4x8",
-		"unpackUnorm2x16", "unpackUnorm4x8", "usubBorrow",
+		"transpose", "trunc", "uaddCarry", "uint16BitsToFloat16", "uintBitsToFloat", "umulExtended", "unpackDouble2x32", "unpackHalf2x16", "unpackInt2x16", "unpackInt4x16",
+		"unpackSnorm2x16", "unpackSnorm4x8", "unpackUint2x16", "unpackUint4x16", "unpackUnorm2x16", "unpackUnorm4x8", "usubBorrow",
 
 		"active", "asm", "atomic_uint", "attribute", "bool", "break", "buffer",
 		"bvec2", "bvec3", "bvec4", "case", "cast", "centroid", "class", "coherent", "common", "const", "continue", "default", "discard",
@@ -5150,12 +5152,16 @@ case OpGroupNonUniform##op: \
 
 string CompilerGLSL::bitcast_glsl_op(const SPIRType &out_type, const SPIRType &in_type)
 {
-	if (out_type.basetype == SPIRType::UInt && in_type.basetype == SPIRType::Int)
+	if (out_type.basetype == SPIRType::UShort && in_type.basetype == SPIRType::Short)
+		return type_to_glsl(out_type);
+	else if (out_type.basetype == SPIRType::UInt && in_type.basetype == SPIRType::Int)
 		return type_to_glsl(out_type);
 	else if (out_type.basetype == SPIRType::UInt64 && in_type.basetype == SPIRType::Int64)
 		return type_to_glsl(out_type);
 	else if (out_type.basetype == SPIRType::UInt && in_type.basetype == SPIRType::Float)
 		return "floatBitsToUint";
+	else if (out_type.basetype == SPIRType::Short && in_type.basetype == SPIRType::UShort)
+		return type_to_glsl(out_type);
 	else if (out_type.basetype == SPIRType::Int && in_type.basetype == SPIRType::UInt)
 		return type_to_glsl(out_type);
 	else if (out_type.basetype == SPIRType::Int64 && in_type.basetype == SPIRType::UInt64)
@@ -5174,12 +5180,36 @@ string CompilerGLSL::bitcast_glsl_op(const SPIRType &out_type, const SPIRType &i
 		return "int64BitsToDouble";
 	else if (out_type.basetype == SPIRType::Double && in_type.basetype == SPIRType::UInt64)
 		return "uint64BitsToDouble";
+	else if (out_type.basetype == SPIRType::Short && in_type.basetype == SPIRType::Half)
+		return "float16BitsToInt16";
+	else if (out_type.basetype == SPIRType::UShort && in_type.basetype == SPIRType::Half)
+		return "float16BitsToUint16";
+	else if (out_type.basetype == SPIRType::Half && in_type.basetype == SPIRType::Short)
+		return "int16BitsToFloat16";
+	else if (out_type.basetype == SPIRType::Half && in_type.basetype == SPIRType::UShort)
+		return "uint16BitsToFloat16";
 	else if (out_type.basetype == SPIRType::UInt64 && in_type.basetype == SPIRType::UInt && in_type.vecsize == 2)
 		return "packUint2x32";
 	else if (out_type.basetype == SPIRType::Half && in_type.basetype == SPIRType::UInt && in_type.vecsize == 1)
 		return "unpackFloat2x16";
 	else if (out_type.basetype == SPIRType::UInt && in_type.basetype == SPIRType::Half && in_type.vecsize == 2)
 		return "packFloat2x16";
+	else if (out_type.basetype == SPIRType::Int && in_type.basetype == SPIRType::Short && in_type.vecsize == 2)
+		return "packInt2x16";
+	else if (out_type.basetype == SPIRType::Short && in_type.basetype == SPIRType::Int && in_type.vecsize == 1)
+		return "unpackInt2x16";
+	else if (out_type.basetype == SPIRType::UInt && in_type.basetype == SPIRType::UShort && in_type.vecsize == 2)
+		return "packUint2x16";
+	else if (out_type.basetype == SPIRType::UShort && in_type.basetype == SPIRType::UInt && in_type.vecsize == 1)
+		return "unpackUint2x16";
+	else if (out_type.basetype == SPIRType::Int64 && in_type.basetype == SPIRType::Short && in_type.vecsize == 4)
+		return "packInt4x16";
+	else if (out_type.basetype == SPIRType::Short && in_type.basetype == SPIRType::Int64 && in_type.vecsize == 1)
+		return "unpackInt4x16";
+	else if (out_type.basetype == SPIRType::UInt64 && in_type.basetype == SPIRType::UShort && in_type.vecsize == 4)
+		return "packUint4x16";
+	else if (out_type.basetype == SPIRType::UShort && in_type.basetype == SPIRType::UInt64 && in_type.vecsize == 1)
+		return "unpackUint4x16";
 	else
 		return "";
 }

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -366,6 +366,8 @@ protected:
 		const char *basic_int16_type = "int16_t";
 		const char *basic_uint16_type = "uint16_t";
 		const char *half_literal_suffix = "hf";
+		const char *int16_t_literal_suffix = "s";
+		const char *uint16_t_literal_suffix = "us";
 		bool swizzle_is_function = false;
 		bool shared_is_implied = false;
 		bool flexible_member_array_supported = true;

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -361,6 +361,10 @@ protected:
 		bool long_long_literal_suffix = false;
 		const char *basic_int_type = "int";
 		const char *basic_uint_type = "uint";
+		const char *basic_int8_type = "int8_t";
+		const char *basic_uint8_type = "uint8_t";
+		const char *basic_int16_type = "int16_t";
+		const char *basic_uint16_type = "uint16_t";
 		const char *half_literal_suffix = "hf";
 		bool swizzle_is_function = false;
 		bool shared_is_implied = false;

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -4616,6 +4616,8 @@ string CompilerHLSL::compile()
 	backend.half_literal_suffix = nullptr;
 	backend.long_long_literal_suffix = true;
 	backend.uint32_t_literal_suffix = true;
+	backend.int16_t_literal_suffix = nullptr;
+	backend.uint16_t_literal_suffix = "u";
 	backend.basic_int_type = "int";
 	backend.basic_uint_type = "uint";
 	backend.swizzle_is_function = false;

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -982,9 +982,8 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage)
 			}
 		}
 		else if (type.basetype == SPIRType::Boolean || type.basetype == SPIRType::Char ||
-		         type.basetype == SPIRType::Int || type.basetype == SPIRType::UInt ||
-		         type.basetype == SPIRType::Int64 || type.basetype == SPIRType::UInt64 ||
-		         type_is_floating_point(type) || type.basetype == SPIRType::Boolean)
+		         type_is_integral(type) || type_is_floating_point(type) ||
+		         type.basetype == SPIRType::Boolean)
 		{
 			bool is_builtin = is_builtin_variable(*p_var);
 			BuiltIn builtin = BuiltIn(get_decoration(p_var->self, DecorationBuiltIn));
@@ -4270,13 +4269,23 @@ string CompilerMSL::type_to_glsl(const SPIRType &type, uint32_t id)
 		type_name = "bool";
 		break;
 	case SPIRType::Char:
+	case SPIRType::SByte:
 		type_name = "char";
 		break;
+	case SPIRType::UByte:
+		type_name = "uchar";
+		break;
+	case SPIRType::Short:
+		type_name = "short";
+		break;
+	case SPIRType::UShort:
+		type_name = "ushort";
+		break;
 	case SPIRType::Int:
-		type_name = (type.width == 8 ? "char" : (type.width == 16 ? "short" : "int"));
+		type_name = "int";
 		break;
 	case SPIRType::UInt:
-		type_name = (type.width == 8 ? "uchar" : (type.width == 16 ? "ushort" : "uint"));
+		type_name = "uint";
 		break;
 	case SPIRType::Int64:
 		type_name = "long"; // Currently unsupported

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -392,6 +392,10 @@ string CompilerMSL::compile()
 	backend.uint32_t_literal_suffix = true;
 	backend.basic_int_type = "int";
 	backend.basic_uint_type = "uint";
+	backend.basic_int8_type = "char";
+	backend.basic_uint8_type = "uchar";
+	backend.basic_int16_type = "short";
+	backend.basic_uint16_type = "ushort";
 	backend.discard_literal = "discard_fragment()";
 	backend.swizzle_is_function = false;
 	backend.shared_is_implied = false;
@@ -4269,10 +4273,10 @@ string CompilerMSL::type_to_glsl(const SPIRType &type, uint32_t id)
 		type_name = "char";
 		break;
 	case SPIRType::Int:
-		type_name = (type.width == 16 ? "short" : "int");
+		type_name = (type.width == 8 ? "char" : (type.width == 16 ? "short" : "int"));
 		break;
 	case SPIRType::UInt:
-		type_name = (type.width == 16 ? "ushort" : "uint");
+		type_name = (type.width == 8 ? "uchar" : (type.width == 16 ? "ushort" : "uint"));
 		break;
 	case SPIRType::Int64:
 		type_name = "long"; // Currently unsupported

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -983,9 +983,8 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage)
 				mbr_idx++;
 			}
 		}
-		else if (type.basetype == SPIRType::Boolean || type.basetype == SPIRType::Char ||
-		         type_is_integral(type) || type_is_floating_point(type) ||
-		         type.basetype == SPIRType::Boolean)
+		else if (type.basetype == SPIRType::Boolean || type.basetype == SPIRType::Char || type_is_integral(type) ||
+		         type_is_floating_point(type) || type.basetype == SPIRType::Boolean)
 		{
 			bool is_builtin = is_builtin_variable(*p_var);
 			BuiltIn builtin = BuiltIn(get_decoration(p_var->self, DecorationBuiltIn));
@@ -4501,7 +4500,9 @@ string CompilerMSL::image_type_glsl(const SPIRType &type, uint32_t id)
 
 string CompilerMSL::bitcast_glsl_op(const SPIRType &out_type, const SPIRType &in_type)
 {
-	if ((out_type.basetype == SPIRType::UInt && in_type.basetype == SPIRType::Int) ||
+	if ((out_type.basetype == SPIRType::UShort && in_type.basetype == SPIRType::Short) ||
+	    (out_type.basetype == SPIRType::Short && in_type.basetype == SPIRType::UShort) ||
+	    (out_type.basetype == SPIRType::UInt && in_type.basetype == SPIRType::Int) ||
 	    (out_type.basetype == SPIRType::Int && in_type.basetype == SPIRType::UInt) ||
 	    (out_type.basetype == SPIRType::UInt64 && in_type.basetype == SPIRType::Int64) ||
 	    (out_type.basetype == SPIRType::Int64 && in_type.basetype == SPIRType::UInt64))
@@ -4516,7 +4517,17 @@ string CompilerMSL::bitcast_glsl_op(const SPIRType &out_type, const SPIRType &in
 	    (out_type.basetype == SPIRType::Double && in_type.basetype == SPIRType::Int64) ||
 	    (out_type.basetype == SPIRType::Double && in_type.basetype == SPIRType::UInt64) ||
 	    (out_type.basetype == SPIRType::Half && in_type.basetype == SPIRType::UInt) ||
-	    (out_type.basetype == SPIRType::UInt && in_type.basetype == SPIRType::Half))
+	    (out_type.basetype == SPIRType::UInt && in_type.basetype == SPIRType::Half) ||
+	    (out_type.basetype == SPIRType::Half && in_type.basetype == SPIRType::Int) ||
+	    (out_type.basetype == SPIRType::Int && in_type.basetype == SPIRType::Half) ||
+	    (out_type.basetype == SPIRType::Half && in_type.basetype == SPIRType::UShort) ||
+	    (out_type.basetype == SPIRType::UShort && in_type.basetype == SPIRType::Half) ||
+	    (out_type.basetype == SPIRType::Half && in_type.basetype == SPIRType::Short) ||
+	    (out_type.basetype == SPIRType::Short && in_type.basetype == SPIRType::Half) ||
+	    (out_type.basetype == SPIRType::UInt && in_type.basetype == SPIRType::UShort && in_type.vecsize == 2) ||
+	    (out_type.basetype == SPIRType::UShort && in_type.basetype == SPIRType::UInt && in_type.vecsize == 1) ||
+	    (out_type.basetype == SPIRType::Int && in_type.basetype == SPIRType::Short && in_type.vecsize == 2) ||
+	    (out_type.basetype == SPIRType::Short && in_type.basetype == SPIRType::Int && in_type.vecsize == 1))
 		return "as_type<" + type_to_glsl(out_type) + ">";
 
 	return "";

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -390,6 +390,8 @@ string CompilerMSL::compile()
 	backend.float_literal_suffix = false;
 	backend.half_literal_suffix = "h";
 	backend.uint32_t_literal_suffix = true;
+	backend.int16_t_literal_suffix = nullptr;
+	backend.uint16_t_literal_suffix = "u";
 	backend.basic_int_type = "int";
 	backend.basic_uint_type = "uint";
 	backend.basic_int8_type = "char";

--- a/spirv_parser.cpp
+++ b/spirv_parser.cpp
@@ -383,9 +383,25 @@ void Parser::parse(const Instruction &instruction)
 	{
 		uint32_t id = ops[0];
 		uint32_t width = ops[1];
+		bool signedness = ops[2];
 		auto &type = set<SPIRType>(id);
-		type.basetype =
-		    ops[2] ? (width > 32 ? SPIRType::Int64 : SPIRType::Int) : (width > 32 ? SPIRType::UInt64 : SPIRType::UInt);
+		switch (width)
+		{
+		case 64:
+			type.basetype = signedness ? SPIRType::Int64 : SPIRType::UInt64;
+			break;
+		case 32:
+			type.basetype = signedness ? SPIRType::Int : SPIRType::UInt;
+			break;
+		case 16:
+			type.basetype = signedness ? SPIRType::Short : SPIRType::UShort;
+			break;
+		case 8:
+			type.basetype = signedness ? SPIRType::SByte : SPIRType::UByte;
+			break;
+		default:
+			SPIRV_CROSS_THROW("Unrecognized bit-width of integral type.");
+		}
 		type.width = width;
 		break;
 	}


### PR DESCRIPTION
In GLSL, 8-bit types require `GL_EXT_shader_8bit_storage`. 16-bit types
can use either `GL_AMD_gpu_shader_int16`/`GL_AMD_gpu_shader_half_float` or
`GL_EXT_shader_16bit_storage`.