### PR TITLE
Deal with depth_greater/depth_less qualifiers.

### DIFF
--- a/reference/opt/shaders-hlsl/frag/depth-greater-than.frag
+++ b/reference/opt/shaders-hlsl/frag/depth-greater-than.frag
@@ -1,0 +1,19 @@
+static float gl_FragDepth;
+struct SPIRV_Cross_Output
+{
+    float gl_FragDepth : SV_DepthGreaterEqual;
+};
+
+void frag_main()
+{
+    gl_FragDepth = 0.5f;
+}
+
+[earlydepthstencil]
+SPIRV_Cross_Output main()
+{
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_FragDepth = gl_FragDepth;
+    return stage_output;
+}

--- a/reference/opt/shaders-hlsl/frag/depth-less-than.frag
+++ b/reference/opt/shaders-hlsl/frag/depth-less-than.frag
@@ -1,0 +1,19 @@
+static float gl_FragDepth;
+struct SPIRV_Cross_Output
+{
+    float gl_FragDepth : SV_DepthLessEqual;
+};
+
+void frag_main()
+{
+    gl_FragDepth = 0.5f;
+}
+
+[earlydepthstencil]
+SPIRV_Cross_Output main()
+{
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_FragDepth = gl_FragDepth;
+    return stage_output;
+}

--- a/reference/opt/shaders-msl/frag/depth-greater-than.frag
+++ b/reference/opt/shaders-msl/frag/depth-greater-than.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float gl_FragDepth [[depth(greater)]];
+};
+
+[[ early_fragment_tests ]] fragment main0_out main0()
+{
+    main0_out out = {};
+    out.gl_FragDepth = 0.5;
+    return out;
+}
+

--- a/reference/opt/shaders-msl/frag/depth-less-than.frag
+++ b/reference/opt/shaders-msl/frag/depth-less-than.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float gl_FragDepth [[depth(less)]];
+};
+
+[[ early_fragment_tests ]] fragment main0_out main0()
+{
+    main0_out out = {};
+    out.gl_FragDepth = 0.5;
+    return out;
+}
+

--- a/reference/opt/shaders/desktop-only/frag/depth-greater-than.desktop.frag
+++ b/reference/opt/shaders/desktop-only/frag/depth-greater-than.desktop.frag
@@ -1,0 +1,9 @@
+#version 450
+layout(depth_greater) out float gl_FragDepth;
+layout(early_fragment_tests) in;
+
+void main()
+{
+    gl_FragDepth = 0.5;
+}
+

--- a/reference/opt/shaders/desktop-only/frag/depth-less-than.desktop.frag
+++ b/reference/opt/shaders/desktop-only/frag/depth-less-than.desktop.frag
@@ -1,0 +1,9 @@
+#version 450
+layout(depth_less) out float gl_FragDepth;
+layout(early_fragment_tests) in;
+
+void main()
+{
+    gl_FragDepth = 0.5;
+}
+

--- a/reference/shaders-hlsl/frag/depth-greater-than.frag
+++ b/reference/shaders-hlsl/frag/depth-greater-than.frag
@@ -1,0 +1,19 @@
+static float gl_FragDepth;
+struct SPIRV_Cross_Output
+{
+    float gl_FragDepth : SV_DepthGreaterEqual;
+};
+
+void frag_main()
+{
+    gl_FragDepth = 0.5f;
+}
+
+[earlydepthstencil]
+SPIRV_Cross_Output main()
+{
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_FragDepth = gl_FragDepth;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/frag/depth-less-than.frag
+++ b/reference/shaders-hlsl/frag/depth-less-than.frag
@@ -1,0 +1,19 @@
+static float gl_FragDepth;
+struct SPIRV_Cross_Output
+{
+    float gl_FragDepth : SV_DepthLessEqual;
+};
+
+void frag_main()
+{
+    gl_FragDepth = 0.5f;
+}
+
+[earlydepthstencil]
+SPIRV_Cross_Output main()
+{
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_FragDepth = gl_FragDepth;
+    return stage_output;
+}

--- a/reference/shaders-msl/frag/depth-greater-than.frag
+++ b/reference/shaders-msl/frag/depth-greater-than.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float gl_FragDepth [[depth(greater)]];
+};
+
+[[ early_fragment_tests ]] fragment main0_out main0()
+{
+    main0_out out = {};
+    out.gl_FragDepth = 0.5;
+    return out;
+}
+

--- a/reference/shaders-msl/frag/depth-less-than.frag
+++ b/reference/shaders-msl/frag/depth-less-than.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float gl_FragDepth [[depth(less)]];
+};
+
+[[ early_fragment_tests ]] fragment main0_out main0()
+{
+    main0_out out = {};
+    out.gl_FragDepth = 0.5;
+    return out;
+}
+

--- a/reference/shaders/desktop-only/frag/depth-greater-than.desktop.frag
+++ b/reference/shaders/desktop-only/frag/depth-greater-than.desktop.frag
@@ -1,0 +1,9 @@
+#version 450
+layout(depth_greater) out float gl_FragDepth;
+layout(early_fragment_tests) in;
+
+void main()
+{
+    gl_FragDepth = 0.5;
+}
+

--- a/reference/shaders/desktop-only/frag/depth-less-than.desktop.frag
+++ b/reference/shaders/desktop-only/frag/depth-less-than.desktop.frag
@@ -1,0 +1,9 @@
+#version 450
+layout(depth_less) out float gl_FragDepth;
+layout(early_fragment_tests) in;
+
+void main()
+{
+    gl_FragDepth = 0.5;
+}
+

--- a/shaders-hlsl/frag/depth-greater-than.frag
+++ b/shaders-hlsl/frag/depth-greater-than.frag
@@ -1,0 +1,8 @@
+#version 450
+layout(early_fragment_tests) in;
+layout(depth_greater) out float gl_FragDepth;
+
+void main()
+{
+	gl_FragDepth = 0.5;
+}

--- a/shaders-hlsl/frag/depth-less-than.frag
+++ b/shaders-hlsl/frag/depth-less-than.frag
@@ -1,0 +1,8 @@
+#version 450
+layout(early_fragment_tests) in;
+layout(depth_less) out float gl_FragDepth;
+
+void main()
+{
+	gl_FragDepth = 0.5;
+}

--- a/shaders-msl/frag/depth-greater-than.frag
+++ b/shaders-msl/frag/depth-greater-than.frag
@@ -1,0 +1,8 @@
+#version 450
+layout(early_fragment_tests) in;
+layout(depth_greater) out float gl_FragDepth;
+
+void main()
+{
+	gl_FragDepth = 0.5;
+}

--- a/shaders-msl/frag/depth-less-than.frag
+++ b/shaders-msl/frag/depth-less-than.frag
@@ -1,0 +1,8 @@
+#version 450
+layout(early_fragment_tests) in;
+layout(depth_less) out float gl_FragDepth;
+
+void main()
+{
+	gl_FragDepth = 0.5;
+}

--- a/shaders/desktop-only/frag/depth-greater-than.desktop.frag
+++ b/shaders/desktop-only/frag/depth-greater-than.desktop.frag
@@ -1,0 +1,8 @@
+#version 450
+layout(early_fragment_tests) in;
+layout(depth_greater) out float gl_FragDepth;
+
+void main()
+{
+	gl_FragDepth = 0.5;
+}

--- a/shaders/desktop-only/frag/depth-less-than.desktop.frag
+++ b/shaders/desktop-only/frag/depth-less-than.desktop.frag
@@ -1,0 +1,8 @@
+#version 450
+layout(early_fragment_tests) in;
+layout(depth_less) out float gl_FragDepth;
+
+void main()
+{
+	gl_FragDepth = 0.5;
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -678,10 +678,11 @@ void CompilerGLSL::emit_header()
 
 		if (execution.flags.get(ExecutionModeEarlyFragmentTests))
 			inputs.push_back("early_fragment_tests");
-		if (execution.flags.get(ExecutionModeDepthGreater))
-			inputs.push_back("depth_greater");
-		if (execution.flags.get(ExecutionModeDepthLess))
-			inputs.push_back("depth_less");
+
+		if (!options.es && execution.flags.get(ExecutionModeDepthGreater))
+			statement("layout(depth_greater) out float gl_FragDepth;");
+		else if (!options.es && execution.flags.get(ExecutionModeDepthLess))
+			statement("layout(depth_less) out float gl_FragDepth;");
 
 		break;
 


### PR DESCRIPTION
Adds support on HLSL SM 5.0, and fixes bug on GLSL.
Makes sure early fragment tests is tested on MSL as well.

Fix #747.