### PR TITLE
MSL: Workaround missing gradient2d() on macOS for typical cascaded shadow mapping

### DIFF
--- a/reference/opt/shaders-msl/frag/sampler-compare-cascade-gradient.frag
+++ b/reference/opt/shaders-msl/frag/sampler-compare-cascade-gradient.frag
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vUV [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], depth2d_array<float> uTex [[texture(0)]], sampler uShadow [[sampler(1)]])
+{
+    main0_out out = {};
+    out.FragColor = uTex.sample_compare(uShadow, in.vUV.xy, uint(round(in.vUV.z)), in.vUV.w, level(0));
+    return out;
+}
+

--- a/reference/opt/shaders-msl/frag/sampler-compare-cascade-gradient.ios.frag
+++ b/reference/opt/shaders-msl/frag/sampler-compare-cascade-gradient.ios.frag
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vUV [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], depth2d_array<float> uTex [[texture(0)]], sampler uShadow [[sampler(1)]])
+{
+    main0_out out = {};
+    out.FragColor = uTex.sample_compare(uShadow, in.vUV.xy, uint(round(in.vUV.z)), in.vUV.w, gradient2d(float2(0.0), float2(0.0)));
+    return out;
+}
+

--- a/reference/shaders-msl/frag/sampler-compare-cascade-gradient.frag
+++ b/reference/shaders-msl/frag/sampler-compare-cascade-gradient.frag
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vUV [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], depth2d_array<float> uTex [[texture(0)]], sampler uShadow [[sampler(1)]])
+{
+    main0_out out = {};
+    out.FragColor = uTex.sample_compare(uShadow, in.vUV.xy, uint(round(in.vUV.z)), in.vUV.w, level(0));
+    return out;
+}
+

--- a/reference/shaders-msl/frag/sampler-compare-cascade-gradient.ios.frag
+++ b/reference/shaders-msl/frag/sampler-compare-cascade-gradient.ios.frag
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vUV [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], depth2d_array<float> uTex [[texture(0)]], sampler uShadow [[sampler(1)]])
+{
+    main0_out out = {};
+    out.FragColor = uTex.sample_compare(uShadow, in.vUV.xy, uint(round(in.vUV.z)), in.vUV.w, gradient2d(float2(0.0), float2(0.0)));
+    return out;
+}
+

--- a/shaders-msl/frag/sampler-compare-cascade-gradient.frag
+++ b/shaders-msl/frag/sampler-compare-cascade-gradient.frag
@@ -1,0 +1,11 @@
+#version 450
+
+layout(binding = 0) uniform texture2DArray uTex;
+layout(binding = 1) uniform samplerShadow uShadow;
+layout(location = 0) in vec4 vUV;
+layout(location = 0) out float FragColor;
+
+void main()
+{
+	FragColor = textureGrad(sampler2DArrayShadow(uTex, uShadow), vUV, vec2(0.0), vec2(0.0));
+}

--- a/shaders-msl/frag/sampler-compare-cascade-gradient.ios.frag
+++ b/shaders-msl/frag/sampler-compare-cascade-gradient.ios.frag
@@ -1,0 +1,11 @@
+#version 450
+
+layout(binding = 0) uniform texture2DArray uTex;
+layout(binding = 1) uniform samplerShadow uShadow;
+layout(location = 0) in vec4 vUV;
+layout(location = 0) out float FragColor;
+
+void main()
+{
+	FragColor = textureGrad(sampler2DArrayShadow(uTex, uShadow), vUV, vec2(0.0), vec2(0.0));
+}

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -1088,6 +1088,21 @@ struct SPIRConstant : IVariant
 			c.vecsize = constant_type_.vecsize;
 	}
 
+	inline bool constant_is_null() const
+	{
+		if (specialization)
+			return false;
+		if (!subconstants.empty())
+			return false;
+
+		for (uint32_t col = 0; col < columns(); col++)
+			for (uint32_t row = 0; row < vector_size(); row++)
+				if (scalar_u64(col, row) != 0)
+					return false;
+
+		return true;
+	}
+
 	explicit SPIRConstant(uint32_t constant_type_)
 	    : constant_type(constant_type_)
 	{

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -901,8 +901,8 @@ void Compiler::flatten_interface_block(uint32_t id)
 	var.storage = storage;
 }
 
-void Compiler::update_name_cache(unordered_set<string> &cache_primary,
-                                 const unordered_set<string> &cache_secondary, string &name)
+void Compiler::update_name_cache(unordered_set<string> &cache_primary, const unordered_set<string> &cache_secondary,
+                                 string &name)
 {
 	if (name.empty())
 		return;
@@ -918,9 +918,7 @@ void Compiler::update_name_cache(unordered_set<string> &cache_primary,
 		return false;
 	};
 
-	const auto insert_name = [&](const string &n) {
-		cache_primary.insert(n);
-	};
+	const auto insert_name = [&](const string &n) { cache_primary.insert(n); };
 
 	if (!find_name(name))
 	{

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -653,8 +653,7 @@ protected:
 	// but the set is not updated when we have found a new name.
 	// Used primarily when adding block interface names.
 	void update_name_cache(std::unordered_set<std::string> &cache_primary,
-	                       const std::unordered_set<std::string> &cache_secondary,
-	                       std::string &name);
+	                       const std::unordered_set<std::string> &cache_secondary, std::string &name);
 
 	bool function_is_pure(const SPIRFunction &func);
 	bool block_is_pure(const SPIRBlock &block);

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1546,8 +1546,7 @@ void CompilerGLSL::emit_buffer_block_native(const SPIRVariable &var)
 	// Shaders never use the block by interface name, so we don't
 	// have to track this other than updating name caches.
 	// If we have a collision for any reason, just fallback immediately.
-	if (ir.meta[type.self].decoration.alias.empty() ||
-	    block_namespace.find(buffer_name) != end(block_namespace) ||
+	if (ir.meta[type.self].decoration.alias.empty() || block_namespace.find(buffer_name) != end(block_namespace) ||
 	    resource_names.find(buffer_name) != end(resource_names))
 	{
 		buffer_name = get_block_fallback_name(var.self);
@@ -4258,7 +4257,7 @@ string CompilerGLSL::to_function_name(uint32_t tex, const SPIRType &imgtype, boo
 		if (!expression_is_constant_null(lod))
 		{
 			SPIRV_CROSS_THROW(
-					"textureLod on sampler2DArrayShadow is not constant 0.0. This cannot be expressed in GLSL.");
+			    "textureLod on sampler2DArrayShadow is not constant 0.0. This cannot be expressed in GLSL.");
 		}
 		workaround_lod_array_shadow_as_grad = true;
 	}

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -615,6 +615,8 @@ protected:
 	void handle_store_to_invariant_variable(uint32_t store_id, uint32_t value_id);
 	void disallow_forwarding_in_expression_chain(const SPIRExpression &expr);
 
+	bool expression_is_constant_null(uint32_t id) const;
+
 private:
 	void init()
 	{

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -577,8 +577,7 @@ protected:
 	// but the set is not updated when we have found a new name.
 	// Used primarily when adding block interface names.
 	void add_variable(std::unordered_set<std::string> &variables_primary,
-	                  const std::unordered_set<std::string> &variables_secondary,
-	                  std::string &name);
+	                  const std::unordered_set<std::string> &variables_secondary, std::string &name);
 
 	void check_function_call_constraints(const uint32_t *args, uint32_t length);
 	void handle_invalid_expression(uint32_t id);

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -3339,7 +3339,8 @@ string CompilerMSL::to_function_args(uint32_t img, const SPIRType &imgtype, bool
 			}
 			else
 			{
-				SPIRV_CROSS_THROW("Using non-constant 0.0 gradient() qualifier for sample_compare. This is not supported in MSL macOS.");
+				SPIRV_CROSS_THROW("Using non-constant 0.0 gradient() qualifier for sample_compare. This is not "
+				                  "supported in MSL macOS.");
 			}
 		}
 
@@ -3354,7 +3355,7 @@ string CompilerMSL::to_function_args(uint32_t img, const SPIRType &imgtype, bool
 			else
 			{
 				SPIRV_CROSS_THROW(
-						"Using non-constant 0.0 bias() qualifier for sample_compare. This is not supported in MSL macOS.");
+				    "Using non-constant 0.0 bias() qualifier for sample_compare. This is not supported in MSL macOS.");
 			}
 		}
 	}


### PR DESCRIPTION
Promote a compile-time constant gradient2d(float2(0), float2(0)) to level(0) to be compliant with macOS.

Fix #796.