### PR TITLE
Add support for 8-bit arithmetic in GLSL and MSL

### DIFF
--- a/checkout_glslang_spirv_tools.sh
+++ b/checkout_glslang_spirv_tools.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-GLSLANG_REV=91ac4290bcf2cb930b4fb0981f09c00c0b6797e1
-SPIRV_TOOLS_REV=9bfe0eb25e3dfdf4f3fd86ab6c0cda009c9bd661
-SPIRV_HEADERS_REV=d5b2e1255f706ce1f88812217e9a554f299848af
+GLSLANG_REV=c9e03360e2a78a95a8571292aefa5ddbdbf66daf
+SPIRV_TOOLS_REV=e2279da7148d19bd21c6d47ffc96ee4176f43dba
+SPIRV_HEADERS_REV=8bea0a266ac9b718aa0818d9e3a47c0b77c2cb23
 
 if [ -d external/glslang ]; then
 	echo "Updating glslang to revision $GLSLANG_REV."

--- a/reference/opt/shaders-hlsl/asm/frag/unreachable.asm.frag
+++ b/reference/opt/shaders-hlsl/asm/frag/unreachable.asm.frag
@@ -13,21 +13,21 @@ struct SPIRV_Cross_Output
 
 void frag_main()
 {
-    bool _29;
+    float4 _33;
     for (;;)
     {
-        _29 = counter == 10;
-        if (_29)
+        if (counter == 10)
         {
+            _33 = 10.0f.xxxx;
             break;
         }
         else
         {
+            _33 = 30.0f.xxxx;
             break;
         }
     }
-    bool4 _35 = _29.xxxx;
-    FragColor = float4(_35.x ? 10.0f.xxxx.x : 30.0f.xxxx.x, _35.y ? 10.0f.xxxx.y : 30.0f.xxxx.y, _35.z ? 10.0f.xxxx.z : 30.0f.xxxx.z, _35.w ? 10.0f.xxxx.w : 30.0f.xxxx.w);
+    FragColor = _33;
 }
 
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)

--- a/reference/opt/shaders-hlsl/asm/vert/vertex-id-instance-id.asm.vert
+++ b/reference/opt/shaders-hlsl/asm/vert/vertex-id-instance-id.asm.vert
@@ -1,10 +1,10 @@
 static float4 gl_Position;
-static int gl_VertexID;
-static int gl_InstanceID;
+static int gl_VertexIndex;
+static int gl_InstanceIndex;
 struct SPIRV_Cross_Input
 {
-    uint gl_VertexID : SV_VertexID;
-    uint gl_InstanceID : SV_InstanceID;
+    uint gl_VertexIndex : SV_VertexID;
+    uint gl_InstanceIndex : SV_InstanceID;
 };
 
 struct SPIRV_Cross_Output
@@ -14,13 +14,13 @@ struct SPIRV_Cross_Output
 
 void vert_main()
 {
-    gl_Position = float(gl_VertexID + gl_InstanceID).xxxx;
+    gl_Position = float(gl_VertexIndex + gl_InstanceIndex).xxxx;
 }
 
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
-    gl_VertexID = int(stage_input.gl_VertexID);
-    gl_InstanceID = int(stage_input.gl_InstanceID);
+    gl_VertexIndex = int(stage_input.gl_VertexIndex);
+    gl_InstanceIndex = int(stage_input.gl_InstanceIndex);
     vert_main();
     SPIRV_Cross_Output stage_output;
     stage_output.gl_Position = gl_Position;

--- a/reference/opt/shaders-hlsl/comp/spec-constant-op-member-array.comp
+++ b/reference/opt/shaders-hlsl/comp/spec-constant-op-member-array.comp
@@ -23,7 +23,7 @@ struct B
 #define SPIRV_CROSS_CONSTANT_ID_2 300
 #endif
 static const int c = SPIRV_CROSS_CONSTANT_ID_2;
-static const int _18 = (c + 50);
+static const int d = (c + 50);
 #ifndef SPIRV_CROSS_CONSTANT_ID_3
 #define SPIRV_CROSS_CONSTANT_ID_3 400
 #endif

--- a/reference/opt/shaders-hlsl/frag/spec-constant-ternary.frag
+++ b/reference/opt/shaders-hlsl/frag/spec-constant-ternary.frag
@@ -3,7 +3,7 @@
 #endif
 static const uint s = SPIRV_CROSS_CONSTANT_ID_0;
 static const bool _13 = (s > 20u);
-static const uint _16 = _13 ? 30u : 50u;
+static const uint f = _13 ? 30u : 50u;
 
 static float FragColor;
 
@@ -14,7 +14,7 @@ struct SPIRV_Cross_Output
 
 void frag_main()
 {
-    FragColor = float(_16);
+    FragColor = float(f);
 }
 
 SPIRV_Cross_Output main()

--- a/reference/opt/shaders-hlsl/vert/basic.vert
+++ b/reference/opt/shaders-hlsl/vert/basic.vert
@@ -1,4 +1,4 @@
-cbuffer UBO
+cbuffer UBO : register(b0)
 {
     row_major float4x4 _16_uMVP : packoffset(c0);
 };

--- a/reference/opt/shaders-msl/asm/frag/unreachable.asm.frag
+++ b/reference/opt/shaders-msl/asm/frag/unreachable.asm.frag
@@ -16,21 +16,21 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
-    bool _29;
+    float4 _33;
     for (;;)
     {
-        _29 = in.counter == 10;
-        if (_29)
+        if (in.counter == 10)
         {
+            _33 = float4(10.0);
             break;
         }
         else
         {
+            _33 = float4(30.0);
             break;
         }
     }
-    bool4 _35 = bool4(_29);
-    out.FragColor = float4(_35.x ? float4(10.0).x : float4(30.0).x, _35.y ? float4(10.0).y : float4(30.0).y, _35.z ? float4(10.0).z : float4(30.0).z, _35.w ? float4(10.0).w : float4(30.0).w);
+    out.FragColor = _33;
     return out;
 }
 

--- a/reference/opt/shaders-msl/comp/atomic.comp
+++ b/reference/opt/shaders-msl/comp/atomic.comp
@@ -40,6 +40,8 @@ kernel void main0(device SSBO& ssbo [[buffer(2)]])
     {
         _52 = 10;
     } while (!atomic_compare_exchange_weak_explicit((volatile device atomic_int*)&ssbo.i32, &_52, 2, memory_order_relaxed, memory_order_relaxed));
+    shared_u32 = 10u;
+    shared_i32 = 10;
     uint _57 = atomic_fetch_add_explicit((volatile threadgroup atomic_uint*)&shared_u32, 1u, memory_order_relaxed);
     uint _58 = atomic_fetch_or_explicit((volatile threadgroup atomic_uint*)&shared_u32, 1u, memory_order_relaxed);
     uint _59 = atomic_fetch_xor_explicit((volatile threadgroup atomic_uint*)&shared_u32, 1u, memory_order_relaxed);

--- a/reference/opt/shaders-msl/comp/bitcast-16bit-1.invalid.comp
+++ b/reference/opt/shaders-msl/comp/bitcast-16bit-1.invalid.comp
@@ -15,7 +15,7 @@ struct SSBO1
 
 kernel void main0(device SSBO0& _25 [[buffer(0)]], device SSBO1& _39 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
-    _39.outputs[gl_GlobalInvocationID.x].x = int(as_type<uint>(as_type<half2>(_25.inputs[gl_GlobalInvocationID.x].xy) + half2(half(1))));
+    _39.outputs[gl_GlobalInvocationID.x].x = int(as_type<uint>(as_type<half2>(_25.inputs[gl_GlobalInvocationID.x].xy) + half2(1.0h)));
     _39.outputs[gl_GlobalInvocationID.x].y = as_type<int>(_25.inputs[gl_GlobalInvocationID.x].zw);
     _39.outputs[gl_GlobalInvocationID.x].z = int(as_type<uint>(ushort2(_25.inputs[gl_GlobalInvocationID.x].xy)));
 }

--- a/reference/opt/shaders-msl/comp/spec-constant-op-member-array.comp
+++ b/reference/opt/shaders-msl/comp/spec-constant-op-member-array.comp
@@ -28,14 +28,14 @@ struct B
 #define SPIRV_CROSS_CONSTANT_ID_2 300
 #endif
 constant int c = SPIRV_CROSS_CONSTANT_ID_2;
-constant int _18 = (c + 50);
+constant int d = (c + 50);
 
 struct SSBO
 {
     A member_a;
     B member_b;
     int v[a];
-    int w[_18];
+    int w[d];
 };
 
 constant int e_tmp [[function_constant(3)]];

--- a/reference/opt/shaders-msl/frag/shader-arithmetic-8bit.frag
+++ b/reference/opt/shaders-msl/frag/shader-arithmetic-8bit.frag
@@ -32,7 +32,7 @@ struct main0_in
     int4 vColor [[user(locn0)]];
 };
 
-fragment main0_out main0(main0_in in [[stage_in]], constant Push& registers [[buffer(0)]], constant UBO& ubo [[buffer(0)]], device SSBO& ssbo [[buffer(1)]])
+fragment main0_out main0(main0_in in [[stage_in]], constant Push& registers [[buffer(0)]], constant UBO& ubo [[buffer(1)]], device SSBO& ssbo [[buffer(2)]])
 {
     main0_out out = {};
     short _196 = 10;

--- a/reference/opt/shaders-msl/frag/shader-arithmetic-8bit.frag
+++ b/reference/opt/shaders-msl/frag/shader-arithmetic-8bit.frag
@@ -1,0 +1,77 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct SSBO
+{
+    char i8[16];
+    uchar u8[16];
+};
+
+struct Push
+{
+    char i8;
+    uchar u8;
+};
+
+struct UBO
+{
+    char i8;
+    uchar u8;
+};
+
+struct main0_out
+{
+    int4 FragColorInt [[color(0)]];
+    uint4 FragColorUint [[color(1)]];
+};
+
+struct main0_in
+{
+    int4 vColor [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant Push& registers [[buffer(0)]], constant UBO& ubo [[buffer(0)]], device SSBO& ssbo [[buffer(1)]])
+{
+    main0_out out = {};
+    short _196 = 10;
+    int _197 = 20;
+    char2 _198 = as_type<char2>(_196);
+    char4 _199 = as_type<char4>(_197);
+    _196 = as_type<short>(_198);
+    _197 = as_type<int>(_199);
+    ssbo.i8[0] = _199.x;
+    ssbo.i8[1] = _199.y;
+    ssbo.i8[2] = _199.z;
+    ssbo.i8[3] = _199.w;
+    ushort _220 = 10u;
+    uint _221 = 20u;
+    uchar2 _222 = as_type<uchar2>(_220);
+    uchar4 _223 = as_type<uchar4>(_221);
+    _220 = as_type<ushort>(_222);
+    _221 = as_type<uint>(_223);
+    ssbo.u8[0] = _223.x;
+    ssbo.u8[1] = _223.y;
+    ssbo.u8[2] = _223.z;
+    ssbo.u8[3] = _223.w;
+    char4 _246 = char4(in.vColor);
+    char4 _244 = _246;
+    _244 += char4(registers.i8);
+    _244 += char4(-40);
+    _244 += char4(-50);
+    _244 += char4(char(10), char(20), char(30), char(40));
+    _244 += char4(ssbo.i8[4]);
+    _244 += char4(ubo.i8);
+    out.FragColorInt = int4(_244);
+    uchar4 _271 = uchar4(_246);
+    _271 += uchar4(registers.u8);
+    _271 += uchar4(216);
+    _271 += uchar4(206);
+    _271 += uchar4(uchar(10), uchar(20), uchar(30), uchar(40));
+    _271 += uchar4(ssbo.u8[4]);
+    _271 += uchar4(ubo.u8);
+    out.FragColorUint = uint4(_271);
+    return out;
+}
+

--- a/reference/opt/shaders-msl/frag/spec-constant-ternary.frag
+++ b/reference/opt/shaders-msl/frag/spec-constant-ternary.frag
@@ -6,7 +6,7 @@ using namespace metal;
 constant uint s_tmp [[function_constant(0)]];
 constant uint s = is_function_constant_defined(s_tmp) ? s_tmp : 10u;
 constant bool _13 = (s > 20u);
-constant uint _16 = _13 ? 30u : 50u;
+constant uint f = _13 ? 30u : 50u;
 
 struct main0_out
 {
@@ -16,7 +16,7 @@ struct main0_out
 fragment main0_out main0()
 {
     main0_out out = {};
-    out.FragColor = float(_16);
+    out.FragColor = float(f);
     return out;
 }
 

--- a/reference/opt/shaders-msl/vert/no_stage_out.write_buff.vert
+++ b/reference/opt/shaders-msl/vert/no_stage_out.write_buff.vert
@@ -27,10 +27,10 @@ vertex void main0(main0_in in [[stage_in]], constant _40& _42 [[buffer(0)]], dev
 {
     main0_out out = {};
     out.gl_Position = in.m_17;
-    for (int _51 = 0; _51 < 1024; )
+    for (int _52 = 0; _52 < 1024; )
     {
-        _37._m0[_51] = _42._m0[_51];
-        _51++;
+        _37._m0[_52] = _42._m0[_52];
+        _52++;
         continue;
     }
 }

--- a/reference/opt/shaders-msl/vert/resource-arrays-leaf.ios.vert
+++ b/reference/opt/shaders-msl/vert/resource-arrays-leaf.ios.vert
@@ -20,14 +20,8 @@ struct constant_block
 #endif
 constant int arraySize = SPIRV_CROSS_CONSTANT_ID_0;
 
-vertex void main0(device storage_block* storage_0 [[buffer(0)]], device storage_block* storage_1 [[buffer(1)]], constant constant_block* constants_0 [[buffer(2)]], constant constant_block* constants_1 [[buffer(3)]], constant constant_block* constants_2 [[buffer(4)]], constant constant_block* constants_3 [[buffer(5)]], array<texture2d<int>, 3> images [[texture(0)]])
+vertex void main0(constant constant_block* constants_0 [[buffer(4)]], constant constant_block* constants_1 [[buffer(5)]], constant constant_block* constants_2 [[buffer(6)]], constant constant_block* constants_3 [[buffer(7)]], device storage_block* storage_0 [[buffer(8)]], device storage_block* storage_1 [[buffer(9)]], array<texture2d<int>, 3> images [[texture(0)]])
 {
-    device storage_block* storage[] =
-    {
-        storage_0,
-        storage_1,
-    };
-    
     constant constant_block* constants[] =
     {
         constants_0,
@@ -35,7 +29,13 @@ vertex void main0(device storage_block* storage_0 [[buffer(0)]], device storage_
         constants_2,
         constants_3,
     };
-    
+
+    device storage_block* storage[] =
+    {
+        storage_0,
+        storage_1,
+    };
+
     storage[0]->baz = uint4(constants[3]->foo);
     storage[1]->quux = images[2].read(uint2(int2(constants[1]->bar))).xy;
 }

--- a/reference/opt/shaders-msl/vert/resource-arrays.ios.vert
+++ b/reference/opt/shaders-msl/vert/resource-arrays.ios.vert
@@ -20,20 +20,20 @@ struct constant_block
 #endif
 constant int arraySize = SPIRV_CROSS_CONSTANT_ID_0;
 
-vertex void main0(device storage_block* storage_0 [[buffer(0)]], device storage_block* storage_1 [[buffer(1)]], constant constant_block* constants_0 [[buffer(0)]], constant constant_block* constants_1 [[buffer(1)]], constant constant_block* constants_2 [[buffer(2)]], constant constant_block* constants_3 [[buffer(3)]], array<texture2d<int>, 3> images [[texture(0)]])
+vertex void main0(constant constant_block* constants_0 [[buffer(4)]], constant constant_block* constants_1 [[buffer(5)]], constant constant_block* constants_2 [[buffer(6)]], constant constant_block* constants_3 [[buffer(7)]], device storage_block* storage_0 [[buffer(8)]], device storage_block* storage_1 [[buffer(9)]], array<texture2d<int>, 3> images [[texture(0)]])
 {
-    device storage_block* storage[] =
-    {
-        storage_0,
-        storage_1,
-    };
-
     constant constant_block* constants[] =
     {
         constants_0,
         constants_1,
         constants_2,
         constants_3,
+    };
+
+    device storage_block* storage[] =
+    {
+        storage_0,
+        storage_1,
     };
 
     storage[0]->baz = uint4(constants[3]->foo);

--- a/reference/opt/shaders-msl/vert/resource-arrays.ios.vert
+++ b/reference/opt/shaders-msl/vert/resource-arrays.ios.vert
@@ -20,14 +20,14 @@ struct constant_block
 #endif
 constant int arraySize = SPIRV_CROSS_CONSTANT_ID_0;
 
-vertex void main0(device storage_block* storage_0 [[buffer(0)]], device storage_block* storage_1 [[buffer(1)]], constant constant_block* constants_0 [[buffer(2)]], constant constant_block* constants_1 [[buffer(3)]], constant constant_block* constants_2 [[buffer(4)]], constant constant_block* constants_3 [[buffer(5)]], array<texture2d<int>, 3> images [[texture(0)]])
+vertex void main0(device storage_block* storage_0 [[buffer(0)]], device storage_block* storage_1 [[buffer(1)]], constant constant_block* constants_0 [[buffer(0)]], constant constant_block* constants_1 [[buffer(1)]], constant constant_block* constants_2 [[buffer(2)]], constant constant_block* constants_3 [[buffer(3)]], array<texture2d<int>, 3> images [[texture(0)]])
 {
     device storage_block* storage[] =
     {
         storage_0,
         storage_1,
     };
-    
+
     constant constant_block* constants[] =
     {
         constants_0,
@@ -35,7 +35,7 @@ vertex void main0(device storage_block* storage_0 [[buffer(0)]], device storage_
         constants_2,
         constants_3,
     };
-    
+
     storage[0]->baz = uint4(constants[3]->foo);
     storage[1]->quux = images[2].read(uint2(int2(constants[1]->bar))).xy;
 }

--- a/reference/opt/shaders/asm/comp/hlsl-functionality.asm.comp
+++ b/reference/opt/shaders/asm/comp/hlsl-functionality.asm.comp
@@ -6,7 +6,7 @@ layout(binding = 0, std430) buffer Buf
     vec4 _data[];
 } Buf_1;
 
-layout(std430) buffer Buf_count
+layout(binding = 1, std430) buffer Buf_count
 {
     int _count;
 } Buf_count_1;

--- a/reference/opt/shaders/asm/frag/loop-body-dominator-continue-access.asm.frag
+++ b/reference/opt/shaders/asm/frag/loop-body-dominator-continue-access.asm.frag
@@ -14,17 +14,16 @@ int _240;
 
 void main()
 {
-    bool _246;
     uint _227;
-    int _237;
+    int _236;
     for (;;)
     {
         _227 = 0u;
-        bool _164;
+        bool _231;
+        int _237;
         for (;;)
         {
-            _164 = _227 < _11.shadowCascadesNum;
-            if (_164)
+            if (_227 < _11.shadowCascadesNum)
             {
                 mat4 _228;
                 for (;;)
@@ -44,6 +43,7 @@ void main()
                 if ((((_179 >= 0.0) && (_179 <= 1.0)) && (max(_186, _188) <= 1.0)) && (min(_186, _188) >= 0.0))
                 {
                     _237 = int(_227);
+                    _231 = true;
                     break;
                 }
                 else
@@ -57,16 +57,18 @@ void main()
             else
             {
                 _237 = _240;
+                _231 = false;
                 break;
             }
         }
-        _246 = _164 ? true : false;
-        if (_246)
+        if (_231)
         {
+            _236 = _237;
             break;
         }
+        _236 = -1;
         break;
     }
-    _entryPointOutput = _246 ? _237 : (-1);
+    _entryPointOutput = _236;
 }
 

--- a/reference/opt/shaders/asm/frag/temporary-phi-hoisting.asm.frag
+++ b/reference/opt/shaders/asm/frag/temporary-phi-hoisting.asm.frag
@@ -5,7 +5,7 @@ struct MyStruct
     vec4 color;
 };
 
-layout(std140) uniform MyStruct_CB
+layout(binding = 0, std140) uniform MyStruct_CB
 {
     MyStruct g_MyStruct[4];
 } _6;

--- a/reference/opt/shaders/asm/frag/unreachable.asm.frag
+++ b/reference/opt/shaders/asm/frag/unreachable.asm.frag
@@ -5,19 +5,20 @@ layout(location = 0) out vec4 FragColor;
 
 void main()
 {
-    bool _29;
+    vec4 _33;
     for (;;)
     {
-        _29 = counter == 10;
-        if (_29)
+        if (counter == 10)
         {
+            _33 = vec4(10.0);
             break;
         }
         else
         {
+            _33 = vec4(30.0);
             break;
         }
     }
-    FragColor = mix(vec4(30.0), vec4(10.0), bvec4(_29));
+    FragColor = _33;
 }
 

--- a/reference/opt/shaders/comp/bitcast-16bit-1.invalid.comp
+++ b/reference/opt/shaders/comp/bitcast-16bit-1.invalid.comp
@@ -3,15 +3,11 @@
 #extension GL_AMD_gpu_shader_half_float : require
 #elif defined(GL_NV_gpu_shader5)
 #extension GL_NV_gpu_shader5 : require
-#elif defined(GL_EXT_shader_16bit_storage)
-#extension GL_EXT_shader_16bit_storage : require
 #else
 #error No extension available for FP16.
 #endif
 #if defined(GL_AMD_gpu_shader_int16)
 #extension GL_AMD_gpu_shader_int16 : require
-#elif defined(GL_EXT_shader_16bit_storage)
-#extension GL_EXT_shader_16bit_storage : require
 #else
 #error No extension available for Int16.
 #endif

--- a/reference/opt/shaders/comp/bitcast-16bit-1.invalid.comp
+++ b/reference/opt/shaders/comp/bitcast-16bit-1.invalid.comp
@@ -31,7 +31,7 @@ void main()
 {
     uint ident = gl_GlobalInvocationID.x;
     f16vec2 a = int16BitsToFloat16(_25.inputs[ident].xy);
-    _39.outputs[ident].x = int(packFloat2x16(a + f16vec2(float16_t(1), float16_t(1))));
+    _39.outputs[ident].x = int(packFloat2x16(a + f16vec2(1.0hf)));
     _39.outputs[ident].y = packInt2x16(_25.inputs[ident].zw);
     _39.outputs[ident].z = int(packUint2x16(u16vec2(_25.inputs[ident].xy)));
 }

--- a/reference/opt/shaders/comp/bitcast-16bit-2.invalid.comp
+++ b/reference/opt/shaders/comp/bitcast-16bit-2.invalid.comp
@@ -1,8 +1,6 @@
 #version 450
 #if defined(GL_AMD_gpu_shader_int16)
 #extension GL_AMD_gpu_shader_int16 : require
-#elif defined(GL_EXT_shader_16bit_storage)
-#extension GL_EXT_shader_16bit_storage : require
 #else
 #error No extension available for Int16.
 #endif
@@ -10,8 +8,6 @@
 #extension GL_AMD_gpu_shader_half_float : require
 #elif defined(GL_NV_gpu_shader5)
 #extension GL_NV_gpu_shader5 : require
-#elif defined(GL_EXT_shader_16bit_storage)
-#extension GL_EXT_shader_16bit_storage : require
 #else
 #error No extension available for FP16.
 #endif

--- a/reference/opt/shaders/desktop-only/frag/fp16.invalid.desktop.frag
+++ b/reference/opt/shaders/desktop-only/frag/fp16.invalid.desktop.frag
@@ -3,8 +3,6 @@
 #extension GL_AMD_gpu_shader_half_float : require
 #elif defined(GL_NV_gpu_shader5)
 #extension GL_NV_gpu_shader5 : require
-#elif defined(GL_EXT_shader_16bit_storage)
-#extension GL_EXT_shader_16bit_storage : require
 #else
 #error No extension available for FP16.
 #endif

--- a/reference/opt/shaders/desktop-only/vert/basic.desktop.sso.vert
+++ b/reference/opt/shaders/desktop-only/vert/basic.desktop.sso.vert
@@ -5,7 +5,7 @@ out gl_PerVertex
     vec4 gl_Position;
 };
 
-layout(std140) uniform UBO
+layout(binding = 0, std140) uniform UBO
 {
     mat4 uMVP;
 } _16;

--- a/reference/opt/shaders/frag/16bit-constants.frag
+++ b/reference/opt/shaders/frag/16bit-constants.frag
@@ -3,15 +3,11 @@
 #extension GL_AMD_gpu_shader_half_float : require
 #elif defined(GL_NV_gpu_shader5)
 #extension GL_NV_gpu_shader5 : require
-#elif defined(GL_EXT_shader_16bit_storage)
-#extension GL_EXT_shader_16bit_storage : require
 #else
 #error No extension available for FP16.
 #endif
 #if defined(GL_AMD_gpu_shader_int16)
 #extension GL_AMD_gpu_shader_int16 : require
-#elif defined(GL_EXT_shader_16bit_storage)
-#extension GL_EXT_shader_16bit_storage : require
 #else
 #error No extension available for Int16.
 #endif

--- a/reference/opt/shaders/tesc/water_tess.tesc
+++ b/reference/opt/shaders/tesc/water_tess.tesc
@@ -2,7 +2,7 @@
 #extension GL_EXT_tessellation_shader : require
 layout(vertices = 1) out;
 
-layout(std140) uniform UBO
+layout(binding = 0, std140) uniform UBO
 {
     vec4 uScale;
     vec3 uCamPos;

--- a/reference/opt/shaders/vert/basic.vert
+++ b/reference/opt/shaders/vert/basic.vert
@@ -1,6 +1,6 @@
 #version 310 es
 
-layout(std140) uniform UBO
+layout(binding = 0, std140) uniform UBO
 {
     mat4 uMVP;
 } _16;

--- a/reference/opt/shaders/vulkan/comp/spec-constant-op-member-array.vk.comp
+++ b/reference/opt/shaders/vulkan/comp/spec-constant-op-member-array.vk.comp
@@ -26,7 +26,7 @@ struct B
 #define SPIRV_CROSS_CONSTANT_ID_2 300
 #endif
 const int c = SPIRV_CROSS_CONSTANT_ID_2;
-const int _18 = (c + 50);
+const int d = (c + 50);
 #ifndef SPIRV_CROSS_CONSTANT_ID_3
 #define SPIRV_CROSS_CONSTANT_ID_3 400
 #endif
@@ -37,7 +37,7 @@ layout(binding = 0, std430) buffer SSBO
     A member_a;
     B member_b;
     int v[a];
-    int w[_18];
+    int w[d];
 } _22;
 
 void main()

--- a/reference/opt/shaders/vulkan/comp/spec-constant-op-member-array.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/spec-constant-op-member-array.vk.comp.vk
@@ -17,7 +17,7 @@ struct B
 };
 
 layout(constant_id = 2) const int c = 300;
-const int _18 = (c + 50);
+const int d = (c + 50);
 layout(constant_id = 3) const int e = 400;
 
 layout(set = 1, binding = 0, std430) buffer SSBO
@@ -25,7 +25,7 @@ layout(set = 1, binding = 0, std430) buffer SSBO
     A member_a;
     B member_b;
     int v[a];
-    int w[_18];
+    int w[d];
 } _22;
 
 void main()

--- a/reference/opt/shaders/vulkan/frag/shader-arithmetic-8bit.nocompat.vk.frag.vk
+++ b/reference/opt/shaders/vulkan/frag/shader-arithmetic-8bit.nocompat.vk.frag.vk
@@ -1,0 +1,69 @@
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_EXT_shader_8bit_storage : require
+
+layout(set = 0, binding = 1, std430) buffer SSBO
+{
+    int8_t i8[16];
+    uint8_t u8[16];
+} ssbo;
+
+layout(set = 0, binding = 0, std140) uniform UBO
+{
+    int8_t i8;
+    uint8_t u8;
+} ubo;
+
+layout(push_constant, std430) uniform Push
+{
+    int8_t i8;
+    uint8_t u8;
+} registers;
+
+layout(location = 0) flat in ivec4 vColor;
+layout(location = 0) out ivec4 FragColorInt;
+layout(location = 1) out uvec4 FragColorUint;
+
+void main()
+{
+    int16_t _196 = 10s;
+    int _197 = 20;
+    i8vec2 _198 = unpack8(_196);
+    i8vec4 _199 = unpack8(_197);
+    _196 = pack16(_198);
+    _197 = pack32(_199);
+    ssbo.i8[0] = _199.x;
+    ssbo.i8[1] = _199.y;
+    ssbo.i8[2] = _199.z;
+    ssbo.i8[3] = _199.w;
+    uint16_t _220 = 10us;
+    uint _221 = 20u;
+    u8vec2 _222 = unpack8(_220);
+    u8vec4 _223 = unpack8(_221);
+    _220 = pack16(_222);
+    _221 = pack32(_223);
+    ssbo.u8[0] = _223.x;
+    ssbo.u8[1] = _223.y;
+    ssbo.u8[2] = _223.z;
+    ssbo.u8[3] = _223.w;
+    i8vec4 _246 = i8vec4(vColor);
+    i8vec4 _244 = _246;
+    _244 += i8vec4(registers.i8);
+    _244 += i8vec4(-40);
+    _244 += i8vec4(-50);
+    _244 += i8vec4(int8_t(10), int8_t(20), int8_t(30), int8_t(40));
+    _244 += i8vec4(ssbo.i8[4]);
+    _244 += i8vec4(ubo.i8);
+    FragColorInt = ivec4(_244);
+    u8vec4 _271 = u8vec4(_246);
+    _271 += u8vec4(registers.u8);
+    _271 += u8vec4(216);
+    _271 += u8vec4(206);
+    _271 += u8vec4(uint8_t(10), uint8_t(20), uint8_t(30), uint8_t(40));
+    _271 += u8vec4(ssbo.u8[4]);
+    _271 += u8vec4(ubo.u8);
+    FragColorUint = uvec4(_271);
+}
+

--- a/reference/opt/shaders/vulkan/frag/spec-constant-ternary.vk.frag
+++ b/reference/opt/shaders/vulkan/frag/spec-constant-ternary.vk.frag
@@ -5,12 +5,12 @@
 #endif
 const uint s = SPIRV_CROSS_CONSTANT_ID_0;
 const bool _13 = (s > 20u);
-const uint _16 = _13 ? 30u : 50u;
+const uint f = _13 ? 30u : 50u;
 
 layout(location = 0) out float FragColor;
 
 void main()
 {
-    FragColor = float(_16);
+    FragColor = float(f);
 }
 

--- a/reference/opt/shaders/vulkan/frag/spec-constant-ternary.vk.frag.vk
+++ b/reference/opt/shaders/vulkan/frag/spec-constant-ternary.vk.frag.vk
@@ -2,12 +2,12 @@
 
 layout(constant_id = 0) const uint s = 10u;
 const bool _13 = (s > 20u);
-const uint _16 = _13 ? 30u : 50u;
+const uint f = _13 ? 30u : 50u;
 
 layout(location = 0) out float FragColor;
 
 void main()
 {
-    FragColor = float(_16);
+    FragColor = float(f);
 }
 

--- a/reference/opt/shaders/vulkan/vert/small-storage.vk.vert
+++ b/reference/opt/shaders/vulkan/vert/small-storage.vk.vert
@@ -1,18 +1,14 @@
 #version 450
 #if defined(GL_AMD_gpu_shader_int16)
 #extension GL_AMD_gpu_shader_int16 : require
-#elif defined(GL_EXT_shader_16bit_storage)
-#extension GL_EXT_shader_16bit_storage : require
 #else
 #error No extension available for Int16.
 #endif
-#extension GL_EXT_shader_8bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #if defined(GL_AMD_gpu_shader_half_float)
 #extension GL_AMD_gpu_shader_half_float : require
 #elif defined(GL_NV_gpu_shader5)
 #extension GL_NV_gpu_shader5 : require
-#elif defined(GL_EXT_shader_16bit_storage)
-#extension GL_EXT_shader_16bit_storage : require
 #else
 #error No extension available for FP16.
 #endif

--- a/reference/opt/shaders/vulkan/vert/small-storage.vk.vert.vk
+++ b/reference/opt/shaders/vulkan/vert/small-storage.vk.vert.vk
@@ -1,16 +1,12 @@
 #version 450
-#if defined(GL_AMD_gpu_shader_int16)
-#extension GL_AMD_gpu_shader_int16 : require
-#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
 #extension GL_EXT_shader_16bit_storage : require
-#else
-#error No extension available for Int16.
-#endif
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_shader_8bit_storage : require
 #if defined(GL_AMD_gpu_shader_half_float)
 #extension GL_AMD_gpu_shader_half_float : require
-#elif defined(GL_EXT_shader_16bit_storage)
-#extension GL_EXT_shader_16bit_storage : require
+#elif defined(GL_EXT_shader_explicit_arithmetic_types_float16)
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
 #else
 #error No extension available for FP16.
 #endif

--- a/reference/shaders-hlsl/asm/vert/vertex-id-instance-id.asm.vert
+++ b/reference/shaders-hlsl/asm/vert/vertex-id-instance-id.asm.vert
@@ -1,10 +1,10 @@
 static float4 gl_Position;
-static int gl_VertexID;
-static int gl_InstanceID;
+static int gl_VertexIndex;
+static int gl_InstanceIndex;
 struct SPIRV_Cross_Input
 {
-    uint gl_VertexID : SV_VertexID;
-    uint gl_InstanceID : SV_InstanceID;
+    uint gl_VertexIndex : SV_VertexID;
+    uint gl_InstanceIndex : SV_InstanceID;
 };
 
 struct SPIRV_Cross_Output
@@ -14,13 +14,13 @@ struct SPIRV_Cross_Output
 
 void vert_main()
 {
-    gl_Position = float(gl_VertexID + gl_InstanceID).xxxx;
+    gl_Position = float(gl_VertexIndex + gl_InstanceIndex).xxxx;
 }
 
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
-    gl_VertexID = int(stage_input.gl_VertexID);
-    gl_InstanceID = int(stage_input.gl_InstanceID);
+    gl_VertexIndex = int(stage_input.gl_VertexIndex);
+    gl_InstanceIndex = int(stage_input.gl_InstanceIndex);
     vert_main();
     SPIRV_Cross_Output stage_output;
     stage_output.gl_Position = gl_Position;

--- a/reference/shaders-hlsl/comp/spec-constant-op-member-array.comp
+++ b/reference/shaders-hlsl/comp/spec-constant-op-member-array.comp
@@ -23,7 +23,7 @@ struct B
 #define SPIRV_CROSS_CONSTANT_ID_2 300
 #endif
 static const int c = SPIRV_CROSS_CONSTANT_ID_2;
-static const int _18 = (c + 50);
+static const int d = (c + 50);
 #ifndef SPIRV_CROSS_CONSTANT_ID_3
 #define SPIRV_CROSS_CONSTANT_ID_3 400
 #endif

--- a/reference/shaders-hlsl/frag/spec-constant-ternary.frag
+++ b/reference/shaders-hlsl/frag/spec-constant-ternary.frag
@@ -3,7 +3,7 @@
 #endif
 static const uint s = SPIRV_CROSS_CONSTANT_ID_0;
 static const bool _13 = (s > 20u);
-static const uint _16 = _13 ? 30u : 50u;
+static const uint f = _13 ? 30u : 50u;
 
 static float FragColor;
 
@@ -14,7 +14,7 @@ struct SPIRV_Cross_Output
 
 void frag_main()
 {
-    FragColor = float(_16);
+    FragColor = float(f);
 }
 
 SPIRV_Cross_Output main()

--- a/reference/shaders-hlsl/vert/basic.vert
+++ b/reference/shaders-hlsl/vert/basic.vert
@@ -1,4 +1,4 @@
-cbuffer UBO
+cbuffer UBO : register(b0)
 {
     row_major float4x4 _16_uMVP : packoffset(c0);
 };

--- a/reference/shaders-msl/comp/bitcast-16bit-1.invalid.comp
+++ b/reference/shaders-msl/comp/bitcast-16bit-1.invalid.comp
@@ -17,7 +17,7 @@ kernel void main0(device SSBO0& _25 [[buffer(0)]], device SSBO1& _39 [[buffer(1)
 {
     uint ident = gl_GlobalInvocationID.x;
     half2 a = as_type<half2>(_25.inputs[ident].xy);
-    _39.outputs[ident].x = int(as_type<uint>(a + half2(half(1), half(1))));
+    _39.outputs[ident].x = int(as_type<uint>(a + half2(1.0h)));
     _39.outputs[ident].y = as_type<int>(_25.inputs[ident].zw);
     _39.outputs[ident].z = int(as_type<uint>(ushort2(_25.inputs[ident].xy)));
 }

--- a/reference/shaders-msl/comp/spec-constant-op-member-array.comp
+++ b/reference/shaders-msl/comp/spec-constant-op-member-array.comp
@@ -28,14 +28,14 @@ struct B
 #define SPIRV_CROSS_CONSTANT_ID_2 300
 #endif
 constant int c = SPIRV_CROSS_CONSTANT_ID_2;
-constant int _18 = (c + 50);
+constant int d = (c + 50);
 
 struct SSBO
 {
     A member_a;
     B member_b;
     int v[a];
-    int w[_18];
+    int w[d];
 };
 
 constant int e_tmp [[function_constant(3)]];

--- a/reference/shaders-msl/frag/shader-arithmetic-8bit.frag
+++ b/reference/shaders-msl/frag/shader-arithmetic-8bit.frag
@@ -1,0 +1,98 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct SSBO
+{
+    char i8[16];
+    uchar u8[16];
+};
+
+struct Push
+{
+    char i8;
+    uchar u8;
+};
+
+struct UBO
+{
+    char i8;
+    uchar u8;
+};
+
+struct main0_out
+{
+    int4 FragColorInt [[color(0)]];
+    uint4 FragColorUint [[color(1)]];
+};
+
+struct main0_in
+{
+    int4 vColor [[user(locn0)]];
+};
+
+void packing_int8(device SSBO& ssbo)
+{
+    short i16 = 10;
+    int i32 = 20;
+    char2 i8_2 = as_type<char2>(i16);
+    char4 i8_4 = as_type<char4>(i32);
+    i16 = as_type<short>(i8_2);
+    i32 = as_type<int>(i8_4);
+    ssbo.i8[0] = i8_4.x;
+    ssbo.i8[1] = i8_4.y;
+    ssbo.i8[2] = i8_4.z;
+    ssbo.i8[3] = i8_4.w;
+}
+
+void packing_uint8(device SSBO& ssbo)
+{
+    ushort u16 = 10u;
+    uint u32 = 20u;
+    uchar2 u8_2 = as_type<uchar2>(u16);
+    uchar4 u8_4 = as_type<uchar4>(u32);
+    u16 = as_type<ushort>(u8_2);
+    u32 = as_type<uint>(u8_4);
+    ssbo.u8[0] = u8_4.x;
+    ssbo.u8[1] = u8_4.y;
+    ssbo.u8[2] = u8_4.z;
+    ssbo.u8[3] = u8_4.w;
+}
+
+void compute_int8(device SSBO& ssbo, thread int4& vColor, constant Push& registers, constant UBO& ubo, thread int4& FragColorInt)
+{
+    char4 tmp = char4(vColor);
+    tmp += char4(registers.i8);
+    tmp += char4(char(-40));
+    tmp += char4(-50);
+    tmp += char4(char(10), char(20), char(30), char(40));
+    tmp += char4(ssbo.i8[4]);
+    tmp += char4(ubo.i8);
+    FragColorInt = int4(tmp);
+}
+
+void compute_uint8(device SSBO& ssbo, thread int4& vColor, constant Push& registers, constant UBO& ubo, thread uint4& FragColorUint)
+{
+    uchar4 tmp = uchar4(char4(vColor));
+    tmp += uchar4(registers.u8);
+    tmp += uchar4(uchar(216));
+    tmp += uchar4(206);
+    tmp += uchar4(uchar(10), uchar(20), uchar(30), uchar(40));
+    tmp += uchar4(ssbo.u8[4]);
+    tmp += uchar4(ubo.u8);
+    FragColorUint = uint4(tmp);
+}
+
+fragment main0_out main0(main0_in in [[stage_in]], constant Push& registers [[buffer(0)]], constant UBO& ubo [[buffer(0)]], device SSBO& ssbo [[buffer(1)]])
+{
+    main0_out out = {};
+    packing_int8(ssbo);
+    packing_uint8(ssbo);
+    compute_int8(ssbo, in.vColor, registers, ubo, out.FragColorInt);
+    compute_uint8(ssbo, in.vColor, registers, ubo, out.FragColorUint);
+    return out;
+}
+

--- a/reference/shaders-msl/frag/shader-arithmetic-8bit.frag
+++ b/reference/shaders-msl/frag/shader-arithmetic-8bit.frag
@@ -86,7 +86,7 @@ void compute_uint8(device SSBO& ssbo, thread int4& vColor, constant Push& regist
     FragColorUint = uint4(tmp);
 }
 
-fragment main0_out main0(main0_in in [[stage_in]], constant Push& registers [[buffer(0)]], constant UBO& ubo [[buffer(0)]], device SSBO& ssbo [[buffer(1)]])
+fragment main0_out main0(main0_in in [[stage_in]], constant Push& registers [[buffer(0)]], constant UBO& ubo [[buffer(1)]], device SSBO& ssbo [[buffer(2)]])
 {
     main0_out out = {};
     packing_int8(ssbo);

--- a/reference/shaders-msl/frag/spec-constant-ternary.frag
+++ b/reference/shaders-msl/frag/spec-constant-ternary.frag
@@ -6,7 +6,7 @@ using namespace metal;
 constant uint s_tmp [[function_constant(0)]];
 constant uint s = is_function_constant_defined(s_tmp) ? s_tmp : 10u;
 constant bool _13 = (s > 20u);
-constant uint _16 = _13 ? 30u : 50u;
+constant uint f = _13 ? 30u : 50u;
 
 struct main0_out
 {
@@ -16,7 +16,7 @@ struct main0_out
 fragment main0_out main0()
 {
     main0_out out = {};
-    out.FragColor = float(_16);
+    out.FragColor = float(f);
     return out;
 }
 

--- a/reference/shaders-msl/vert/resource-arrays-leaf.ios.vert
+++ b/reference/shaders-msl/vert/resource-arrays-leaf.ios.vert
@@ -28,14 +28,8 @@ void doWork(device storage_block* (&storage)[2], constant constant_block* (&cons
     storage[1]->quux = images[2].read(uint2(int2(constants[1]->bar))).xy;
 }
 
-vertex void main0(device storage_block* storage_0 [[buffer(0)]], device storage_block* storage_1 [[buffer(1)]], constant constant_block* constants_0 [[buffer(2)]], constant constant_block* constants_1 [[buffer(3)]], constant constant_block* constants_2 [[buffer(4)]], constant constant_block* constants_3 [[buffer(5)]], array<texture2d<int>, 3> images [[texture(0)]])
+vertex void main0(constant constant_block* constants_0 [[buffer(4)]], constant constant_block* constants_1 [[buffer(5)]], constant constant_block* constants_2 [[buffer(6)]], constant constant_block* constants_3 [[buffer(7)]], device storage_block* storage_0 [[buffer(8)]], device storage_block* storage_1 [[buffer(9)]], array<texture2d<int>, 3> images [[texture(0)]])
 {
-    device storage_block* storage[] =
-    {
-        storage_0,
-        storage_1,
-    };
-    
     constant constant_block* constants[] =
     {
         constants_0,
@@ -43,7 +37,13 @@ vertex void main0(device storage_block* storage_0 [[buffer(0)]], device storage_
         constants_2,
         constants_3,
     };
-    
+
+    device storage_block* storage[] =
+    {
+        storage_0,
+        storage_1,
+    };
+
     doWork(storage, constants, images);
 }
 

--- a/reference/shaders-msl/vert/resource-arrays.ios.vert
+++ b/reference/shaders-msl/vert/resource-arrays.ios.vert
@@ -20,20 +20,20 @@ struct constant_block
 #endif
 constant int arraySize = SPIRV_CROSS_CONSTANT_ID_0;
 
-vertex void main0(device storage_block* storage_0 [[buffer(0)]], device storage_block* storage_1 [[buffer(1)]], constant constant_block* constants_0 [[buffer(0)]], constant constant_block* constants_1 [[buffer(1)]], constant constant_block* constants_2 [[buffer(2)]], constant constant_block* constants_3 [[buffer(3)]], array<texture2d<int>, 3> images [[texture(0)]])
+vertex void main0(constant constant_block* constants_0 [[buffer(4)]], constant constant_block* constants_1 [[buffer(5)]], constant constant_block* constants_2 [[buffer(6)]], constant constant_block* constants_3 [[buffer(7)]], device storage_block* storage_0 [[buffer(8)]], device storage_block* storage_1 [[buffer(9)]], array<texture2d<int>, 3> images [[texture(0)]])
 {
-    device storage_block* storage[] =
-    {
-        storage_0,
-        storage_1,
-    };
-
     constant constant_block* constants[] =
     {
         constants_0,
         constants_1,
         constants_2,
         constants_3,
+    };
+
+    device storage_block* storage[] =
+    {
+        storage_0,
+        storage_1,
     };
 
     storage[0]->baz = uint4(constants[3]->foo);

--- a/reference/shaders-msl/vert/resource-arrays.ios.vert
+++ b/reference/shaders-msl/vert/resource-arrays.ios.vert
@@ -20,14 +20,14 @@ struct constant_block
 #endif
 constant int arraySize = SPIRV_CROSS_CONSTANT_ID_0;
 
-vertex void main0(device storage_block* storage_0 [[buffer(0)]], device storage_block* storage_1 [[buffer(1)]], constant constant_block* constants_0 [[buffer(2)]], constant constant_block* constants_1 [[buffer(3)]], constant constant_block* constants_2 [[buffer(4)]], constant constant_block* constants_3 [[buffer(5)]], array<texture2d<int>, 3> images [[texture(0)]])
+vertex void main0(device storage_block* storage_0 [[buffer(0)]], device storage_block* storage_1 [[buffer(1)]], constant constant_block* constants_0 [[buffer(0)]], constant constant_block* constants_1 [[buffer(1)]], constant constant_block* constants_2 [[buffer(2)]], constant constant_block* constants_3 [[buffer(3)]], array<texture2d<int>, 3> images [[texture(0)]])
 {
     device storage_block* storage[] =
     {
         storage_0,
         storage_1,
     };
-    
+
     constant constant_block* constants[] =
     {
         constants_0,
@@ -35,7 +35,7 @@ vertex void main0(device storage_block* storage_0 [[buffer(0)]], device storage_
         constants_2,
         constants_3,
     };
-    
+
     storage[0]->baz = uint4(constants[3]->foo);
     storage[1]->quux = images[2].read(uint2(int2(constants[1]->bar))).xy;
 }

--- a/reference/shaders/asm/comp/hlsl-functionality.asm.comp
+++ b/reference/shaders/asm/comp/hlsl-functionality.asm.comp
@@ -6,7 +6,7 @@ layout(binding = 0, std430) buffer Buf
     vec4 _data[];
 } Buf_1;
 
-layout(std430) buffer Buf_count
+layout(binding = 1, std430) buffer Buf_count
 {
     int _count;
 } Buf_count_1;

--- a/reference/shaders/asm/frag/temporary-phi-hoisting.asm.frag
+++ b/reference/shaders/asm/frag/temporary-phi-hoisting.asm.frag
@@ -5,7 +5,7 @@ struct MyStruct
     vec4 color;
 };
 
-layout(std140) uniform MyStruct_CB
+layout(binding = 0, std140) uniform MyStruct_CB
 {
     MyStruct g_MyStruct[4];
 } _6;

--- a/reference/shaders/comp/bitcast-16bit-1.invalid.comp
+++ b/reference/shaders/comp/bitcast-16bit-1.invalid.comp
@@ -3,15 +3,11 @@
 #extension GL_AMD_gpu_shader_half_float : require
 #elif defined(GL_NV_gpu_shader5)
 #extension GL_NV_gpu_shader5 : require
-#elif defined(GL_EXT_shader_16bit_storage)
-#extension GL_EXT_shader_16bit_storage : require
 #else
 #error No extension available for FP16.
 #endif
 #if defined(GL_AMD_gpu_shader_int16)
 #extension GL_AMD_gpu_shader_int16 : require
-#elif defined(GL_EXT_shader_16bit_storage)
-#extension GL_EXT_shader_16bit_storage : require
 #else
 #error No extension available for Int16.
 #endif

--- a/reference/shaders/comp/bitcast-16bit-1.invalid.comp
+++ b/reference/shaders/comp/bitcast-16bit-1.invalid.comp
@@ -31,7 +31,7 @@ void main()
 {
     uint ident = gl_GlobalInvocationID.x;
     f16vec2 a = int16BitsToFloat16(_25.inputs[ident].xy);
-    _39.outputs[ident].x = int(packFloat2x16(a + f16vec2(float16_t(1), float16_t(1))));
+    _39.outputs[ident].x = int(packFloat2x16(a + f16vec2(1.0hf)));
     _39.outputs[ident].y = packInt2x16(_25.inputs[ident].zw);
     _39.outputs[ident].z = int(packUint2x16(u16vec2(_25.inputs[ident].xy)));
 }

--- a/reference/shaders/comp/bitcast-16bit-2.invalid.comp
+++ b/reference/shaders/comp/bitcast-16bit-2.invalid.comp
@@ -1,8 +1,6 @@
 #version 450
 #if defined(GL_AMD_gpu_shader_int16)
 #extension GL_AMD_gpu_shader_int16 : require
-#elif defined(GL_EXT_shader_16bit_storage)
-#extension GL_EXT_shader_16bit_storage : require
 #else
 #error No extension available for Int16.
 #endif
@@ -10,8 +8,6 @@
 #extension GL_AMD_gpu_shader_half_float : require
 #elif defined(GL_NV_gpu_shader5)
 #extension GL_NV_gpu_shader5 : require
-#elif defined(GL_EXT_shader_16bit_storage)
-#extension GL_EXT_shader_16bit_storage : require
 #else
 #error No extension available for FP16.
 #endif

--- a/reference/shaders/desktop-only/frag/fp16.invalid.desktop.frag
+++ b/reference/shaders/desktop-only/frag/fp16.invalid.desktop.frag
@@ -3,8 +3,6 @@
 #extension GL_AMD_gpu_shader_half_float : require
 #elif defined(GL_NV_gpu_shader5)
 #extension GL_NV_gpu_shader5 : require
-#elif defined(GL_EXT_shader_16bit_storage)
-#extension GL_EXT_shader_16bit_storage : require
 #else
 #error No extension available for FP16.
 #endif

--- a/reference/shaders/desktop-only/vert/basic.desktop.sso.vert
+++ b/reference/shaders/desktop-only/vert/basic.desktop.sso.vert
@@ -5,7 +5,7 @@ out gl_PerVertex
     vec4 gl_Position;
 };
 
-layout(std140) uniform UBO
+layout(binding = 0, std140) uniform UBO
 {
     mat4 uMVP;
 } _16;

--- a/reference/shaders/frag/16bit-constants.frag
+++ b/reference/shaders/frag/16bit-constants.frag
@@ -3,15 +3,11 @@
 #extension GL_AMD_gpu_shader_half_float : require
 #elif defined(GL_NV_gpu_shader5)
 #extension GL_NV_gpu_shader5 : require
-#elif defined(GL_EXT_shader_16bit_storage)
-#extension GL_EXT_shader_16bit_storage : require
 #else
 #error No extension available for FP16.
 #endif
 #if defined(GL_AMD_gpu_shader_int16)
 #extension GL_AMD_gpu_shader_int16 : require
-#elif defined(GL_EXT_shader_16bit_storage)
-#extension GL_EXT_shader_16bit_storage : require
 #else
 #error No extension available for Int16.
 #endif

--- a/reference/shaders/tesc/water_tess.tesc
+++ b/reference/shaders/tesc/water_tess.tesc
@@ -2,7 +2,7 @@
 #extension GL_EXT_tessellation_shader : require
 layout(vertices = 1) out;
 
-layout(std140) uniform UBO
+layout(binding = 0, std140) uniform UBO
 {
     vec4 uScale;
     vec3 uCamPos;

--- a/reference/shaders/vert/basic.vert
+++ b/reference/shaders/vert/basic.vert
@@ -1,6 +1,6 @@
 #version 310 es
 
-layout(std140) uniform UBO
+layout(binding = 0, std140) uniform UBO
 {
     mat4 uMVP;
 } _16;

--- a/reference/shaders/vulkan/comp/spec-constant-op-member-array.vk.comp
+++ b/reference/shaders/vulkan/comp/spec-constant-op-member-array.vk.comp
@@ -26,7 +26,7 @@ struct B
 #define SPIRV_CROSS_CONSTANT_ID_2 300
 #endif
 const int c = SPIRV_CROSS_CONSTANT_ID_2;
-const int _18 = (c + 50);
+const int d = (c + 50);
 #ifndef SPIRV_CROSS_CONSTANT_ID_3
 #define SPIRV_CROSS_CONSTANT_ID_3 400
 #endif
@@ -37,7 +37,7 @@ layout(binding = 0, std430) buffer SSBO
     A member_a;
     B member_b;
     int v[a];
-    int w[_18];
+    int w[d];
 } _22;
 
 void main()

--- a/reference/shaders/vulkan/comp/spec-constant-op-member-array.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/spec-constant-op-member-array.vk.comp.vk
@@ -17,7 +17,7 @@ struct B
 };
 
 layout(constant_id = 2) const int c = 300;
-const int _18 = (c + 50);
+const int d = (c + 50);
 layout(constant_id = 3) const int e = 400;
 
 layout(set = 1, binding = 0, std430) buffer SSBO
@@ -25,7 +25,7 @@ layout(set = 1, binding = 0, std430) buffer SSBO
     A member_a;
     B member_b;
     int v[a];
-    int w[_18];
+    int w[d];
 } _22;
 
 void main()

--- a/reference/shaders/vulkan/frag/shader-arithmetic-8bit.nocompat.vk.frag.vk
+++ b/reference/shaders/vulkan/frag/shader-arithmetic-8bit.nocompat.vk.frag.vk
@@ -1,0 +1,88 @@
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_EXT_shader_8bit_storage : require
+
+layout(set = 0, binding = 1, std430) buffer SSBO
+{
+    int8_t i8[16];
+    uint8_t u8[16];
+} ssbo;
+
+layout(set = 0, binding = 0, std140) uniform UBO
+{
+    int8_t i8;
+    uint8_t u8;
+} ubo;
+
+layout(push_constant, std430) uniform Push
+{
+    int8_t i8;
+    uint8_t u8;
+} registers;
+
+layout(location = 0) flat in ivec4 vColor;
+layout(location = 0) out ivec4 FragColorInt;
+layout(location = 1) out uvec4 FragColorUint;
+
+void packing_int8()
+{
+    int16_t i16 = 10s;
+    int i32 = 20;
+    i8vec2 i8_2 = unpack8(i16);
+    i8vec4 i8_4 = unpack8(i32);
+    i16 = pack16(i8_2);
+    i32 = pack32(i8_4);
+    ssbo.i8[0] = i8_4.x;
+    ssbo.i8[1] = i8_4.y;
+    ssbo.i8[2] = i8_4.z;
+    ssbo.i8[3] = i8_4.w;
+}
+
+void packing_uint8()
+{
+    uint16_t u16 = 10us;
+    uint u32 = 20u;
+    u8vec2 u8_2 = unpack8(u16);
+    u8vec4 u8_4 = unpack8(u32);
+    u16 = pack16(u8_2);
+    u32 = pack32(u8_4);
+    ssbo.u8[0] = u8_4.x;
+    ssbo.u8[1] = u8_4.y;
+    ssbo.u8[2] = u8_4.z;
+    ssbo.u8[3] = u8_4.w;
+}
+
+void compute_int8()
+{
+    i8vec4 tmp = i8vec4(vColor);
+    tmp += i8vec4(registers.i8);
+    tmp += i8vec4(int8_t(-40));
+    tmp += i8vec4(-50);
+    tmp += i8vec4(int8_t(10), int8_t(20), int8_t(30), int8_t(40));
+    tmp += i8vec4(ssbo.i8[4]);
+    tmp += i8vec4(ubo.i8);
+    FragColorInt = ivec4(tmp);
+}
+
+void compute_uint8()
+{
+    u8vec4 tmp = u8vec4(i8vec4(vColor));
+    tmp += u8vec4(registers.u8);
+    tmp += u8vec4(uint8_t(216));
+    tmp += u8vec4(206);
+    tmp += u8vec4(uint8_t(10), uint8_t(20), uint8_t(30), uint8_t(40));
+    tmp += u8vec4(ssbo.u8[4]);
+    tmp += u8vec4(ubo.u8);
+    FragColorUint = uvec4(tmp);
+}
+
+void main()
+{
+    packing_int8();
+    packing_uint8();
+    compute_int8();
+    compute_uint8();
+}
+

--- a/reference/shaders/vulkan/frag/spec-constant-ternary.vk.frag
+++ b/reference/shaders/vulkan/frag/spec-constant-ternary.vk.frag
@@ -5,12 +5,12 @@
 #endif
 const uint s = SPIRV_CROSS_CONSTANT_ID_0;
 const bool _13 = (s > 20u);
-const uint _16 = _13 ? 30u : 50u;
+const uint f = _13 ? 30u : 50u;
 
 layout(location = 0) out float FragColor;
 
 void main()
 {
-    FragColor = float(_16);
+    FragColor = float(f);
 }
 

--- a/reference/shaders/vulkan/frag/spec-constant-ternary.vk.frag.vk
+++ b/reference/shaders/vulkan/frag/spec-constant-ternary.vk.frag.vk
@@ -2,12 +2,12 @@
 
 layout(constant_id = 0) const uint s = 10u;
 const bool _13 = (s > 20u);
-const uint _16 = _13 ? 30u : 50u;
+const uint f = _13 ? 30u : 50u;
 
 layout(location = 0) out float FragColor;
 
 void main()
 {
-    FragColor = float(_16);
+    FragColor = float(f);
 }
 

--- a/reference/shaders/vulkan/vert/small-storage.vk.vert
+++ b/reference/shaders/vulkan/vert/small-storage.vk.vert
@@ -1,18 +1,14 @@
 #version 450
 #if defined(GL_AMD_gpu_shader_int16)
 #extension GL_AMD_gpu_shader_int16 : require
-#elif defined(GL_EXT_shader_16bit_storage)
-#extension GL_EXT_shader_16bit_storage : require
 #else
 #error No extension available for Int16.
 #endif
-#extension GL_EXT_shader_8bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #if defined(GL_AMD_gpu_shader_half_float)
 #extension GL_AMD_gpu_shader_half_float : require
 #elif defined(GL_NV_gpu_shader5)
 #extension GL_NV_gpu_shader5 : require
-#elif defined(GL_EXT_shader_16bit_storage)
-#extension GL_EXT_shader_16bit_storage : require
 #else
 #error No extension available for FP16.
 #endif

--- a/reference/shaders/vulkan/vert/small-storage.vk.vert.vk
+++ b/reference/shaders/vulkan/vert/small-storage.vk.vert.vk
@@ -1,16 +1,12 @@
 #version 450
-#if defined(GL_AMD_gpu_shader_int16)
-#extension GL_AMD_gpu_shader_int16 : require
-#elif defined(GL_EXT_shader_16bit_storage)
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
 #extension GL_EXT_shader_16bit_storage : require
-#else
-#error No extension available for Int16.
-#endif
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_shader_8bit_storage : require
 #if defined(GL_AMD_gpu_shader_half_float)
 #extension GL_AMD_gpu_shader_half_float : require
-#elif defined(GL_EXT_shader_16bit_storage)
-#extension GL_EXT_shader_16bit_storage : require
+#elif defined(GL_EXT_shader_explicit_arithmetic_types_float16)
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
 #else
 #error No extension available for FP16.
 #endif

--- a/shaders-hlsl-no-opt/asm/vert/empty-struct-composite.asm.vert
+++ b/shaders-hlsl-no-opt/asm/vert/empty-struct-composite.asm.vert
@@ -7,7 +7,6 @@
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %2 "main"
-               OpExecutionMode %2 OriginUpperLeft
                OpName %Test "Test"
                OpName %t "t"
                OpName %retvar "retvar"

--- a/shaders-hlsl/asm/vert/vertex-id-instance-id.asm.vert
+++ b/shaders-hlsl/asm/vert/vertex-id-instance-id.asm.vert
@@ -22,8 +22,8 @@
                OpMemberDecorate %gl_PerVertex 2 BuiltIn ClipDistance
                OpMemberDecorate %gl_PerVertex 3 BuiltIn CullDistance
                OpDecorate %gl_PerVertex Block
-               OpDecorate %gl_VertexID BuiltIn VertexId
-               OpDecorate %gl_InstanceID BuiltIn InstanceId
+               OpDecorate %gl_VertexID BuiltIn VertexIndex
+               OpDecorate %gl_InstanceID BuiltIn InstanceIndex
        %void = OpTypeVoid
           %3 = OpTypeFunction %void
       %float = OpTypeFloat 32

--- a/shaders-msl-no-opt/asm/vert/empty-struct-composite.asm.vert
+++ b/shaders-msl-no-opt/asm/vert/empty-struct-composite.asm.vert
@@ -7,7 +7,6 @@
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %2 "main"
-               OpExecutionMode %2 OriginUpperLeft
                OpName %Test "Test"
                OpName %t "t"
                OpName %retvar "retvar"

--- a/shaders-msl/asm/comp/buffer-write.asm.comp
+++ b/shaders-msl/asm/comp/buffer-write.asm.comp
@@ -22,6 +22,7 @@
                OpDecorate %_ DescriptorSet 0
                OpDecorate %_ Binding 7
                OpDecorate %buffer DescriptorSet 0
+               OpDecorate %buffer Binding 0
                OpDecorate %group_id BuiltIn WorkgroupId
                OpDecorate %group_index BuiltIn LocalInvocationIndex
        %void = OpTypeVoid

--- a/shaders-msl/asm/comp/multiple-entry.asm.comp
+++ b/shaders-msl/asm/comp/multiple-entry.asm.comp
@@ -9,6 +9,7 @@
                OpEntryPoint Fragment %func_alt "main2" %frag_in %frag_out
                OpEntryPoint GLCompute %func "main"
                OpExecutionMode %func LocalSize 1 1 1
+               OpExecutionMode %func_alt OriginUpperLeft
                OpSource ESSL 310
                OpSourceExtension "GL_GOOGLE_cpp_style_line_directive"
                OpSourceExtension "GL_GOOGLE_include_directive"

--- a/shaders-msl/asm/comp/struct-resource-name-aliasing.asm.comp
+++ b/shaders-msl/asm/comp/struct-resource-name-aliasing.asm.comp
@@ -20,6 +20,8 @@
                OpDecorate %bufA BufferBlock
                OpDecorate %bufA_0 DescriptorSet 0
                OpDecorate %bufB DescriptorSet 0
+               OpDecorate %bufA_0 Binding 0
+               OpDecorate %bufB Binding 1
        %void = OpTypeVoid
           %3 = OpTypeFunction %void
        %uint = OpTypeInt 32 0

--- a/shaders-msl/asm/frag/default-member-names.asm.frag
+++ b/shaders-msl/asm/frag/default-member-names.asm.frag
@@ -7,7 +7,7 @@
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %2 "main" %3
-               OpExecutionMode %2 OriginLowerLeft
+               OpExecutionMode %2 OriginUpperLeft
                OpDecorate %3 Location 0
        %void = OpTypeVoid
           %9 = OpTypeFunction %void

--- a/shaders-msl/asm/frag/extract-packed-from-composite.asm.frag
+++ b/shaders-msl/asm/frag/extract-packed-from-composite.asm.frag
@@ -34,6 +34,7 @@
                OpMemberDecorate %buf 1 Offset 256
                OpDecorate %buf Block
                OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 0
                OpDecorate %pos_1 BuiltIn FragCoord
                OpDecorate %_entryPointOutput Location 0
        %void = OpTypeVoid

--- a/shaders-msl/asm/frag/locations-components.asm.frag
+++ b/shaders-msl/asm/frag/locations-components.asm.frag
@@ -6,6 +6,7 @@
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %8 %16 %22 %28 %33 %o0
+			   OpExecutionMode %main OriginUpperLeft
                OpName %main "main"
                OpName %v1 "v1"
                OpName %v2 "v2"

--- a/shaders-msl/asm/frag/op-image-sampled-image.asm.frag
+++ b/shaders-msl/asm/frag/op-image-sampled-image.asm.frag
@@ -6,6 +6,7 @@
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %o0
+			   OpExecutionMode %main OriginUpperLeft
                OpName %main "main"
                OpName %t0 "t0"
                OpName %o0 "o0"

--- a/shaders-msl/frag/shader-arithmetic-8bit.frag
+++ b/shaders-msl/frag/shader-arithmetic-8bit.frag
@@ -1,0 +1,88 @@
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+
+layout(location = 0) flat in ivec4 vColor;
+layout(location = 0) out ivec4 FragColorInt;
+layout(location = 1) out uvec4 FragColorUint;
+
+layout(push_constant, std140) uniform Push
+{
+	int8_t i8;
+	uint8_t u8;
+} registers;
+
+layout(binding = 0, std140) uniform UBO
+{
+	int8_t i8;
+	uint8_t u8;
+} ubo;
+
+layout(binding = 1, std430) buffer SSBO
+{
+	int8_t i8[16];
+	uint8_t u8[16];
+} ssbo;
+
+void packing_int8()
+{
+	int16_t i16 = 10s;
+	int i32 = 20;
+
+	i8vec2 i8_2 = unpack8(i16);
+	i8vec4 i8_4 = unpack8(i32);
+	i16 = pack16(i8_2);
+	i32 = pack32(i8_4);
+	ssbo.i8[0] = i8_4.x;
+	ssbo.i8[1] = i8_4.y;
+	ssbo.i8[2] = i8_4.z;
+	ssbo.i8[3] = i8_4.w;
+}
+
+void packing_uint8()
+{
+	uint16_t u16 = 10us;
+	uint u32 = 20u;
+
+	u8vec2 u8_2 = unpack8(u16);
+	u8vec4 u8_4 = unpack8(u32);
+	u16 = pack16(u8_2);
+	u32 = pack32(u8_4);
+
+	ssbo.u8[0] = u8_4.x;
+	ssbo.u8[1] = u8_4.y;
+	ssbo.u8[2] = u8_4.z;
+	ssbo.u8[3] = u8_4.w;
+}
+
+void compute_int8()
+{
+	i8vec4 tmp = i8vec4(vColor);
+	tmp += registers.i8;
+	tmp += int8_t(-40);
+	tmp += i8vec4(-50);
+	tmp += i8vec4(10, 20, 30, 40);
+	tmp += ssbo.i8[4];
+	tmp += ubo.i8;
+	FragColorInt = ivec4(tmp);
+}
+
+void compute_uint8()
+{
+	u8vec4 tmp = u8vec4(vColor);
+	tmp += registers.u8;
+	tmp += uint8_t(-40);
+	tmp += u8vec4(-50);
+	tmp += u8vec4(10, 20, 30, 40);
+	tmp += ssbo.u8[4];
+	tmp += ubo.u8;
+	FragColorUint = uvec4(tmp);
+}
+
+void main()
+{
+	packing_int8();
+	packing_uint8();
+	compute_int8();
+	compute_uint8();
+}

--- a/shaders-msl/frag/shader-arithmetic-8bit.frag
+++ b/shaders-msl/frag/shader-arithmetic-8bit.frag
@@ -12,13 +12,13 @@ layout(push_constant, std140) uniform Push
 	uint8_t u8;
 } registers;
 
-layout(binding = 0, std140) uniform UBO
+layout(binding = 1, std140) uniform UBO
 {
 	int8_t i8;
 	uint8_t u8;
 } ubo;
 
-layout(binding = 1, std430) buffer SSBO
+layout(binding = 2, std430) buffer SSBO
 {
 	int8_t i8[16];
 	uint8_t u8[16];

--- a/shaders-msl/vert/resource-arrays-leaf.ios.vert
+++ b/shaders-msl/vert/resource-arrays-leaf.ios.vert
@@ -3,12 +3,13 @@
 layout(constant_id = 0) const int arraySize = 3;
 
 layout(binding = 0, rgba32i) uniform iimage2D images[arraySize];
-uniform constant_block
+layout(binding = 4) uniform constant_block
 {
 	vec4 foo;
 	int bar;
 } constants[4];
-buffer storage_block
+
+layout(binding = 8) buffer storage_block
 {
 	uvec4 baz;
 	ivec2 quux;

--- a/shaders-msl/vert/resource-arrays.ios.vert
+++ b/shaders-msl/vert/resource-arrays.ios.vert
@@ -3,12 +3,14 @@
 layout(constant_id = 0) const int arraySize = 3;
 
 layout(binding = 0, rgba32i) uniform iimage2D images[arraySize];
-uniform constant_block
+
+layout(binding = 4) uniform constant_block
 {
 	vec4 foo;
 	int bar;
 } constants[4];
-buffer storage_block
+
+layout(binding = 8) buffer storage_block
 {
 	uvec4 baz;
 	ivec2 quux;

--- a/shaders-no-opt/asm/vert/empty-struct-composite.asm.vert
+++ b/shaders-no-opt/asm/vert/empty-struct-composite.asm.vert
@@ -7,7 +7,6 @@
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %2 "main"
-               OpExecutionMode %2 OriginUpperLeft
                OpName %Test "Test"
                OpName %t "t"
                OpName %retvar "retvar"

--- a/shaders/asm/comp/hlsl-functionality.asm.comp
+++ b/shaders/asm/comp/hlsl-functionality.asm.comp
@@ -26,6 +26,7 @@
                OpMemberDecorate %Buf_count 0 Offset 0
                OpDecorate %Buf_count BufferBlock
                OpDecorate %Buf_count_0 DescriptorSet 0
+               OpDecorate %Buf_count_0 Binding 1
                OpDecorateId %Buf_0 HlslCounterBufferGOOGLE %Buf_count_0
        %void = OpTypeVoid
           %3 = OpTypeFunction %void

--- a/shaders/asm/comp/multiple-entry.asm.comp
+++ b/shaders/asm/comp/multiple-entry.asm.comp
@@ -9,6 +9,7 @@
                OpEntryPoint Fragment %func_alt "main2" %frag_in %frag_out
                OpEntryPoint GLCompute %func "main"
                OpExecutionMode %func LocalSize 1 1 1
+               OpExecutionMode %func_alt OriginUpperLeft
                OpSource ESSL 310
                OpSourceExtension "GL_GOOGLE_cpp_style_line_directive"
                OpSourceExtension "GL_GOOGLE_include_directive"

--- a/shaders/asm/frag/default-member-names.asm.frag
+++ b/shaders/asm/frag/default-member-names.asm.frag
@@ -7,7 +7,7 @@
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %2 "main" %3
-               OpExecutionMode %2 OriginLowerLeft
+               OpExecutionMode %2 OriginUpperLeft
                OpDecorate %3 Location 0
        %void = OpTypeVoid
           %9 = OpTypeFunction %void

--- a/shaders/asm/frag/locations-components.asm.frag
+++ b/shaders/asm/frag/locations-components.asm.frag
@@ -6,6 +6,7 @@
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %8 %16 %22 %28 %33 %o0
+			   OpExecutionMode %main OriginUpperLeft
                OpName %main "main"
                OpName %v1 "v1"
                OpName %v2 "v2"

--- a/shaders/asm/frag/temporary-phi-hoisting.asm.frag
+++ b/shaders/asm/frag/temporary-phi-hoisting.asm.frag
@@ -21,6 +21,7 @@
                OpMemberDecorate %MyStruct_CB 0 Offset 0
                OpDecorate %MyStruct_CB Block
                OpDecorate %_ DescriptorSet 0
+			   OpDecorate %_ Binding 0
                OpDecorate %_entryPointOutput Location 0
        %void = OpTypeVoid
           %3 = OpTypeFunction %void

--- a/shaders/vulkan/frag/shader-arithmetic-8bit.nocompat.vk.frag
+++ b/shaders/vulkan/frag/shader-arithmetic-8bit.nocompat.vk.frag
@@ -1,0 +1,88 @@
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+
+layout(location = 0) flat in ivec4 vColor;
+layout(location = 0) out ivec4 FragColorInt;
+layout(location = 1) out uvec4 FragColorUint;
+
+layout(push_constant, std140) uniform Push
+{
+	int8_t i8;
+	uint8_t u8;
+} registers;
+
+layout(binding = 0, std140) uniform UBO
+{
+	int8_t i8;
+	uint8_t u8;
+} ubo;
+
+layout(binding = 1, std430) buffer SSBO
+{
+	int8_t i8[16];
+	uint8_t u8[16];
+} ssbo;
+
+void packing_int8()
+{
+	int16_t i16 = 10s;
+	int i32 = 20;
+
+	i8vec2 i8_2 = unpack8(i16);
+	i8vec4 i8_4 = unpack8(i32);
+	i16 = pack16(i8_2);
+	i32 = pack32(i8_4);
+	ssbo.i8[0] = i8_4.x;
+	ssbo.i8[1] = i8_4.y;
+	ssbo.i8[2] = i8_4.z;
+	ssbo.i8[3] = i8_4.w;
+}
+
+void packing_uint8()
+{
+	uint16_t u16 = 10us;
+	uint u32 = 20u;
+
+	u8vec2 u8_2 = unpack8(u16);
+	u8vec4 u8_4 = unpack8(u32);
+	u16 = pack16(u8_2);
+	u32 = pack32(u8_4);
+
+	ssbo.u8[0] = u8_4.x;
+	ssbo.u8[1] = u8_4.y;
+	ssbo.u8[2] = u8_4.z;
+	ssbo.u8[3] = u8_4.w;
+}
+
+void compute_int8()
+{
+	i8vec4 tmp = i8vec4(vColor);
+	tmp += registers.i8;
+	tmp += int8_t(-40);
+	tmp += i8vec4(-50);
+	tmp += i8vec4(10, 20, 30, 40);
+	tmp += ssbo.i8[4];
+	tmp += ubo.i8;
+	FragColorInt = ivec4(tmp);
+}
+
+void compute_uint8()
+{
+	u8vec4 tmp = u8vec4(vColor);
+	tmp += registers.u8;
+	tmp += uint8_t(-40);
+	tmp += u8vec4(-50);
+	tmp += u8vec4(10, 20, 30, 40);
+	tmp += ssbo.u8[4];
+	tmp += ubo.u8;
+	FragColorUint = uvec4(tmp);
+}
+
+void main()
+{
+	packing_int8();
+	packing_uint8();
+	compute_int8();
+	compute_uint8();
+}

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -1047,6 +1047,16 @@ struct SPIRConstant : IVariant
 		return uint16_t(m.c[col].r[row].u32 & 0xffffu);
 	}
 
+	inline int8_t scalar_i8(uint32_t col = 0, uint32_t row = 0) const
+	{
+		return int8_t(m.c[col].r[row].u32 & 0xffu);
+	}
+
+	inline uint8_t scalar_u8(uint32_t col = 0, uint32_t row = 0) const
+	{
+		return uint8_t(m.c[col].r[row].u32 & 0xffu);
+	}
+
 	inline float scalar_f16(uint32_t col = 0, uint32_t row = 0) const
 	{
 		return f16_to_f32(scalar_u16(col, row));
@@ -1434,6 +1444,61 @@ static inline bool type_is_integral(const SPIRType &type)
 	return type.basetype == SPIRType::SByte || type.basetype == SPIRType::UByte || type.basetype == SPIRType::Short ||
 	       type.basetype == SPIRType::UShort || type.basetype == SPIRType::Int || type.basetype == SPIRType::UInt ||
 	       type.basetype == SPIRType::Int64 || type.basetype == SPIRType::UInt64;
+}
+
+static inline SPIRType::BaseType to_signed_basetype(uint32_t width)
+{
+	switch (width)
+	{
+	case 8:
+		return SPIRType::SByte;
+	case 16:
+		return SPIRType::Short;
+	case 32:
+		return SPIRType::Int;
+	case 64:
+		return SPIRType::Int64;
+	default:
+		SPIRV_CROSS_THROW("Invalid bit width.");
+	}
+}
+
+static inline SPIRType::BaseType to_unsigned_basetype(uint32_t width)
+{
+	switch (width)
+	{
+	case 8:
+		return SPIRType::UByte;
+	case 16:
+		return SPIRType::UShort;
+	case 32:
+		return SPIRType::UInt;
+	case 64:
+		return SPIRType::UInt64;
+	default:
+		SPIRV_CROSS_THROW("Invalid bit width.");
+	}
+}
+
+// Returns true if an arithmetic operation does not change behavior depending on signedness.
+static inline bool opcode_is_sign_invariant(spv::Op opcode)
+{
+	switch (opcode)
+	{
+	case spv::OpIEqual:
+	case spv::OpINotEqual:
+	case spv::OpISub:
+	case spv::OpIAdd:
+	case spv::OpIMul:
+	case spv::OpShiftLeftLogical:
+	case spv::OpBitwiseOr:
+	case spv::OpBitwiseXor:
+	case spv::OpBitwiseAnd:
+		return true;
+
+	default:
+		return false;
+	}
 }
 } // namespace spirv_cross
 

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1748,9 +1748,8 @@ void CompilerGLSL::emit_interface_block(const SPIRVariable &var)
 			if (var.storage == StorageClassOutput && var.initializer)
 			{
 				auto &entry_func = this->get<SPIRFunction>(ir.default_entry_point);
-				entry_func.fixup_hooks_in.push_back([&]() {
-					statement(to_name(var.self), " = ", to_expression(var.initializer), ";");
-				});
+				entry_func.fixup_hooks_in.push_back(
+				    [&]() { statement(to_name(var.self), " = ", to_expression(var.initializer), ";"); });
 			}
 		}
 	}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -149,27 +149,6 @@ string CompilerGLSL::sanitize_underscores(const string &str)
 	return res;
 }
 
-// Returns true if an arithmetic operation does not change behavior depending on signedness.
-static bool glsl_opcode_is_sign_invariant(Op opcode)
-{
-	switch (opcode)
-	{
-	case OpIEqual:
-	case OpINotEqual:
-	case OpISub:
-	case OpIAdd:
-	case OpIMul:
-	case OpShiftLeftLogical:
-	case OpBitwiseOr:
-	case OpBitwiseXor:
-	case OpBitwiseAnd:
-		return true;
-
-	default:
-		return false;
-	}
-}
-
 static const char *to_pls_layout(PlsFormat format)
 {
 	switch (format)
@@ -342,23 +321,31 @@ void CompilerGLSL::find_static_extensions()
 			if (!options.es && options.version < 400)
 				require_extension_internal("GL_ARB_gpu_shader_fp64");
 		}
-
-		if (type.basetype == SPIRType::Int64 || type.basetype == SPIRType::UInt64)
+		else if (type.basetype == SPIRType::Int64 || type.basetype == SPIRType::UInt64)
 		{
 			if (options.es)
 				SPIRV_CROSS_THROW("64-bit integers not supported in ES profile.");
 			if (!options.es)
 				require_extension_internal("GL_ARB_gpu_shader_int64");
 		}
-
-		if (type.basetype == SPIRType::Half)
-			require_extension_internal("GL_AMD_gpu_shader_half_float");
-
-		if (type.basetype == SPIRType::SByte || type.basetype == SPIRType::UByte)
-			require_extension_internal("GL_EXT_shader_8bit_storage");
-
-		if (type.basetype == SPIRType::Short || type.basetype == SPIRType::UShort)
-			require_extension_internal("GL_AMD_gpu_shader_int16");
+		else if (type.basetype == SPIRType::Half)
+		{
+			require_extension_internal("GL_EXT_shader_explicit_arithmetic_types_float16");
+			if (options.vulkan_semantics)
+				require_extension_internal("GL_EXT_shader_16bit_storage");
+		}
+		else if (type.basetype == SPIRType::SByte || type.basetype == SPIRType::UByte)
+		{
+			require_extension_internal("GL_EXT_shader_explicit_arithmetic_types_int8");
+			if (options.vulkan_semantics)
+				require_extension_internal("GL_EXT_shader_8bit_storage");
+		}
+		else if (type.basetype == SPIRType::Short || type.basetype == SPIRType::UShort)
+		{
+			require_extension_internal("GL_EXT_shader_explicit_arithmetic_types_int16");
+			if (options.vulkan_semantics)
+				require_extension_internal("GL_EXT_shader_16bit_storage");
+		}
 	});
 
 	auto &execution = get_entry_point();
@@ -508,7 +495,7 @@ void CompilerGLSL::emit_header()
 
 	for (auto &ext : forced_extensions)
 	{
-		if (ext == "GL_AMD_gpu_shader_half_float")
+		if (ext == "GL_EXT_shader_explicit_arithmetic_types_float16")
 		{
 			// Special case, this extension has a potential fallback to another vendor extension in normal GLSL.
 			// GL_AMD_gpu_shader_half_float is a superset, so try that first.
@@ -519,22 +506,27 @@ void CompilerGLSL::emit_header()
 				statement("#elif defined(GL_NV_gpu_shader5)");
 				statement("#extension GL_NV_gpu_shader5 : require");
 			}
-			statement("#elif defined(GL_EXT_shader_16bit_storage)");
-			statement("#extension GL_EXT_shader_16bit_storage : require");
+			else
+			{
+				statement("#elif defined(GL_EXT_shader_explicit_arithmetic_types_float16)");
+				statement("#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require");
+			}
 			statement("#else");
 			statement("#error No extension available for FP16.");
 			statement("#endif");
 		}
-		else if (ext == "GL_AMD_gpu_shader_int16")
+		else if (ext == "GL_EXT_shader_explicit_arithmetic_types_int16")
 		{
-			// GL_AMD_gpu_shader_int16 is a superset, so try that first.
-			statement("#if defined(GL_AMD_gpu_shader_int16)");
-			statement("#extension GL_AMD_gpu_shader_int16 : require");
-			statement("#elif defined(GL_EXT_shader_16bit_storage)");
-			statement("#extension GL_EXT_shader_16bit_storage : require");
-			statement("#else");
-			statement("#error No extension available for Int16.");
-			statement("#endif");
+			if (options.vulkan_semantics)
+				statement("#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require");
+			else
+			{
+				statement("#if defined(GL_AMD_gpu_shader_int16)");
+				statement("#extension GL_AMD_gpu_shader_int16 : require");
+				statement("#else");
+				statement("#error No extension available for Int16.");
+				statement("#endif");
+			}
 		}
 		else
 			statement("#extension ", ext, " : require");
@@ -2799,14 +2791,38 @@ string CompilerGLSL::constant_op_expression(const SPIRConstantOp &cop)
 		SPIRV_CROSS_THROW("Unimplemented spec constant op.");
 	}
 
+	uint32_t bit_width = 0;
+	if (unary || binary)
+		bit_width = expression_type(cop.arguments[0]).width;
+
 	SPIRType::BaseType input_type;
-	bool skip_cast_if_equal_type = glsl_opcode_is_sign_invariant(cop.opcode);
+	bool skip_cast_if_equal_type = opcode_is_sign_invariant(cop.opcode);
 
 	switch (cop.opcode)
 	{
 	case OpIEqual:
 	case OpINotEqual:
-		input_type = SPIRType::Int;
+		input_type = to_signed_basetype(bit_width);
+		break;
+
+	case OpSLessThan:
+	case OpSLessThanEqual:
+	case OpSGreaterThan:
+	case OpSGreaterThanEqual:
+	case OpSMod:
+	case OpSDiv:
+	case OpShiftRightArithmetic:
+		input_type = to_signed_basetype(bit_width);
+		break;
+
+	case OpULessThan:
+	case OpULessThanEqual:
+	case OpUGreaterThan:
+	case OpUGreaterThanEqual:
+	case OpUMod:
+	case OpUDiv:
+	case OpShiftRightLogical:
+		input_type = to_unsigned_basetype(bit_width);
 		break;
 
 	default:
@@ -3121,6 +3137,9 @@ string CompilerGLSL::constant_expression_vector(const SPIRConstant &c, uint32_t 
 	auto type = get<SPIRType>(c.constant_type);
 	type.columns = 1;
 
+	auto scalar_type = type;
+	scalar_type.vecsize = 1;
+
 	string res;
 	bool splat = backend.use_constructor_splatting && c.vector_size() > 1;
 	bool swizzle_splat = backend.can_swizzle_scalar && c.vector_size() > 1;
@@ -3423,6 +3442,56 @@ string CompilerGLSL::constant_expression_vector(const SPIRConstant &c, uint32_t 
 					if (backend.int16_t_literal_suffix)
 						res += backend.int16_t_literal_suffix;
 				}
+				if (i + 1 < c.vector_size())
+					res += ", ";
+			}
+		}
+		break;
+
+	case SPIRType::UByte:
+		if (splat)
+		{
+			res += convert_to_string(c.scalar_u8(vector, 0));
+		}
+		else
+		{
+			for (uint32_t i = 0; i < c.vector_size(); i++)
+			{
+				if (c.vector_size() > 1 && c.specialization_constant_id(vector, i) != 0)
+					res += to_name(c.specialization_constant_id(vector, i));
+				else
+				{
+					res += type_to_glsl(scalar_type);
+					res += "(";
+					res += convert_to_string(c.scalar_u8(vector, i));
+					res += ")";
+				}
+
+				if (i + 1 < c.vector_size())
+					res += ", ";
+			}
+		}
+		break;
+
+	case SPIRType::SByte:
+		if (splat)
+		{
+			res += convert_to_string(c.scalar_i8(vector, 0));
+		}
+		else
+		{
+			for (uint32_t i = 0; i < c.vector_size(); i++)
+			{
+				if (c.vector_size() > 1 && c.specialization_constant_id(vector, i) != 0)
+					res += to_name(c.specialization_constant_id(vector, i));
+				else
+				{
+					res += type_to_glsl(scalar_type);
+					res += "(";
+					res += convert_to_string(c.scalar_i8(vector, i));
+					res += ")";
+				}
+
 				if (i + 1 < c.vector_size())
 					res += ", ";
 			}
@@ -5185,20 +5254,31 @@ case OpGroupNonUniform##op: \
 
 string CompilerGLSL::bitcast_glsl_op(const SPIRType &out_type, const SPIRType &in_type)
 {
-	if (out_type.basetype == SPIRType::UShort && in_type.basetype == SPIRType::Short)
+	assert(out_type.basetype != SPIRType::Boolean);
+	assert(in_type.basetype != SPIRType::Boolean);
+
+	if (out_type.basetype == in_type.basetype)
+		return "";
+
+	bool integral_cast = type_is_integral(out_type) && type_is_integral(in_type);
+	bool same_size_cast = out_type.width == in_type.width;
+
+	// Trivial bitcast case, casts between integers.
+	if (integral_cast && same_size_cast)
 		return type_to_glsl(out_type);
-	else if (out_type.basetype == SPIRType::UInt && in_type.basetype == SPIRType::Int)
-		return type_to_glsl(out_type);
-	else if (out_type.basetype == SPIRType::UInt64 && in_type.basetype == SPIRType::Int64)
-		return type_to_glsl(out_type);
-	else if (out_type.basetype == SPIRType::UInt && in_type.basetype == SPIRType::Float)
+
+	// Catch-all 8-bit arithmetic casts (GL_EXT_shader_explicit_arithmetic_types).
+	if (out_type.width == 8 && in_type.width >= 16 && integral_cast && in_type.vecsize == 1)
+		return "unpack8";
+	else if (in_type.width == 8 && out_type.width == 16 && integral_cast && out_type.vecsize == 1)
+		return "pack16";
+	else if (in_type.width == 8 && out_type.width == 32 && integral_cast && out_type.vecsize == 1)
+		return "pack32";
+
+	// Floating <-> Integer special casts. Just have to enumerate all cases. :(
+	// 16-bit, 32-bit and 64-bit floats.
+	if (out_type.basetype == SPIRType::UInt && in_type.basetype == SPIRType::Float)
 		return "floatBitsToUint";
-	else if (out_type.basetype == SPIRType::Short && in_type.basetype == SPIRType::UShort)
-		return type_to_glsl(out_type);
-	else if (out_type.basetype == SPIRType::Int && in_type.basetype == SPIRType::UInt)
-		return type_to_glsl(out_type);
-	else if (out_type.basetype == SPIRType::Int64 && in_type.basetype == SPIRType::UInt64)
-		return type_to_glsl(out_type);
 	else if (out_type.basetype == SPIRType::Int && in_type.basetype == SPIRType::Float)
 		return "floatBitsToInt";
 	else if (out_type.basetype == SPIRType::Float && in_type.basetype == SPIRType::UInt)
@@ -5221,7 +5301,9 @@ string CompilerGLSL::bitcast_glsl_op(const SPIRType &out_type, const SPIRType &i
 		return "int16BitsToFloat16";
 	else if (out_type.basetype == SPIRType::Half && in_type.basetype == SPIRType::UShort)
 		return "uint16BitsToFloat16";
-	else if (out_type.basetype == SPIRType::UInt64 && in_type.basetype == SPIRType::UInt && in_type.vecsize == 2)
+
+	// And finally, some even more special purpose casts.
+	if (out_type.basetype == SPIRType::UInt64 && in_type.basetype == SPIRType::UInt && in_type.vecsize == 2)
 		return "packUint2x32";
 	else if (out_type.basetype == SPIRType::Half && in_type.basetype == SPIRType::UInt && in_type.vecsize == 1)
 		return "unpackFloat2x16";
@@ -5243,8 +5325,8 @@ string CompilerGLSL::bitcast_glsl_op(const SPIRType &out_type, const SPIRType &i
 		return "packUint4x16";
 	else if (out_type.basetype == SPIRType::UShort && in_type.basetype == SPIRType::UInt64 && in_type.vecsize == 1)
 		return "unpackUint4x16";
-	else
-		return "";
+
+	return "";
 }
 
 string CompilerGLSL::bitcast_glsl(const SPIRType &result_type, uint32_t argument)
@@ -6662,6 +6744,35 @@ void CompilerGLSL::emit_store_statement(uint32_t lhs_expression, uint32_t rhs_ex
 	}
 }
 
+uint32_t CompilerGLSL::get_integer_width_for_instruction(const Instruction &instr) const
+{
+	if (instr.length < 3)
+		return 32;
+
+	auto *ops = stream(instr);
+
+	switch (instr.op)
+	{
+	case OpIEqual:
+	case OpINotEqual:
+	case OpSLessThan:
+	case OpSLessThanEqual:
+	case OpSGreaterThan:
+	case OpSGreaterThanEqual:
+		return expression_type(ops[2]).width;
+
+	default:
+	{
+		// We can look at result type which is more robust.
+		auto *type = maybe_get<SPIRType>(ops[0]);
+		if (type && type_is_integral(*type))
+			return type->width;
+		else
+			return 32;
+	}
+	}
+}
+
 void CompilerGLSL::emit_instruction(const Instruction &instruction)
 {
 	auto ops = stream(instruction);
@@ -6670,15 +6781,20 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 
 #define GLSL_BOP(op) emit_binary_op(ops[0], ops[1], ops[2], ops[3], #op)
 #define GLSL_BOP_CAST(op, type) \
-	emit_binary_op_cast(ops[0], ops[1], ops[2], ops[3], #op, type, glsl_opcode_is_sign_invariant(opcode))
+	emit_binary_op_cast(ops[0], ops[1], ops[2], ops[3], #op, type, opcode_is_sign_invariant(opcode))
 #define GLSL_UOP(op) emit_unary_op(ops[0], ops[1], ops[2], #op)
 #define GLSL_QFOP(op) emit_quaternary_func_op(ops[0], ops[1], ops[2], ops[3], ops[4], ops[5], #op)
 #define GLSL_TFOP(op) emit_trinary_func_op(ops[0], ops[1], ops[2], ops[3], ops[4], #op)
 #define GLSL_BFOP(op) emit_binary_func_op(ops[0], ops[1], ops[2], ops[3], #op)
 #define GLSL_BFOP_CAST(op, type) \
-	emit_binary_func_op_cast(ops[0], ops[1], ops[2], ops[3], #op, type, glsl_opcode_is_sign_invariant(opcode))
+	emit_binary_func_op_cast(ops[0], ops[1], ops[2], ops[3], #op, type, opcode_is_sign_invariant(opcode))
 #define GLSL_BFOP(op) emit_binary_func_op(ops[0], ops[1], ops[2], ops[3], #op)
 #define GLSL_UFOP(op) emit_unary_func_op(ops[0], ops[1], ops[2], #op)
+
+	// If we need to do implicit bitcasts, make sure we do it with the correct type.
+	uint32_t integer_width = get_integer_width_for_instruction(instruction);
+	auto int_type = to_signed_basetype(integer_width);
+	auto uint_type = to_unsigned_basetype(integer_width);
 
 	switch (opcode)
 	{
@@ -7357,11 +7473,11 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 	}
 
 	case OpSDiv:
-		GLSL_BOP_CAST(/, SPIRType::Int);
+		GLSL_BOP_CAST(/, int_type);
 		break;
 
 	case OpUDiv:
-		GLSL_BOP_CAST(/, SPIRType::UInt);
+		GLSL_BOP_CAST(/, uint_type);
 		break;
 
 	case OpIAddCarry:
@@ -7419,11 +7535,11 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		break;
 
 	case OpShiftRightLogical:
-		GLSL_BOP_CAST(>>, SPIRType::UInt);
+		GLSL_BOP_CAST(>>, uint_type);
 		break;
 
 	case OpShiftRightArithmetic:
-		GLSL_BOP_CAST(>>, SPIRType::Int);
+		GLSL_BOP_CAST(>>, int_type);
 		break;
 
 	case OpShiftLeftLogical:
@@ -7459,11 +7575,11 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		break;
 
 	case OpUMod:
-		GLSL_BOP_CAST(%, SPIRType::UInt);
+		GLSL_BOP_CAST(%, uint_type);
 		break;
 
 	case OpSMod:
-		GLSL_BOP_CAST(%, SPIRType::Int);
+		GLSL_BOP_CAST(%, int_type);
 		break;
 
 	case OpFMod:
@@ -7546,9 +7662,9 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 	case OpIEqual:
 	{
 		if (expression_type(ops[2]).vecsize > 1)
-			GLSL_BFOP_CAST(equal, SPIRType::Int);
+			GLSL_BFOP_CAST(equal, int_type);
 		else
-			GLSL_BOP_CAST(==, SPIRType::Int);
+			GLSL_BOP_CAST(==, int_type);
 		break;
 	}
 
@@ -7565,9 +7681,9 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 	case OpINotEqual:
 	{
 		if (expression_type(ops[2]).vecsize > 1)
-			GLSL_BFOP_CAST(notEqual, SPIRType::Int);
+			GLSL_BFOP_CAST(notEqual, int_type);
 		else
-			GLSL_BOP_CAST(!=, SPIRType::Int);
+			GLSL_BOP_CAST(!=, int_type);
 		break;
 	}
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -636,6 +636,8 @@ protected:
 	bool expression_is_constant_null(uint32_t id) const;
 	virtual void emit_store_statement(uint32_t lhs_expression, uint32_t rhs_expression);
 
+	uint32_t get_integer_width_for_instruction(const Instruction &instr) const;
+
 private:
 	void init()
 	{

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -369,7 +369,7 @@ void CompilerMSL::emit_entry_point_declarations()
 		for (uint32_t i = 0; i < type.array[0]; ++i)
 			statement(name + "_" + convert_to_string(i) + ",");
 		end_scope_decl();
-		statement("");
+		statement_no_indent("");
 	}
 	// For some reason, without this, we end up emitting the arrays twice.
 	buffer_arrays.clear();

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -2441,7 +2441,6 @@ void CompilerMSL::emit_binary_unord_op(uint32_t result_type, uint32_t result_id,
 // Override for MSL-specific syntax instructions
 void CompilerMSL::emit_instruction(const Instruction &instruction)
 {
-
 #define MSL_BOP(op) emit_binary_op(ops[0], ops[1], ops[2], ops[3], #op)
 #define MSL_BOP_CAST(op, type) \
 	emit_binary_op_cast(ops[0], ops[1], ops[2], ops[3], #op, type, opcode_is_sign_invariant(opcode))
@@ -2457,42 +2456,77 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 	auto ops = stream(instruction);
 	auto opcode = static_cast<Op>(instruction.op);
 
+	// If we need to do implicit bitcasts, make sure we do it with the correct type.
+	uint32_t integer_width = get_integer_width_for_instruction(instruction);
+	auto int_type = to_signed_basetype(integer_width);
+	auto uint_type = to_unsigned_basetype(integer_width);
+
 	switch (opcode)
 	{
 
 	// Comparisons
 	case OpIEqual:
+		MSL_BOP_CAST(==, int_type);
+		break;
+
 	case OpLogicalEqual:
 	case OpFOrdEqual:
 		MSL_BOP(==);
 		break;
 
 	case OpINotEqual:
+		MSL_BOP_CAST(!=, int_type);
+		break;
+
 	case OpLogicalNotEqual:
 	case OpFOrdNotEqual:
 		MSL_BOP(!=);
 		break;
 
 	case OpUGreaterThan:
+		MSL_BOP_CAST(>, uint_type);
+		break;
+
 	case OpSGreaterThan:
+		MSL_BOP_CAST(>, int_type);
+		break;
+
 	case OpFOrdGreaterThan:
 		MSL_BOP(>);
 		break;
 
 	case OpUGreaterThanEqual:
+		MSL_BOP_CAST(>=, uint_type);
+		break;
+
 	case OpSGreaterThanEqual:
+		MSL_BOP_CAST(>=, int_type);
+		break;
+
 	case OpFOrdGreaterThanEqual:
 		MSL_BOP(>=);
 		break;
 
 	case OpULessThan:
+		MSL_BOP_CAST(<, uint_type);
+		break;
+
 	case OpSLessThan:
+		MSL_BOP_CAST(<, int_type);
+		break;
+
 	case OpFOrdLessThan:
 		MSL_BOP(<);
 		break;
 
 	case OpULessThanEqual:
+		MSL_BOP_CAST(<=, uint_type);
+		break;
+
 	case OpSLessThanEqual:
+		MSL_BOP_CAST(<=, int_type);
+		break;
+
 	case OpFOrdLessThanEqual:
 		MSL_BOP(<=);
 		break;
@@ -5433,37 +5467,25 @@ string CompilerMSL::image_type_glsl(const SPIRType &type, uint32_t id)
 
 string CompilerMSL::bitcast_glsl_op(const SPIRType &out_type, const SPIRType &in_type)
 {
-	if ((out_type.basetype == SPIRType::UShort && in_type.basetype == SPIRType::Short) ||
-	    (out_type.basetype == SPIRType::Short && in_type.basetype == SPIRType::UShort) ||
-	    (out_type.basetype == SPIRType::UInt && in_type.basetype == SPIRType::Int) ||
-	    (out_type.basetype == SPIRType::Int && in_type.basetype == SPIRType::UInt) ||
-	    (out_type.basetype == SPIRType::UInt64 && in_type.basetype == SPIRType::Int64) ||
-	    (out_type.basetype == SPIRType::Int64 && in_type.basetype == SPIRType::UInt64))
+	assert(out_type.basetype != SPIRType::Boolean);
+	assert(in_type.basetype != SPIRType::Boolean);
+
+	if (out_type.basetype == in_type.basetype)
+		return "";
+
+	bool integral_cast = type_is_integral(out_type) && type_is_integral(in_type);
+	bool same_size_cast = out_type.width == in_type.width;
+
+	if (integral_cast && same_size_cast)
+	{
+		// Trivial bitcast case, casts between integers.
 		return type_to_glsl(out_type);
-
-	if ((out_type.basetype == SPIRType::UInt && in_type.basetype == SPIRType::Float) ||
-	    (out_type.basetype == SPIRType::Int && in_type.basetype == SPIRType::Float) ||
-	    (out_type.basetype == SPIRType::Float && in_type.basetype == SPIRType::UInt) ||
-	    (out_type.basetype == SPIRType::Float && in_type.basetype == SPIRType::Int) ||
-	    (out_type.basetype == SPIRType::Int64 && in_type.basetype == SPIRType::Double) ||
-	    (out_type.basetype == SPIRType::UInt64 && in_type.basetype == SPIRType::Double) ||
-	    (out_type.basetype == SPIRType::Double && in_type.basetype == SPIRType::Int64) ||
-	    (out_type.basetype == SPIRType::Double && in_type.basetype == SPIRType::UInt64) ||
-	    (out_type.basetype == SPIRType::Half && in_type.basetype == SPIRType::UInt) ||
-	    (out_type.basetype == SPIRType::UInt && in_type.basetype == SPIRType::Half) ||
-	    (out_type.basetype == SPIRType::Half && in_type.basetype == SPIRType::Int) ||
-	    (out_type.basetype == SPIRType::Int && in_type.basetype == SPIRType::Half) ||
-	    (out_type.basetype == SPIRType::Half && in_type.basetype == SPIRType::UShort) ||
-	    (out_type.basetype == SPIRType::UShort && in_type.basetype == SPIRType::Half) ||
-	    (out_type.basetype == SPIRType::Half && in_type.basetype == SPIRType::Short) ||
-	    (out_type.basetype == SPIRType::Short && in_type.basetype == SPIRType::Half) ||
-	    (out_type.basetype == SPIRType::UInt && in_type.basetype == SPIRType::UShort && in_type.vecsize == 2) ||
-	    (out_type.basetype == SPIRType::UShort && in_type.basetype == SPIRType::UInt && in_type.vecsize == 1) ||
-	    (out_type.basetype == SPIRType::Int && in_type.basetype == SPIRType::Short && in_type.vecsize == 2) ||
-	    (out_type.basetype == SPIRType::Short && in_type.basetype == SPIRType::Int && in_type.vecsize == 1))
+	}
+	else
+	{
+		// Fall back to the catch-all bitcast in MSL.
 		return "as_type<" + type_to_glsl(out_type) + ">";
-
-	return "";
+	}
 }
 
 // Returns an MSL string identifying the name of a SPIR-V builtin.

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -868,9 +868,8 @@ void CompilerMSL::add_plain_variable_to_interface_block(StorageClass storage, co
 
 	if (var.storage == StorageClassOutput && var.initializer != 0)
 	{
-		entry_func.fixup_hooks_in.push_back([=, &var]() {
-			statement(qual_var_name, " = ", to_expression(var.initializer), ";");
-		});
+		entry_func.fixup_hooks_in.push_back(
+		    [=, &var]() { statement(qual_var_name, " = ", to_expression(var.initializer), ";"); });
 	}
 
 	// Copy the variable location from the original variable to the member

--- a/spirv_parser.cpp
+++ b/spirv_parser.cpp
@@ -461,23 +461,7 @@ void Parser::parse(const Instruction &instruction)
 		uint32_t width = ops[1];
 		bool signedness = ops[2] != 0;
 		auto &type = set<SPIRType>(id);
-		switch (width)
-		{
-		case 64:
-			type.basetype = signedness ? SPIRType::Int64 : SPIRType::UInt64;
-			break;
-		case 32:
-			type.basetype = signedness ? SPIRType::Int : SPIRType::UInt;
-			break;
-		case 16:
-			type.basetype = signedness ? SPIRType::Short : SPIRType::UShort;
-			break;
-		case 8:
-			type.basetype = signedness ? SPIRType::SByte : SPIRType::UByte;
-			break;
-		default:
-			SPIRV_CROSS_THROW("Unrecognized bit-width of integral type.");
-		}
+		type.basetype = signedness ? to_signed_basetype(width) : to_unsigned_basetype(width);
 		type.width = width;
 		break;
 	}

--- a/spirv_reflect.cpp
+++ b/spirv_reflect.cpp
@@ -475,7 +475,8 @@ void CompilerReflection::emit_resources(const char *tag, const vector<Resource> 
 
 		{
 			bool is_sized_block = is_block && (get_storage_class(res.id) == StorageClassUniform ||
-			                                   get_storage_class(res.id) == StorageClassUniformConstant);
+			                                   get_storage_class(res.id) == StorageClassUniformConstant ||
+			                                   get_storage_class(res.id) == StorageClassStorageBuffer);
 			if (is_sized_block)
 			{
 				uint32_t block_size = uint32_t(get_declared_struct_size(get_type(res.base_type_id)));


### PR DESCRIPTION
Completes full support for small integers in GLSL and MSL now that we finally have GL_EXT_shader_explicit_arithmetic_types.

Also updates the reference toolchain for glslang/SPIRV-Tools to be able to support these new extensions.

Fix #783.