### PR TITLE
Remove old hack for dealing with HLSL counter buffers.

### DIFF
--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -1326,15 +1326,7 @@ struct Meta
 
 	std::unordered_map<uint32_t, uint32_t> decoration_word_offset;
 
-	// Used when the parser has detected a candidate identifier which matches
-	// known "magic" counter buffers as emitted by HLSL frontends.
-	// We will need to match the identifiers by name later when reflecting resources.
-	// We could use the regular alias later, but the alias will be mangled when parsing SPIR-V because the identifier
-	// is not a valid identifier in any high-level language.
-	std::string hlsl_magic_counter_buffer_name;
-	bool hlsl_magic_counter_buffer_candidate = false;
-
-	// For SPV_GOOGLE_hlsl_functionality1, this avoids the workaround.
+	// For SPV_GOOGLE_hlsl_functionality1.
 	bool hlsl_is_magic_counter_buffer = false;
 	// ID for the sibling counter buffer.
 	uint32_t hlsl_magic_counter_buffer = 0;

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -3481,22 +3481,7 @@ bool Compiler::CombinedImageSamplerUsageHandler::handle(Op opcode, const uint32_
 
 bool Compiler::buffer_is_hlsl_counter_buffer(uint32_t id) const
 {
-	// First, check for the proper decoration.
-	if (ir.meta.at(id).hlsl_is_magic_counter_buffer)
-		return true;
-
-	// Check for legacy fallback method.
-	// FIXME: This should be deprecated eventually.
-
-	if (ir.meta.at(id).hlsl_magic_counter_buffer_candidate)
-	{
-		auto *var = maybe_get<SPIRVariable>(id);
-		// Ensure that this is actually a buffer object.
-		return var && (var->storage == StorageClassStorageBuffer ||
-		               has_decoration(get<SPIRType>(var->basetype).self, DecorationBufferBlock));
-	}
-	else
-		return false;
+	return ir.meta.at(id).hlsl_is_magic_counter_buffer;
 }
 
 bool Compiler::buffer_get_hlsl_counter_buffer(uint32_t id, uint32_t &counter_id) const
@@ -3507,27 +3492,8 @@ bool Compiler::buffer_get_hlsl_counter_buffer(uint32_t id, uint32_t &counter_id)
 		counter_id = ir.meta[id].hlsl_magic_counter_buffer;
 		return true;
 	}
-
-	// Check for legacy fallback method.
-	// FIXME: This should be deprecated eventually.
-
-	auto &name = get_name(id);
-	uint32_t id_bound = get_current_id_bound();
-	for (uint32_t i = 0; i < id_bound; i++)
-	{
-		if (ir.meta[i].hlsl_magic_counter_buffer_candidate && ir.meta[i].hlsl_magic_counter_buffer_name == name)
-		{
-			auto *var = maybe_get<SPIRVariable>(i);
-			// Ensure that this is actually a buffer object.
-			if (var && (var->storage == StorageClassStorageBuffer ||
-			            has_decoration(get<SPIRType>(var->basetype).self, DecorationBufferBlock)))
-			{
-				counter_id = i;
-				return true;
-			}
-		}
-	}
-	return false;
+	else
+		return false;
 }
 
 void Compiler::make_constant_null(uint32_t id, uint32_t type)

--- a/spirv_cross_parsed_ir.cpp
+++ b/spirv_cross_parsed_ir.cpp
@@ -88,21 +88,6 @@ void ParsedIR::set_name(uint32_t id, const string &name)
 	if (name.empty())
 		return;
 
-	// glslang uses identifiers to pass along meaningful information
-	// about HLSL reflection.
-	// FIXME: This should be deprecated eventually.
-	auto &m = meta[id];
-	if (source.hlsl && name.size() >= 6 && name.find("@count") == name.size() - 6)
-	{
-		m.hlsl_magic_counter_buffer_candidate = true;
-		m.hlsl_magic_counter_buffer_name = name.substr(0, name.find("@count"));
-	}
-	else
-	{
-		m.hlsl_magic_counter_buffer_candidate = false;
-		m.hlsl_magic_counter_buffer_name.clear();
-	}
-
 	// Reserved for temporaries.
 	if (name[0] == '_' && name.size() >= 2 && isdigit(name[1]))
 		return;
@@ -196,7 +181,7 @@ void ParsedIR::set_decoration(uint32_t id, Decoration decoration, uint32_t argum
 
 	case DecorationHlslCounterBufferGOOGLE:
 		meta[id].hlsl_magic_counter_buffer = argument;
-		meta[id].hlsl_is_magic_counter_buffer = true;
+		meta[argument].hlsl_is_magic_counter_buffer = true;
 		break;
 
 	default:


### PR DESCRIPTION
No longer needed.

Fix #764.