### PR TITLE
MSL: Add an option to set the tessellation domain origin.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -494,6 +494,7 @@ struct CLIArguments
 	bool msl_swizzle_texture_samples = false;
 	bool msl_ios = false;
 	bool msl_pad_fragment_output = false;
+	bool msl_domain_lower_left = false;
 	vector<PLSArg> pls_in;
 	vector<PLSArg> pls_out;
 	vector<Remap> remaps;
@@ -550,6 +551,7 @@ static void print_help()
 	                "\t[--msl-swizzle-texture-samples]\n"
 	                "\t[--msl-ios]\n"
 	                "\t[--msl-pad-fragment-output]\n"
+	                "\t[--msl-domain-lower-left]\n"
 	                "\t[--hlsl]\n"
 	                "\t[--reflect]\n"
 	                "\t[--shader-model]\n"
@@ -720,6 +722,7 @@ static int main_inner(int argc, char *argv[])
 	cbs.add("--msl-swizzle-texture-samples", [&args](CLIParser &) { args.msl_swizzle_texture_samples = true; });
 	cbs.add("--msl-ios", [&args](CLIParser &) { args.msl_ios = true; });
 	cbs.add("--msl-pad-fragment-output", [&args](CLIParser &) { args.msl_pad_fragment_output = true; });
+	cbs.add("--msl-domain-lower-left", [&args](CLIParser &) { args.msl_domain_lower_left = true; });
 	cbs.add("--extension", [&args](CLIParser &parser) { args.extensions.push_back(parser.next_string()); });
 	cbs.add("--rename-entry-point", [&args](CLIParser &parser) {
 		auto old_name = parser.next_string();
@@ -851,6 +854,7 @@ static int main_inner(int argc, char *argv[])
 		if (args.msl_ios)
 			msl_opts.platform = CompilerMSL::Options::iOS;
 		msl_opts.pad_fragment_output_components = args.msl_pad_fragment_output;
+		msl_opts.tess_domain_origin_lower_left = args.msl_domain_lower_left;
 		msl_comp->set_msl_options(msl_opts);
 	}
 	else if (args.hlsl)

--- a/reference/opt/shaders-msl/desktop-only/tese/triangle.desktop.sso.domain.tese
+++ b/reference/opt/shaders-msl/desktop-only/tese/triangle.desktop.sso.domain.tese
@@ -1,0 +1,28 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 gl_Position [[attribute(0)]];
+};
+
+struct main0_patchIn
+{
+    patch_control_point<main0_in> gl_in;
+};
+
+[[ patch(triangle, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float3 gl_TessCoord [[position_in_patch]])
+{
+    main0_out out = {};
+    gl_TessCoord.yz = float2(gl_TessCoord.y - gl_TessCoord.x, 1.0 - gl_TessCoord.y);
+    out.gl_Position = ((patchIn.gl_in[0].gl_Position * gl_TessCoord.x) + (patchIn.gl_in[1].gl_Position * gl_TessCoord.y)) + (patchIn.gl_in[2].gl_Position * gl_TessCoord.z);
+    return out;
+}
+

--- a/reference/opt/shaders-msl/tese/quad.domain.tese
+++ b/reference/opt/shaders-msl/tese/quad.domain.tese
@@ -1,0 +1,36 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_patchIn
+{
+    float gl_TessLevelInner_0 [[attribute(0)]];
+    float gl_TessLevelInner_1 [[attribute(1)]];
+    float gl_TessLevelOuter_0 [[attribute(2)]];
+    float gl_TessLevelOuter_1 [[attribute(3)]];
+    float gl_TessLevelOuter_2 [[attribute(4)]];
+    float gl_TessLevelOuter_3 [[attribute(5)]];
+};
+
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoord [[position_in_patch]])
+{
+    main0_out out = {};
+    float gl_TessLevelInner[2] = {};
+    float gl_TessLevelOuter[4] = {};
+    gl_TessLevelInner[0] = patchIn.gl_TessLevelInner_0;
+    gl_TessLevelInner[1] = patchIn.gl_TessLevelInner_1;
+    gl_TessLevelOuter[0] = patchIn.gl_TessLevelOuter_0;
+    gl_TessLevelOuter[1] = patchIn.gl_TessLevelOuter_1;
+    gl_TessLevelOuter[2] = patchIn.gl_TessLevelOuter_2;
+    gl_TessLevelOuter[3] = patchIn.gl_TessLevelOuter_3;
+    gl_TessCoord.y = 1.0 - gl_TessCoord.y;
+    out.gl_Position = float4(((gl_TessCoord.x * as_type<float>(gl_TessLevelInner[0])) * as_type<float>(gl_TessLevelOuter[0])) + (((1.0 - gl_TessCoord.x) * as_type<float>(gl_TessLevelInner[0])) * as_type<float>(gl_TessLevelOuter[2])), ((gl_TessCoord.y * as_type<float>(gl_TessLevelInner[1])) * as_type<float>(gl_TessLevelOuter[3])) + (((1.0 - gl_TessCoord.y) * as_type<float>(gl_TessLevelInner[1])) * as_type<float>(gl_TessLevelOuter[1])), 0.0, 1.0);
+    return out;
+}
+

--- a/reference/shaders-msl/desktop-only/tese/triangle.desktop.sso.domain.tese
+++ b/reference/shaders-msl/desktop-only/tese/triangle.desktop.sso.domain.tese
@@ -1,0 +1,28 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 gl_Position [[attribute(0)]];
+};
+
+struct main0_patchIn
+{
+    patch_control_point<main0_in> gl_in;
+};
+
+[[ patch(triangle, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float3 gl_TessCoord [[position_in_patch]])
+{
+    main0_out out = {};
+    gl_TessCoord.yz = float2(gl_TessCoord.y - gl_TessCoord.x, 1.0 - gl_TessCoord.y);
+    out.gl_Position = ((patchIn.gl_in[0].gl_Position * gl_TessCoord.x) + (patchIn.gl_in[1].gl_Position * gl_TessCoord.y)) + (patchIn.gl_in[2].gl_Position * gl_TessCoord.z);
+    return out;
+}
+

--- a/reference/shaders-msl/tese/quad.domain.tese
+++ b/reference/shaders-msl/tese/quad.domain.tese
@@ -1,0 +1,36 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_patchIn
+{
+    float gl_TessLevelInner_0 [[attribute(0)]];
+    float gl_TessLevelInner_1 [[attribute(1)]];
+    float gl_TessLevelOuter_0 [[attribute(2)]];
+    float gl_TessLevelOuter_1 [[attribute(3)]];
+    float gl_TessLevelOuter_2 [[attribute(4)]];
+    float gl_TessLevelOuter_3 [[attribute(5)]];
+};
+
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoord [[position_in_patch]])
+{
+    main0_out out = {};
+    float gl_TessLevelInner[2] = {};
+    float gl_TessLevelOuter[4] = {};
+    gl_TessLevelInner[0] = patchIn.gl_TessLevelInner_0;
+    gl_TessLevelInner[1] = patchIn.gl_TessLevelInner_1;
+    gl_TessLevelOuter[0] = patchIn.gl_TessLevelOuter_0;
+    gl_TessLevelOuter[1] = patchIn.gl_TessLevelOuter_1;
+    gl_TessLevelOuter[2] = patchIn.gl_TessLevelOuter_2;
+    gl_TessLevelOuter[3] = patchIn.gl_TessLevelOuter_3;
+    gl_TessCoord.y = 1.0 - gl_TessCoord.y;
+    out.gl_Position = float4(((gl_TessCoord.x * as_type<float>(gl_TessLevelInner[0])) * as_type<float>(gl_TessLevelOuter[0])) + (((1.0 - gl_TessCoord.x) * as_type<float>(gl_TessLevelInner[0])) * as_type<float>(gl_TessLevelOuter[2])), ((gl_TessCoord.y * as_type<float>(gl_TessLevelInner[1])) * as_type<float>(gl_TessLevelOuter[3])) + (((1.0 - gl_TessCoord.y) * as_type<float>(gl_TessLevelInner[1])) * as_type<float>(gl_TessLevelOuter[1])), 0.0, 1.0);
+    return out;
+}
+

--- a/shaders-msl/desktop-only/tese/triangle.desktop.sso.domain.tese
+++ b/shaders-msl/desktop-only/tese/triangle.desktop.sso.domain.tese
@@ -1,0 +1,22 @@
+#version 450
+
+layout(cw, triangles, fractional_even_spacing) in;
+
+in gl_PerVertex
+{
+   vec4 gl_Position;
+} gl_in[gl_MaxPatchVertices];
+
+out gl_PerVertex
+{
+   vec4 gl_Position;
+};
+
+void main()
+{
+   gl_Position =
+      gl_in[0].gl_Position * gl_TessCoord.x +
+      gl_in[1].gl_Position * gl_TessCoord.y +
+      gl_in[2].gl_Position * gl_TessCoord.z;
+}
+

--- a/shaders-msl/tese/quad.domain.tese
+++ b/shaders-msl/tese/quad.domain.tese
@@ -1,0 +1,12 @@
+#version 310 es
+#extension GL_EXT_tessellation_shader : require
+
+layout(cw, quads, fractional_even_spacing) in;
+
+void main()
+{
+	gl_Position = vec4(gl_TessCoord.x * gl_TessLevelInner[0] * gl_TessLevelOuter[0] + (1.0 - gl_TessCoord.x) * gl_TessLevelInner[0] * gl_TessLevelOuter[2],
+	                   gl_TessCoord.y * gl_TessLevelInner[1] * gl_TessLevelOuter[3] + (1.0 - gl_TessCoord.y) * gl_TessLevelInner[1] * gl_TessLevelOuter[1],
+	                   0, 1);
+}
+

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -177,6 +177,7 @@ public:
 		bool disable_rasterization = false;
 		bool capture_output_to_buffer = false;
 		bool swizzle_texture_samples = false;
+		bool tess_domain_origin_lower_left = false;
 
 		// Fragment output in MSL must have at least as many components as the render pass.
 		// Add support to explicit pad out components.

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -156,6 +156,8 @@ def cross_compile_msl(shader, spirv, opt):
         msl_args.append('--msl-pad-fragment-output')
     if '.capture.' in shader:
         msl_args.append('--msl-capture-output')
+    if '.domain.' in shader:
+        msl_args.append('--msl-domain-lower-left')
 
     subprocess.check_call(msl_args)
 


### PR DESCRIPTION
This is intended to be used to support `VK_KHR_maintenance2`'s
tessellation domain origin feature. If `tess_domain_origin_lower_left`
is `true`, the `v` coordinate will be inverted with respect to the
domain. Additionally, in `Triangles` mode, the `v` and `w` coordinates
will be swapped. This is because the winding order is interpreted
differently in lower-left mode.