### PR TITLE
Handle invariant decoration more robustly.

### DIFF
--- a/reference/opt/shaders/vert/invariant.vert
+++ b/reference/opt/shaders/vert/invariant.vert
@@ -1,0 +1,19 @@
+#version 310 es
+
+invariant gl_Position;
+
+layout(location = 0) in vec4 vInput0;
+layout(location = 1) in vec4 vInput1;
+layout(location = 2) in vec4 vInput2;
+layout(location = 0) invariant out vec4 vColor;
+
+void main()
+{
+    vec4 _20 = vInput1 * vInput2;
+    vec4 _21 = vInput0 + _20;
+    gl_Position = _21;
+    vec4 _27 = vInput0 - vInput1;
+    vec4 _29 = _27 * vInput2;
+    vColor = _29;
+}
+

--- a/reference/shaders/asm/vert/invariant.asm.vert
+++ b/reference/shaders/asm/vert/invariant.asm.vert
@@ -9,6 +9,7 @@ vec4 _main()
 
 void main()
 {
-    gl_Position = _main();
+    vec4 _14 = _main();
+    gl_Position = _14;
 }
 

--- a/reference/shaders/asm/vert/invariant.sso.asm.vert
+++ b/reference/shaders/asm/vert/invariant.sso.asm.vert
@@ -14,6 +14,7 @@ vec4 _main()
 
 void main()
 {
-    gl_Position = _main();
+    vec4 _14 = _main();
+    gl_Position = _14;
 }
 

--- a/reference/shaders/vert/invariant.vert
+++ b/reference/shaders/vert/invariant.vert
@@ -1,0 +1,19 @@
+#version 310 es
+
+invariant gl_Position;
+
+layout(location = 0) in vec4 vInput0;
+layout(location = 1) in vec4 vInput1;
+layout(location = 2) in vec4 vInput2;
+layout(location = 0) invariant out vec4 vColor;
+
+void main()
+{
+    vec4 _20 = vInput1 * vInput2;
+    vec4 _21 = vInput0 + _20;
+    gl_Position = _21;
+    vec4 _27 = vInput0 - vInput1;
+    vec4 _29 = _27 * vInput2;
+    vColor = _29;
+}
+

--- a/shaders/vert/invariant.vert
+++ b/shaders/vert/invariant.vert
@@ -1,0 +1,13 @@
+#version 310 es
+
+invariant gl_Position;
+layout(location = 0) invariant out vec4 vColor;
+layout(location = 0) in vec4 vInput0;
+layout(location = 1) in vec4 vInput1;
+layout(location = 2) in vec4 vInput2;
+
+void main()
+{
+	gl_Position = vInput0 + vInput1 * vInput2;
+	vColor = (vInput0 - vInput1) * vInput2;
+}

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -1299,6 +1299,13 @@ T &variant_set(Variant &var, P &&... args)
 	return *ptr;
 }
 
+struct AccessChainMeta
+{
+	bool need_transpose = false;
+	bool storage_is_packed = false;
+	bool storage_is_invariant = false;
+};
+
 struct Meta
 {
 	struct Decoration

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -444,10 +444,9 @@ protected:
 	SPIRExpression &emit_op(uint32_t result_type, uint32_t result_id, const std::string &rhs, bool forward_rhs,
 	                        bool suppress_usage_tracking = false);
 	std::string access_chain_internal(uint32_t base, const uint32_t *indices, uint32_t count, bool index_is_literal,
-	                                  bool chain_only = false, bool *need_transpose = nullptr,
-	                                  bool *result_is_packed = nullptr);
+	                                  bool chain_only = false, AccessChainMeta *meta = nullptr);
 	std::string access_chain(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type,
-	                         bool *need_transpose = nullptr, bool *result_is_packed = nullptr);
+	                         AccessChainMeta *meta = nullptr);
 
 	std::string flattened_access_chain(uint32_t base, const uint32_t *indices, uint32_t count,
 	                                   const SPIRType &target_type, uint32_t offset, uint32_t matrix_stride,
@@ -605,6 +604,9 @@ protected:
 	// Sometimes we will need to automatically perform bitcasts on load and store to make this work.
 	virtual void bitcast_to_builtin_store(uint32_t target_id, std::string &expr, const SPIRType &expr_type);
 	virtual void bitcast_from_builtin_load(uint32_t source_id, std::string &expr, const SPIRType &expr_type);
+
+	void handle_store_to_invariant_variable(uint32_t store_id, uint32_t value_id);
+	void disallow_forwarding_in_expression_chain(const SPIRExpression &expr);
 
 private:
 	void init()

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -3608,10 +3608,7 @@ void CompilerHLSL::emit_access_chain(const Instruction &instruction)
 
 		string base;
 		if (to_plain_buffer_length != 0)
-		{
-			bool need_transpose;
-			base = access_chain(ops[2], &ops[3], to_plain_buffer_length, get<SPIRType>(ops[0]), &need_transpose);
-		}
+			base = access_chain(ops[2], &ops[3], to_plain_buffer_length, get<SPIRType>(ops[0]));
 		else if (chain)
 			base = chain->base;
 		else


### PR DESCRIPTION
Avoids certain cases of variance between translation units by forcing
every dependent expression of a store to be temporary.
Should avoid the major failure cases where invariance matters.

Fix #761.