### PR TITLE
MSL: Add support for tessellation evaluation shaders.

### DIFF
--- a/reference/opt/shaders-msl/desktop-only/tese/triangle.desktop.sso.tese
+++ b/reference/opt/shaders-msl/desktop-only/tese/triangle.desktop.sso.tese
@@ -1,0 +1,27 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 gl_Position [[attribute(0)]];
+};
+
+struct main0_patchIn
+{
+    patch_control_point<main0_in> gl_in;
+};
+
+[[ patch(triangle, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float3 gl_TessCoord [[position_in_patch]])
+{
+    main0_out out = {};
+    out.gl_Position = ((patchIn.gl_in[0].gl_Position * gl_TessCoord.x) + (patchIn.gl_in[1].gl_Position * gl_TessCoord.y)) + (patchIn.gl_in[2].gl_Position * gl_TessCoord.z);
+    return out;
+}
+

--- a/reference/opt/shaders-msl/tese/input-array.tese
+++ b/reference/opt/shaders-msl/tese/input-array.tese
@@ -1,0 +1,28 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 Floats [[attribute(0)]];
+    float4 Floats2 [[attribute(2)]];
+};
+
+struct main0_patchIn
+{
+    patch_control_point<main0_in> gl_in;
+};
+
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoord [[position_in_patch]])
+{
+    main0_out out = {};
+    out.gl_Position = (patchIn.gl_in[0].Floats * gl_TessCoord.x) + (patchIn.gl_in[1].Floats2 * gl_TessCoord.y);
+    return out;
+}
+

--- a/reference/opt/shaders-msl/tese/input-types.tese
+++ b/reference/opt/shaders-msl/tese/input-types.tese
@@ -1,0 +1,80 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Block
+{
+    float4 a;
+    float4 b;
+};
+
+struct PatchBlock
+{
+    float4 a;
+    float4 b;
+};
+
+struct Foo
+{
+    float4 a;
+    float4 b;
+};
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 vColor [[attribute(0)]];
+    float4 Block_a [[attribute(4)]];
+    float4 Block_b [[attribute(5)]];
+    float4 Foo_a [[attribute(14)]];
+    float4 Foo_b [[attribute(15)]];
+};
+
+struct main0_patchIn
+{
+    float4 vColors [[attribute(1)]];
+    float4 PatchBlock_a [[attribute(6)]];
+    float4 PatchBlock_b [[attribute(7)]];
+    float4 Foo_a [[attribute(8)]];
+    float4 Foo_b [[attribute(9)]];
+    patch_control_point<main0_in> gl_in;
+};
+
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]])
+{
+    main0_out out = {};
+    PatchBlock patch_block = {};
+    Foo vFoo = {};
+    patch_block.a = patchIn.PatchBlock_a;
+    patch_block.b = patchIn.PatchBlock_b;
+    vFoo.a = patchIn.Foo_a;
+    vFoo.b = patchIn.Foo_b;
+    out.gl_Position = patchIn.gl_in[0].Block_a;
+    out.gl_Position += patchIn.gl_in[0].Block_b;
+    out.gl_Position += patchIn.gl_in[1].Block_a;
+    out.gl_Position += patchIn.gl_in[1].Block_b;
+    out.gl_Position += patch_block.a;
+    out.gl_Position += patch_block.b;
+    out.gl_Position += patchIn.gl_in[0].vColor;
+    out.gl_Position += patchIn.gl_in[1].vColor;
+    out.gl_Position += patchIn.vColors;
+    out.gl_Position += vFoo.a;
+    out.gl_Position += vFoo.b;
+    Foo vFoos_202;
+    vFoos_202.a = patchIn.gl_in[0].Foo_a;
+    vFoos_202.b = patchIn.gl_in[0].Foo_b;
+    out.gl_Position += vFoos_202.a;
+    out.gl_Position += vFoos_202.b;
+    Foo vFoos_216;
+    vFoos_216.a = patchIn.gl_in[1].Foo_a;
+    vFoos_216.b = patchIn.gl_in[1].Foo_b;
+    out.gl_Position += vFoos_216.a;
+    out.gl_Position += vFoos_216.b;
+    return out;
+}
+

--- a/reference/opt/shaders-msl/tese/quad.tese
+++ b/reference/opt/shaders-msl/tese/quad.tese
@@ -1,0 +1,35 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_patchIn
+{
+    float gl_TessLevelInner_0 [[attribute(0)]];
+    float gl_TessLevelInner_1 [[attribute(1)]];
+    float gl_TessLevelOuter_0 [[attribute(2)]];
+    float gl_TessLevelOuter_1 [[attribute(3)]];
+    float gl_TessLevelOuter_2 [[attribute(4)]];
+    float gl_TessLevelOuter_3 [[attribute(5)]];
+};
+
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoord [[position_in_patch]])
+{
+    main0_out out = {};
+    float gl_TessLevelInner[2] = {};
+    float gl_TessLevelOuter[4] = {};
+    gl_TessLevelInner[0] = patchIn.gl_TessLevelInner_0;
+    gl_TessLevelInner[1] = patchIn.gl_TessLevelInner_1;
+    gl_TessLevelOuter[0] = patchIn.gl_TessLevelOuter_0;
+    gl_TessLevelOuter[1] = patchIn.gl_TessLevelOuter_1;
+    gl_TessLevelOuter[2] = patchIn.gl_TessLevelOuter_2;
+    gl_TessLevelOuter[3] = patchIn.gl_TessLevelOuter_3;
+    out.gl_Position = float4(((gl_TessCoord.x * as_type<float>(gl_TessLevelInner[0])) * as_type<float>(gl_TessLevelOuter[0])) + (((1.0 - gl_TessCoord.x) * as_type<float>(gl_TessLevelInner[0])) * as_type<float>(gl_TessLevelOuter[2])), ((gl_TessCoord.y * as_type<float>(gl_TessLevelInner[1])) * as_type<float>(gl_TessLevelOuter[1])) + (((1.0 - gl_TessCoord.y) * as_type<float>(gl_TessLevelInner[1])) * as_type<float>(gl_TessLevelOuter[3])), 0.0, 1.0);
+    return out;
+}
+

--- a/reference/opt/shaders-msl/tese/set-from-function.tese
+++ b/reference/opt/shaders-msl/tese/set-from-function.tese
@@ -1,0 +1,55 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Block
+{
+    float4 a;
+    float4 b;
+};
+
+struct Foo
+{
+    float4 a;
+    float4 b;
+};
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 vColor [[attribute(0)]];
+    float4 Block_a [[attribute(2)]];
+    float4 Block_b [[attribute(3)]];
+};
+
+struct main0_patchIn
+{
+    float4 vColors [[attribute(1)]];
+    float4 Foo_a [[attribute(4)]];
+    float4 Foo_b [[attribute(5)]];
+    patch_control_point<main0_in> gl_in;
+};
+
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]])
+{
+    main0_out out = {};
+    Foo vFoo = {};
+    vFoo.a = patchIn.Foo_a;
+    vFoo.b = patchIn.Foo_b;
+    out.gl_Position = patchIn.gl_in[0].Block_a;
+    out.gl_Position += patchIn.gl_in[0].Block_b;
+    out.gl_Position += patchIn.gl_in[1].Block_a;
+    out.gl_Position += patchIn.gl_in[1].Block_b;
+    out.gl_Position += patchIn.gl_in[0].vColor;
+    out.gl_Position += patchIn.gl_in[1].vColor;
+    out.gl_Position += patchIn.vColors;
+    out.gl_Position += vFoo.a;
+    out.gl_Position += vFoo.b;
+    return out;
+}
+

--- a/reference/opt/shaders-msl/tese/triangle.tese
+++ b/reference/opt/shaders-msl/tese/triangle.tese
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+[[ patch(triangle, 0) ]] vertex main0_out main0()
+{
+    main0_out out = {};
+    out.gl_Position = float4(1.0);
+    return out;
+}
+

--- a/reference/opt/shaders-msl/tese/water_tess.tese
+++ b/reference/opt/shaders-msl/tese/water_tess.tese
@@ -1,0 +1,45 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBO
+{
+    float4x4 uMVP;
+    float4 uScale;
+    float2 uInvScale;
+    float3 uCamPos;
+    float2 uPatchSize;
+    float2 uInvHeightmapSize;
+};
+
+struct main0_out
+{
+    float3 vWorld [[user(locn0)]];
+    float4 vGradNormalTex [[user(locn1)]];
+    float4 gl_Position [[position]];
+};
+
+struct main0_patchIn
+{
+    float2 vOutPatchPosBase [[attribute(0)]];
+    float4 vPatchLods [[attribute(1)]];
+};
+
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], constant UBO& _31 [[buffer(1)]], texture2d<float> uHeightmapDisplacement [[texture(0)]], sampler uHeightmapDisplacementSmplr [[sampler(0)]], float2 gl_TessCoord [[position_in_patch]])
+{
+    main0_out out = {};
+    float2 _201 = patchIn.vOutPatchPosBase + (gl_TessCoord.xy * _31.uPatchSize);
+    float2 _214 = mix(patchIn.vPatchLods.yx, patchIn.vPatchLods.zw, float2(gl_TessCoord.x));
+    float _221 = mix(_214.x, _214.y, gl_TessCoord.y);
+    float _223 = floor(_221);
+    float2 _125 = _201 * _31.uInvHeightmapSize;
+    float2 _141 = _31.uInvHeightmapSize * exp2(_223);
+    out.vGradNormalTex = float4(_125 + (_31.uInvHeightmapSize * 0.5), _125 * _31.uScale.zw);
+    float3 _253 = mix(uHeightmapDisplacement.sample(uHeightmapDisplacementSmplr, (_125 + (_141 * 0.5)), level(_223)).xyz, uHeightmapDisplacement.sample(uHeightmapDisplacementSmplr, (_125 + (_141 * 1.0)), level(_223 + 1.0)).xyz, float3(_221 - _223));
+    float2 _171 = (_201 * _31.uScale.xy) + _253.yz;
+    out.vWorld = float3(_171.x, _253.x, _171.y);
+    out.gl_Position = _31.uMVP * float4(out.vWorld, 1.0);
+    return out;
+}
+

--- a/reference/shaders-msl/desktop-only/tese/triangle.desktop.sso.tese
+++ b/reference/shaders-msl/desktop-only/tese/triangle.desktop.sso.tese
@@ -1,0 +1,27 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 gl_Position [[attribute(0)]];
+};
+
+struct main0_patchIn
+{
+    patch_control_point<main0_in> gl_in;
+};
+
+[[ patch(triangle, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float3 gl_TessCoord [[position_in_patch]])
+{
+    main0_out out = {};
+    out.gl_Position = ((patchIn.gl_in[0].gl_Position * gl_TessCoord.x) + (patchIn.gl_in[1].gl_Position * gl_TessCoord.y)) + (patchIn.gl_in[2].gl_Position * gl_TessCoord.z);
+    return out;
+}
+

--- a/reference/shaders-msl/tese/input-array.tese
+++ b/reference/shaders-msl/tese/input-array.tese
@@ -1,0 +1,35 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 Floats [[attribute(0)]];
+    float4 Floats2 [[attribute(2)]];
+};
+
+struct main0_patchIn
+{
+    patch_control_point<main0_in> gl_in;
+};
+
+void set_position(thread float4& gl_Position, thread patch_control_point<main0_in>& gl_in, thread float2& gl_TessCoord)
+{
+    gl_Position = (gl_in[0].Floats * gl_TessCoord.x) + (gl_in[1].Floats2 * gl_TessCoord.y);
+}
+
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoord [[position_in_patch]])
+{
+    main0_out out = {};
+    set_position(out.gl_Position, patchIn.gl_in, gl_TessCoord);
+    return out;
+}
+

--- a/reference/shaders-msl/tese/input-types.tese
+++ b/reference/shaders-msl/tese/input-types.tese
@@ -1,0 +1,90 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Block
+{
+    float4 a;
+    float4 b;
+};
+
+struct PatchBlock
+{
+    float4 a;
+    float4 b;
+};
+
+struct Foo
+{
+    float4 a;
+    float4 b;
+};
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 vColor [[attribute(0)]];
+    float4 Block_a [[attribute(4)]];
+    float4 Block_b [[attribute(5)]];
+    float4 Foo_a [[attribute(14)]];
+    float4 Foo_b [[attribute(15)]];
+};
+
+struct main0_patchIn
+{
+    float4 vColors [[attribute(1)]];
+    float4 PatchBlock_a [[attribute(6)]];
+    float4 PatchBlock_b [[attribute(7)]];
+    float4 Foo_a [[attribute(8)]];
+    float4 Foo_b [[attribute(9)]];
+    patch_control_point<main0_in> gl_in;
+};
+
+void set_from_function(thread float4& gl_Position, thread patch_control_point<main0_in>& gl_in, thread PatchBlock& patch_block, thread float4& vColors, thread Foo& vFoo)
+{
+    gl_Position = gl_in[0].Block_a;
+    gl_Position += gl_in[0].Block_b;
+    gl_Position += gl_in[1].Block_a;
+    gl_Position += gl_in[1].Block_b;
+    gl_Position += patch_block.a;
+    gl_Position += patch_block.b;
+    gl_Position += gl_in[0].vColor;
+    gl_Position += gl_in[1].vColor;
+    gl_Position += vColors;
+    Foo foo = vFoo;
+    gl_Position += foo.a;
+    gl_Position += foo.b;
+    Foo vFoos_105;
+    vFoos_105.a = gl_in[0].Foo_a;
+    vFoos_105.b = gl_in[0].Foo_b;
+    foo = vFoos_105;
+    gl_Position += foo.a;
+    gl_Position += foo.b;
+    Foo vFoos_119;
+    vFoos_119.a = gl_in[1].Foo_a;
+    vFoos_119.b = gl_in[1].Foo_b;
+    foo = vFoos_119;
+    gl_Position += foo.a;
+    gl_Position += foo.b;
+}
+
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]])
+{
+    main0_out out = {};
+    PatchBlock patch_block = {};
+    Foo vFoo = {};
+    patch_block.a = patchIn.PatchBlock_a;
+    patch_block.b = patchIn.PatchBlock_b;
+    vFoo.a = patchIn.Foo_a;
+    vFoo.b = patchIn.Foo_b;
+    set_from_function(out.gl_Position, patchIn.gl_in, patch_block, patchIn.vColors, vFoo);
+    return out;
+}
+

--- a/reference/shaders-msl/tese/quad.tese
+++ b/reference/shaders-msl/tese/quad.tese
@@ -1,0 +1,35 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_patchIn
+{
+    float gl_TessLevelInner_0 [[attribute(0)]];
+    float gl_TessLevelInner_1 [[attribute(1)]];
+    float gl_TessLevelOuter_0 [[attribute(2)]];
+    float gl_TessLevelOuter_1 [[attribute(3)]];
+    float gl_TessLevelOuter_2 [[attribute(4)]];
+    float gl_TessLevelOuter_3 [[attribute(5)]];
+};
+
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoord [[position_in_patch]])
+{
+    main0_out out = {};
+    float gl_TessLevelInner[2] = {};
+    float gl_TessLevelOuter[4] = {};
+    gl_TessLevelInner[0] = patchIn.gl_TessLevelInner_0;
+    gl_TessLevelInner[1] = patchIn.gl_TessLevelInner_1;
+    gl_TessLevelOuter[0] = patchIn.gl_TessLevelOuter_0;
+    gl_TessLevelOuter[1] = patchIn.gl_TessLevelOuter_1;
+    gl_TessLevelOuter[2] = patchIn.gl_TessLevelOuter_2;
+    gl_TessLevelOuter[3] = patchIn.gl_TessLevelOuter_3;
+    out.gl_Position = float4(((gl_TessCoord.x * as_type<float>(gl_TessLevelInner[0])) * as_type<float>(gl_TessLevelOuter[0])) + (((1.0 - gl_TessCoord.x) * as_type<float>(gl_TessLevelInner[0])) * as_type<float>(gl_TessLevelOuter[2])), ((gl_TessCoord.y * as_type<float>(gl_TessLevelInner[1])) * as_type<float>(gl_TessLevelOuter[1])) + (((1.0 - gl_TessCoord.y) * as_type<float>(gl_TessLevelInner[1])) * as_type<float>(gl_TessLevelOuter[3])), 0.0, 1.0);
+    return out;
+}
+

--- a/reference/shaders-msl/tese/set-from-function.tese
+++ b/reference/shaders-msl/tese/set-from-function.tese
@@ -1,0 +1,62 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Block
+{
+    float4 a;
+    float4 b;
+};
+
+struct Foo
+{
+    float4 a;
+    float4 b;
+};
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 vColor [[attribute(0)]];
+    float4 Block_a [[attribute(2)]];
+    float4 Block_b [[attribute(3)]];
+};
+
+struct main0_patchIn
+{
+    float4 vColors [[attribute(1)]];
+    float4 Foo_a [[attribute(4)]];
+    float4 Foo_b [[attribute(5)]];
+    patch_control_point<main0_in> gl_in;
+};
+
+void set_from_function(thread float4& gl_Position, thread patch_control_point<main0_in>& gl_in, thread float4& vColors, thread Foo& vFoo)
+{
+    gl_Position = gl_in[0].Block_a;
+    gl_Position += gl_in[0].Block_b;
+    gl_Position += gl_in[1].Block_a;
+    gl_Position += gl_in[1].Block_b;
+    gl_Position += gl_in[0].vColor;
+    gl_Position += gl_in[1].vColor;
+    gl_Position += vColors;
+    gl_Position += vFoo.a;
+    gl_Position += vFoo.b;
+}
+
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]])
+{
+    main0_out out = {};
+    Foo vFoo = {};
+    vFoo.a = patchIn.Foo_a;
+    vFoo.b = patchIn.Foo_b;
+    set_from_function(out.gl_Position, patchIn.gl_in, patchIn.vColors, vFoo);
+    return out;
+}
+

--- a/reference/shaders-msl/tese/triangle.tese
+++ b/reference/shaders-msl/tese/triangle.tese
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+[[ patch(triangle, 0) ]] vertex main0_out main0()
+{
+    main0_out out = {};
+    out.gl_Position = float4(1.0);
+    return out;
+}
+

--- a/reference/shaders-msl/tese/water_tess.tese
+++ b/reference/shaders-msl/tese/water_tess.tese
@@ -1,0 +1,72 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBO
+{
+    float4x4 uMVP;
+    float4 uScale;
+    float2 uInvScale;
+    float3 uCamPos;
+    float2 uPatchSize;
+    float2 uInvHeightmapSize;
+};
+
+struct main0_out
+{
+    float3 vWorld [[user(locn0)]];
+    float4 vGradNormalTex [[user(locn1)]];
+    float4 gl_Position [[position]];
+};
+
+struct main0_patchIn
+{
+    float2 vOutPatchPosBase [[attribute(0)]];
+    float4 vPatchLods [[attribute(1)]];
+};
+
+float2 lerp_vertex(thread const float2& tess_coord, thread float2& vOutPatchPosBase, constant UBO& v_31)
+{
+    return vOutPatchPosBase + (tess_coord * v_31.uPatchSize);
+}
+
+float2 lod_factor(thread const float2& tess_coord, thread float4& vPatchLods)
+{
+    float2 x = mix(vPatchLods.yx, vPatchLods.zw, float2(tess_coord.x));
+    float level = mix(x.x, x.y, tess_coord.y);
+    float floor_level = floor(level);
+    float fract_level = level - floor_level;
+    return float2(floor_level, fract_level);
+}
+
+float3 sample_height_displacement(thread const float2& uv, thread const float2& off, thread const float2& lod, thread texture2d<float> uHeightmapDisplacement, thread const sampler uHeightmapDisplacementSmplr)
+{
+    return mix(uHeightmapDisplacement.sample(uHeightmapDisplacementSmplr, (uv + (off * 0.5)), level(lod.x)).xyz, uHeightmapDisplacement.sample(uHeightmapDisplacementSmplr, (uv + (off * 1.0)), level(lod.x + 1.0)).xyz, float3(lod.y));
+}
+
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], constant UBO& v_31 [[buffer(1)]], texture2d<float> uHeightmapDisplacement [[texture(0)]], sampler uHeightmapDisplacementSmplr [[sampler(0)]], float2 gl_TessCoord [[position_in_patch]])
+{
+    main0_out out = {};
+    float2 tess_coord = gl_TessCoord.xy;
+    float2 param = tess_coord;
+    float2 pos = lerp_vertex(param, patchIn.vOutPatchPosBase, v_31);
+    float2 param_1 = tess_coord;
+    float2 lod = lod_factor(param_1, patchIn.vPatchLods);
+    float2 tex = pos * v_31.uInvHeightmapSize;
+    pos *= v_31.uScale.xy;
+    float delta_mod = exp2(lod.x);
+    float2 off = v_31.uInvHeightmapSize * delta_mod;
+    out.vGradNormalTex = float4(tex + (v_31.uInvHeightmapSize * 0.5), tex * v_31.uScale.zw);
+    float2 param_2 = tex;
+    float2 param_3 = off;
+    float2 param_4 = lod;
+    float3 height_displacement = sample_height_displacement(param_2, param_3, param_4, uHeightmapDisplacement, uHeightmapDisplacementSmplr);
+    pos += height_displacement.yz;
+    out.vWorld = float3(pos.x, height_displacement.x, pos.y);
+    out.gl_Position = v_31.uMVP * float4(out.vWorld, 1.0);
+    return out;
+}
+

--- a/shaders-msl/desktop-only/tese/triangle.desktop.sso.tese
+++ b/shaders-msl/desktop-only/tese/triangle.desktop.sso.tese
@@ -1,0 +1,22 @@
+#version 450
+
+layout(cw, triangles, fractional_even_spacing) in;
+
+in gl_PerVertex
+{
+   vec4 gl_Position;
+} gl_in[gl_MaxPatchVertices];
+
+out gl_PerVertex
+{
+   vec4 gl_Position;
+};
+
+void main()
+{
+   gl_Position =
+      gl_in[0].gl_Position * gl_TessCoord.x +
+      gl_in[1].gl_Position * gl_TessCoord.y +
+      gl_in[2].gl_Position * gl_TessCoord.z;
+}
+

--- a/shaders-msl/tese/input-array.tese
+++ b/shaders-msl/tese/input-array.tese
@@ -1,0 +1,15 @@
+#version 450
+
+layout(ccw, quads, fractional_odd_spacing) in;
+layout(location = 0) in vec4 Floats[];
+layout(location = 2) in vec4 Floats2[gl_MaxPatchVertices];
+
+void set_position()
+{
+	gl_Position = Floats[0] * gl_TessCoord.x + Floats2[1] * gl_TessCoord.y;
+}
+
+void main()
+{
+	set_position();
+}

--- a/shaders-msl/tese/input-types.tese
+++ b/shaders-msl/tese/input-types.tese
@@ -1,0 +1,75 @@
+#version 450
+
+layout(ccw, quads, fractional_even_spacing) in;
+
+// Try to use the whole taxonomy of input methods.
+
+// Per-vertex vector.
+layout(location = 0) in vec4 vColor[];
+// Per-patch vector.
+layout(location = 1) patch in vec4 vColors;
+// Per-patch vector array.
+layout(location = 2) patch in vec4 vColorsArray[2];
+
+// I/O blocks, per patch and per control point.
+layout(location = 4) in Block
+{
+        vec4 a;
+        vec4 b;
+} blocks[];
+
+layout(location = 6) patch in PatchBlock
+{
+        vec4 a;
+        vec4 b;
+} patch_block;
+
+// Composites.
+struct Foo
+{
+        vec4 a;
+        vec4 b;
+};
+layout(location = 8) patch in Foo vFoo;
+//layout(location = 10) patch in Foo vFooArray[2];
+
+// Per-control point struct.
+layout(location = 14) in Foo vFoos[];
+
+void set_from_function()
+{
+        gl_Position = blocks[0].a;
+        gl_Position += blocks[0].b;
+        gl_Position += blocks[1].a;
+        gl_Position += blocks[1].b;
+        gl_Position += patch_block.a;
+        gl_Position += patch_block.b;
+        gl_Position += vColor[0];
+        gl_Position += vColor[1];
+        gl_Position += vColors;
+
+        Foo foo = vFoo;
+        gl_Position += foo.a;
+        gl_Position += foo.b;
+
+        /*foo = vFooArray[0];
+        gl_Position += foo.a;
+        gl_Position += foo.b;
+
+        foo = vFooArray[1];
+        gl_Position += foo.a;
+        gl_Position += foo.b;*/
+
+        foo = vFoos[0];
+        gl_Position += foo.a;
+        gl_Position += foo.b;
+
+        foo = vFoos[1];
+        gl_Position += foo.a;
+        gl_Position += foo.b;
+}
+
+void main()
+{
+        set_from_function();
+}

--- a/shaders-msl/tese/input-types.tese
+++ b/shaders-msl/tese/input-types.tese
@@ -31,7 +31,7 @@ struct Foo
         vec4 b;
 };
 layout(location = 8) patch in Foo vFoo;
-//layout(location = 10) patch in Foo vFooArray[2];
+//layout(location = 10) patch in Foo vFooArray[2];  // FIXME: Handling of array-of-struct input is broken!
 
 // Per-control point struct.
 layout(location = 14) in Foo vFoos[];

--- a/shaders-msl/tese/quad.tese
+++ b/shaders-msl/tese/quad.tese
@@ -1,0 +1,12 @@
+#version 310 es
+#extension GL_EXT_tessellation_shader : require
+
+layout(cw, quads, fractional_even_spacing) in;
+
+void main()
+{
+	gl_Position = vec4(gl_TessCoord.x * gl_TessLevelInner[0] * gl_TessLevelOuter[0] + (1.0 - gl_TessCoord.x) * gl_TessLevelInner[0] * gl_TessLevelOuter[2],
+	                   gl_TessCoord.y * gl_TessLevelInner[1] * gl_TessLevelOuter[1] + (1.0 - gl_TessCoord.y) * gl_TessLevelInner[1] * gl_TessLevelOuter[3],
+	                   0, 1);
+}
+

--- a/shaders-msl/tese/set-from-function.tese
+++ b/shaders-msl/tese/set-from-function.tese
@@ -1,0 +1,36 @@
+#version 450
+
+layout(ccw, quads, fractional_even_spacing) in;
+
+layout(location = 0) in vec4 vColor[];
+layout(location = 1) patch in vec4 vColors;
+layout(location = 2) in Block
+{
+        vec4 a;
+        vec4 b;
+} blocks[];
+
+struct Foo
+{
+        vec4 a;
+        vec4 b;
+};
+layout(location = 4) patch in Foo vFoo;
+
+void set_from_function()
+{
+        gl_Position = blocks[0].a;
+        gl_Position += blocks[0].b;
+        gl_Position += blocks[1].a;
+        gl_Position += blocks[1].b;
+        gl_Position += vColor[0];
+        gl_Position += vColor[1];
+        gl_Position += vColors;
+        gl_Position += vFoo.a;
+        gl_Position += vFoo.b;
+}
+
+void main()
+{
+        set_from_function();
+}

--- a/shaders-msl/tese/triangle.tese
+++ b/shaders-msl/tese/triangle.tese
@@ -1,0 +1,10 @@
+#version 310 es
+#extension GL_EXT_tessellation_shader : require
+
+layout(cw, triangles, fractional_even_spacing) in;
+
+void main()
+{
+   gl_Position = vec4(1.0);
+}
+

--- a/shaders-msl/tese/water_tess.tese
+++ b/shaders-msl/tese/water_tess.tese
@@ -1,0 +1,65 @@
+#version 310 es
+#extension GL_EXT_tessellation_shader : require
+precision highp int;
+
+layout(cw, quads, fractional_even_spacing) in;
+
+layout(location = 0) patch in vec2 vOutPatchPosBase;
+layout(location = 1) patch in vec4 vPatchLods;
+
+layout(binding = 1, std140) uniform UBO
+{
+    mat4 uMVP;
+    vec4 uScale;
+    vec2 uInvScale;
+    vec3 uCamPos;
+    vec2 uPatchSize;
+    vec2 uInvHeightmapSize;
+};
+layout(binding = 0) uniform mediump sampler2D uHeightmapDisplacement;
+
+layout(location = 0) highp out vec3 vWorld;
+layout(location = 1) highp out vec4 vGradNormalTex;
+
+vec2 lerp_vertex(vec2 tess_coord)
+{
+    return vOutPatchPosBase + tess_coord * uPatchSize;
+}
+
+mediump vec2 lod_factor(vec2 tess_coord)
+{
+    mediump vec2 x = mix(vPatchLods.yx, vPatchLods.zw, tess_coord.x);
+    mediump float level = mix(x.x, x.y, tess_coord.y);
+    mediump float floor_level = floor(level);
+    mediump float fract_level = level - floor_level;
+    return vec2(floor_level, fract_level);
+}
+
+mediump vec3 sample_height_displacement(vec2 uv, vec2 off, mediump vec2 lod)
+{
+    return mix(
+            textureLod(uHeightmapDisplacement, uv + 0.5 * off, lod.x).xyz,
+            textureLod(uHeightmapDisplacement, uv + 1.0 * off, lod.x + 1.0).xyz,
+            lod.y);
+}
+
+void main()
+{
+    vec2 tess_coord = gl_TessCoord.xy;
+    vec2 pos = lerp_vertex(tess_coord);
+    mediump vec2 lod = lod_factor(tess_coord);
+
+    vec2 tex = pos * uInvHeightmapSize.xy;
+    pos *= uScale.xy;
+
+    mediump float delta_mod = exp2(lod.x);
+    vec2 off = uInvHeightmapSize.xy * delta_mod;
+
+    vGradNormalTex = vec4(tex + 0.5 * uInvHeightmapSize.xy, tex * uScale.zw);
+    vec3 height_displacement = sample_height_displacement(tex, off, lod);
+
+    pos += height_displacement.yz;
+    vWorld = vec3(pos.x, height_displacement.x, pos.y);
+    gl_Position = uMVP * vec4(vWorld, 1.0);
+}
+

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -417,7 +417,8 @@ struct SPIRType : IVariant
 		Struct,
 		Image,
 		SampledImage,
-		Sampler
+		Sampler,
+		ControlPointArray
 	};
 
 	// Scalar/vector/matrix support.

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -2017,6 +2017,16 @@ ExecutionModel Compiler::get_execution_model() const
 	return execution.model;
 }
 
+bool Compiler::is_tessellation_shader(ExecutionModel model)
+{
+	return model == ExecutionModelTessellationControl || model == ExecutionModelTessellationEvaluation;
+}
+
+bool Compiler::is_tessellation_shader() const
+{
+	return is_tessellation_shader(get_execution_model());
+}
+
 void Compiler::set_remapped_variable_state(uint32_t id, bool remap_enable)
 {
 	get<SPIRVariable>(id).remapped_variable = remap_enable;

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -360,6 +360,9 @@ public:
 	uint32_t get_execution_mode_argument(spv::ExecutionMode mode, uint32_t index = 0) const;
 	spv::ExecutionModel get_execution_model() const;
 
+	static bool is_tessellation_shader(spv::ExecutionModel model);
+	bool is_tessellation_shader() const;
+
 	// In SPIR-V, the compute work group size can be represented by a constant vector, in which case
 	// the LocalSize execution mode is ignored.
 	//

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -360,7 +360,6 @@ public:
 	uint32_t get_execution_mode_argument(spv::ExecutionMode mode, uint32_t index = 0) const;
 	spv::ExecutionModel get_execution_model() const;
 
-	static bool is_tessellation_shader(spv::ExecutionModel model);
 	bool is_tessellation_shader() const;
 
 	// In SPIR-V, the compute work group size can be represented by a constant vector, in which case
@@ -616,6 +615,7 @@ protected:
 
 	const SPIREntryPoint &get_entry_point() const;
 	SPIREntryPoint &get_entry_point();
+	static bool is_tessellation_shader(spv::ExecutionModel model);
 
 	virtual std::string to_name(uint32_t id, bool allow_alias = true) const;
 	bool is_builtin_variable(const SPIRVariable &var) const;

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -5671,6 +5671,12 @@ string CompilerGLSL::access_chain_internal(uint32_t base, const uint32_t *indice
 				append_index();
 			}
 
+			if (type->basetype == SPIRType::ControlPointArray)
+			{
+				type_id = type->parent_type;
+				type = &get<SPIRType>(type_id);
+			}
+
 			access_chain_is_arrayed = true;
 		}
 		// Arrays

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -391,6 +391,12 @@ SPIRType &CompilerMSL::get_stage_out_struct_type()
 	return get_variable_data_type(so_var);
 }
 
+SPIRType &CompilerMSL::get_patch_stage_in_struct_type()
+{
+	auto &si_var = get<SPIRVariable>(patch_stage_in_var_id);
+	return get_variable_data_type(si_var);
+}
+
 SPIRType &CompilerMSL::get_patch_stage_out_struct_type()
 {
 	auto &so_var = get<SPIRVariable>(patch_stage_out_var_id);
@@ -609,12 +615,13 @@ string CompilerMSL::compile()
 	stage_out_var_id = add_interface_block(StorageClassOutput);
 	patch_stage_out_var_id = add_interface_block(StorageClassOutput, true);
 	stage_in_var_id = add_interface_block(StorageClassInput);
+	if (get_execution_model() == ExecutionModelTessellationEvaluation)
+		patch_stage_in_var_id = add_interface_block(StorageClassInput, true);
 
 	if (get_execution_model() == ExecutionModelTessellationControl)
-	{
 		stage_out_ptr_var_id = add_interface_block_pointer(stage_out_var_id, StorageClassOutput);
+	if (is_tessellation_shader())
 		stage_in_ptr_var_id = add_interface_block_pointer(stage_in_var_id, StorageClassInput);
-	}
 
 	// Metal vertex functions that define no output must disable rasterization and return void.
 	if (!stage_out_var_id)
@@ -869,14 +876,15 @@ void CompilerMSL::extract_global_variables_from_function(uint32_t func_id, std::
 			auto *p_type = &get<SPIRType>(type_id);
 			BuiltIn bi_type = BuiltIn(get_decoration(arg_id, DecorationBuiltIn));
 
-			if (get_execution_model() == ExecutionModelTessellationControl &&
-			    (var.storage == StorageClassInput || var.storage == StorageClassOutput) &&
+			if (((is_tessellation_shader() && var.storage == StorageClassInput) ||
+			     (get_execution_model() == ExecutionModelTessellationControl && var.storage == StorageClassOutput)) &&
 			    !has_decoration(arg_id, DecorationPatch) &&
 			    (!is_builtin_variable(var) || bi_type == BuiltInPosition || bi_type == BuiltInPointSize ||
 			     bi_type == BuiltInClipDistance || bi_type == BuiltInCullDistance ||
 			     p_type->basetype == SPIRType::Struct))
 			{
 				// Tessellation control shaders see inputs and per-vertex outputs as arrays.
+				// Similarly, tessellation evaluation shaders see per-vertex inputs as arrays.
 				// We collected them into a structure; we must pass the array of this
 				// structure to the function.
 				std::string name;
@@ -1003,8 +1011,8 @@ void CompilerMSL::mark_as_packable(SPIRType &type)
 void CompilerMSL::mark_location_as_used_by_shader(uint32_t location, StorageClass storage)
 {
 	MSLVertexAttr *p_va;
-	if ((get_execution_model() == ExecutionModelVertex || get_execution_model() == ExecutionModelTessellationControl) &&
-	    (storage == StorageClassInput) && (p_va = vtx_attrs_by_location[location]))
+	if ((get_execution_model() == ExecutionModelVertex || is_tessellation_shader()) && (storage == StorageClassInput) &&
+	    (p_va = vtx_attrs_by_location[location]))
 		p_va->used_by_shader = true;
 }
 
@@ -1099,8 +1107,7 @@ void CompilerMSL::add_plain_variable_to_interface_block(StorageClass storage, co
 	if (get_decoration_bitset(var.self).get(DecorationLocation))
 	{
 		uint32_t locn = get_decoration(var.self, DecorationLocation);
-		if (storage == StorageClassInput && (get_execution_model() == ExecutionModelVertex ||
-		                                     get_execution_model() == ExecutionModelTessellationControl))
+		if (storage == StorageClassInput && (get_execution_model() == ExecutionModelVertex || is_tessellation_shader()))
 		{
 			type_id = ensure_correct_attribute_type(var.basetype, locn);
 			var.basetype = type_id;
@@ -1217,8 +1224,8 @@ void CompilerMSL::add_composite_variable_to_interface_block(StorageClass storage
 		if (get_decoration_bitset(var.self).get(DecorationLocation))
 		{
 			uint32_t locn = get_decoration(var.self, DecorationLocation) + i;
-			if (storage == StorageClassInput && (get_execution_model() == ExecutionModelVertex ||
-			                                     get_execution_model() == ExecutionModelTessellationControl))
+			if (storage == StorageClassInput &&
+			    (get_execution_model() == ExecutionModelVertex || is_tessellation_shader()))
 			{
 				var.basetype = ensure_correct_attribute_type(var.basetype, locn);
 				uint32_t mbr_type_id = ensure_correct_attribute_type(usable_type->self, locn);
@@ -1468,8 +1475,7 @@ void CompilerMSL::add_plain_member_variable_to_interface_block(StorageClass stor
 	if (has_member_decoration(var_type.self, mbr_idx, DecorationLocation))
 	{
 		uint32_t locn = get_member_decoration(var_type.self, mbr_idx, DecorationLocation);
-		if (storage == StorageClassInput && (get_execution_model() == ExecutionModelVertex ||
-		                                     get_execution_model() == ExecutionModelTessellationControl))
+		if (storage == StorageClassInput && (get_execution_model() == ExecutionModelVertex || is_tessellation_shader()))
 		{
 			mbr_type_id = ensure_correct_attribute_type(mbr_type_id, locn);
 			var_type.member_types[mbr_idx] = mbr_type_id;
@@ -1483,8 +1489,7 @@ void CompilerMSL::add_plain_member_variable_to_interface_block(StorageClass stor
 		// The block itself might have a location and in this case, all members of the block
 		// receive incrementing locations.
 		uint32_t locn = get_accumulated_member_location(var, mbr_idx, strip_array);
-		if (storage == StorageClassInput && (get_execution_model() == ExecutionModelVertex ||
-		                                     get_execution_model() == ExecutionModelTessellationControl))
+		if (storage == StorageClassInput && (get_execution_model() == ExecutionModelVertex || is_tessellation_shader()))
 		{
 			mbr_type_id = ensure_correct_attribute_type(mbr_type_id, locn);
 			var_type.member_types[mbr_idx] = mbr_type_id;
@@ -1566,7 +1571,9 @@ void CompilerMSL::add_variable_to_interface_block(StorageClass storage, const st
 
 				if (!is_builtin || has_active_builtin(builtin, storage))
 				{
-					if (!is_builtin && (storage == StorageClassInput || storage == StorageClassOutput) &&
+					if ((!is_builtin ||
+					     (storage == StorageClassInput && get_execution_model() != ExecutionModelFragment)) &&
+					    (storage == StorageClassInput || storage == StorageClassOutput) &&
 					    (is_matrix(mbr_type) || is_array(mbr_type)))
 					{
 						add_composite_member_variable_to_interface_block(storage, ib_var_ref, ib_type, var, mbr_idx,
@@ -1590,7 +1597,7 @@ void CompilerMSL::add_variable_to_interface_block(StorageClass storage, const st
 		if (!is_builtin || has_active_builtin(builtin, storage))
 		{
 			// MSL does not allow matrices or arrays in input or output variables, so need to handle it specially.
-			if (!is_builtin &&
+			if ((!is_builtin || (storage == StorageClassInput && get_execution_model() != ExecutionModelFragment)) &&
 			    (storage == StorageClassInput || (storage == StorageClassOutput && !capture_output_to_buffer)) &&
 			    (is_matrix(var_type) || is_array(var_type)))
 			{
@@ -1608,8 +1615,9 @@ void CompilerMSL::add_variable_to_interface_block(StorageClass storage, const st
 // for per-vertex variables in a tessellation control shader.
 void CompilerMSL::fix_up_interface_member_indices(StorageClass storage, uint32_t ib_type_id)
 {
-	// Only needed for tessellation control shaders.
-	if (get_execution_model() != ExecutionModelTessellationControl)
+	// Only needed for tessellation shaders.
+	if (get_execution_model() != ExecutionModelTessellationControl &&
+	    !(get_execution_model() == ExecutionModelTessellationEvaluation && storage == StorageClassInput))
 		return;
 
 	bool in_array = false;
@@ -1672,7 +1680,7 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage, bool patch)
 {
 	// Accumulate the variables that should appear in the interface struct
 	vector<SPIRVariable *> vars;
-	bool incl_builtins = (storage == StorageClassOutput || get_execution_model() == ExecutionModelTessellationControl);
+	bool incl_builtins = (storage == StorageClassOutput || is_tessellation_shader());
 
 	ir.for_each_typed_id<SPIRVariable>([&](uint32_t var_id, SPIRVariable &var) {
 		auto &type = this->get<SPIRType>(var.basetype);
@@ -1682,14 +1690,18 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage, bool patch)
 		    has_decoration(var_id, DecorationPatch) == patch &&
 		    (!is_builtin_variable(var) || bi_type == BuiltInPosition || bi_type == BuiltInPointSize ||
 		     bi_type == BuiltInClipDistance || bi_type == BuiltInCullDistance || bi_type == BuiltInLayer ||
-		     bi_type == BuiltInViewportIndex || bi_type == BuiltInFragDepth || bi_type == BuiltInSampleMask))
+		     bi_type == BuiltInViewportIndex || bi_type == BuiltInFragDepth || bi_type == BuiltInSampleMask ||
+		     (get_execution_model() == ExecutionModelTessellationEvaluation &&
+		      (bi_type == BuiltInTessLevelOuter || bi_type == BuiltInTessLevelInner))))
 		{
 			vars.push_back(&var);
 		}
 	});
 
-	// If no variables qualify, leave
-	if (vars.empty())
+	// If no variables qualify, leave.
+	// For patch input in a tessellation evaluation shader, the per-vertex stage inputs
+	// are included in a special patch control point array.
+	if (vars.empty() && !(storage == StorageClassInput && patch && stage_in_var_id))
 		return 0;
 
 	// Add a new typed variable for this interface structure.
@@ -1711,7 +1723,7 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage, bool patch)
 	switch (storage)
 	{
 	case StorageClassInput:
-		ib_var_ref = stage_in_var_name;
+		ib_var_ref = patch ? patch_stage_in_var_name : stage_in_var_name;
 		if (get_execution_model() == ExecutionModelTessellationControl)
 		{
 			// Add a hook to populate the shared workgroup memory containing
@@ -1752,6 +1764,7 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage, bool patch)
 			switch (get_execution_model())
 			{
 			case ExecutionModelVertex:
+			case ExecutionModelTessellationEvaluation:
 				// Instead of declaring a struct variable to hold the output and then
 				// copying that to the output buffer, we'll declare the output variable
 				// as a reference to the final output element in the buffer. Then we can
@@ -1798,7 +1811,10 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage, bool patch)
 
 	for (auto p_var : vars)
 	{
-		bool strip_array = get_execution_model() == ExecutionModelTessellationControl && !patch;
+		bool strip_array =
+		    (get_execution_model() == ExecutionModelTessellationControl ||
+		     (get_execution_model() == ExecutionModelTessellationEvaluation && storage == StorageClassInput)) &&
+		    !patch;
 		add_variable_to_interface_block(storage, ib_var_ref, ib_type, *p_var, strip_array);
 	}
 
@@ -1811,6 +1827,21 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage, bool patch)
 	if (!patch)
 		fix_up_interface_member_indices(storage, ib_type_id);
 
+	// For patch inputs, add one more member, holding the array of control point data.
+	if (get_execution_model() == ExecutionModelTessellationEvaluation && storage == StorageClassInput && patch &&
+	    stage_in_var_id)
+	{
+		uint32_t pcp_type_id = ir.increase_bound_by(1);
+		auto &pcp_type = set<SPIRType>(pcp_type_id, ib_type);
+		pcp_type.basetype = SPIRType::ControlPointArray;
+		pcp_type.parent_type = pcp_type.type_alias = get_stage_in_struct_type().self;
+		pcp_type.storage = storage;
+		ir.meta[pcp_type_id] = ir.meta[ib_type.self];
+		uint32_t mbr_idx = ib_type.member_types.size();
+		ib_type.member_types.push_back(pcp_type_id);
+		set_member_name(ib_type.self, mbr_idx, "gl_in");
+	}
+
 	return ib_var_id;
 }
 
@@ -1819,28 +1850,52 @@ uint32_t CompilerMSL::add_interface_block_pointer(uint32_t ib_var_id, StorageCla
 	if (!ib_var_id)
 		return 0;
 
-	// Tessellation control per-vertex I/O is presented as an array, so we must
-	// do the same with our struct here.
+	uint32_t ib_ptr_var_id;
 	uint32_t next_id = ir.increase_bound_by(3);
-	uint32_t ib_ptr_type_id = next_id++;
 	auto &ib_type = expression_type(ib_var_id);
-	auto &ib_ptr_type = set<SPIRType>(ib_ptr_type_id, ib_type);
-	ib_ptr_type.parent_type = ib_ptr_type.type_alias = ib_type.self;
-	ib_ptr_type.pointer = true;
-	ib_ptr_type.storage = storage == StorageClassInput ? StorageClassWorkgroup : StorageClassStorageBuffer;
-	ir.meta[ib_ptr_type_id] = ir.meta[ib_type.self];
-	// To ensure that get_variable_data_type() doesn't strip off the pointer,
-	// which we need, use another pointer.
-	uint32_t ib_ptr_ptr_type_id = next_id++;
-	auto &ib_ptr_ptr_type = set<SPIRType>(ib_ptr_ptr_type_id, ib_ptr_type);
-	ib_ptr_ptr_type.parent_type = ib_ptr_type_id;
-	ib_ptr_ptr_type.type_alias = ib_type.self;
-	ib_ptr_ptr_type.storage = StorageClassFunction;
-	ir.meta[ib_ptr_ptr_type_id] = ir.meta[ib_type.self];
+	if (get_execution_model() == ExecutionModelTessellationControl)
+	{
+		// Tessellation control per-vertex I/O is presented as an array, so we must
+		// do the same with our struct here.
+		uint32_t ib_ptr_type_id = next_id++;
+		auto &ib_ptr_type = set<SPIRType>(ib_ptr_type_id, ib_type);
+		ib_ptr_type.parent_type = ib_ptr_type.type_alias = ib_type.self;
+		ib_ptr_type.pointer = true;
+		ib_ptr_type.storage = storage == StorageClassInput ? StorageClassWorkgroup : StorageClassStorageBuffer;
+		ir.meta[ib_ptr_type_id] = ir.meta[ib_type.self];
+		// To ensure that get_variable_data_type() doesn't strip off the pointer,
+		// which we need, use another pointer.
+		uint32_t ib_ptr_ptr_type_id = next_id++;
+		auto &ib_ptr_ptr_type = set<SPIRType>(ib_ptr_ptr_type_id, ib_ptr_type);
+		ib_ptr_ptr_type.parent_type = ib_ptr_type_id;
+		ib_ptr_ptr_type.type_alias = ib_type.self;
+		ib_ptr_ptr_type.storage = StorageClassFunction;
+		ir.meta[ib_ptr_ptr_type_id] = ir.meta[ib_type.self];
 
-	uint32_t ib_ptr_var_id = next_id;
-	set<SPIRVariable>(ib_ptr_var_id, ib_ptr_ptr_type_id, StorageClassFunction, 0);
-	set_name(ib_ptr_var_id, storage == StorageClassInput ? input_wg_var_name : "gl_out");
+		ib_ptr_var_id = next_id;
+		set<SPIRVariable>(ib_ptr_var_id, ib_ptr_ptr_type_id, StorageClassFunction, 0);
+		set_name(ib_ptr_var_id, storage == StorageClassInput ? input_wg_var_name : "gl_out");
+	}
+	else
+	{
+		// Tessellation evaluation per-vertex inputs are also presented as arrays.
+		// But, in Metal, this array uses a very special type, 'patch_control_point<T>',
+		// which is a container that can be used to access the control point data.
+		// To represent this, a special 'ControlPointArray' type has been added to the
+		// SPIRV-Cross type system. It should only be generated by and seen in the MSL
+		// backend (i.e. this one).
+		uint32_t pcp_type_id = next_id++;
+		auto &pcp_type = set<SPIRType>(pcp_type_id, ib_type);
+		pcp_type.basetype = SPIRType::ControlPointArray;
+		pcp_type.parent_type = pcp_type.type_alias = ib_type.self;
+		pcp_type.storage = storage;
+		ir.meta[pcp_type_id] = ir.meta[ib_type.self];
+
+		ib_ptr_var_id = next_id;
+		set<SPIRVariable>(ib_ptr_var_id, pcp_type_id, storage, 0);
+		set_name(ib_ptr_var_id, "gl_in");
+		ir.meta[ib_ptr_var_id].decoration.qualified_alias = join(patch_stage_in_var_name, ".gl_in");
+	}
 	return ib_ptr_var_id;
 }
 
@@ -2723,6 +2778,7 @@ void CompilerMSL::emit_resources()
 	emit_interface_block(stage_out_var_id);
 	emit_interface_block(patch_stage_out_var_id);
 	emit_interface_block(stage_in_var_id);
+	emit_interface_block(patch_stage_in_var_id);
 }
 
 // Emit declarations for the specialization Metal function constants
@@ -2822,6 +2878,8 @@ void CompilerMSL::emit_specialization_constants_and_structs()
 				is_declarable_struct = false;
 			if (stage_in_var_id && get_stage_in_struct_type().self == type_id)
 				is_declarable_struct = false;
+			if (patch_stage_in_var_id && get_patch_stage_in_struct_type().self == type_id)
+				is_declarable_struct = false;
 
 			// Align and emit declarable structs...but avoid declaring each more than once.
 			if (is_declarable_struct && declared_structs.count(type_id) == 0)
@@ -2859,12 +2917,14 @@ void CompilerMSL::emit_binary_unord_op(uint32_t result_type, uint32_t result_id,
 	inherit_expression_dependencies(result_id, op1);
 }
 
-bool CompilerMSL::emit_tessellation_control_access_chain(const uint32_t *ops, uint32_t length)
+bool CompilerMSL::emit_tessellation_access_chain(const uint32_t *ops, uint32_t length)
 {
 	// If this is a per-vertex output, remap it to the I/O array buffer.
 	auto *var = maybe_get<SPIRVariable>(ops[2]);
 	BuiltIn bi_type = BuiltIn(get_decoration(ops[2], DecorationBuiltIn));
-	if (var && (var->storage == StorageClassInput || var->storage == StorageClassOutput) &&
+	if (var &&
+	    (var->storage == StorageClassInput ||
+	     (get_execution_model() == ExecutionModelTessellationControl && var->storage == StorageClassOutput)) &&
 	    !has_decoration(ops[2], DecorationPatch) &&
 	    (!is_builtin_variable(*var) || bi_type == BuiltInPosition || bi_type == BuiltInPointSize ||
 	     bi_type == BuiltInClipDistance || bi_type == BuiltInCullDistance ||
@@ -3034,8 +3094,8 @@ bool CompilerMSL::emit_tessellation_control_access_chain(const uint32_t *ops, ui
 	// array reference here. We need to make this ID a variable instead of an
 	// expression so we don't try to dereference it as a variable pointer.
 	auto *m = ir.find_meta(var ? var->self : 0);
-	if (var && m && m->decoration.builtin_type == BuiltInTessLevelInner &&
-	    get_entry_point().flags.get(ExecutionModeTriangles))
+	if (get_execution_model() == ExecutionModelTessellationControl && var && m &&
+	    m->decoration.builtin_type == BuiltInTessLevelInner && get_entry_point().flags.get(ExecutionModeTriangles))
 	{
 		auto &dest_var = set<SPIRVariable>(ops[1], *var);
 		dest_var.basetype = ops[0];
@@ -3518,9 +3578,9 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 	case OpInBoundsAccessChain:
 	case OpAccessChain:
 	case OpPtrAccessChain:
-		if (get_execution_model() == ExecutionModelTessellationControl)
+		if (is_tessellation_shader())
 		{
-			if (!emit_tessellation_control_access_chain(ops, instruction.length))
+			if (!emit_tessellation_access_chain(ops, instruction.length))
 				CompilerGLSL::emit_instruction(instruction);
 		}
 		else
@@ -4792,8 +4852,9 @@ string CompilerMSL::member_attribute_qualifier(const SPIRType &type, uint32_t in
 			return string(" [[attribute(") + convert_to_string(locn) + ")]]";
 	}
 
-	// Vertex function outputs
-	if (execution.model == ExecutionModelVertex && type.storage == StorageClassOutput)
+	// Vertex and tessellation evaluation function outputs
+	if ((execution.model == ExecutionModelVertex || execution.model == ExecutionModelTessellationEvaluation) &&
+	    type.storage == StorageClassOutput)
 	{
 		if (is_builtin)
 		{
@@ -4859,6 +4920,33 @@ string CompilerMSL::member_attribute_qualifier(const SPIRType &type, uint32_t in
 		// output to a buffer. For this reason, qualifiers are irrelevant here.
 		return "";
 	}
+
+	// Tessellation evaluation function inputs
+	if (execution.model == ExecutionModelTessellationEvaluation && type.storage == StorageClassInput)
+	{
+		if (is_builtin)
+		{
+			switch (builtin)
+			{
+			case BuiltInPrimitiveId:
+			case BuiltInTessCoord:
+				return string(" [[") + builtin_qualifier(builtin) + "]]";
+			case BuiltInPatchVertices:
+				return "";
+			// Others come from stage input.
+			default:
+				break;
+			}
+		}
+		// The special control point array must not be marked with an attribute.
+		if (get_type(type.member_types[index]).basetype == SPIRType::ControlPointArray)
+			return "";
+		uint32_t locn = get_ordered_member_location(type.self, index);
+		if (locn != k_unknown_location)
+			return string(" [[attribute(") + convert_to_string(locn) + ")]]";
+	}
+
+	// Tessellation evaluation function outputs were handled above.
 
 	// Fragment function inputs
 	if (execution.model == ExecutionModelFragment && type.storage == StorageClassInput)
@@ -5028,6 +5116,18 @@ string CompilerMSL::func_type_decl(SPIRType &type)
 	case ExecutionModelVertex:
 		entry_type = "vertex";
 		break;
+	case ExecutionModelTessellationEvaluation:
+		if (!msl_options.supports_msl_version(1, 2))
+			SPIRV_CROSS_THROW("Tessellation requires Metal 1.2.");
+		if (execution.flags.get(ExecutionModeIsolines))
+			SPIRV_CROSS_THROW("Metal does not support isoline tessellation.");
+		if (msl_options.is_ios())
+			entry_type =
+			    join("[[ patch(", execution.flags.get(ExecutionModeTriangles) ? "triangle" : "quad", ") ]] vertex");
+		else
+			entry_type = join("[[ patch(", execution.flags.get(ExecutionModeTriangles) ? "triangle" : "quad", ", ",
+			                  execution.output_vertices, ") ]] vertex");
+		break;
 	case ExecutionModelFragment:
 		entry_type =
 		    execution.flags.get(ExecutionModeEarlyFragmentTests) ? "[[ early_fragment_tests ]] fragment" : "fragment";
@@ -5152,9 +5252,15 @@ string CompilerMSL::entry_point_args(bool append_comma)
 	string ep_args;
 
 	// Stage-in structure
-	if (stage_in_var_id)
+	uint32_t stage_in_id;
+	if (get_execution_model() == ExecutionModelTessellationEvaluation)
+		stage_in_id = patch_stage_in_var_id;
+	else
+		stage_in_id = stage_in_var_id;
+
+	if (stage_in_id)
 	{
-		auto &var = get<SPIRVariable>(stage_in_var_id);
+		auto &var = get<SPIRVariable>(stage_in_id);
 		auto &type = get_variable_data_type(var);
 
 		if (!ep_args.empty())
@@ -5284,7 +5390,8 @@ string CompilerMSL::entry_point_args(bool append_comma)
 		// Don't emit SamplePosition as a separate parameter. In the entry
 		// point, we get that by calling get_sample_position() on the sample ID.
 		if (var.storage == StorageClassInput && is_builtin_variable(var) &&
-		    get_variable_data_type(var).basetype != SPIRType::Struct)
+		    get_variable_data_type(var).basetype != SPIRType::Struct &&
+		    get_variable_data_type(var).basetype != SPIRType::ControlPointArray)
 		{
 			if (bi_type != BuiltInSamplePosition && bi_type != BuiltInHelperInvocation &&
 			    bi_type != BuiltInPatchVertices && bi_type != BuiltInTessLevelInner &&
@@ -5413,9 +5520,15 @@ void CompilerMSL::fix_up_shader_inputs_outputs()
 				});
 				break;
 			case BuiltInPatchVertices:
-				entry_func.fixup_hooks_in.push_back([=]() {
-					statement(builtin_type_decl(bi_type), " ", to_expression(var_id), " = spvIndirectParams[0];");
-				});
+				if (get_execution_model() == ExecutionModelTessellationEvaluation)
+					entry_func.fixup_hooks_in.push_back([=]() {
+						statement(builtin_type_decl(bi_type), " ", to_expression(var_id), " = ",
+						          to_expression(patch_stage_in_var_id), ".gl_in.size();");
+					});
+				else
+					entry_func.fixup_hooks_in.push_back([=]() {
+						statement(builtin_type_decl(bi_type), " ", to_expression(var_id), " = spvIndirectParams[0];");
+					});
 				break;
 			default:
 				break;
@@ -5982,6 +6095,9 @@ string CompilerMSL::type_to_glsl(const SPIRType &type, uint32_t id)
 	case SPIRType::AtomicCounter:
 		return "atomic_uint";
 
+	case SPIRType::ControlPointArray:
+		return join("patch_control_point<", type_to_glsl(get<SPIRType>(type.parent_type), id), ">");
+
 	// Scalars
 	case SPIRType::Boolean:
 		type_name = "bool";
@@ -6263,7 +6379,7 @@ string CompilerMSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 
 	// When used in the entry function, output builtins are qualified with output struct name.
 	// Test storage class as NOT Input, as output builtins might be part of generic type.
-	// Also don't do this for tessellation shaders.
+	// Also don't do this for tessellation control shaders.
 	case BuiltInViewportIndex:
 		if (!msl_options.supports_msl_version(2, 0))
 			SPIRV_CROSS_THROW("ViewportIndex requires Metal 2.0.");
@@ -6283,12 +6399,16 @@ string CompilerMSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 		break;
 
 	case BuiltInTessLevelOuter:
+		if (get_execution_model() == ExecutionModelTessellationEvaluation)
+			break;
 		if (storage != StorageClassInput && current_function && (current_function->self == ir.default_entry_point))
 			return join(tess_factor_buffer_var_name, "[", to_expression(builtin_primitive_id_id),
 			            "].edgeTessellationFactor");
 		break;
 
 	case BuiltInTessLevelInner:
+		if (get_execution_model() == ExecutionModelTessellationEvaluation)
+			break;
 		if (storage != StorageClassInput && current_function && (current_function->self == ir.default_entry_point))
 			return join(tess_factor_buffer_var_name, "[", to_expression(builtin_primitive_id_id),
 			            "].insideTessellationFactor");
@@ -6345,13 +6465,25 @@ string CompilerMSL::builtin_qualifier(BuiltIn builtin)
 		// Shouldn't be reached.
 		SPIRV_CROSS_THROW("PatchVertices is derived from the auxiliary buffer in MSL.");
 	case BuiltInPrimitiveId:
-		return "threadgroup_position_in_grid";
+		switch (execution.model)
+		{
+		case ExecutionModelTessellationControl:
+			return "threadgroup_position_in_grid";
+		case ExecutionModelTessellationEvaluation:
+			return "patch_id";
+		default:
+			SPIRV_CROSS_THROW("PrimitiveId is not supported in this execution model.");
+		}
 
 	// Tess. control function out
 	case BuiltInTessLevelOuter:
 	case BuiltInTessLevelInner:
 		// Shouldn't be reached.
 		SPIRV_CROSS_THROW("Tessellation levels are handled specially in MSL.");
+
+	// Tess. evaluation function in
+	case BuiltInTessCoord:
+		return "position_in_patch";
 
 	// Fragment function in
 	case BuiltInFrontFacing:
@@ -6446,6 +6578,10 @@ string CompilerMSL::builtin_type_decl(BuiltIn builtin)
 		return "half";
 	case BuiltInTessLevelOuter:
 		return "half";
+
+	// Tess. evaluation function in
+	case BuiltInTessCoord:
+		return get_entry_point().flags.get(ExecutionModeTriangles) ? "float3" : "float2";
 
 	// Fragment function in
 	case BuiltInFrontFacing:

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -388,6 +388,7 @@ protected:
 	void replace_illegal_names() override;
 	void declare_undefined_values() override;
 	void declare_constant_arrays();
+	bool is_patch_block(const SPIRType &type);
 	bool is_non_native_row_major_matrix(uint32_t id) override;
 	bool member_is_non_native_row_major_matrix(const SPIRType &type, uint32_t index) override;
 	std::string convert_row_major_matrix(std::string exp_str, const SPIRType &exp_type, bool is_packed) override;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -456,6 +456,7 @@ protected:
 	std::string get_type_address_space(const SPIRType &type);
 	SPIRType &get_stage_in_struct_type();
 	SPIRType &get_stage_out_struct_type();
+	SPIRType &get_patch_stage_in_struct_type();
 	SPIRType &get_patch_stage_out_struct_type();
 	std::string get_tess_factor_struct_name();
 	void emit_atomic_func_op(uint32_t result_type, uint32_t result_id, const char *op, uint32_t mem_order_1,
@@ -484,7 +485,7 @@ protected:
 
 	void analyze_sampled_image_usage();
 
-	bool emit_tessellation_control_access_chain(const uint32_t *ops, uint32_t length);
+	bool emit_tessellation_access_chain(const uint32_t *ops, uint32_t length);
 
 	Options msl_options;
 	std::set<SPVFuncImpl> spv_function_implementations;
@@ -498,6 +499,7 @@ protected:
 	MSLResourceBinding next_metal_resource_index;
 	uint32_t stage_in_var_id = 0;
 	uint32_t stage_out_var_id = 0;
+	uint32_t patch_stage_in_var_id = 0;
 	uint32_t patch_stage_out_var_id = 0;
 	uint32_t stage_in_ptr_var_id = 0;
 	uint32_t stage_out_ptr_var_id = 0;
@@ -511,6 +513,7 @@ protected:
 	std::string qual_pos_var_name;
 	std::string stage_in_var_name = "in";
 	std::string stage_out_var_name = "out";
+	std::string patch_stage_in_var_name = "patchIn";
 	std::string patch_stage_out_var_name = "patchOut";
 	std::string sampler_name_suffix = "Smplr";
 	std::string swizzle_name_suffix = "Swzl";


### PR DESCRIPTION
These are mapped to Metal's post-tessellation vertex functions. The
semantic difference is much less here, so this change should be simpler
than the previous one. There are still some hairy parts, though.

In MSL, the array of control point data is represented by a special
type, `patch_control_point<T>`, where `T` is a valid stage-input type.
This object must be embedded inside the patch-level stage input. For
this reason, I've added a new type to the type system to represent this.

On Mac, the number of input control points to the function must be
specified in the `patch()` attribute. This is optional on iOS.
SPIRV-Cross takes this from the `OutputVertices` execution mode; the
intent is that if it's not set in the shader itself, MoltenVK will set
it from the tessellation control shader. If you're translating these
offline, you'll have to update the control point count manually, since
this number must match the number that is passed to the
`drawPatches:...` family of methods.

Fixes #120.