### PR TITLE
Handle opcode OpSourceContinued.

### DIFF
--- a/spirv_parser.cpp
+++ b/spirv_parser.cpp
@@ -147,6 +147,7 @@ void Parser::parse(const Instruction &instruction)
 	switch (op)
 	{
 	case OpMemoryModel:
+	case OpSourceContinued:
 	case OpSourceExtension:
 	case OpNop:
 	case OpLine:


### PR DESCRIPTION
SPEC:
Continue specifying the Source text from the previous instruction. This has no semantic impact and can safely be removed from a module.