### PR TITLE
MSL: Force signedness of shader vertex attributes to match the host.

### DIFF
--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -37,6 +37,8 @@ struct MSLVertexAttr
 	uint32_t msl_offset = 0;
 	uint32_t msl_stride = 0;
 	bool per_instance = false;
+	bool uint8 = false;
+	bool uint16 = false;
 	bool used_by_shader = false;
 };
 
@@ -352,6 +354,7 @@ protected:
 	uint32_t add_interface_block(spv::StorageClass storage);
 	void mark_location_as_used_by_shader(uint32_t location, spv::StorageClass storage);
 	uint32_t ensure_correct_builtin_type(uint32_t type_id, spv::BuiltIn builtin);
+	uint32_t ensure_correct_attribute_type(uint32_t type_id, uint32_t location);
 
 	void emit_custom_functions();
 	void emit_resources();


### PR DESCRIPTION
Based on a patch by Stefan Dösinger.

Metal cannot do signedness conversion on vertex attributes, and for good
reason. Putting a `uint4` into an `int4`, or a `char4` into a `uint4`,
would lose those values that are outside the range of the target type.
But putting a `uchar4` into a `short4` or an `int4`, or a `ushort4` into
an `int4`, should work. In that case, force the signedness in the shader
to match the declared type of the host.

Unfortunately, I don't really know how to automatically test this. This
remapping is done based on input parameters normally supplied by
MoltenVK. I'm not sure how we'd set this up for the command-line
`spirv-cross` tool.