### PR TITLE
MSL: Fix mapping of identity-swizzled components.

### DIFF
--- a/reference/shaders-msl-no-opt/asm/frag/texture-access.swizzle.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/texture-access.swizzle.asm.frag
@@ -40,10 +40,12 @@ template<typename T> inline constexpr thread T&& spvForward(thread typename spvR
 }
 
 template<typename T>
-inline T spvGetSwizzle(vec<T, 4> x, spvSwizzle s)
+inline T spvGetSwizzle(vec<T, 4> x, T c, spvSwizzle s)
 {
     switch (s)
     {
+        case spvSwizzle::none:
+            return c;
         case spvSwizzle::zero:
             return 0;
         case spvSwizzle::one:
@@ -56,10 +58,7 @@ inline T spvGetSwizzle(vec<T, 4> x, spvSwizzle s)
             return x.b;
         case spvSwizzle::alpha:
             return x.a;
-        default:
-            break;
     }
-    return 0;
 }
 
 // Wrapper function that swizzles texture samples and fetches.
@@ -68,7 +67,7 @@ inline vec<T, 4> spvTextureSwizzle(vec<T, 4> x, uint s)
 {
     if (!s)
         return x;
-    return vec<T, 4>(spvGetSwizzle(x, spvSwizzle((s >> 0) & 0xFF)), spvGetSwizzle(x, spvSwizzle((s >> 8) & 0xFF)), spvGetSwizzle(x, spvSwizzle((s >> 16) & 0xFF)), spvGetSwizzle(x, spvSwizzle((s >> 24) & 0xFF)));
+    return vec<T, 4>(spvGetSwizzle(x, x.r, spvSwizzle((s >> 0) & 0xFF)), spvGetSwizzle(x, x.g, spvSwizzle((s >> 8) & 0xFF)), spvGetSwizzle(x, x.b, spvSwizzle((s >> 16) & 0xFF)), spvGetSwizzle(x, x.a, spvSwizzle((s >> 24) & 0xFF)));
 }
 
 template<typename T>

--- a/reference/shaders-msl-no-opt/frag/texture-access-int.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access-int.swizzle.frag
@@ -40,10 +40,12 @@ template<typename T> inline constexpr thread T&& spvForward(thread typename spvR
 }
 
 template<typename T>
-inline T spvGetSwizzle(vec<T, 4> x, spvSwizzle s)
+inline T spvGetSwizzle(vec<T, 4> x, T c, spvSwizzle s)
 {
     switch (s)
     {
+        case spvSwizzle::none:
+            return c;
         case spvSwizzle::zero:
             return 0;
         case spvSwizzle::one:
@@ -56,10 +58,7 @@ inline T spvGetSwizzle(vec<T, 4> x, spvSwizzle s)
             return x.b;
         case spvSwizzle::alpha:
             return x.a;
-        default:
-            break;
     }
-    return 0;
 }
 
 // Wrapper function that swizzles texture samples and fetches.
@@ -68,7 +67,7 @@ inline vec<T, 4> spvTextureSwizzle(vec<T, 4> x, uint s)
 {
     if (!s)
         return x;
-    return vec<T, 4>(spvGetSwizzle(x, spvSwizzle((s >> 0) & 0xFF)), spvGetSwizzle(x, spvSwizzle((s >> 8) & 0xFF)), spvGetSwizzle(x, spvSwizzle((s >> 16) & 0xFF)), spvGetSwizzle(x, spvSwizzle((s >> 24) & 0xFF)));
+    return vec<T, 4>(spvGetSwizzle(x, x.r, spvSwizzle((s >> 0) & 0xFF)), spvGetSwizzle(x, x.g, spvSwizzle((s >> 8) & 0xFF)), spvGetSwizzle(x, x.b, spvSwizzle((s >> 16) & 0xFF)), spvGetSwizzle(x, x.a, spvSwizzle((s >> 24) & 0xFF)));
 }
 
 template<typename T>

--- a/reference/shaders-msl-no-opt/frag/texture-access-leaf.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access-leaf.swizzle.frag
@@ -40,10 +40,12 @@ template<typename T> inline constexpr thread T&& spvForward(thread typename spvR
 }
 
 template<typename T>
-inline T spvGetSwizzle(vec<T, 4> x, spvSwizzle s)
+inline T spvGetSwizzle(vec<T, 4> x, T c, spvSwizzle s)
 {
     switch (s)
     {
+        case spvSwizzle::none:
+            return c;
         case spvSwizzle::zero:
             return 0;
         case spvSwizzle::one:
@@ -56,10 +58,7 @@ inline T spvGetSwizzle(vec<T, 4> x, spvSwizzle s)
             return x.b;
         case spvSwizzle::alpha:
             return x.a;
-        default:
-            break;
     }
-    return 0;
 }
 
 // Wrapper function that swizzles texture samples and fetches.
@@ -68,7 +67,7 @@ inline vec<T, 4> spvTextureSwizzle(vec<T, 4> x, uint s)
 {
     if (!s)
         return x;
-    return vec<T, 4>(spvGetSwizzle(x, spvSwizzle((s >> 0) & 0xFF)), spvGetSwizzle(x, spvSwizzle((s >> 8) & 0xFF)), spvGetSwizzle(x, spvSwizzle((s >> 16) & 0xFF)), spvGetSwizzle(x, spvSwizzle((s >> 24) & 0xFF)));
+    return vec<T, 4>(spvGetSwizzle(x, x.r, spvSwizzle((s >> 0) & 0xFF)), spvGetSwizzle(x, x.g, spvSwizzle((s >> 8) & 0xFF)), spvGetSwizzle(x, x.b, spvSwizzle((s >> 16) & 0xFF)), spvGetSwizzle(x, x.a, spvSwizzle((s >> 24) & 0xFF)));
 }
 
 template<typename T>

--- a/reference/shaders-msl-no-opt/frag/texture-access-uint.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access-uint.swizzle.frag
@@ -40,10 +40,12 @@ template<typename T> inline constexpr thread T&& spvForward(thread typename spvR
 }
 
 template<typename T>
-inline T spvGetSwizzle(vec<T, 4> x, spvSwizzle s)
+inline T spvGetSwizzle(vec<T, 4> x, T c, spvSwizzle s)
 {
     switch (s)
     {
+        case spvSwizzle::none:
+            return c;
         case spvSwizzle::zero:
             return 0;
         case spvSwizzle::one:
@@ -56,10 +58,7 @@ inline T spvGetSwizzle(vec<T, 4> x, spvSwizzle s)
             return x.b;
         case spvSwizzle::alpha:
             return x.a;
-        default:
-            break;
     }
-    return 0;
 }
 
 // Wrapper function that swizzles texture samples and fetches.
@@ -68,7 +67,7 @@ inline vec<T, 4> spvTextureSwizzle(vec<T, 4> x, uint s)
 {
     if (!s)
         return x;
-    return vec<T, 4>(spvGetSwizzle(x, spvSwizzle((s >> 0) & 0xFF)), spvGetSwizzle(x, spvSwizzle((s >> 8) & 0xFF)), spvGetSwizzle(x, spvSwizzle((s >> 16) & 0xFF)), spvGetSwizzle(x, spvSwizzle((s >> 24) & 0xFF)));
+    return vec<T, 4>(spvGetSwizzle(x, x.r, spvSwizzle((s >> 0) & 0xFF)), spvGetSwizzle(x, x.g, spvSwizzle((s >> 8) & 0xFF)), spvGetSwizzle(x, x.b, spvSwizzle((s >> 16) & 0xFF)), spvGetSwizzle(x, x.a, spvSwizzle((s >> 24) & 0xFF)));
 }
 
 template<typename T>

--- a/reference/shaders-msl-no-opt/frag/texture-access.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access.swizzle.frag
@@ -40,10 +40,12 @@ template<typename T> inline constexpr thread T&& spvForward(thread typename spvR
 }
 
 template<typename T>
-inline T spvGetSwizzle(vec<T, 4> x, spvSwizzle s)
+inline T spvGetSwizzle(vec<T, 4> x, T c, spvSwizzle s)
 {
     switch (s)
     {
+        case spvSwizzle::none:
+            return c;
         case spvSwizzle::zero:
             return 0;
         case spvSwizzle::one:
@@ -56,10 +58,7 @@ inline T spvGetSwizzle(vec<T, 4> x, spvSwizzle s)
             return x.b;
         case spvSwizzle::alpha:
             return x.a;
-        default:
-            break;
     }
-    return 0;
 }
 
 // Wrapper function that swizzles texture samples and fetches.
@@ -68,7 +67,7 @@ inline vec<T, 4> spvTextureSwizzle(vec<T, 4> x, uint s)
 {
     if (!s)
         return x;
-    return vec<T, 4>(spvGetSwizzle(x, spvSwizzle((s >> 0) & 0xFF)), spvGetSwizzle(x, spvSwizzle((s >> 8) & 0xFF)), spvGetSwizzle(x, spvSwizzle((s >> 16) & 0xFF)), spvGetSwizzle(x, spvSwizzle((s >> 24) & 0xFF)));
+    return vec<T, 4>(spvGetSwizzle(x, x.r, spvSwizzle((s >> 0) & 0xFF)), spvGetSwizzle(x, x.g, spvSwizzle((s >> 8) & 0xFF)), spvGetSwizzle(x, x.b, spvSwizzle((s >> 16) & 0xFF)), spvGetSwizzle(x, x.a, spvSwizzle((s >> 24) & 0xFF)));
 }
 
 template<typename T>

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1819,10 +1819,12 @@ void CompilerMSL::emit_custom_functions()
 			end_scope();
 			statement("");
 			statement("template<typename T>");
-			statement("inline T spvGetSwizzle(vec<T, 4> x, spvSwizzle s)");
+			statement("inline T spvGetSwizzle(vec<T, 4> x, T c, spvSwizzle s)");
 			begin_scope();
 			statement("switch (s)");
 			begin_scope();
+			statement("case spvSwizzle::none:");
+			statement("    return c;");
 			statement("case spvSwizzle::zero:");
 			statement("    return 0;");
 			statement("case spvSwizzle::one:");
@@ -1835,10 +1837,7 @@ void CompilerMSL::emit_custom_functions()
 			statement("    return x.b;");
 			statement("case spvSwizzle::alpha:");
 			statement("    return x.a;");
-			statement("default:");
-			statement("    break;");
 			end_scope();
-			statement("return 0;");
 			end_scope();
 			statement("");
 			statement("// Wrapper function that swizzles texture samples and fetches.");
@@ -1847,9 +1846,9 @@ void CompilerMSL::emit_custom_functions()
 			begin_scope();
 			statement("if (!s)");
 			statement("    return x;");
-			statement("return vec<T, 4>(spvGetSwizzle(x, spvSwizzle((s >> 0) & 0xFF)), "
-			          "spvGetSwizzle(x, spvSwizzle((s >> 8) & 0xFF)), spvGetSwizzle(x, spvSwizzle((s >> 16) & 0xFF)), "
-			          "spvGetSwizzle(x, spvSwizzle((s >> 24) & 0xFF)));");
+			statement("return vec<T, 4>(spvGetSwizzle(x, x.r, spvSwizzle((s >> 0) & 0xFF)), "
+			          "spvGetSwizzle(x, x.g, spvSwizzle((s >> 8) & 0xFF)), spvGetSwizzle(x, x.b, spvSwizzle((s >> 16) & 0xFF)), "
+			          "spvGetSwizzle(x, x.a, spvSwizzle((s >> 24) & 0xFF)));");
 			end_scope();
 			statement("");
 			statement("template<typename T>");


### PR DESCRIPTION
Before, if any component was not identity-mapped, those components that
were still identity-mapped were set to 0. Now we properly leave them
alone.