### PR TITLE
Keep track of pointer-to-pointer depth in parser.

### DIFF
--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -437,7 +437,10 @@ struct SPIRType : IVariant
 	std::vector<bool> array_size_literal;
 
 	// Pointers
+	// Keep track of how many pointer layers we have.
+	uint32_t pointer_depth = 0;
 	bool pointer = false;
+
 	spv::StorageClass storage = spv::StorageClassGeneric;
 
 	std::vector<uint32_t> member_types;

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -8778,6 +8778,9 @@ string CompilerGLSL::variable_decl(const SPIRVariable &variable)
 	// Ignore the pointer type since GLSL doesn't have pointers.
 	auto &type = get<SPIRType>(variable.basetype);
 
+	if (type.pointer_depth > 1)
+		SPIRV_CROSS_THROW("Cannot declare pointer-to-pointer types.");
+
 	auto res = join(to_qualifiers_glsl(variable.self), variable_decl(type, to_name(variable.self), variable.self));
 
 	if (variable.loop_variable && variable.static_expression)

--- a/spirv_parser.cpp
+++ b/spirv_parser.cpp
@@ -599,9 +599,8 @@ void Parser::parse(const Instruction &instruction)
 		auto &ptrbase = set<SPIRType>(id);
 
 		ptrbase = base;
-		if (ptrbase.pointer)
-			SPIRV_CROSS_THROW("Cannot make pointer-to-pointer type.");
 		ptrbase.pointer = true;
+		ptrbase.pointer_depth++;
 		ptrbase.storage = static_cast<StorageClass>(ops[1]);
 
 		if (ptrbase.storage == StorageClassAtomicCounter)


### PR DESCRIPTION
Defer failure of pointer-to-pointer to compilation time, so we can still
reflect VK_KHR_variable_pointer shaders.

Fix #770.