### PR TITLE
MSL: Print early_fragment_tests specifier before fragment

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -3750,7 +3750,7 @@ string CompilerMSL::func_type_decl(SPIRType &type)
 		break;
 	case ExecutionModelFragment:
 		entry_type =
-		    execution.flags.get(ExecutionModeEarlyFragmentTests) ? "fragment [[ early_fragment_tests ]]" : "fragment";
+		    execution.flags.get(ExecutionModeEarlyFragmentTests) ? "[[ early_fragment_tests ]] fragment" : "fragment";
 		break;
 	case ExecutionModelGLCompute:
 	case ExecutionModelKernel:


### PR DESCRIPTION
The compiler in 10.14 reports an error that the attribute cannot be applied to types if the specifier is printed before the fragment specifier.

I can't see anywhere in the spec that suggests where the specifier must be inserted, but the examples place it at the beginning.