### PR TITLE
MSL: Use correct alignment for structs which are members of other structs.

### DIFF
--- a/reference/opt/shaders-msl/asm/comp/block-name-alias-global.asm.comp
+++ b/reference/opt/shaders-msl/asm/comp/block-name-alias-global.asm.comp
@@ -22,7 +22,7 @@ struct A_2
 
 struct A_3
 {
-    A_2 Data[1024];
+    /* FIXME: A padded struct is needed here. If you see this message, file a bug! */ A_2 Data[1024];
 };
 
 struct B
@@ -32,7 +32,7 @@ struct B
 
 struct B_1
 {
-    A_2 Data[1024];
+    /* FIXME: A padded struct is needed here. If you see this message, file a bug! */ A_2 Data[1024];
 };
 
 kernel void main0(device B& C3 [[buffer(0)]], device A_1& C1 [[buffer(1)]], constant A_3& C2 [[buffer(2)]], constant B_1& C4 [[buffer(3)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])

--- a/reference/opt/shaders-msl/asm/frag/vector-shuffle-oom.asm.frag
+++ b/reference/opt/shaders-msl/asm/frag/vector-shuffle-oom.asm.frag
@@ -73,7 +73,7 @@ struct _18
     float2 _m24;
     float2 _m25;
     float2 _m26;
-    char pad27[8];
+    char _m27_pad[8];
     packed_float3 _m27;
     float _m28;
     float _m29;

--- a/reference/opt/shaders-msl/comp/struct-packing.comp
+++ b/reference/opt/shaders-msl/comp/struct-packing.comp
@@ -40,10 +40,12 @@ struct Content
     S1 m1s[1];
     S2 m2s[1];
     S0 m0;
+    char _m4_pad[4];
     S1 m1;
     S2 m2;
+    char _m6_pad[8];
     S3 m3;
-    char pad7[4];
+    char _m7_pad[4];
     float m4;
     S4 m3s[8];
 };
@@ -53,7 +55,7 @@ struct SSBO1
     Content content;
     Content content1[2];
     Content content2;
-    char pad3[8];
+    char _m3_pad[8];
     float2x2 m0;
     float2x2 m1;
     float2x3 m2[4];
@@ -61,9 +63,9 @@ struct SSBO1
     float2x2 m4;
     float2x2 m5[9];
     packed_float2x3 m6[4][2];
-    char pad10[8];
+    char _m10_pad[8];
     float3x2 m7;
-    char pad11[8];
+    char _m11_pad[8];
     float array[1];
 };
 
@@ -102,11 +104,14 @@ struct Content_1
     S1_1 m1s[1];
     S2_1 m2s[1];
     S0_1 m0;
+    char _m4_pad[12];
     S1_1 m1;
     S2_1 m2;
+    char _m6_pad[8];
     S3_1 m3;
-    char pad7[4];
+    char _m7_pad[4];
     float m4;
+    char _m8_pad[8];
     S4_1 m3s[8];
 };
 

--- a/reference/opt/shaders-msl/comp/struct-packing.comp
+++ b/reference/opt/shaders-msl/comp/struct-packing.comp
@@ -100,7 +100,7 @@ struct S4_1
 
 struct Content_1
 {
-    S0_1 m0s[1];
+    /* FIXME: A padded struct is needed here. If you see this message, file a bug! */ S0_1 m0s[1];
     S1_1 m1s[1];
     S2_1 m2s[1];
     S0_1 m0;
@@ -112,7 +112,7 @@ struct Content_1
     char _m7_pad[4];
     float m4;
     char _m8_pad[8];
-    S4_1 m3s[8];
+    /* FIXME: A padded struct is needed here. If you see this message, file a bug! */ S4_1 m3s[8];
 };
 
 struct SSBO0

--- a/reference/opt/shaders-msl/comp/struct-packing.comp
+++ b/reference/opt/shaders-msl/comp/struct-packing.comp
@@ -40,12 +40,9 @@ struct Content
     S1 m1s[1];
     S2 m2s[1];
     S0 m0;
-    char _m4_pad[4];
     S1 m1;
     S2 m2;
-    char _m6_pad[8];
     S3 m3;
-    char _m7_pad[4];
     float m4;
     S4 m3s[8];
 };
@@ -55,7 +52,6 @@ struct SSBO1
     Content content;
     Content content1[2];
     Content content2;
-    char _m3_pad[8];
     float2x2 m0;
     float2x2 m1;
     float2x3 m2[4];
@@ -100,18 +96,15 @@ struct S4_1
 
 struct Content_1
 {
-    /* FIXME: A padded struct is needed here. If you see this message, file a bug! */ S0_1 m0s[1];
+    S0_1 m0s[1];
     S1_1 m1s[1];
     S2_1 m2s[1];
     S0_1 m0;
-    char _m4_pad[12];
     S1_1 m1;
     S2_1 m2;
-    char _m6_pad[8];
     S3_1 m3;
-    char _m7_pad[4];
     float m4;
-    char _m8_pad[8];
+    char _m8_pad[12];
     /* FIXME: A padded struct is needed here. If you see this message, file a bug! */ S4_1 m3s[8];
 };
 

--- a/reference/opt/shaders-msl/vert/packed_matrix.vert
+++ b/reference/opt/shaders-msl/vert/packed_matrix.vert
@@ -16,7 +16,7 @@ struct _42
     float4x4 _m0;
     float4x4 _m1;
     float _m2;
-    char pad3[12];
+    char _m3_pad[12];
     packed_float3 _m3;
     float _m4;
     packed_float3 _m5;

--- a/reference/opt/shaders-msl/vert/ubo.alignment.vert
+++ b/reference/opt/shaders-msl/vert/ubo.alignment.vert
@@ -7,7 +7,7 @@ struct UBO
 {
     float4x4 mvp;
     float2 targSize;
-    char pad2[8];
+    char _m2_pad[8];
     packed_float3 color;
     float opacity;
 };

--- a/reference/shaders-msl/asm/comp/block-name-alias-global.asm.comp
+++ b/reference/shaders-msl/asm/comp/block-name-alias-global.asm.comp
@@ -22,7 +22,7 @@ struct A_2
 
 struct A_3
 {
-    A_2 Data[1024];
+    /* FIXME: A padded struct is needed here. If you see this message, file a bug! */ A_2 Data[1024];
 };
 
 struct B
@@ -32,7 +32,7 @@ struct B
 
 struct B_1
 {
-    A_2 Data[1024];
+    /* FIXME: A padded struct is needed here. If you see this message, file a bug! */ A_2 Data[1024];
 };
 
 kernel void main0(device B& C3 [[buffer(0)]], device A_1& C1 [[buffer(1)]], constant A_3& C2 [[buffer(2)]], constant B_1& C4 [[buffer(3)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])

--- a/reference/shaders-msl/asm/frag/vector-shuffle-oom.asm.frag
+++ b/reference/shaders-msl/asm/frag/vector-shuffle-oom.asm.frag
@@ -73,7 +73,7 @@ struct _18
     float2 _m24;
     float2 _m25;
     float2 _m26;
-    char pad27[8];
+    char _m27_pad[8];
     packed_float3 _m27;
     float _m28;
     float _m29;

--- a/reference/shaders-msl/comp/struct-packing.comp
+++ b/reference/shaders-msl/comp/struct-packing.comp
@@ -40,10 +40,12 @@ struct Content
     S1 m1s[1];
     S2 m2s[1];
     S0 m0;
+    char _m4_pad[4];
     S1 m1;
     S2 m2;
+    char _m6_pad[8];
     S3 m3;
-    char pad7[4];
+    char _m7_pad[4];
     float m4;
     S4 m3s[8];
 };
@@ -53,7 +55,7 @@ struct SSBO1
     Content content;
     Content content1[2];
     Content content2;
-    char pad3[8];
+    char _m3_pad[8];
     float2x2 m0;
     float2x2 m1;
     float2x3 m2[4];
@@ -61,9 +63,9 @@ struct SSBO1
     float2x2 m4;
     float2x2 m5[9];
     packed_float2x3 m6[4][2];
-    char pad10[8];
+    char _m10_pad[8];
     float3x2 m7;
-    char pad11[8];
+    char _m11_pad[8];
     float array[1];
 };
 
@@ -102,11 +104,14 @@ struct Content_1
     S1_1 m1s[1];
     S2_1 m2s[1];
     S0_1 m0;
+    char _m4_pad[12];
     S1_1 m1;
     S2_1 m2;
+    char _m6_pad[8];
     S3_1 m3;
-    char pad7[4];
+    char _m7_pad[4];
     float m4;
+    char _m8_pad[8];
     S4_1 m3s[8];
 };
 

--- a/reference/shaders-msl/comp/struct-packing.comp
+++ b/reference/shaders-msl/comp/struct-packing.comp
@@ -100,7 +100,7 @@ struct S4_1
 
 struct Content_1
 {
-    S0_1 m0s[1];
+    /* FIXME: A padded struct is needed here. If you see this message, file a bug! */ S0_1 m0s[1];
     S1_1 m1s[1];
     S2_1 m2s[1];
     S0_1 m0;
@@ -112,7 +112,7 @@ struct Content_1
     char _m7_pad[4];
     float m4;
     char _m8_pad[8];
-    S4_1 m3s[8];
+    /* FIXME: A padded struct is needed here. If you see this message, file a bug! */ S4_1 m3s[8];
 };
 
 struct SSBO0

--- a/reference/shaders-msl/comp/struct-packing.comp
+++ b/reference/shaders-msl/comp/struct-packing.comp
@@ -40,12 +40,9 @@ struct Content
     S1 m1s[1];
     S2 m2s[1];
     S0 m0;
-    char _m4_pad[4];
     S1 m1;
     S2 m2;
-    char _m6_pad[8];
     S3 m3;
-    char _m7_pad[4];
     float m4;
     S4 m3s[8];
 };
@@ -55,7 +52,6 @@ struct SSBO1
     Content content;
     Content content1[2];
     Content content2;
-    char _m3_pad[8];
     float2x2 m0;
     float2x2 m1;
     float2x3 m2[4];
@@ -100,18 +96,15 @@ struct S4_1
 
 struct Content_1
 {
-    /* FIXME: A padded struct is needed here. If you see this message, file a bug! */ S0_1 m0s[1];
+    S0_1 m0s[1];
     S1_1 m1s[1];
     S2_1 m2s[1];
     S0_1 m0;
-    char _m4_pad[12];
     S1_1 m1;
     S2_1 m2;
-    char _m6_pad[8];
     S3_1 m3;
-    char _m7_pad[4];
     float m4;
-    char _m8_pad[8];
+    char _m8_pad[12];
     /* FIXME: A padded struct is needed here. If you see this message, file a bug! */ S4_1 m3s[8];
 };
 

--- a/reference/shaders-msl/vert/packed_matrix.vert
+++ b/reference/shaders-msl/vert/packed_matrix.vert
@@ -16,7 +16,7 @@ struct _42
     float4x4 _m0;
     float4x4 _m1;
     float _m2;
-    char pad3[12];
+    char _m3_pad[12];
     packed_float3 _m3;
     float _m4;
     packed_float3 _m5;

--- a/reference/shaders-msl/vert/ubo.alignment.vert
+++ b/reference/shaders-msl/vert/ubo.alignment.vert
@@ -7,7 +7,7 @@ struct UBO
 {
     float4x4 mvp;
     float2 targSize;
-    char pad2[8];
+    char _m2_pad[8];
     packed_float3 color;
     float opacity;
 };

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -960,7 +960,7 @@ uint32_t CompilerGLSL::type_to_packed_alignment(const SPIRType &type, const Bits
 	if (type.basetype == SPIRType::Struct)
 	{
 		// Rule 9. Structs alignments are maximum alignment of its members.
-		uint32_t alignment = 0;
+		uint32_t alignment = 1;
 		for (uint32_t i = 0; i < type.member_types.size(); i++)
 		{
 			auto member_flags = ir.meta[type.self].members[i].decoration_flags;

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -5750,9 +5750,11 @@ size_t CompilerMSL::get_declared_struct_member_alignment(const SPIRType &struct_
 		{
 			// This is getting pretty complicated.
 			// The special case of array of float/float2 needs to be handled here.
-			uint32_t packed_type_id = get_extended_member_decoration(struct_type.self, index, SPIRVCrossDecorationPackedType);
+			uint32_t packed_type_id =
+			    get_extended_member_decoration(struct_type.self, index, SPIRVCrossDecorationPackedType);
 			const SPIRType *packed_type = packed_type_id != 0 ? &get<SPIRType>(packed_type_id) : nullptr;
-			if (packed_type && is_array(*packed_type) && !is_matrix(*packed_type) && packed_type->basetype != SPIRType::Struct)
+			if (packed_type && is_array(*packed_type) && !is_matrix(*packed_type) &&
+			    packed_type->basetype != SPIRType::Struct)
 				return (packed_type->width / 8) * 4;
 			else
 				return (type.width / 8) * (type.columns == 3 ? 4 : type.columns);


### PR DESCRIPTION
Structs in MSL are packed with "normal" rules, i.e. alignment of the struct is max(alignof(members)), not 16 bytes which is the case in std140. Also fix a complex case where an MSL struct is declared with a very low natural alignment due to use of packed_float3.

Also adds a check for arrays of structs where the struct will need to be padded, but we cannot emit correct code yet, just warn about it in the code for now.

Fix #838.