### PR TITLE
MSL: Add option to pad fragment outputs.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -492,6 +492,7 @@ struct CLIArguments
 	bool support_nonzero_baseinstance = true;
 	bool msl_swizzle_texture_samples = false;
 	bool msl_ios = false;
+	bool msl_pad_fragment_output = false;
 	vector<PLSArg> pls_in;
 	vector<PLSArg> pls_out;
 	vector<Remap> remaps;
@@ -546,6 +547,7 @@ static void print_help()
 	                "\t[--msl-version <MMmmpp>]\n"
 	                "\t[--msl-swizzle-texture-samples]\n"
 	                "\t[--msl-ios]\n"
+	                "\t[--msl-pad-fragment-output]\n"
 	                "\t[--hlsl]\n"
 	                "\t[--reflect]\n"
 	                "\t[--shader-model]\n"
@@ -714,6 +716,7 @@ static int main_inner(int argc, char *argv[])
 	cbs.add("--no-420pack-extension", [&args](CLIParser &) { args.use_420pack_extension = false; });
 	cbs.add("--msl-swizzle-texture-samples", [&args](CLIParser &) { args.msl_swizzle_texture_samples = true; });
 	cbs.add("--msl-ios", [&args](CLIParser &) { args.msl_ios = true; });
+	cbs.add("--msl-pad-fragment-output", [&args](CLIParser &) { args.msl_pad_fragment_output = true; });
 	cbs.add("--extension", [&args](CLIParser &parser) { args.extensions.push_back(parser.next_string()); });
 	cbs.add("--rename-entry-point", [&args](CLIParser &parser) {
 		auto old_name = parser.next_string();
@@ -843,6 +846,7 @@ static int main_inner(int argc, char *argv[])
 		msl_opts.swizzle_texture_samples = args.msl_swizzle_texture_samples;
 		if (args.msl_ios)
 			msl_opts.platform = CompilerMSL::Options::iOS;
+		msl_opts.pad_fragment_output_components = args.msl_pad_fragment_output;
 		msl_comp->set_msl_options(msl_opts);
 	}
 	else if (args.hlsl)

--- a/reference/opt/shaders-msl/frag/fragment-component-padding.pad-fragment.frag
+++ b/reference/opt/shaders-msl/frag/fragment-component-padding.pad-fragment.frag
@@ -1,0 +1,35 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColors_0 [[color(0)]];
+    float4 FragColors_1 [[color(1)]];
+    float4 FragColor2 [[color(2)]];
+    float4 FragColor3 [[color(3)]];
+};
+
+struct main0_in
+{
+    float3 vColor [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    float FragColors[2] = {};
+    float2 FragColor2 = {};
+    float3 FragColor3 = {};
+    FragColors[0] = in.vColor.x;
+    FragColors[1] = in.vColor.y;
+    FragColor2 = in.vColor.xz;
+    FragColor3 = in.vColor.zzz;
+    out.FragColors_0 = float4(FragColors[0]);
+    out.FragColors_1 = float4(FragColors[1]);
+    out.FragColor2 = FragColor2.xyyy;
+    out.FragColor3 = FragColor3.xyzz;
+    return out;
+}
+

--- a/reference/shaders-msl/frag/fragment-component-padding.pad-fragment.frag
+++ b/reference/shaders-msl/frag/fragment-component-padding.pad-fragment.frag
@@ -1,0 +1,42 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColors_0 [[color(0)]];
+    float4 FragColors_1 [[color(1)]];
+    float4 FragColor2 [[color(2)]];
+    float4 FragColor3 [[color(3)]];
+};
+
+struct main0_in
+{
+    float3 vColor [[user(locn0)]];
+};
+
+void set_globals(thread float (&FragColors)[2], thread float3& vColor, thread float2& FragColor2, thread float3& FragColor3)
+{
+    FragColors[0] = vColor.x;
+    FragColors[1] = vColor.y;
+    FragColor2 = vColor.xz;
+    FragColor3 = vColor.zzz;
+}
+
+fragment main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    float FragColors[2] = {};
+    float2 FragColor2 = {};
+    float3 FragColor3 = {};
+    set_globals(FragColors, in.vColor, FragColor2, FragColor3);
+    out.FragColors_0 = float4(FragColors[0]);
+    out.FragColors_1 = float4(FragColors[1]);
+    out.FragColor2 = FragColor2.xyyy;
+    out.FragColor3 = FragColor3.xyzz;
+    return out;
+}
+

--- a/shaders-msl/frag/fragment-component-padding.pad-fragment.frag
+++ b/shaders-msl/frag/fragment-component-padding.pad-fragment.frag
@@ -1,0 +1,18 @@
+#version 450
+layout(location = 0) out float FragColors[2];
+layout(location = 2) out vec2 FragColor2;
+layout(location = 3) out vec3 FragColor3;
+layout(location = 0) in vec3 vColor;
+
+void set_globals()
+{
+	FragColors[0] = vColor.x;
+	FragColors[1] = vColor.y;
+	FragColor2 = vColor.xz;
+	FragColor3 = vColor.zzz;
+}
+
+void main()
+{
+	set_globals();
+}

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -168,6 +168,10 @@ public:
 		bool disable_rasterization = false;
 		bool swizzle_texture_samples = false;
 
+		// Fragment output in MSL must have at least as many components as the render pass.
+		// Add support to explicit pad out components.
+		bool pad_fragment_output_components = false;
+
 		bool is_ios()
 		{
 			return platform == iOS;
@@ -312,6 +316,10 @@ public:
 	// The remapped sampler must not be an array of samplers.
 	void remap_constexpr_sampler(uint32_t id, const MSLConstexprSampler &sampler);
 
+	// If using CompilerMSL::Options::pad_fragment_output_components, override the number of components we expect
+	// to use for a particular location. The default is 4 if number of components is not overridden.
+	void set_fragment_output_components(uint32_t location, uint32_t components);
+
 protected:
 	void emit_binary_unord_op(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, const char *op);
 	void emit_instruction(const Instruction &instr) override;
@@ -427,6 +435,7 @@ protected:
 	Options msl_options;
 	std::set<SPVFuncImpl> spv_function_implementations;
 	std::unordered_map<uint32_t, MSLVertexAttr *> vtx_attrs_by_location;
+	std::unordered_map<uint32_t, uint32_t> fragment_output_components;
 	std::unordered_map<MSLStructMemberKey, uint32_t> struct_member_padding;
 	std::set<std::string> pragma_lines;
 	std::set<std::string> typedef_lines;
@@ -448,6 +457,9 @@ protected:
 
 	std::unordered_map<uint32_t, MSLConstexprSampler> constexpr_samplers;
 	std::vector<uint32_t> buffer_arrays;
+
+	uint32_t get_target_components_for_fragment_location(uint32_t location) const;
+	uint32_t build_extended_vector_type(uint32_t type_id, uint32_t components);
 
 	// OpcodeHandler that handles several MSL preprocessing operations.
 	struct OpCodePreprocessor : OpcodeHandler

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -152,6 +152,8 @@ def cross_compile_msl(shader, spirv, opt):
         msl_args.append('--msl-swizzle-texture-samples')
     if '.ios.' in shader:
         msl_args.append('--msl-ios')
+    if '.pad-fragment.' in shader:
+        msl_args.append('--msl-pad-fragment-output')
 
     subprocess.check_call(msl_args)
 


### PR DESCRIPTION
If not enough components are provided in the shader,
the shader MSL compiler throws an error rather than make components
undefined. This hurts portability, so we need to add explicit padding
here.

Fix #819.