### PR TITLE
MSL: Add support for emitting structs and arrays within I/O blocks.

### DIFF
--- a/reference/opt/shaders-msl/vert/interface-block-block-composites.frag
+++ b/reference/opt/shaders-msl/vert/interface-block-block-composites.frag
@@ -1,0 +1,58 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Vert
+{
+    float3x3 wMatrix;
+    float4 wTmp;
+    float arr[4];
+};
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 vMatrix_0 [[user(locn0)]];
+    float3 vMatrix_1 [[user(locn1)]];
+    float3 vMatrix_2 [[user(locn2)]];
+    float3 Vert_wMatrix_0 [[user(locn4)]];
+    float3 Vert_wMatrix_1 [[user(locn5)]];
+    float3 Vert_wMatrix_2 [[user(locn6)]];
+    float4 Vert_wTmp [[user(locn7)]];
+    float Vert_arr_0 [[user(locn8)]];
+    float Vert_arr_1 [[user(locn9)]];
+    float Vert_arr_2 [[user(locn10)]];
+    float Vert_arr_3 [[user(locn11)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    Vert _17 = {};
+    float3x3 vMatrix = {};
+    _17.wMatrix[0] = in.Vert_wMatrix_0;
+    _17.wMatrix[1] = in.Vert_wMatrix_1;
+    _17.wMatrix[2] = in.Vert_wMatrix_2;
+    _17.wTmp = in.Vert_wTmp;
+    _17.arr[0] = in.Vert_arr_0;
+    _17.arr[1] = in.Vert_arr_1;
+    _17.arr[2] = in.Vert_arr_2;
+    _17.arr[3] = in.Vert_arr_3;
+    vMatrix[0] = in.vMatrix_0;
+    vMatrix[1] = in.vMatrix_1;
+    vMatrix[2] = in.vMatrix_2;
+    out.FragColor = (_17.wMatrix[0].xxyy + _17.wTmp) + vMatrix[1].yyzz;
+    for (int _56 = 0; _56 < 4; )
+    {
+        out.FragColor += float4(_17.arr[_56]);
+        _56++;
+        continue;
+    }
+    return out;
+}
+

--- a/reference/opt/shaders-msl/vert/interface-block-block-composites.vert
+++ b/reference/opt/shaders-msl/vert/interface-block-block-composites.vert
@@ -1,0 +1,64 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Vert
+{
+    float arr[3];
+    float3x3 wMatrix;
+    float4 wTmp;
+};
+
+struct main0_out
+{
+    float3 vMatrix_0 [[user(locn0)]];
+    float3 vMatrix_1 [[user(locn1)]];
+    float3 vMatrix_2 [[user(locn2)]];
+    float Vert_arr_0 [[user(locn4)]];
+    float Vert_arr_1 [[user(locn5)]];
+    float Vert_arr_2 [[user(locn6)]];
+    float3 Vert_wMatrix_0 [[user(locn7)]];
+    float3 Vert_wMatrix_1 [[user(locn8)]];
+    float3 Vert_wMatrix_2 [[user(locn9)]];
+    float4 Vert_wTmp [[user(locn10)]];
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float3 Matrix_0 [[attribute(0)]];
+    float3 Matrix_1 [[attribute(1)]];
+    float3 Matrix_2 [[attribute(2)]];
+    float4 Pos [[attribute(4)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    float3x3 vMatrix = {};
+    Vert _20 = {};
+    float3x3 Matrix = {};
+    Matrix[0] = in.Matrix_0;
+    Matrix[1] = in.Matrix_1;
+    Matrix[2] = in.Matrix_2;
+    vMatrix = Matrix;
+    _20.wMatrix = Matrix;
+    _20.arr[0] = 1.0;
+    _20.arr[1] = 2.0;
+    _20.arr[2] = 3.0;
+    _20.wTmp = in.Pos;
+    out.gl_Position = in.Pos;
+    out.vMatrix_0 = vMatrix[0];
+    out.vMatrix_1 = vMatrix[1];
+    out.vMatrix_2 = vMatrix[2];
+    out.Vert_arr_0 = _20.arr[0];
+    out.Vert_arr_1 = _20.arr[1];
+    out.Vert_arr_2 = _20.arr[2];
+    out.Vert_wMatrix_0 = _20.wMatrix[0];
+    out.Vert_wMatrix_1 = _20.wMatrix[1];
+    out.Vert_wMatrix_2 = _20.wMatrix[2];
+    out.Vert_wTmp = _20.wTmp;
+    return out;
+}
+

--- a/reference/shaders-msl/vert/interface-block-block-composites.frag
+++ b/reference/shaders-msl/vert/interface-block-block-composites.frag
@@ -1,0 +1,56 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Vert
+{
+    float3x3 wMatrix;
+    float4 wTmp;
+    float arr[4];
+};
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 vMatrix_0 [[user(locn0)]];
+    float3 vMatrix_1 [[user(locn1)]];
+    float3 vMatrix_2 [[user(locn2)]];
+    float3 Vert_wMatrix_0 [[user(locn4)]];
+    float3 Vert_wMatrix_1 [[user(locn5)]];
+    float3 Vert_wMatrix_2 [[user(locn6)]];
+    float4 Vert_wTmp [[user(locn7)]];
+    float Vert_arr_0 [[user(locn8)]];
+    float Vert_arr_1 [[user(locn9)]];
+    float Vert_arr_2 [[user(locn10)]];
+    float Vert_arr_3 [[user(locn11)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    Vert _17 = {};
+    float3x3 vMatrix = {};
+    _17.wMatrix[0] = in.Vert_wMatrix_0;
+    _17.wMatrix[1] = in.Vert_wMatrix_1;
+    _17.wMatrix[2] = in.Vert_wMatrix_2;
+    _17.wTmp = in.Vert_wTmp;
+    _17.arr[0] = in.Vert_arr_0;
+    _17.arr[1] = in.Vert_arr_1;
+    _17.arr[2] = in.Vert_arr_2;
+    _17.arr[3] = in.Vert_arr_3;
+    vMatrix[0] = in.vMatrix_0;
+    vMatrix[1] = in.vMatrix_1;
+    vMatrix[2] = in.vMatrix_2;
+    out.FragColor = (_17.wMatrix[0].xxyy + _17.wTmp) + vMatrix[1].yyzz;
+    for (int i = 0; i < 4; i++)
+    {
+        out.FragColor += float4(_17.arr[i]);
+    }
+    return out;
+}
+

--- a/reference/shaders-msl/vert/interface-block-block-composites.vert
+++ b/reference/shaders-msl/vert/interface-block-block-composites.vert
@@ -1,0 +1,64 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Vert
+{
+    float arr[3];
+    float3x3 wMatrix;
+    float4 wTmp;
+};
+
+struct main0_out
+{
+    float3 vMatrix_0 [[user(locn0)]];
+    float3 vMatrix_1 [[user(locn1)]];
+    float3 vMatrix_2 [[user(locn2)]];
+    float Vert_arr_0 [[user(locn4)]];
+    float Vert_arr_1 [[user(locn5)]];
+    float Vert_arr_2 [[user(locn6)]];
+    float3 Vert_wMatrix_0 [[user(locn7)]];
+    float3 Vert_wMatrix_1 [[user(locn8)]];
+    float3 Vert_wMatrix_2 [[user(locn9)]];
+    float4 Vert_wTmp [[user(locn10)]];
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float3 Matrix_0 [[attribute(0)]];
+    float3 Matrix_1 [[attribute(1)]];
+    float3 Matrix_2 [[attribute(2)]];
+    float4 Pos [[attribute(4)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    float3x3 vMatrix = {};
+    Vert _20 = {};
+    float3x3 Matrix = {};
+    Matrix[0] = in.Matrix_0;
+    Matrix[1] = in.Matrix_1;
+    Matrix[2] = in.Matrix_2;
+    vMatrix = Matrix;
+    _20.wMatrix = Matrix;
+    _20.arr[0] = 1.0;
+    _20.arr[1] = 2.0;
+    _20.arr[2] = 3.0;
+    _20.wTmp = in.Pos;
+    out.gl_Position = in.Pos;
+    out.vMatrix_0 = vMatrix[0];
+    out.vMatrix_1 = vMatrix[1];
+    out.vMatrix_2 = vMatrix[2];
+    out.Vert_arr_0 = _20.arr[0];
+    out.Vert_arr_1 = _20.arr[1];
+    out.Vert_arr_2 = _20.arr[2];
+    out.Vert_wMatrix_0 = _20.wMatrix[0];
+    out.Vert_wMatrix_1 = _20.wMatrix[1];
+    out.Vert_wMatrix_2 = _20.wMatrix[2];
+    out.Vert_wTmp = _20.wTmp;
+    return out;
+}
+

--- a/shaders-msl/vert/interface-block-block-composites.frag
+++ b/shaders-msl/vert/interface-block-block-composites.frag
@@ -1,0 +1,17 @@
+#version 450
+layout(location = 0) in mat3 vMatrix;
+layout(location = 4) in Vert
+{
+	mat3 wMatrix;
+	vec4 wTmp;
+	float arr[4];
+};
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = wMatrix[0].xxyy + wTmp + vMatrix[1].yyzz;
+	for (int i = 0; i < 4; i++)
+		FragColor += arr[i];
+}

--- a/shaders-msl/vert/interface-block-block-composites.vert
+++ b/shaders-msl/vert/interface-block-block-composites.vert
@@ -1,0 +1,22 @@
+#version 450
+layout(location = 0) out mat3 vMatrix;
+layout(location = 0) in mat3 Matrix;
+layout(location = 4) in vec4 Pos;
+
+layout(location = 4) out Vert
+{
+	float arr[3];
+	mat3 wMatrix;
+	vec4 wTmp;
+};
+
+void main()
+{
+	vMatrix = Matrix;
+	wMatrix = Matrix;
+	arr[0] = 1.0;
+	arr[1] = 2.0;
+	arr[2] = 3.0;
+	wTmp = Pos;
+	gl_Position = Pos;
+}

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -1347,7 +1347,7 @@ struct Meta
 		std::string qualified_alias;
 		std::string hlsl_semantic;
 		Bitset decoration_flags;
-		spv::BuiltIn builtin_type;
+		spv::BuiltIn builtin_type = spv::BuiltInMax;
 		uint32_t location = 0;
 		uint32_t component = 0;
 		uint32_t set = 0;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -361,6 +361,19 @@ protected:
 	                                            std::unordered_set<uint32_t> &global_var_ids,
 	                                            std::unordered_set<uint32_t> &processed_func_ids);
 	uint32_t add_interface_block(spv::StorageClass storage);
+
+	void add_variable_to_interface_block(spv::StorageClass storage, const std::string &ib_var_ref, SPIRType &ib_type,
+	                                     SPIRVariable &var);
+	void add_composite_variable_to_interface_block(spv::StorageClass storage, const std::string &ib_var_ref,
+	                                               SPIRType &ib_type, SPIRVariable &var);
+	void add_plain_variable_to_interface_block(spv::StorageClass storage, const std::string &ib_var_ref,
+	                                           SPIRType &ib_type, SPIRVariable &var);
+	void add_plain_member_variable_to_interface_block(spv::StorageClass storage, const std::string &ib_var_ref,
+	                                                  SPIRType &ib_type, SPIRVariable &var, uint32_t index);
+	void add_composite_member_variable_to_interface_block(spv::StorageClass storage, const std::string &ib_var_ref,
+	                                                      SPIRType &ib_type, SPIRVariable &var, uint32_t index);
+	uint32_t get_accumulated_member_location(const SPIRVariable &var, uint32_t mbr_idx);
+
 	void mark_location_as_used_by_shader(uint32_t location, spv::StorageClass storage);
 	uint32_t ensure_correct_builtin_type(uint32_t type_id, spv::BuiltIn builtin);
 	uint32_t ensure_correct_attribute_type(uint32_t type_id, uint32_t location);


### PR DESCRIPTION
I had to refactor the existing add_interface_block as it was getting extremely large. Now it's all split up into different readable functions.

Fix #797.