### PR TITLE
Register implied expression reads in OpLoad/OpAccessChain.

### DIFF
--- a/reference/opt/shaders-hlsl/frag/complex-expression-in-access-chain.frag
+++ b/reference/opt/shaders-hlsl/frag/complex-expression-in-access-chain.frag
@@ -1,0 +1,37 @@
+RWByteAddressBuffer _34 : register(u0);
+Texture2D<int4> Buf : register(t1);
+SamplerState _Buf_sampler : register(s1);
+
+static float4 gl_FragCoord;
+static int vIn;
+static int vIn2;
+static float4 FragColor;
+
+struct SPIRV_Cross_Input
+{
+    nointerpolation int vIn : TEXCOORD0;
+    nointerpolation int vIn2 : TEXCOORD1;
+    float4 gl_FragCoord : SV_Position;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    int _40 = Buf.Load(int3(int2(gl_FragCoord.xy), 0)).x % 16;
+    FragColor = (asfloat(_34.Load4(_40 * 16 + 0)) + asfloat(_34.Load4(_40 * 16 + 0))) + asfloat(_34.Load4(((vIn * vIn) + (vIn2 * vIn2)) * 16 + 0));
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    gl_FragCoord = stage_input.gl_FragCoord;
+    vIn = stage_input.vIn;
+    vIn2 = stage_input.vIn2;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/opt/shaders-msl/frag/complex-expression-in-access-chain.frag
+++ b/reference/opt/shaders-msl/frag/complex-expression-in-access-chain.frag
@@ -1,0 +1,29 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBO
+{
+    float4 results[1024];
+};
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    int vIn [[user(locn0)]];
+    int vIn2 [[user(locn1)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], device UBO& _34 [[buffer(0)]], texture2d<int> Buf [[texture(1)]], sampler BufSmplr [[sampler(1)]], float4 gl_FragCoord [[position]])
+{
+    main0_out out = {};
+    int _40 = Buf.read(uint2(int2(gl_FragCoord.xy)), 0).x % 16;
+    out.FragColor = (_34.results[_40] + _34.results[_40]) + _34.results[(in.vIn * in.vIn) + (in.vIn2 * in.vIn2)];
+    return out;
+}
+

--- a/reference/opt/shaders/comp/generate_height.comp
+++ b/reference/opt/shaders/comp/generate_height.comp
@@ -41,6 +41,7 @@ void main()
     }
     uint _276 = _264.x;
     uint _280 = (gl_GlobalInvocationID.y * _276) + gl_GlobalInvocationID.x;
+    uint _290 = (_455 * _276) + _454;
     vec2 _297 = vec2(gl_GlobalInvocationID.xy);
     vec2 _299 = vec2(_264);
     float _309 = sqrt(9.81000041961669921875 * length(_166.uModTime.xy * mix(_297, _297 - _299, greaterThan(_297, _299 * 0.5)))) * _166.uModTime.z;
@@ -48,8 +49,8 @@ void main()
     vec2 _387 = _316.xx;
     vec2 _392 = _316.yy;
     vec2 _395 = _392 * _137.distribution[_280].yx;
-    vec2 _421 = _392 * _137.distribution[(_455 * _276) + _454].yx;
-    vec2 _429 = (_137.distribution[(_455 * _276) + _454] * _387) + vec2(-_421.x, _421.y);
+    vec2 _421 = _392 * _137.distribution[_290].yx;
+    vec2 _429 = (_137.distribution[_290] * _387) + vec2(-_421.x, _421.y);
     _225.heights[_280] = packHalf2x16(((_137.distribution[_280] * _387) + vec2(-_395.x, _395.y)) + vec2(_429.x, -_429.y));
 }
 

--- a/reference/opt/shaders/frag/complex-expression-in-access-chain.frag
+++ b/reference/opt/shaders/frag/complex-expression-in-access-chain.frag
@@ -1,0 +1,21 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+layout(binding = 0, std430) buffer UBO
+{
+    vec4 results[1024];
+} _34;
+
+layout(binding = 1) uniform highp isampler2D Buf;
+
+layout(location = 0) flat in mediump int vIn;
+layout(location = 1) flat in mediump int vIn2;
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    mediump int _40 = texelFetch(Buf, ivec2(gl_FragCoord.xy), 0).x % 16;
+    FragColor = (_34.results[_40] + _34.results[_40]) + _34.results[(vIn * vIn) + (vIn2 * vIn2)];
+}
+

--- a/reference/shaders-hlsl/frag/complex-expression-in-access-chain.frag
+++ b/reference/shaders-hlsl/frag/complex-expression-in-access-chain.frag
@@ -1,0 +1,40 @@
+RWByteAddressBuffer _34 : register(u0);
+Texture2D<int4> Buf : register(t1);
+SamplerState _Buf_sampler : register(s1);
+
+static float4 gl_FragCoord;
+static int vIn;
+static int vIn2;
+static float4 FragColor;
+
+struct SPIRV_Cross_Input
+{
+    nointerpolation int vIn : TEXCOORD0;
+    nointerpolation int vIn2 : TEXCOORD1;
+    float4 gl_FragCoord : SV_Position;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    int4 coords = Buf.Load(int3(int2(gl_FragCoord.xy), 0));
+    float4 foo = asfloat(_34.Load4((coords.x % 16) * 16 + 0));
+    int c = vIn * vIn;
+    int d = vIn2 * vIn2;
+    FragColor = (foo + foo) + asfloat(_34.Load4((c + d) * 16 + 0));
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    gl_FragCoord = stage_input.gl_FragCoord;
+    vIn = stage_input.vIn;
+    vIn2 = stage_input.vIn2;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/frag/sampler-array.frag
+++ b/reference/shaders-hlsl/frag/sampler-array.frag
@@ -29,7 +29,8 @@ void frag_main()
 {
     float4 color = uCombined[vIndex].Sample(_uCombined_sampler[vIndex], vTex);
     color += uTex[vIndex].Sample(uSampler[vIndex], vTex);
-    color += sample_in_function(uCombined[vIndex + 1], _uCombined_sampler[vIndex + 1]);
+    int _72 = vIndex + 1;
+    color += sample_in_function(uCombined[_72], _uCombined_sampler[_72]);
     color += sample_in_function2(uTex[vIndex + 1], uSampler[vIndex + 1]);
     uImage[vIndex][int2(gl_FragCoord.xy)] = color;
 }

--- a/reference/shaders-msl/frag/complex-expression-in-access-chain.frag
+++ b/reference/shaders-msl/frag/complex-expression-in-access-chain.frag
@@ -1,0 +1,32 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBO
+{
+    float4 results[1024];
+};
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    int vIn [[user(locn0)]];
+    int vIn2 [[user(locn1)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], device UBO& _34 [[buffer(0)]], texture2d<int> Buf [[texture(1)]], sampler BufSmplr [[sampler(1)]], float4 gl_FragCoord [[position]])
+{
+    main0_out out = {};
+    int4 coords = Buf.read(uint2(int2(gl_FragCoord.xy)), 0);
+    float4 foo = _34.results[coords.x % 16];
+    int c = in.vIn * in.vIn;
+    int d = in.vIn2 * in.vIn2;
+    out.FragColor = (foo + foo) + _34.results[c + d];
+    return out;
+}
+

--- a/reference/shaders/frag/complex-expression-in-access-chain.frag
+++ b/reference/shaders/frag/complex-expression-in-access-chain.frag
@@ -1,0 +1,24 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+layout(binding = 0, std430) buffer UBO
+{
+    vec4 results[1024];
+} _34;
+
+layout(binding = 1) uniform highp isampler2D Buf;
+
+layout(location = 0) flat in mediump int vIn;
+layout(location = 1) flat in mediump int vIn2;
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    mediump ivec4 coords = texelFetch(Buf, ivec2(gl_FragCoord.xy), 0);
+    vec4 foo = _34.results[coords.x % 16];
+    mediump int c = vIn * vIn;
+    mediump int d = vIn2 * vIn2;
+    FragColor = (foo + foo) + _34.results[c + d];
+}
+

--- a/shaders-hlsl/frag/complex-expression-in-access-chain.frag
+++ b/shaders-hlsl/frag/complex-expression-in-access-chain.frag
@@ -1,0 +1,29 @@
+#version 310 es
+precision mediump float;
+
+struct Foo
+{
+	vec4 a;
+	vec4 b;
+};
+
+layout(binding = 0) buffer UBO
+{
+	vec4 results[1024];
+};
+
+layout(binding = 1) uniform highp isampler2D Buf;
+layout(location = 0) flat in int vIn;
+layout(location = 1) flat in int vIn2;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	ivec4 coords = texelFetch(Buf, ivec2(gl_FragCoord.xy), 0);
+	vec4 foo = results[coords.x % 16];
+
+	int c = vIn * vIn;
+	int d = vIn2 * vIn2;
+	FragColor = foo + foo + results[c + d];
+}

--- a/shaders-msl/frag/complex-expression-in-access-chain.frag
+++ b/shaders-msl/frag/complex-expression-in-access-chain.frag
@@ -1,0 +1,29 @@
+#version 310 es
+precision mediump float;
+
+struct Foo
+{
+	vec4 a;
+	vec4 b;
+};
+
+layout(binding = 0) buffer UBO
+{
+	vec4 results[1024];
+};
+
+layout(binding = 1) uniform highp isampler2D Buf;
+layout(location = 0) flat in int vIn;
+layout(location = 1) flat in int vIn2;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	ivec4 coords = texelFetch(Buf, ivec2(gl_FragCoord.xy), 0);
+	vec4 foo = results[coords.x % 16];
+
+	int c = vIn * vIn;
+	int d = vIn2 * vIn2;
+	FragColor = foo + foo + results[c + d];
+}

--- a/shaders/frag/complex-expression-in-access-chain.frag
+++ b/shaders/frag/complex-expression-in-access-chain.frag
@@ -1,0 +1,29 @@
+#version 310 es
+precision mediump float;
+
+struct Foo
+{
+	vec4 a;
+	vec4 b;
+};
+
+layout(binding = 0) buffer UBO
+{
+	vec4 results[1024];
+};
+
+layout(binding = 1) uniform highp isampler2D Buf;
+layout(location = 0) flat in int vIn;
+layout(location = 1) flat in int vIn2;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	ivec4 coords = texelFetch(Buf, ivec2(gl_FragCoord.xy), 0);
+	vec4 foo = results[coords.x % 16];
+
+	int c = vIn * vIn;
+	int d = vIn2 * vIn2;
+	FragColor = foo + foo + results[c + d];
+}

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -567,6 +567,10 @@ struct SPIRExpression : IVariant
 	// A list of expressions which this expression depends on.
 	std::vector<uint32_t> expression_dependencies;
 
+	// By reading this expression, we implicitly read these expressions as well.
+	// Used by access chain Store and Load since we read multiple expressions in this case.
+	std::vector<uint32_t> implied_read_expressions;
+
 	SPIRV_CROSS_DECLARE_CLONE(SPIRExpression)
 };
 
@@ -844,6 +848,10 @@ struct SPIRAccessChain : IVariant
 	uint32_t matrix_stride = 0;
 	bool row_major_matrix = false;
 	bool immutable = false;
+
+	// By reading this expression, we implicitly read these expressions as well.
+	// Used by access chain Store and Load since we read multiple expressions in this case.
+	std::vector<uint32_t> implied_read_expressions;
 
 	SPIRV_CROSS_DECLARE_CLONE(SPIRAccessChain)
 };

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -1685,6 +1685,20 @@ uint32_t Compiler::get_subpass_input_remapped_components(uint32_t id) const
 	return get<SPIRVariable>(id).remapped_components;
 }
 
+void Compiler::add_implied_read_expression(SPIRExpression &e, uint32_t source)
+{
+	auto itr = find(begin(e.implied_read_expressions), end(e.implied_read_expressions), source);
+	if (itr == end(e.implied_read_expressions))
+		e.implied_read_expressions.push_back(source);
+}
+
+void Compiler::add_implied_read_expression(SPIRAccessChain &e, uint32_t source)
+{
+	auto itr = find(begin(e.implied_read_expressions), end(e.implied_read_expressions), source);
+	if (itr == end(e.implied_read_expressions))
+		e.implied_read_expressions.push_back(source);
+}
+
 void Compiler::inherit_expression_dependencies(uint32_t dst, uint32_t source_expression)
 {
 	// Don't inherit any expression dependencies if the expression in dst

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -663,6 +663,8 @@ protected:
 
 	bool types_are_logically_equivalent(const SPIRType &a, const SPIRType &b) const;
 	void inherit_expression_dependencies(uint32_t dst, uint32_t source);
+	void add_implied_read_expression(SPIRExpression &e, uint32_t source);
+	void add_implied_read_expression(SPIRAccessChain &e, uint32_t source);
 
 	// For proper multiple entry point support, allow querying if an Input or Output
 	// variable is part of that entry points interface.

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -444,7 +444,8 @@ protected:
 	SPIRExpression &emit_op(uint32_t result_type, uint32_t result_id, const std::string &rhs, bool forward_rhs,
 	                        bool suppress_usage_tracking = false);
 	std::string access_chain_internal(uint32_t base, const uint32_t *indices, uint32_t count, bool index_is_literal,
-	                                  bool chain_only = false, AccessChainMeta *meta = nullptr);
+	                                  bool chain_only = false, AccessChainMeta *meta = nullptr,
+	                                  bool register_expression_read = true);
 	std::string access_chain(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type,
 	                         AccessChainMeta *meta = nullptr);
 
@@ -468,8 +469,8 @@ protected:
 	std::string remap_swizzle(const SPIRType &result_type, uint32_t input_components, const std::string &expr);
 	std::string declare_temporary(uint32_t type, uint32_t id);
 	void append_global_func_args(const SPIRFunction &func, uint32_t index, std::vector<std::string> &arglist);
-	std::string to_expression(uint32_t id);
-	std::string to_enclosed_expression(uint32_t id);
+	std::string to_expression(uint32_t id, bool register_expression_read = true);
+	std::string to_enclosed_expression(uint32_t id, bool register_expression_read = true);
 	std::string to_unpacked_expression(uint32_t id);
 	std::string to_enclosed_unpacked_expression(uint32_t id);
 	std::string to_extract_component_expression(uint32_t id, uint32_t index);

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -4145,7 +4145,8 @@ string CompilerMSL::entry_point_args(bool append_comma)
 
 					auto &entry_func = get<SPIRFunction>(ir.default_entry_point);
 					entry_func.fixup_hooks_in.push_back([=]() {
-						statement(builtin_type_decl(bi_type), " ", to_expression(var_id), " = simd_is_helper_thread();");
+						statement(builtin_type_decl(bi_type), " ", to_expression(var_id),
+						          " = simd_is_helper_thread();");
 					});
 				}
 				else


### PR DESCRIPTION
This is required to avoid relying on complex sub-expression elimination
in compilers, and generates cleaner code.

The problem case is if a complex expression is used in an access chain,
like:

Composite comp = buffer[texture(...)];
vec4 a = comp.a + comp.b + comp.c;

Before, we did not have common subexpression tracking for
OpLoad/OpAccessChain, so we easily ended up with code like:

vec4 a = buffer[texture(...)].a + buffer[texture(...)].b + buffer[texture(...)].c;

A good compiler will optimize this, but we should not rely on it, and
forcing texture(...) to a temporary also looks better.

The solution is to add a vector "implied_expression_reads", which works
similarly to expression_dependencies. We also need an extra mechanism in
to_expression which lets us skip expression read checking and do it
later. E.g. for expr -> access chain -> load, we should only trigger
a read of expr when using the loaded expression.

Fix #787.