### PR TITLE
Support for sampler2DRect and legacy texture2DRect() sampling function

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -3752,6 +3752,9 @@ string CompilerGLSL::legacy_tex_op(const std::string &op, const SPIRType &imgtyp
 	case spv::DimCube:
 		type = "Cube";
 		break;
+	case spv::DimRect:
+		type = "2DRect";
+		break;
 	case spv::DimBuffer:
 		type = "Buffer";
 		break;
@@ -9010,6 +9013,15 @@ string CompilerGLSL::image_type_glsl(const SPIRType &type, uint32_t id)
 	case DimCube:
 		res += "Cube";
 		break;
+	case DimRect:
+		if (options.es)
+			SPIRV_CROSS_THROW("Rectangle textures are not supported on OpenGL ES.");
+
+		if (is_legacy_desktop())
+			require_extension_internal("GL_ARB_texture_rectangle");
+
+		res += "2DRect";
+		break;
 
 	case DimBuffer:
 		if (options.es && options.version < 320)
@@ -9023,7 +9035,7 @@ string CompilerGLSL::image_type_glsl(const SPIRType &type, uint32_t id)
 		res += "2D";
 		break;
 	default:
-		SPIRV_CROSS_THROW("Only 1D, 2D, 3D, Buffer, InputTarget and Cube textures supported.");
+		SPIRV_CROSS_THROW("Only 1D, 2D, 2DRect, 3D, Buffer, InputTarget and Cube textures supported.");
 	}
 
 	if (type.image.ms)


### PR DESCRIPTION
More (legacy) texture stuff from me. We use this to share textures between Metal and OpenGL via an `IOSurfaceRef`, unfortunately that has a hard requirement for rectangle textures.

I wasn't exactly sure what extension requirement to pick, texture rectangle support is available via `GL_ARB_texture_rectangle` and `GL_EXT_gpu_shader4`. I've chosen `GL_ARB_texture_rectangle` for now, but if you prefer `GL_EXT_gpu_shader4` (since that's already used elsewhere for `textureLodOffset`), I'm happy to change it.