### PR TITLE
MSL: Emit wrapper for SSign (sign() for int types)

### DIFF
--- a/reference/opt/shaders-msl/vert/sign-int-types.vert
+++ b/reference/opt/shaders-msl/vert/sign-int-types.vert
@@ -1,0 +1,60 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBO
+{
+    float4x4 uMVP;
+    float4 uFloatVec4;
+    float3 uFloatVec3;
+    float2 uFloatVec2;
+    float uFloat;
+    int4 uIntVec4;
+    int3 uIntVec3;
+    int2 uIntVec2;
+    int uInt;
+};
+
+struct main0_out
+{
+    float4 vFloatVec4 [[user(locn0)]];
+    float3 vFloatVec3 [[user(locn1)]];
+    float2 vFloatVec2 [[user(locn2)]];
+    float vFloat [[user(locn3)]];
+    int4 vIntVec4 [[user(locn4)]];
+    int3 vIntVec3 [[user(locn5)]];
+    int2 vIntVec2 [[user(locn6)]];
+    int vInt [[user(locn7)]];
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+};
+
+// Implementation of the GLSL sign() function for integer types
+template<typename T, typename E = typename enable_if<is_integral<T>::value>::type>
+T sign(T x)
+{
+    return select(select(select(x, T(0), x == T(0)), T(1), x > T(0)), T(-1), x < T(0));
+}
+
+vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _21 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = _21.uMVP * in.aVertex;
+    out.vFloatVec4 = sign(_21.uFloatVec4);
+    out.vFloatVec3 = sign(_21.uFloatVec3);
+    out.vFloatVec2 = sign(_21.uFloatVec2);
+    out.vFloat = sign(_21.uFloat);
+    out.vIntVec4 = sign(_21.uIntVec4);
+    out.vIntVec3 = sign(_21.uIntVec3);
+    out.vIntVec2 = sign(_21.uIntVec2);
+    out.vInt = sign(_21.uInt);
+    return out;
+}
+

--- a/reference/shaders-msl/vert/sign-int-types.vert
+++ b/reference/shaders-msl/vert/sign-int-types.vert
@@ -1,0 +1,60 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBO
+{
+    float4x4 uMVP;
+    float4 uFloatVec4;
+    float3 uFloatVec3;
+    float2 uFloatVec2;
+    float uFloat;
+    int4 uIntVec4;
+    int3 uIntVec3;
+    int2 uIntVec2;
+    int uInt;
+};
+
+struct main0_out
+{
+    float4 vFloatVec4 [[user(locn0)]];
+    float3 vFloatVec3 [[user(locn1)]];
+    float2 vFloatVec2 [[user(locn2)]];
+    float vFloat [[user(locn3)]];
+    int4 vIntVec4 [[user(locn4)]];
+    int3 vIntVec3 [[user(locn5)]];
+    int2 vIntVec2 [[user(locn6)]];
+    int vInt [[user(locn7)]];
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 aVertex [[attribute(0)]];
+};
+
+// Implementation of the GLSL sign() function for integer types
+template<typename T, typename E = typename enable_if<is_integral<T>::value>::type>
+T sign(T x)
+{
+    return select(select(select(x, T(0), x == T(0)), T(1), x > T(0)), T(-1), x < T(0));
+}
+
+vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _21 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = _21.uMVP * in.aVertex;
+    out.vFloatVec4 = sign(_21.uFloatVec4);
+    out.vFloatVec3 = sign(_21.uFloatVec3);
+    out.vFloatVec2 = sign(_21.uFloatVec2);
+    out.vFloat = sign(_21.uFloat);
+    out.vIntVec4 = sign(_21.uIntVec4);
+    out.vIntVec3 = sign(_21.uIntVec3);
+    out.vIntVec2 = sign(_21.uIntVec2);
+    out.vInt = sign(_21.uInt);
+    return out;
+}
+

--- a/shaders-msl/vert/sign-int-types.vert
+++ b/shaders-msl/vert/sign-int-types.vert
@@ -1,0 +1,38 @@
+#version 310 es
+
+layout(std140) uniform UBO
+{
+    uniform mat4 uMVP;
+    uniform vec4 uFloatVec4;
+    uniform vec3 uFloatVec3;
+    uniform vec2 uFloatVec2;
+    uniform float uFloat;
+    uniform ivec4 uIntVec4;
+    uniform ivec3 uIntVec3;
+    uniform ivec2 uIntVec2;
+    uniform int uInt;
+};
+
+layout(location = 0) in vec4 aVertex;
+
+layout(location = 0) out vec4 vFloatVec4;
+layout(location = 1) out vec3 vFloatVec3;
+layout(location = 2) out vec2 vFloatVec2;
+layout(location = 3) out float vFloat;
+layout(location = 4) flat out ivec4 vIntVec4;
+layout(location = 5) flat out ivec3 vIntVec3;
+layout(location = 6) flat out ivec2 vIntVec2;
+layout(location = 7) flat out int vInt;
+
+void main()
+{
+    gl_Position = uMVP * aVertex;
+    vFloatVec4 = sign(uFloatVec4);
+    vFloatVec3 = sign(uFloatVec3);
+    vFloatVec2 = sign(uFloatVec2);
+    vFloat = sign(uFloat);
+    vIntVec4 = sign(uIntVec4);
+    vIntVec3 = sign(uIntVec3);
+    vIntVec2 = sign(uIntVec2);
+    vInt = sign(uInt);
+}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1401,6 +1401,16 @@ void CompilerMSL::emit_custom_functions()
 			statement("");
 			break;
 
+		case SPVFuncImplSSign:
+			statement("// Implementation of the GLSL sign() function for integer types");
+			statement("template<typename T, typename E = typename enable_if<is_integral<T>::value>::type>");
+			statement("T sign(T x)");
+			begin_scope();
+			statement("return select(select(select(x, T(0), x == T(0)), T(1), x > T(0)), T(-1), x < T(0));");
+			end_scope();
+			statement("");
+			break;
+
 		case SPVFuncImplArrayCopy:
 			statement("// Implementation of an array copy function to cover GLSL's ability to copy an array via "
 			          "assignment.");
@@ -5067,6 +5077,8 @@ CompilerMSL::SPVFuncImpl CompilerMSL::OpCodePreprocessor::get_spv_func_impl(Op o
 				return SPVFuncImplFindSMsb;
 			case GLSLstd450FindUMsb:
 				return SPVFuncImplFindUMsb;
+			case GLSLstd450SSign:
+				return SPVFuncImplSSign;
 			case GLSLstd450MatrixInverse:
 			{
 				auto &mat_type = compiler.get<SPIRType>(args[0]);

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -230,6 +230,7 @@ public:
 		SPVFuncImplFindILsb,
 		SPVFuncImplFindSMsb,
 		SPVFuncImplFindUMsb,
+		SPVFuncImplSSign,
 		SPVFuncImplArrayCopyMultidimBase,
 		// Unfortunately, we cannot use recursive templates in the MSL compiler properly,
 		// so stamp out variants up to some arbitrary maximum.


### PR DESCRIPTION
Metal does not define the sign() function for integer types, only floating-point types. GLSL defines sign() for genType, genDType, and genIType (Section 8.3 - Common Functions).

This PR generates a wrapper function which uses select() to return -1, 0, or 1 depending on the input, using the select() function. Not sure if this is the optimal method of implementing these semantics, but it seems cleaner to me than a series of ternaries, and uses templates like the surrounding wrappers.

Please let me know if I'm going about this the wrong way. If it is acceptable, should I also add a test shader for this function overload?