### PR TITLE
MSL: Use an enum instead of two mutually exclusive booleans.

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1209,7 +1209,9 @@ uint32_t CompilerMSL::ensure_correct_attribute_type(uint32_t type_id, uint32_t l
 	if (!p_va)
 		return type_id;
 
-	if (p_va->uint8)
+	switch (p_va->format)
+	{
+	case MSL_VERTEX_FORMAT_UINT8:
 	{
 		switch (type.basetype)
 		{
@@ -1240,7 +1242,7 @@ uint32_t CompilerMSL::ensure_correct_attribute_type(uint32_t type_id, uint32_t l
 		ptr_type.parent_type = base_type_id;
 		return ptr_type_id;
 	}
-	else if (p_va->uint16)
+	case MSL_VERTEX_FORMAT_UINT16:
 	{
 		switch (type.basetype)
 		{
@@ -1268,6 +1270,10 @@ uint32_t CompilerMSL::ensure_correct_attribute_type(uint32_t type_id, uint32_t l
 		ptr_type.storage = type.storage;
 		ptr_type.parent_type = base_type_id;
 		return ptr_type_id;
+	}
+
+	case MSL_VERTEX_FORMAT_OTHER:
+		break;
 	}
 
 	return type_id;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -27,6 +27,16 @@
 namespace spirv_cross
 {
 
+// Indicates the format of the vertex attribute. Currently limited to specifying
+// if the attribute is an 8-bit unsigned integer, 16-bit unsigned integer, or
+// some other format.
+enum MSLVertexFormat
+{
+	MSL_VERTEX_FORMAT_OTHER,
+	MSL_VERTEX_FORMAT_UINT8,
+	MSL_VERTEX_FORMAT_UINT16
+};
+
 // Defines MSL characteristics of a vertex attribute at a particular location.
 // The used_by_shader flag is set to true during compilation of SPIR-V to MSL
 // if the shader makes use of this vertex attribute.
@@ -37,8 +47,7 @@ struct MSLVertexAttr
 	uint32_t msl_offset = 0;
 	uint32_t msl_stride = 0;
 	bool per_instance = false;
-	bool uint8 = false;
-	bool uint16 = false;
+	MSLVertexFormat format = MSL_VERTEX_FORMAT_OTHER;
 	bool used_by_shader = false;
 };
 


### PR DESCRIPTION
NFCI.