### PR TITLE
HLSL/MSL: Fix texture projection with Dref.

### DIFF
--- a/reference/opt/shaders-hlsl/frag/sample-cmp-level-zero.frag
+++ b/reference/opt/shaders-hlsl/frag/sample-cmp-level-zero.frag
@@ -22,26 +22,11 @@ struct SPIRV_Cross_Output
     float FragColor : SV_Target0;
 };
 
-float SPIRV_Cross_projectTextureCoordinate(float2 coord)
-{
-    return coord.x / coord.y;
-}
-
-float2 SPIRV_Cross_projectTextureCoordinate(float3 coord)
-{
-    return float2(coord.x, coord.y) / coord.z;
-}
-
-float3 SPIRV_Cross_projectTextureCoordinate(float4 coord)
-{
-    return float3(coord.x, coord.y, coord.z) / coord.w;
-}
-
 void frag_main()
 {
     float4 _80 = vDirRef;
     _80.z = vDirRef.w;
-    FragColor = (((((((uSampler2D.SampleCmp(_uSampler2D_sampler, vUVRef.xy, vUVRef.z, int2(-1, -1)) + uSampler2DArray.SampleCmp(_uSampler2DArray_sampler, vDirRef.xyz, vDirRef.w, int2(-1, -1))) + uSamplerCube.SampleCmp(_uSamplerCube_sampler, vDirRef.xyz, vDirRef.w)) + uSamplerCubeArray.SampleCmp(_uSamplerCubeArray_sampler, vDirRef, 0.5f)) + uSampler2D.SampleCmpLevelZero(_uSampler2D_sampler, vUVRef.xy, vUVRef.z, int2(-1, -1))) + uSampler2DArray.SampleCmpLevelZero(_uSampler2DArray_sampler, vDirRef.xyz, vDirRef.w, int2(-1, -1))) + uSamplerCube.SampleCmpLevelZero(_uSamplerCube_sampler, vDirRef.xyz, vDirRef.w)) + uSampler2D.SampleCmp(_uSampler2D_sampler, SPIRV_Cross_projectTextureCoordinate(_80.xyz), vDirRef.z, int2(1, 1))) + uSampler2D.SampleCmpLevelZero(_uSampler2D_sampler, SPIRV_Cross_projectTextureCoordinate(_80.xyz), vDirRef.z, int2(1, 1));
+    FragColor = (((((((uSampler2D.SampleCmp(_uSampler2D_sampler, vUVRef.xy, vUVRef.z, int2(-1, -1)) + uSampler2DArray.SampleCmp(_uSampler2DArray_sampler, vDirRef.xyz, vDirRef.w, int2(-1, -1))) + uSamplerCube.SampleCmp(_uSamplerCube_sampler, vDirRef.xyz, vDirRef.w)) + uSamplerCubeArray.SampleCmp(_uSamplerCubeArray_sampler, vDirRef, 0.5f)) + uSampler2D.SampleCmpLevelZero(_uSampler2D_sampler, vUVRef.xy, vUVRef.z, int2(-1, -1))) + uSampler2DArray.SampleCmpLevelZero(_uSampler2DArray_sampler, vDirRef.xyz, vDirRef.w, int2(-1, -1))) + uSamplerCube.SampleCmpLevelZero(_uSamplerCube_sampler, vDirRef.xyz, vDirRef.w)) + uSampler2D.SampleCmp(_uSampler2D_sampler, _80.xy / _80.z, vDirRef.z / _80.z, int2(1, 1))) + uSampler2D.SampleCmpLevelZero(_uSampler2D_sampler, _80.xy / _80.z, vDirRef.z / _80.z, int2(1, 1));
 }
 
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)

--- a/reference/opt/shaders-hlsl/frag/tex-sampling.frag
+++ b/reference/opt/shaders-hlsl/frag/tex-sampling.frag
@@ -42,24 +42,12 @@ struct SPIRV_Cross_Output
     float4 FragColor : SV_Target0;
 };
 
-float SPIRV_Cross_projectTextureCoordinate(float2 coord)
-{
-    return coord.x / coord.y;
-}
-
-float2 SPIRV_Cross_projectTextureCoordinate(float3 coord)
-{
-    return float2(coord.x, coord.y) / coord.z;
-}
-
-float3 SPIRV_Cross_projectTextureCoordinate(float4 coord)
-{
-    return float3(coord.x, coord.y, coord.z) / coord.w;
-}
-
 void frag_main()
 {
-    float4 _162 = (((((((((((((((((((tex1d.Sample(_tex1d_sampler, texCoord1d) + tex1d.Sample(_tex1d_sampler, texCoord1d, 1)) + tex1d.SampleLevel(_tex1d_sampler, texCoord1d, 2.0f)) + tex1d.SampleGrad(_tex1d_sampler, texCoord1d, 1.0f, 2.0f)) + tex1d.Sample(_tex1d_sampler, SPIRV_Cross_projectTextureCoordinate(float2(texCoord1d, 2.0f)))) + tex1d.SampleBias(_tex1d_sampler, texCoord1d, 1.0f)) + tex2d.Sample(_tex2d_sampler, texCoord2d)) + tex2d.Sample(_tex2d_sampler, texCoord2d, int2(1, 2))) + tex2d.SampleLevel(_tex2d_sampler, texCoord2d, 2.0f)) + tex2d.SampleGrad(_tex2d_sampler, texCoord2d, float2(1.0f, 2.0f), float2(3.0f, 4.0f))) + tex2d.Sample(_tex2d_sampler, SPIRV_Cross_projectTextureCoordinate(float3(texCoord2d, 2.0f)))) + tex2d.SampleBias(_tex2d_sampler, texCoord2d, 1.0f)) + tex3d.Sample(_tex3d_sampler, texCoord3d)) + tex3d.Sample(_tex3d_sampler, texCoord3d, int3(1, 2, 3))) + tex3d.SampleLevel(_tex3d_sampler, texCoord3d, 2.0f)) + tex3d.SampleGrad(_tex3d_sampler, texCoord3d, float3(1.0f, 2.0f, 3.0f), float3(4.0f, 5.0f, 6.0f))) + tex3d.Sample(_tex3d_sampler, SPIRV_Cross_projectTextureCoordinate(float4(texCoord3d, 2.0f)))) + tex3d.SampleBias(_tex3d_sampler, texCoord3d, 1.0f)) + texCube.Sample(_texCube_sampler, texCoord3d)) + texCube.SampleLevel(_texCube_sampler, texCoord3d, 2.0f)) + texCube.SampleBias(_texCube_sampler, texCoord3d, 1.0f);
+    float2 _41 = float2(texCoord1d, 2.0f);
+    float3 _88 = float3(texCoord2d, 2.0f);
+    float4 _135 = float4(texCoord3d, 2.0f);
+    float4 _162 = (((((((((((((((((((tex1d.Sample(_tex1d_sampler, texCoord1d) + tex1d.Sample(_tex1d_sampler, texCoord1d, 1)) + tex1d.SampleLevel(_tex1d_sampler, texCoord1d, 2.0f)) + tex1d.SampleGrad(_tex1d_sampler, texCoord1d, 1.0f, 2.0f)) + tex1d.Sample(_tex1d_sampler, _41.x / _41.y)) + tex1d.SampleBias(_tex1d_sampler, texCoord1d, 1.0f)) + tex2d.Sample(_tex2d_sampler, texCoord2d)) + tex2d.Sample(_tex2d_sampler, texCoord2d, int2(1, 2))) + tex2d.SampleLevel(_tex2d_sampler, texCoord2d, 2.0f)) + tex2d.SampleGrad(_tex2d_sampler, texCoord2d, float2(1.0f, 2.0f), float2(3.0f, 4.0f))) + tex2d.Sample(_tex2d_sampler, _88.xy / _88.z)) + tex2d.SampleBias(_tex2d_sampler, texCoord2d, 1.0f)) + tex3d.Sample(_tex3d_sampler, texCoord3d)) + tex3d.Sample(_tex3d_sampler, texCoord3d, int3(1, 2, 3))) + tex3d.SampleLevel(_tex3d_sampler, texCoord3d, 2.0f)) + tex3d.SampleGrad(_tex3d_sampler, texCoord3d, float3(1.0f, 2.0f, 3.0f), float3(4.0f, 5.0f, 6.0f))) + tex3d.Sample(_tex3d_sampler, _135.xyz / _135.w)) + tex3d.SampleBias(_tex3d_sampler, texCoord3d, 1.0f)) + texCube.Sample(_texCube_sampler, texCoord3d)) + texCube.SampleLevel(_texCube_sampler, texCoord3d, 2.0f)) + texCube.SampleBias(_texCube_sampler, texCoord3d, 1.0f);
     float4 _333 = _162;
     _333.w = ((_162.w + tex1dShadow.SampleCmp(_tex1dShadow_sampler, float3(texCoord1d, 0.0f, 0.0f).x, 0.0f)) + tex2dShadow.SampleCmp(_tex2dShadow_sampler, float3(texCoord2d, 0.0f).xy, 0.0f)) + texCubeShadow.SampleCmp(_texCubeShadow_sampler, float4(texCoord3d, 0.0f).xyz, 0.0f);
     float4 _308 = ((((((((((((((_333 + tex1dArray.Sample(_tex1dArray_sampler, texCoord2d)) + tex2dArray.Sample(_tex2dArray_sampler, texCoord3d)) + texCubeArray.Sample(_texCubeArray_sampler, texCoord4d)) + tex2d.GatherRed(_tex2d_sampler, texCoord2d)) + tex2d.GatherRed(_tex2d_sampler, texCoord2d)) + tex2d.GatherGreen(_tex2d_sampler, texCoord2d)) + tex2d.GatherBlue(_tex2d_sampler, texCoord2d)) + tex2d.GatherAlpha(_tex2d_sampler, texCoord2d)) + tex2d.GatherRed(_tex2d_sampler, texCoord2d, int2(1, 1))) + tex2d.GatherRed(_tex2d_sampler, texCoord2d, int2(1, 1))) + tex2d.GatherGreen(_tex2d_sampler, texCoord2d, int2(1, 1))) + tex2d.GatherBlue(_tex2d_sampler, texCoord2d, int2(1, 1))) + tex2d.GatherAlpha(_tex2d_sampler, texCoord2d, int2(1, 1))) + tex2d.Load(int3(int2(1, 2), 0))) + separateTex2d.Sample(samplerNonDepth, texCoord2d);

--- a/reference/opt/shaders-hlsl/frag/texture-proj-shadow.frag
+++ b/reference/opt/shaders-hlsl/frag/texture-proj-shadow.frag
@@ -26,32 +26,17 @@ struct SPIRV_Cross_Output
     float FragColor : SV_Target0;
 };
 
-float SPIRV_Cross_projectTextureCoordinate(float2 coord)
-{
-    return coord.x / coord.y;
-}
-
-float2 SPIRV_Cross_projectTextureCoordinate(float3 coord)
-{
-    return float2(coord.x, coord.y) / coord.z;
-}
-
-float3 SPIRV_Cross_projectTextureCoordinate(float4 coord)
-{
-    return float3(coord.x, coord.y, coord.z) / coord.w;
-}
-
 void frag_main()
 {
     float4 _20 = vClip4;
     _20.y = vClip4.w;
-    FragColor = uShadow1D.SampleCmp(_uShadow1D_sampler, SPIRV_Cross_projectTextureCoordinate(_20.xy), vClip4.z);
+    FragColor = uShadow1D.SampleCmp(_uShadow1D_sampler, _20.x / _20.y, vClip4.z / _20.y);
     float4 _30 = vClip4;
     _30.z = vClip4.w;
-    FragColor = uShadow2D.SampleCmp(_uShadow2D_sampler, SPIRV_Cross_projectTextureCoordinate(_30.xyz), vClip4.z);
-    FragColor = uSampler1D.Sample(_uSampler1D_sampler, SPIRV_Cross_projectTextureCoordinate(vClip2)).x;
-    FragColor = uSampler2D.Sample(_uSampler2D_sampler, SPIRV_Cross_projectTextureCoordinate(vClip3)).x;
-    FragColor = uSampler3D.Sample(_uSampler3D_sampler, SPIRV_Cross_projectTextureCoordinate(vClip4)).x;
+    FragColor = uShadow2D.SampleCmp(_uShadow2D_sampler, _30.xy / _30.z, vClip4.z / _30.z);
+    FragColor = uSampler1D.Sample(_uSampler1D_sampler, vClip2.x / vClip2.y).x;
+    FragColor = uSampler2D.Sample(_uSampler2D_sampler, vClip3.xy / vClip3.z).x;
+    FragColor = uSampler3D.Sample(_uSampler3D_sampler, vClip4.xyz / vClip4.w).x;
 }
 
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)

--- a/reference/opt/shaders-msl/frag/texture-proj-shadow.frag
+++ b/reference/opt/shaders-msl/frag/texture-proj-shadow.frag
@@ -20,7 +20,7 @@ fragment main0_out main0(main0_in in [[stage_in]], depth2d<float> uShadow2D [[te
     main0_out out = {};
     float4 _20 = in.vClip4;
     _20.z = in.vClip4.w;
-    out.FragColor = uShadow2D.sample_compare(uShadow2DSmplr, _20.xy / _20.z, in.vClip4.z);
+    out.FragColor = uShadow2D.sample_compare(uShadow2DSmplr, _20.xy / _20.z, in.vClip4.z / _20.z);
     out.FragColor = uSampler1D.sample(uSampler1DSmplr, in.vClip2.x / in.vClip2.y).x;
     out.FragColor = uSampler2D.sample(uSampler2DSmplr, in.vClip3.xy / in.vClip3.z).x;
     out.FragColor = uSampler3D.sample(uSampler3DSmplr, in.vClip4.xyz / in.vClip4.w).x;

--- a/reference/shaders-hlsl/frag/sample-cmp-level-zero.frag
+++ b/reference/shaders-hlsl/frag/sample-cmp-level-zero.frag
@@ -22,21 +22,6 @@ struct SPIRV_Cross_Output
     float FragColor : SV_Target0;
 };
 
-float SPIRV_Cross_projectTextureCoordinate(float2 coord)
-{
-    return coord.x / coord.y;
-}
-
-float2 SPIRV_Cross_projectTextureCoordinate(float3 coord)
-{
-    return float2(coord.x, coord.y) / coord.z;
-}
-
-float3 SPIRV_Cross_projectTextureCoordinate(float4 coord)
-{
-    return float3(coord.x, coord.y, coord.z) / coord.w;
-}
-
 void frag_main()
 {
     float s0 = uSampler2D.SampleCmp(_uSampler2D_sampler, vUVRef.xy, vUVRef.z, int2(-1, -1));
@@ -48,10 +33,10 @@ void frag_main()
     float l2 = uSamplerCube.SampleCmpLevelZero(_uSamplerCube_sampler, vDirRef.xyz, vDirRef.w);
     float4 _80 = vDirRef;
     _80.z = vDirRef.w;
-    float p0 = uSampler2D.SampleCmp(_uSampler2D_sampler, SPIRV_Cross_projectTextureCoordinate(_80.xyz), vDirRef.z, int2(1, 1));
+    float p0 = uSampler2D.SampleCmp(_uSampler2D_sampler, _80.xy / _80.z, vDirRef.z / _80.z, int2(1, 1));
     float4 _87 = vDirRef;
     _87.z = vDirRef.w;
-    float p1 = uSampler2D.SampleCmpLevelZero(_uSampler2D_sampler, SPIRV_Cross_projectTextureCoordinate(_87.xyz), vDirRef.z, int2(1, 1));
+    float p1 = uSampler2D.SampleCmpLevelZero(_uSampler2D_sampler, _87.xy / _87.z, vDirRef.z / _87.z, int2(1, 1));
     FragColor = (((((((s0 + s1) + s2) + s3) + l0) + l1) + l2) + p0) + p1;
 }
 

--- a/reference/shaders-hlsl/frag/tex-sampling.frag
+++ b/reference/shaders-hlsl/frag/tex-sampling.frag
@@ -42,40 +42,28 @@ struct SPIRV_Cross_Output
     float4 FragColor : SV_Target0;
 };
 
-float SPIRV_Cross_projectTextureCoordinate(float2 coord)
-{
-    return coord.x / coord.y;
-}
-
-float2 SPIRV_Cross_projectTextureCoordinate(float3 coord)
-{
-    return float2(coord.x, coord.y) / coord.z;
-}
-
-float3 SPIRV_Cross_projectTextureCoordinate(float4 coord)
-{
-    return float3(coord.x, coord.y, coord.z) / coord.w;
-}
-
 void frag_main()
 {
     float4 texcolor = tex1d.Sample(_tex1d_sampler, texCoord1d);
     texcolor += tex1d.Sample(_tex1d_sampler, texCoord1d, 1);
     texcolor += tex1d.SampleLevel(_tex1d_sampler, texCoord1d, 2.0f);
     texcolor += tex1d.SampleGrad(_tex1d_sampler, texCoord1d, 1.0f, 2.0f);
-    texcolor += tex1d.Sample(_tex1d_sampler, SPIRV_Cross_projectTextureCoordinate(float2(texCoord1d, 2.0f)));
+    float2 _41 = float2(texCoord1d, 2.0f);
+    texcolor += tex1d.Sample(_tex1d_sampler, _41.x / _41.y);
     texcolor += tex1d.SampleBias(_tex1d_sampler, texCoord1d, 1.0f);
     texcolor += tex2d.Sample(_tex2d_sampler, texCoord2d);
     texcolor += tex2d.Sample(_tex2d_sampler, texCoord2d, int2(1, 2));
     texcolor += tex2d.SampleLevel(_tex2d_sampler, texCoord2d, 2.0f);
     texcolor += tex2d.SampleGrad(_tex2d_sampler, texCoord2d, float2(1.0f, 2.0f), float2(3.0f, 4.0f));
-    texcolor += tex2d.Sample(_tex2d_sampler, SPIRV_Cross_projectTextureCoordinate(float3(texCoord2d, 2.0f)));
+    float3 _88 = float3(texCoord2d, 2.0f);
+    texcolor += tex2d.Sample(_tex2d_sampler, _88.xy / _88.z);
     texcolor += tex2d.SampleBias(_tex2d_sampler, texCoord2d, 1.0f);
     texcolor += tex3d.Sample(_tex3d_sampler, texCoord3d);
     texcolor += tex3d.Sample(_tex3d_sampler, texCoord3d, int3(1, 2, 3));
     texcolor += tex3d.SampleLevel(_tex3d_sampler, texCoord3d, 2.0f);
     texcolor += tex3d.SampleGrad(_tex3d_sampler, texCoord3d, float3(1.0f, 2.0f, 3.0f), float3(4.0f, 5.0f, 6.0f));
-    texcolor += tex3d.Sample(_tex3d_sampler, SPIRV_Cross_projectTextureCoordinate(float4(texCoord3d, 2.0f)));
+    float4 _135 = float4(texCoord3d, 2.0f);
+    texcolor += tex3d.Sample(_tex3d_sampler, _135.xyz / _135.w);
     texcolor += tex3d.SampleBias(_tex3d_sampler, texCoord3d, 1.0f);
     texcolor += texCube.Sample(_texCube_sampler, texCoord3d);
     texcolor += texCube.SampleLevel(_texCube_sampler, texCoord3d, 2.0f);

--- a/reference/shaders-hlsl/frag/texture-proj-shadow.frag
+++ b/reference/shaders-hlsl/frag/texture-proj-shadow.frag
@@ -26,32 +26,17 @@ struct SPIRV_Cross_Output
     float FragColor : SV_Target0;
 };
 
-float SPIRV_Cross_projectTextureCoordinate(float2 coord)
-{
-    return coord.x / coord.y;
-}
-
-float2 SPIRV_Cross_projectTextureCoordinate(float3 coord)
-{
-    return float2(coord.x, coord.y) / coord.z;
-}
-
-float3 SPIRV_Cross_projectTextureCoordinate(float4 coord)
-{
-    return float3(coord.x, coord.y, coord.z) / coord.w;
-}
-
 void frag_main()
 {
     float4 _20 = vClip4;
     _20.y = vClip4.w;
-    FragColor = uShadow1D.SampleCmp(_uShadow1D_sampler, SPIRV_Cross_projectTextureCoordinate(_20.xy), vClip4.z);
+    FragColor = uShadow1D.SampleCmp(_uShadow1D_sampler, _20.x / _20.y, vClip4.z / _20.y);
     float4 _30 = vClip4;
     _30.z = vClip4.w;
-    FragColor = uShadow2D.SampleCmp(_uShadow2D_sampler, SPIRV_Cross_projectTextureCoordinate(_30.xyz), vClip4.z);
-    FragColor = uSampler1D.Sample(_uSampler1D_sampler, SPIRV_Cross_projectTextureCoordinate(vClip2)).x;
-    FragColor = uSampler2D.Sample(_uSampler2D_sampler, SPIRV_Cross_projectTextureCoordinate(vClip3)).x;
-    FragColor = uSampler3D.Sample(_uSampler3D_sampler, SPIRV_Cross_projectTextureCoordinate(vClip4)).x;
+    FragColor = uShadow2D.SampleCmp(_uShadow2D_sampler, _30.xy / _30.z, vClip4.z / _30.z);
+    FragColor = uSampler1D.Sample(_uSampler1D_sampler, vClip2.x / vClip2.y).x;
+    FragColor = uSampler2D.Sample(_uSampler2D_sampler, vClip3.xy / vClip3.z).x;
+    FragColor = uSampler3D.Sample(_uSampler3D_sampler, vClip4.xyz / vClip4.w).x;
 }
 
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)

--- a/reference/shaders-msl-no-opt/asm/frag/texture-access.swizzle.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/texture-access.swizzle.asm.frag
@@ -163,7 +163,7 @@ fragment void main0(constant spvAux& spvAuxBuffer [[buffer(0)]], texture1d<float
     c = spvTextureSwizzle(tex3d.sample(tex3dSamp, float4(0.0, 0.0, 0.0, 1.0).xyz / float4(0.0, 0.0, 0.0, 1.0).w), tex3dSwzl);
     float4 _152 = float4(0.0, 0.0, 1.0, 1.0);
     _152.z = float4(0.0, 0.0, 1.0, 1.0).w;
-    c.x = spvTextureSwizzle(depth2d.sample_compare(depth2dSamp, _152.xy / _152.z, float4(0.0, 0.0, 1.0, 1.0).z), depth2dSwzl);
+    c.x = spvTextureSwizzle(depth2d.sample_compare(depth2dSamp, _152.xy / _152.z, float4(0.0, 0.0, 1.0, 1.0).z / _152.z), depth2dSwzl);
     c = spvTextureSwizzle(tex1d.sample(tex1dSamp, 0.0), tex1dSwzl);
     c = spvTextureSwizzle(tex2d.sample(tex2dSamp, float2(0.0), level(0.0)), tex2dSwzl);
     c = spvTextureSwizzle(tex3d.sample(tex3dSamp, float3(0.0), level(0.0)), tex3dSwzl);
@@ -176,7 +176,7 @@ fragment void main0(constant spvAux& spvAuxBuffer [[buffer(0)]], texture1d<float
     c = spvTextureSwizzle(tex3d.sample(tex3dSamp, float4(0.0, 0.0, 0.0, 1.0).xyz / float4(0.0, 0.0, 0.0, 1.0).w, level(0.0)), tex3dSwzl);
     float4 _202 = float4(0.0, 0.0, 1.0, 1.0);
     _202.z = float4(0.0, 0.0, 1.0, 1.0).w;
-    c.x = spvTextureSwizzle(depth2d.sample_compare(depth2dSamp, _202.xy / _202.z, float4(0.0, 0.0, 1.0, 1.0).z, level(0.0)), depth2dSwzl);
+    c.x = spvTextureSwizzle(depth2d.sample_compare(depth2dSamp, _202.xy / _202.z, float4(0.0, 0.0, 1.0, 1.0).z / _202.z, level(0.0)), depth2dSwzl);
     c = spvTextureSwizzle(tex1d.read(uint(0)), tex1dSwzl);
     c = spvTextureSwizzle(tex2d.read(uint2(int2(0)), 0), tex2dSwzl);
     c = spvTextureSwizzle(tex3d.read(uint3(int3(0)), 0), tex3dSwzl);

--- a/reference/shaders-msl-no-opt/frag/texture-access-leaf.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access-leaf.swizzle.frag
@@ -153,7 +153,7 @@ float4 doSwizzle(thread texture1d<float> tex1d, thread const sampler tex1dSmplr,
     c = spvTextureSwizzle(tex3d.sample(tex3dSmplr, float4(0.0, 0.0, 0.0, 1.0).xyz / float4(0.0, 0.0, 0.0, 1.0).w), tex3dSwzl);
     float4 _103 = float4(0.0, 0.0, 1.0, 1.0);
     _103.z = float4(0.0, 0.0, 1.0, 1.0).w;
-    c.x = spvTextureSwizzle(depth2d.sample_compare(depth2dSmplr, _103.xy / _103.z, float4(0.0, 0.0, 1.0, 1.0).z), depth2dSwzl);
+    c.x = spvTextureSwizzle(depth2d.sample_compare(depth2dSmplr, _103.xy / _103.z, float4(0.0, 0.0, 1.0, 1.0).z / _103.z), depth2dSwzl);
     c = spvTextureSwizzle(tex1d.sample(tex1dSmplr, 0.0), tex1dSwzl);
     c = spvTextureSwizzle(tex2d.sample(tex2dSmplr, float2(0.0), level(0.0)), tex2dSwzl);
     c = spvTextureSwizzle(tex3d.sample(tex3dSmplr, float3(0.0), level(0.0)), tex3dSwzl);
@@ -166,7 +166,7 @@ float4 doSwizzle(thread texture1d<float> tex1d, thread const sampler tex1dSmplr,
     c = spvTextureSwizzle(tex3d.sample(tex3dSmplr, float4(0.0, 0.0, 0.0, 1.0).xyz / float4(0.0, 0.0, 0.0, 1.0).w, level(0.0)), tex3dSwzl);
     float4 _131 = float4(0.0, 0.0, 1.0, 1.0);
     _131.z = float4(0.0, 0.0, 1.0, 1.0).w;
-    c.x = spvTextureSwizzle(depth2d.sample_compare(depth2dSmplr, _131.xy / _131.z, float4(0.0, 0.0, 1.0, 1.0).z, level(0.0)), depth2dSwzl);
+    c.x = spvTextureSwizzle(depth2d.sample_compare(depth2dSmplr, _131.xy / _131.z, float4(0.0, 0.0, 1.0, 1.0).z / _131.z, level(0.0)), depth2dSwzl);
     c = spvTextureSwizzle(tex1d.read(uint(0)), tex1dSwzl);
     c = spvTextureSwizzle(tex2d.read(uint2(int2(0)), 0), tex2dSwzl);
     c = spvTextureSwizzle(tex3d.read(uint3(int3(0)), 0), tex3dSwzl);

--- a/reference/shaders-msl-no-opt/frag/texture-access.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access.swizzle.frag
@@ -163,7 +163,7 @@ fragment void main0(constant spvAux& spvAuxBuffer [[buffer(0)]], texture1d<float
     c = spvTextureSwizzle(tex3d.sample(tex3dSmplr, float4(0.0, 0.0, 0.0, 1.0).xyz / float4(0.0, 0.0, 0.0, 1.0).w), tex3dSwzl);
     float4 _100 = float4(0.0, 0.0, 1.0, 1.0);
     _100.z = float4(0.0, 0.0, 1.0, 1.0).w;
-    c.x = spvTextureSwizzle(depth2d.sample_compare(depth2dSmplr, _100.xy / _100.z, float4(0.0, 0.0, 1.0, 1.0).z), depth2dSwzl);
+    c.x = spvTextureSwizzle(depth2d.sample_compare(depth2dSmplr, _100.xy / _100.z, float4(0.0, 0.0, 1.0, 1.0).z / _100.z), depth2dSwzl);
     c = spvTextureSwizzle(tex1d.sample(tex1dSmplr, 0.0), tex1dSwzl);
     c = spvTextureSwizzle(tex2d.sample(tex2dSmplr, float2(0.0), level(0.0)), tex2dSwzl);
     c = spvTextureSwizzle(tex3d.sample(tex3dSmplr, float3(0.0), level(0.0)), tex3dSwzl);
@@ -176,7 +176,7 @@ fragment void main0(constant spvAux& spvAuxBuffer [[buffer(0)]], texture1d<float
     c = spvTextureSwizzle(tex3d.sample(tex3dSmplr, float4(0.0, 0.0, 0.0, 1.0).xyz / float4(0.0, 0.0, 0.0, 1.0).w, level(0.0)), tex3dSwzl);
     float4 _128 = float4(0.0, 0.0, 1.0, 1.0);
     _128.z = float4(0.0, 0.0, 1.0, 1.0).w;
-    c.x = spvTextureSwizzle(depth2d.sample_compare(depth2dSmplr, _128.xy / _128.z, float4(0.0, 0.0, 1.0, 1.0).z, level(0.0)), depth2dSwzl);
+    c.x = spvTextureSwizzle(depth2d.sample_compare(depth2dSmplr, _128.xy / _128.z, float4(0.0, 0.0, 1.0, 1.0).z / _128.z, level(0.0)), depth2dSwzl);
     c = spvTextureSwizzle(tex1d.read(uint(0)), tex1dSwzl);
     c = spvTextureSwizzle(tex2d.read(uint2(int2(0)), 0), tex2dSwzl);
     c = spvTextureSwizzle(tex3d.read(uint3(int3(0)), 0), tex3dSwzl);

--- a/reference/shaders-msl-no-opt/vulkan/frag/texture-access-function.swizzle.vk.frag
+++ b/reference/shaders-msl-no-opt/vulkan/frag/texture-access-function.swizzle.vk.frag
@@ -158,7 +158,7 @@ float4 do_samples(thread const texture1d<float> t1, thread const sampler t1Smplr
     c = spvTextureSwizzle(t3.sample(t3Smplr, float4(0.0, 0.0, 0.0, 1.0).xyz / float4(0.0, 0.0, 0.0, 1.0).w), t3Swzl);
     float4 _119 = float4(0.0, 0.0, 1.0, 1.0);
     _119.z = float4(0.0, 0.0, 1.0, 1.0).w;
-    c.x = spvTextureSwizzle(d2.sample_compare(d2Smplr, _119.xy / _119.z, float4(0.0, 0.0, 1.0, 1.0).z), d2Swzl);
+    c.x = spvTextureSwizzle(d2.sample_compare(d2Smplr, _119.xy / _119.z, float4(0.0, 0.0, 1.0, 1.0).z / _119.z), d2Swzl);
     c = spvTextureSwizzle(t1.sample(t1Smplr, 0.0), t1Swzl);
     c = spvTextureSwizzle(t2.sample(defaultSampler, float2(0.0), level(0.0)), t2Swzl);
     c = spvTextureSwizzle(t3.sample(t3Smplr, float3(0.0), level(0.0)), t3Swzl);
@@ -171,7 +171,7 @@ float4 do_samples(thread const texture1d<float> t1, thread const sampler t1Smplr
     c = spvTextureSwizzle(t3.sample(t3Smplr, float4(0.0, 0.0, 0.0, 1.0).xyz / float4(0.0, 0.0, 0.0, 1.0).w, level(0.0)), t3Swzl);
     float4 _153 = float4(0.0, 0.0, 1.0, 1.0);
     _153.z = float4(0.0, 0.0, 1.0, 1.0).w;
-    c.x = spvTextureSwizzle(d2.sample_compare(d2Smplr, _153.xy / _153.z, float4(0.0, 0.0, 1.0, 1.0).z, level(0.0)), d2Swzl);
+    c.x = spvTextureSwizzle(d2.sample_compare(d2Smplr, _153.xy / _153.z, float4(0.0, 0.0, 1.0, 1.0).z / _153.z, level(0.0)), d2Swzl);
     c = spvTextureSwizzle(t1.read(uint(0)), t1Swzl);
     c = spvTextureSwizzle(t2.read(uint2(int2(0)), 0), t2Swzl);
     c = spvTextureSwizzle(t3.read(uint3(int3(0)), 0), t3Swzl);

--- a/reference/shaders-msl/frag/texture-proj-shadow.frag
+++ b/reference/shaders-msl/frag/texture-proj-shadow.frag
@@ -20,7 +20,7 @@ fragment main0_out main0(main0_in in [[stage_in]], depth2d<float> uShadow2D [[te
     main0_out out = {};
     float4 _20 = in.vClip4;
     _20.z = in.vClip4.w;
-    out.FragColor = uShadow2D.sample_compare(uShadow2DSmplr, _20.xy / _20.z, in.vClip4.z);
+    out.FragColor = uShadow2D.sample_compare(uShadow2DSmplr, _20.xy / _20.z, in.vClip4.z / _20.z);
     out.FragColor = uSampler1D.sample(uSampler1DSmplr, in.vClip2.x / in.vClip2.y).x;
     out.FragColor = uSampler2D.sample(uSampler2DSmplr, in.vClip3.xy / in.vClip3.z).x;
     out.FragColor = uSampler3D.sample(uSampler3DSmplr, in.vClip4.xyz / in.vClip4.w).x;

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -184,7 +184,6 @@ private:
 
 	Options hlsl_options;
 	bool requires_op_fmod = false;
-	bool requires_textureProj = false;
 	bool requires_fp16_packing = false;
 	bool requires_explicit_fp16_packing = false;
 	bool requires_unorm8_packing = false;


### PR DESCRIPTION
We need to divide the Dref by q.
Fix #840.