### PR TITLE
GLSL: Support extended arithmetic opcodes.

### DIFF
--- a/reference/opt/shaders/desktop-only/comp/extended-arithmetic.desktop.comp
+++ b/reference/opt/shaders/desktop-only/comp/extended-arithmetic.desktop.comp
@@ -1,0 +1,159 @@
+#version 450
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+struct ResType
+{
+    uint _m0;
+    uint _m1;
+};
+
+struct ResType_1
+{
+    uvec2 _m0;
+    uvec2 _m1;
+};
+
+struct ResType_2
+{
+    uvec3 _m0;
+    uvec3 _m1;
+};
+
+struct ResType_3
+{
+    uvec4 _m0;
+    uvec4 _m1;
+};
+
+struct ResType_4
+{
+    int _m0;
+    int _m1;
+};
+
+struct ResType_5
+{
+    ivec2 _m0;
+    ivec2 _m1;
+};
+
+struct ResType_6
+{
+    ivec3 _m0;
+    ivec3 _m1;
+};
+
+struct ResType_7
+{
+    ivec4 _m0;
+    ivec4 _m1;
+};
+
+layout(binding = 0, std430) buffer SSBOUint
+{
+    uint a;
+    uint b;
+    uint c;
+    uint d;
+    uvec2 a2;
+    uvec2 b2;
+    uvec2 c2;
+    uvec2 d2;
+    uvec3 a3;
+    uvec3 b3;
+    uvec3 c3;
+    uvec3 d3;
+    uvec4 a4;
+    uvec4 b4;
+    uvec4 c4;
+    uvec4 d4;
+} u;
+
+layout(binding = 1, std430) buffer SSBOInt
+{
+    int a;
+    int b;
+    int c;
+    int d;
+    ivec2 a2;
+    ivec2 b2;
+    ivec2 c2;
+    ivec2 d2;
+    ivec3 a3;
+    ivec3 b3;
+    ivec3 c3;
+    ivec3 d3;
+    ivec4 a4;
+    ivec4 b4;
+    ivec4 c4;
+    ivec4 d4;
+} i;
+
+void main()
+{
+    ResType _25;
+    _25._m0 = uaddCarry(u.a, u.b, _25._m1);
+    u.d = _25._m1;
+    u.c = _25._m0;
+    ResType_1 _40;
+    _40._m0 = uaddCarry(u.a2, u.b2, _40._m1);
+    u.d2 = _40._m1;
+    u.c2 = _40._m0;
+    ResType_2 _55;
+    _55._m0 = uaddCarry(u.a3, u.b3, _55._m1);
+    u.d3 = _55._m1;
+    u.c3 = _55._m0;
+    ResType_3 _70;
+    _70._m0 = uaddCarry(u.a4, u.b4, _70._m1);
+    u.d4 = _70._m1;
+    u.c4 = _70._m0;
+    ResType _79;
+    _79._m0 = usubBorrow(u.a, u.b, _79._m1);
+    u.d = _79._m1;
+    u.c = _79._m0;
+    ResType_1 _88;
+    _88._m0 = usubBorrow(u.a2, u.b2, _88._m1);
+    u.d2 = _88._m1;
+    u.c2 = _88._m0;
+    ResType_2 _97;
+    _97._m0 = usubBorrow(u.a3, u.b3, _97._m1);
+    u.d3 = _97._m1;
+    u.c3 = _97._m0;
+    ResType_3 _106;
+    _106._m0 = usubBorrow(u.a4, u.b4, _106._m1);
+    u.d4 = _106._m1;
+    u.c4 = _106._m0;
+    ResType _116;
+    umulExtended(u.a, u.b, _116._m1, _116._m0);
+    u.d = _116._m0;
+    u.c = _116._m1;
+    ResType_1 _125;
+    umulExtended(u.a2, u.b2, _125._m1, _125._m0);
+    u.d2 = _125._m0;
+    u.c2 = _125._m1;
+    ResType_2 _134;
+    umulExtended(u.a3, u.b3, _134._m1, _134._m0);
+    u.d3 = _134._m0;
+    u.c3 = _134._m1;
+    ResType_3 _143;
+    umulExtended(u.a4, u.b4, _143._m1, _143._m0);
+    u.d4 = _143._m0;
+    u.c4 = _143._m1;
+    ResType_4 _160;
+    imulExtended(i.a, i.b, _160._m1, _160._m0);
+    i.d = _160._m0;
+    i.c = _160._m1;
+    ResType_5 _171;
+    imulExtended(i.a2, i.b2, _171._m1, _171._m0);
+    i.d2 = _171._m0;
+    i.c2 = _171._m1;
+    ResType_6 _182;
+    imulExtended(i.a3, i.b3, _182._m1, _182._m0);
+    i.d3 = _182._m0;
+    i.c3 = _182._m1;
+    ResType_7 _193;
+    imulExtended(i.a4, i.b4, _193._m1, _193._m0);
+    i.d4 = _193._m0;
+    i.c4 = _193._m1;
+}
+

--- a/reference/shaders/desktop-only/comp/extended-arithmetic.desktop.comp
+++ b/reference/shaders/desktop-only/comp/extended-arithmetic.desktop.comp
@@ -1,0 +1,159 @@
+#version 450
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+struct ResType
+{
+    uint _m0;
+    uint _m1;
+};
+
+struct ResType_1
+{
+    uvec2 _m0;
+    uvec2 _m1;
+};
+
+struct ResType_2
+{
+    uvec3 _m0;
+    uvec3 _m1;
+};
+
+struct ResType_3
+{
+    uvec4 _m0;
+    uvec4 _m1;
+};
+
+struct ResType_4
+{
+    int _m0;
+    int _m1;
+};
+
+struct ResType_5
+{
+    ivec2 _m0;
+    ivec2 _m1;
+};
+
+struct ResType_6
+{
+    ivec3 _m0;
+    ivec3 _m1;
+};
+
+struct ResType_7
+{
+    ivec4 _m0;
+    ivec4 _m1;
+};
+
+layout(binding = 0, std430) buffer SSBOUint
+{
+    uint a;
+    uint b;
+    uint c;
+    uint d;
+    uvec2 a2;
+    uvec2 b2;
+    uvec2 c2;
+    uvec2 d2;
+    uvec3 a3;
+    uvec3 b3;
+    uvec3 c3;
+    uvec3 d3;
+    uvec4 a4;
+    uvec4 b4;
+    uvec4 c4;
+    uvec4 d4;
+} u;
+
+layout(binding = 1, std430) buffer SSBOInt
+{
+    int a;
+    int b;
+    int c;
+    int d;
+    ivec2 a2;
+    ivec2 b2;
+    ivec2 c2;
+    ivec2 d2;
+    ivec3 a3;
+    ivec3 b3;
+    ivec3 c3;
+    ivec3 d3;
+    ivec4 a4;
+    ivec4 b4;
+    ivec4 c4;
+    ivec4 d4;
+} i;
+
+void main()
+{
+    ResType _25;
+    _25._m0 = uaddCarry(u.a, u.b, _25._m1);
+    u.d = _25._m1;
+    u.c = _25._m0;
+    ResType_1 _40;
+    _40._m0 = uaddCarry(u.a2, u.b2, _40._m1);
+    u.d2 = _40._m1;
+    u.c2 = _40._m0;
+    ResType_2 _55;
+    _55._m0 = uaddCarry(u.a3, u.b3, _55._m1);
+    u.d3 = _55._m1;
+    u.c3 = _55._m0;
+    ResType_3 _70;
+    _70._m0 = uaddCarry(u.a4, u.b4, _70._m1);
+    u.d4 = _70._m1;
+    u.c4 = _70._m0;
+    ResType _79;
+    _79._m0 = usubBorrow(u.a, u.b, _79._m1);
+    u.d = _79._m1;
+    u.c = _79._m0;
+    ResType_1 _88;
+    _88._m0 = usubBorrow(u.a2, u.b2, _88._m1);
+    u.d2 = _88._m1;
+    u.c2 = _88._m0;
+    ResType_2 _97;
+    _97._m0 = usubBorrow(u.a3, u.b3, _97._m1);
+    u.d3 = _97._m1;
+    u.c3 = _97._m0;
+    ResType_3 _106;
+    _106._m0 = usubBorrow(u.a4, u.b4, _106._m1);
+    u.d4 = _106._m1;
+    u.c4 = _106._m0;
+    ResType _116;
+    umulExtended(u.a, u.b, _116._m1, _116._m0);
+    u.d = _116._m0;
+    u.c = _116._m1;
+    ResType_1 _125;
+    umulExtended(u.a2, u.b2, _125._m1, _125._m0);
+    u.d2 = _125._m0;
+    u.c2 = _125._m1;
+    ResType_2 _134;
+    umulExtended(u.a3, u.b3, _134._m1, _134._m0);
+    u.d3 = _134._m0;
+    u.c3 = _134._m1;
+    ResType_3 _143;
+    umulExtended(u.a4, u.b4, _143._m1, _143._m0);
+    u.d4 = _143._m0;
+    u.c4 = _143._m1;
+    ResType_4 _160;
+    imulExtended(i.a, i.b, _160._m1, _160._m0);
+    i.d = _160._m0;
+    i.c = _160._m1;
+    ResType_5 _171;
+    imulExtended(i.a2, i.b2, _171._m1, _171._m0);
+    i.d2 = _171._m0;
+    i.c2 = _171._m1;
+    ResType_6 _182;
+    imulExtended(i.a3, i.b3, _182._m1, _182._m0);
+    i.d3 = _182._m0;
+    i.c3 = _182._m1;
+    ResType_7 _193;
+    imulExtended(i.a4, i.b4, _193._m1, _193._m0);
+    i.d4 = _193._m0;
+    i.c4 = _193._m1;
+}
+

--- a/shaders/desktop-only/comp/extended-arithmetic.desktop.comp
+++ b/shaders/desktop-only/comp/extended-arithmetic.desktop.comp
@@ -1,0 +1,41 @@
+#version 450
+layout(local_size_x = 1) in;
+
+layout(binding = 0, std430) buffer SSBOUint
+{
+	uint a, b, c, d;
+	uvec2 a2, b2, c2, d2;
+	uvec3 a3, b3, c3, d3;
+	uvec4 a4, b4, c4, d4;
+} u;
+
+layout(binding = 1, std430) buffer SSBOInt
+{
+	int a, b, c, d;
+	ivec2 a2, b2, c2, d2;
+	ivec3 a3, b3, c3, d3;
+	ivec4 a4, b4, c4, d4;
+} i;
+
+void main()
+{
+	u.c = uaddCarry(u.a, u.b, u.d);
+	u.c2 = uaddCarry(u.a2, u.b2, u.d2);
+	u.c3 = uaddCarry(u.a3, u.b3, u.d3);
+	u.c4 = uaddCarry(u.a4, u.b4, u.d4);
+
+	u.c = usubBorrow(u.a, u.b, u.d);
+	u.c2 = usubBorrow(u.a2, u.b2, u.d2);
+	u.c3 = usubBorrow(u.a3, u.b3, u.d3);
+	u.c4 = usubBorrow(u.a4, u.b4, u.d4);
+
+	umulExtended(u.a, u.b, u.c, u.d);
+	umulExtended(u.a2, u.b2, u.c2, u.d2);
+	umulExtended(u.a3, u.b3, u.c3, u.d3);
+	umulExtended(u.a4, u.b4, u.c4, u.d4);
+
+	imulExtended(i.a, i.b, i.c, i.d);
+	imulExtended(i.a2, i.b2, i.c2, i.d2);
+	imulExtended(i.a3, i.b3, i.c3, i.d3);
+	imulExtended(i.a4, i.b4, i.c4, i.d4);
+}


### PR DESCRIPTION
- uaddCarry
- usubBorrow
- umulExtended
- imulExtended

Fix #740.
Fix #745.