### PR TITLE
Handle FPRoundingMode decoration.

### DIFF
--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -1336,6 +1336,7 @@ struct Meta
 		uint32_t input_attachment = 0;
 		uint32_t spec_id = 0;
 		uint32_t index = 0;
+		spv::FPRoundingMode fp_rounding_mode = spv::FPRoundingModeMax;
 		bool builtin = false;
 	};
 

--- a/spirv_cross_parsed_ir.cpp
+++ b/spirv_cross_parsed_ir.cpp
@@ -184,6 +184,10 @@ void ParsedIR::set_decoration(uint32_t id, Decoration decoration, uint32_t argum
 		meta[argument].hlsl_is_magic_counter_buffer = true;
 		break;
 
+	case DecorationFPRoundingMode:
+		dec.fp_rounding_mode = static_cast<FPRoundingMode>(argument);
+		break;
+
 	default:
 		break;
 	}
@@ -329,6 +333,8 @@ uint32_t ParsedIR::get_decoration(uint32_t id, Decoration decoration) const
 		return dec.matrix_stride;
 	case DecorationIndex:
 		return dec.index;
+	case DecorationFPRoundingMode:
+		return dec.fp_rounding_mode;
 	default:
 		return 1;
 	}
@@ -392,6 +398,10 @@ void ParsedIR::unset_decoration(uint32_t id, Decoration decoration)
 
 	case DecorationHlslSemanticGOOGLE:
 		dec.hlsl_semantic.clear();
+		break;
+
+	case DecorationFPRoundingMode:
+		dec.fp_rounding_mode = FPRoundingModeMax;
 		break;
 
 	case DecorationHlslCounterBufferGOOGLE:


### PR DESCRIPTION
Doesn't do anything, but we can parse it correctly for now.

Fix #786.