### PR TITLE
HLSL: Combine image and sampler on shader model <= 30

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -984,6 +984,11 @@ static int main_inner(int argc, char *argv[])
 			hlsl_opts.point_size_compat = true;
 			hlsl_opts.point_coord_compat = true;
 		}
+		if (hlsl_opts.shader_model <= 30)
+		{
+			combined_image_samplers = true;
+			build_dummy_sampler = true;
+		}
 		hlsl->set_hlsl_options(hlsl_opts);
 	}
 


### PR DESCRIPTION
When compiling a fragment shader to a HLSL shader model 30, an exception "Separate image and samplers not supported in legacy HLSL." fired from CompilerHLSL::emit_legacy_uniform.

This change combines image and sampler and skip the separated one, if shader model <= 30.