### PR TITLE
Fix case where a struct is loaded which contains a row-major matrix.

### DIFF
--- a/reference/opt/shaders-hlsl/asm/vert/extract-transposed-matrix-from-struct.asm.vert
+++ b/reference/opt/shaders-hlsl/asm/vert/extract-transposed-matrix-from-struct.asm.vert
@@ -1,0 +1,45 @@
+struct InstanceData
+{
+    column_major float4x4 MATRIX_MVP;
+    float4 Color;
+};
+
+cbuffer gInstanceData : register(b0)
+{
+    InstanceData gInstanceData_1_data[32] : packoffset(c0);
+};
+
+
+static float4 gl_Position;
+static int gl_InstanceIndex;
+static float3 PosL;
+static float4 _entryPointOutput_Color;
+
+struct SPIRV_Cross_Input
+{
+    float3 PosL : TEXCOORD0;
+    uint gl_InstanceIndex : SV_InstanceID;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 _entryPointOutput_Color : TEXCOORD0;
+    float4 gl_Position : SV_Position;
+};
+
+void vert_main()
+{
+    gl_Position = mul(float4(PosL, 1.0f), gInstanceData_1_data[uint(gl_InstanceIndex)].MATRIX_MVP);
+    _entryPointOutput_Color = gInstanceData_1_data[uint(gl_InstanceIndex)].Color;
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    gl_InstanceIndex = int(stage_input.gl_InstanceIndex);
+    PosL = stage_input.PosL;
+    vert_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    stage_output._entryPointOutput_Color = _entryPointOutput_Color;
+    return stage_output;
+}

--- a/reference/opt/shaders-msl/asm/vert/extract-transposed-matrix-from-struct.asm.vert
+++ b/reference/opt/shaders-msl/asm/vert/extract-transposed-matrix-from-struct.asm.vert
@@ -1,0 +1,35 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct InstanceData
+{
+    float4x4 MATRIX_MVP;
+    float4 Color;
+};
+
+struct gInstanceData
+{
+    InstanceData _data[1];
+};
+
+struct main0_out
+{
+    float4 _entryPointOutput_Color [[user(locn0)]];
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float3 PosL [[attribute(0)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], const device gInstanceData& gInstanceData_1 [[buffer(0)]], uint gl_InstanceIndex [[instance_id]])
+{
+    main0_out out = {};
+    out.gl_Position = float4(in.PosL, 1.0) * gInstanceData_1._data[gl_InstanceIndex].MATRIX_MVP;
+    out._entryPointOutput_Color = gInstanceData_1._data[gl_InstanceIndex].Color;
+    return out;
+}
+

--- a/reference/opt/shaders/asm/vert/extract-transposed-matrix-from-struct.asm.vert
+++ b/reference/opt/shaders/asm/vert/extract-transposed-matrix-from-struct.asm.vert
@@ -1,0 +1,23 @@
+#version 450
+
+struct InstanceData
+{
+    mat4 MATRIX_MVP;
+    vec4 Color;
+};
+
+layout(binding = 0, std430) readonly buffer gInstanceData
+{
+    layout(row_major) InstanceData _data[];
+} gInstanceData_1;
+
+layout(location = 0) in vec3 PosL;
+uniform int SPIRV_Cross_BaseInstance;
+layout(location = 0) out vec4 _entryPointOutput_Color;
+
+void main()
+{
+    gl_Position = gInstanceData_1._data[uint((gl_InstanceID + SPIRV_Cross_BaseInstance))].MATRIX_MVP * vec4(PosL, 1.0);
+    _entryPointOutput_Color = gInstanceData_1._data[uint((gl_InstanceID + SPIRV_Cross_BaseInstance))].Color;
+}
+

--- a/reference/shaders-hlsl/asm/vert/extract-transposed-matrix-from-struct.asm.vert
+++ b/reference/shaders-hlsl/asm/vert/extract-transposed-matrix-from-struct.asm.vert
@@ -1,0 +1,67 @@
+struct V2F
+{
+    float4 Position;
+    float4 Color;
+};
+
+struct InstanceData
+{
+    column_major float4x4 MATRIX_MVP;
+    float4 Color;
+};
+
+cbuffer gInstanceData : register(b0)
+{
+    InstanceData gInstanceData_1_data[32] : packoffset(c0);
+};
+
+
+static float4 gl_Position;
+static int gl_InstanceIndex;
+static float3 PosL;
+static float4 _entryPointOutput_Color;
+
+struct SPIRV_Cross_Input
+{
+    float3 PosL : TEXCOORD0;
+    uint gl_InstanceIndex : SV_InstanceID;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 _entryPointOutput_Color : TEXCOORD0;
+    float4 gl_Position : SV_Position;
+};
+
+V2F _VS(float3 PosL_1, uint instanceID)
+{
+    InstanceData instData;
+    instData.MATRIX_MVP = gInstanceData_1_data[instanceID].MATRIX_MVP;
+    instData.Color = gInstanceData_1_data[instanceID].Color;
+    V2F v2f;
+    v2f.Position = mul(float4(PosL_1, 1.0f), instData.MATRIX_MVP);
+    v2f.Color = instData.Color;
+    return v2f;
+}
+
+void vert_main()
+{
+    float3 PosL_1 = PosL;
+    uint instanceID = uint(gl_InstanceIndex);
+    float3 param = PosL_1;
+    uint param_1 = instanceID;
+    V2F flattenTemp = _VS(param, param_1);
+    gl_Position = flattenTemp.Position;
+    _entryPointOutput_Color = flattenTemp.Color;
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    gl_InstanceIndex = int(stage_input.gl_InstanceIndex);
+    PosL = stage_input.PosL;
+    vert_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    stage_output._entryPointOutput_Color = _entryPointOutput_Color;
+    return stage_output;
+}

--- a/reference/shaders-msl/asm/vert/extract-transposed-matrix-from-struct.asm.vert
+++ b/reference/shaders-msl/asm/vert/extract-transposed-matrix-from-struct.asm.vert
@@ -1,0 +1,65 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct V2F
+{
+    float4 Position;
+    float4 Color;
+};
+
+struct InstanceData
+{
+    float4x4 MATRIX_MVP;
+    float4 Color;
+};
+
+struct InstanceData_1
+{
+    float4x4 MATRIX_MVP;
+    float4 Color;
+};
+
+struct gInstanceData
+{
+    InstanceData _data[1];
+};
+
+struct main0_out
+{
+    float4 _entryPointOutput_Color [[user(locn0)]];
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float3 PosL [[attribute(0)]];
+};
+
+V2F _VS(thread const float3& PosL, thread const uint& instanceID, const device gInstanceData& gInstanceData_1)
+{
+    InstanceData_1 instData;
+    instData.MATRIX_MVP = transpose(gInstanceData_1._data[instanceID].MATRIX_MVP);
+    instData.Color = gInstanceData_1._data[instanceID].Color;
+    V2F v2f;
+    v2f.Position = instData.MATRIX_MVP * float4(PosL, 1.0);
+    v2f.Color = instData.Color;
+    return v2f;
+}
+
+vertex main0_out main0(main0_in in [[stage_in]], const device gInstanceData& gInstanceData_1 [[buffer(0)]], uint gl_InstanceIndex [[instance_id]])
+{
+    main0_out out = {};
+    float3 PosL = in.PosL;
+    uint instanceID = gl_InstanceIndex;
+    float3 param = PosL;
+    uint param_1 = instanceID;
+    V2F flattenTemp = _VS(param, param_1, gInstanceData_1);
+    out.gl_Position = flattenTemp.Position;
+    out._entryPointOutput_Color = flattenTemp.Color;
+    return out;
+}
+

--- a/reference/shaders/asm/vert/extract-transposed-matrix-from-struct.asm.vert
+++ b/reference/shaders/asm/vert/extract-transposed-matrix-from-struct.asm.vert
@@ -1,0 +1,45 @@
+#version 450
+
+struct V2F
+{
+    vec4 Position;
+    vec4 Color;
+};
+
+struct InstanceData
+{
+    mat4 MATRIX_MVP;
+    vec4 Color;
+};
+
+layout(binding = 0, std430) readonly buffer gInstanceData
+{
+    layout(row_major) InstanceData _data[];
+} gInstanceData_1;
+
+layout(location = 0) in vec3 PosL;
+uniform int SPIRV_Cross_BaseInstance;
+layout(location = 0) out vec4 _entryPointOutput_Color;
+
+V2F _VS(vec3 PosL_1, uint instanceID)
+{
+    InstanceData instData;
+    instData.MATRIX_MVP = gInstanceData_1._data[instanceID].MATRIX_MVP;
+    instData.Color = gInstanceData_1._data[instanceID].Color;
+    V2F v2f;
+    v2f.Position = instData.MATRIX_MVP * vec4(PosL_1, 1.0);
+    v2f.Color = instData.Color;
+    return v2f;
+}
+
+void main()
+{
+    vec3 PosL_1 = PosL;
+    uint instanceID = uint((gl_InstanceID + SPIRV_Cross_BaseInstance));
+    vec3 param = PosL_1;
+    uint param_1 = instanceID;
+    V2F flattenTemp = _VS(param, param_1);
+    gl_Position = flattenTemp.Position;
+    _entryPointOutput_Color = flattenTemp.Color;
+}
+

--- a/shaders-hlsl/asm/vert/extract-transposed-matrix-from-struct.asm.vert
+++ b/shaders-hlsl/asm/vert/extract-transposed-matrix-from-struct.asm.vert
@@ -1,0 +1,141 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 79
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %VS "main" %PosL_1 %instanceID_1 %_entryPointOutput_Position %_entryPointOutput_Color
+               OpSource HLSL 500
+               OpName %VS "VS"
+               OpName %V2F "V2F"
+               OpMemberName %V2F 0 "Position"
+               OpMemberName %V2F 1 "Color"
+               OpName %_VS_vf3_u1_ "@VS(vf3;u1;"
+               OpName %PosL "PosL"
+               OpName %instanceID "instanceID"
+               OpName %InstanceData "InstanceData"
+               OpMemberName %InstanceData 0 "MATRIX_MVP"
+               OpMemberName %InstanceData 1 "Color"
+               OpName %instData "instData"
+               OpName %InstanceData_0 "InstanceData"
+               OpMemberName %InstanceData_0 0 "MATRIX_MVP"
+               OpMemberName %InstanceData_0 1 "Color"
+               OpName %gInstanceData "gInstanceData"
+               OpMemberName %gInstanceData 0 "@data"
+               OpName %gInstanceData_0 "gInstanceData"
+               OpName %v2f "v2f"
+               OpName %PosL_0 "PosL"
+               OpName %PosL_1 "PosL"
+               OpName %instanceID_0 "instanceID"
+               OpName %instanceID_1 "instanceID"
+               OpName %flattenTemp "flattenTemp"
+               OpName %param "param"
+               OpName %param_0 "param"
+               OpName %_entryPointOutput_Position "@entryPointOutput.Position"
+               OpName %_entryPointOutput_Color "@entryPointOutput.Color"
+               OpMemberDecorate %InstanceData_0 0 RowMajor
+               OpMemberDecorate %InstanceData_0 0 Offset 0
+               OpMemberDecorate %InstanceData_0 0 MatrixStride 16
+               OpMemberDecorate %InstanceData_0 1 Offset 64
+               OpDecorate %_runtimearr_InstanceData_0 ArrayStride 80
+               OpMemberDecorate %gInstanceData 0 Offset 0
+               OpDecorate %gInstanceData Block
+               OpDecorate %gInstanceData_0 DescriptorSet 1
+               OpDecorate %gInstanceData_0 Binding 0
+               OpDecorate %PosL_1 Location 0
+               OpDecorate %instanceID_1 BuiltIn InstanceIndex
+               OpDecorate %_entryPointOutput_Position BuiltIn Position
+               OpDecorate %_entryPointOutput_Color Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%_ptr_Function_v3float = OpTypePointer Function %v3float
+       %uint = OpTypeInt 32 0
+	   %int_32 = OpConstant %uint 32
+%_ptr_Function_uint = OpTypePointer Function %uint
+    %v4float = OpTypeVector %float 4
+        %V2F = OpTypeStruct %v4float %v4float
+         %13 = OpTypeFunction %V2F %_ptr_Function_v3float %_ptr_Function_uint
+%mat4v4float = OpTypeMatrix %v4float 4
+%InstanceData = OpTypeStruct %mat4v4float %v4float
+%_ptr_Function_InstanceData = OpTypePointer Function %InstanceData
+%InstanceData_0 = OpTypeStruct %mat4v4float %v4float
+%_runtimearr_InstanceData_0 = OpTypeArray %InstanceData_0 %int_32
+%gInstanceData = OpTypeStruct %_runtimearr_InstanceData_0
+%_ptr_Uniform_gInstanceData = OpTypePointer Uniform %gInstanceData
+%gInstanceData_0 = OpVariable %_ptr_Uniform_gInstanceData Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_InstanceData_0 = OpTypePointer Uniform %InstanceData_0
+%_ptr_Function_mat4v4float = OpTypePointer Function %mat4v4float
+      %int_1 = OpConstant %int 1
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+%_ptr_Function_V2F = OpTypePointer Function %V2F
+    %float_1 = OpConstant %float 1
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+     %PosL_1 = OpVariable %_ptr_Input_v3float Input
+%_ptr_Input_uint = OpTypePointer Input %uint
+%instanceID_1 = OpVariable %_ptr_Input_uint Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%_entryPointOutput_Position = OpVariable %_ptr_Output_v4float Output
+%_entryPointOutput_Color = OpVariable %_ptr_Output_v4float Output
+         %VS = OpFunction %void None %3
+          %5 = OpLabel
+     %PosL_0 = OpVariable %_ptr_Function_v3float Function
+%instanceID_0 = OpVariable %_ptr_Function_uint Function
+%flattenTemp = OpVariable %_ptr_Function_V2F Function
+      %param = OpVariable %_ptr_Function_v3float Function
+    %param_0 = OpVariable %_ptr_Function_uint Function
+         %61 = OpLoad %v3float %PosL_1
+               OpStore %PosL_0 %61
+         %65 = OpLoad %uint %instanceID_1
+               OpStore %instanceID_0 %65
+         %68 = OpLoad %v3float %PosL_0
+               OpStore %param %68
+         %70 = OpLoad %uint %instanceID_0
+               OpStore %param_0 %70
+         %71 = OpFunctionCall %V2F %_VS_vf3_u1_ %param %param_0
+               OpStore %flattenTemp %71
+         %74 = OpAccessChain %_ptr_Function_v4float %flattenTemp %int_0
+         %75 = OpLoad %v4float %74
+               OpStore %_entryPointOutput_Position %75
+         %77 = OpAccessChain %_ptr_Function_v4float %flattenTemp %int_1
+         %78 = OpLoad %v4float %77
+               OpStore %_entryPointOutput_Color %78
+               OpReturn
+               OpFunctionEnd
+%_VS_vf3_u1_ = OpFunction %V2F None %13
+       %PosL = OpFunctionParameter %_ptr_Function_v3float
+ %instanceID = OpFunctionParameter %_ptr_Function_uint
+         %17 = OpLabel
+   %instData = OpVariable %_ptr_Function_InstanceData Function
+        %v2f = OpVariable %_ptr_Function_V2F Function
+         %29 = OpLoad %uint %instanceID
+         %31 = OpAccessChain %_ptr_Uniform_InstanceData_0 %gInstanceData_0 %int_0 %29
+         %32 = OpLoad %InstanceData_0 %31
+         %33 = OpCompositeExtract %mat4v4float %32 0
+         %35 = OpAccessChain %_ptr_Function_mat4v4float %instData %int_0
+               OpStore %35 %33
+         %36 = OpCompositeExtract %v4float %32 1
+         %39 = OpAccessChain %_ptr_Function_v4float %instData %int_1
+               OpStore %39 %36
+         %42 = OpAccessChain %_ptr_Function_mat4v4float %instData %int_0
+         %43 = OpLoad %mat4v4float %42
+         %44 = OpLoad %v3float %PosL
+         %46 = OpCompositeExtract %float %44 0
+         %47 = OpCompositeExtract %float %44 1
+         %48 = OpCompositeExtract %float %44 2
+         %49 = OpCompositeConstruct %v4float %46 %47 %48 %float_1
+         %50 = OpMatrixTimesVector %v4float %43 %49
+         %51 = OpAccessChain %_ptr_Function_v4float %v2f %int_0
+               OpStore %51 %50
+         %52 = OpAccessChain %_ptr_Function_v4float %instData %int_1
+         %53 = OpLoad %v4float %52
+         %54 = OpAccessChain %_ptr_Function_v4float %v2f %int_1
+               OpStore %54 %53
+         %55 = OpLoad %V2F %v2f
+               OpReturnValue %55
+               OpFunctionEnd

--- a/shaders-msl/asm/vert/extract-transposed-matrix-from-struct.asm.vert
+++ b/shaders-msl/asm/vert/extract-transposed-matrix-from-struct.asm.vert
@@ -1,0 +1,141 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 79
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %VS "main" %PosL_1 %instanceID_1 %_entryPointOutput_Position %_entryPointOutput_Color
+               OpSource HLSL 500
+               OpName %VS "VS"
+               OpName %V2F "V2F"
+               OpMemberName %V2F 0 "Position"
+               OpMemberName %V2F 1 "Color"
+               OpName %_VS_vf3_u1_ "@VS(vf3;u1;"
+               OpName %PosL "PosL"
+               OpName %instanceID "instanceID"
+               OpName %InstanceData "InstanceData"
+               OpMemberName %InstanceData 0 "MATRIX_MVP"
+               OpMemberName %InstanceData 1 "Color"
+               OpName %instData "instData"
+               OpName %InstanceData_0 "InstanceData"
+               OpMemberName %InstanceData_0 0 "MATRIX_MVP"
+               OpMemberName %InstanceData_0 1 "Color"
+               OpName %gInstanceData "gInstanceData"
+               OpMemberName %gInstanceData 0 "@data"
+               OpName %gInstanceData_0 "gInstanceData"
+               OpName %v2f "v2f"
+               OpName %PosL_0 "PosL"
+               OpName %PosL_1 "PosL"
+               OpName %instanceID_0 "instanceID"
+               OpName %instanceID_1 "instanceID"
+               OpName %flattenTemp "flattenTemp"
+               OpName %param "param"
+               OpName %param_0 "param"
+               OpName %_entryPointOutput_Position "@entryPointOutput.Position"
+               OpName %_entryPointOutput_Color "@entryPointOutput.Color"
+               OpMemberDecorate %InstanceData_0 0 RowMajor
+               OpMemberDecorate %InstanceData_0 0 Offset 0
+               OpMemberDecorate %InstanceData_0 0 MatrixStride 16
+               OpMemberDecorate %InstanceData_0 1 Offset 64
+               OpDecorate %_runtimearr_InstanceData_0 ArrayStride 80
+               OpMemberDecorate %gInstanceData 0 NonWritable
+               OpMemberDecorate %gInstanceData 0 Offset 0
+               OpDecorate %gInstanceData BufferBlock
+               OpDecorate %gInstanceData_0 DescriptorSet 1
+               OpDecorate %gInstanceData_0 Binding 0
+               OpDecorate %PosL_1 Location 0
+               OpDecorate %instanceID_1 BuiltIn InstanceIndex
+               OpDecorate %_entryPointOutput_Position BuiltIn Position
+               OpDecorate %_entryPointOutput_Color Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%_ptr_Function_v3float = OpTypePointer Function %v3float
+       %uint = OpTypeInt 32 0
+%_ptr_Function_uint = OpTypePointer Function %uint
+    %v4float = OpTypeVector %float 4
+        %V2F = OpTypeStruct %v4float %v4float
+         %13 = OpTypeFunction %V2F %_ptr_Function_v3float %_ptr_Function_uint
+%mat4v4float = OpTypeMatrix %v4float 4
+%InstanceData = OpTypeStruct %mat4v4float %v4float
+%_ptr_Function_InstanceData = OpTypePointer Function %InstanceData
+%InstanceData_0 = OpTypeStruct %mat4v4float %v4float
+%_runtimearr_InstanceData_0 = OpTypeRuntimeArray %InstanceData_0
+%gInstanceData = OpTypeStruct %_runtimearr_InstanceData_0
+%_ptr_Uniform_gInstanceData = OpTypePointer Uniform %gInstanceData
+%gInstanceData_0 = OpVariable %_ptr_Uniform_gInstanceData Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_InstanceData_0 = OpTypePointer Uniform %InstanceData_0
+%_ptr_Function_mat4v4float = OpTypePointer Function %mat4v4float
+      %int_1 = OpConstant %int 1
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+%_ptr_Function_V2F = OpTypePointer Function %V2F
+    %float_1 = OpConstant %float 1
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+     %PosL_1 = OpVariable %_ptr_Input_v3float Input
+%_ptr_Input_uint = OpTypePointer Input %uint
+%instanceID_1 = OpVariable %_ptr_Input_uint Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%_entryPointOutput_Position = OpVariable %_ptr_Output_v4float Output
+%_entryPointOutput_Color = OpVariable %_ptr_Output_v4float Output
+         %VS = OpFunction %void None %3
+          %5 = OpLabel
+     %PosL_0 = OpVariable %_ptr_Function_v3float Function
+%instanceID_0 = OpVariable %_ptr_Function_uint Function
+%flattenTemp = OpVariable %_ptr_Function_V2F Function
+      %param = OpVariable %_ptr_Function_v3float Function
+    %param_0 = OpVariable %_ptr_Function_uint Function
+         %61 = OpLoad %v3float %PosL_1
+               OpStore %PosL_0 %61
+         %65 = OpLoad %uint %instanceID_1
+               OpStore %instanceID_0 %65
+         %68 = OpLoad %v3float %PosL_0
+               OpStore %param %68
+         %70 = OpLoad %uint %instanceID_0
+               OpStore %param_0 %70
+         %71 = OpFunctionCall %V2F %_VS_vf3_u1_ %param %param_0
+               OpStore %flattenTemp %71
+         %74 = OpAccessChain %_ptr_Function_v4float %flattenTemp %int_0
+         %75 = OpLoad %v4float %74
+               OpStore %_entryPointOutput_Position %75
+         %77 = OpAccessChain %_ptr_Function_v4float %flattenTemp %int_1
+         %78 = OpLoad %v4float %77
+               OpStore %_entryPointOutput_Color %78
+               OpReturn
+               OpFunctionEnd
+%_VS_vf3_u1_ = OpFunction %V2F None %13
+       %PosL = OpFunctionParameter %_ptr_Function_v3float
+ %instanceID = OpFunctionParameter %_ptr_Function_uint
+         %17 = OpLabel
+   %instData = OpVariable %_ptr_Function_InstanceData Function
+        %v2f = OpVariable %_ptr_Function_V2F Function
+         %29 = OpLoad %uint %instanceID
+         %31 = OpAccessChain %_ptr_Uniform_InstanceData_0 %gInstanceData_0 %int_0 %29
+         %32 = OpLoad %InstanceData_0 %31
+         %33 = OpCompositeExtract %mat4v4float %32 0
+         %35 = OpAccessChain %_ptr_Function_mat4v4float %instData %int_0
+               OpStore %35 %33
+         %36 = OpCompositeExtract %v4float %32 1
+         %39 = OpAccessChain %_ptr_Function_v4float %instData %int_1
+               OpStore %39 %36
+         %42 = OpAccessChain %_ptr_Function_mat4v4float %instData %int_0
+         %43 = OpLoad %mat4v4float %42
+         %44 = OpLoad %v3float %PosL
+         %46 = OpCompositeExtract %float %44 0
+         %47 = OpCompositeExtract %float %44 1
+         %48 = OpCompositeExtract %float %44 2
+         %49 = OpCompositeConstruct %v4float %46 %47 %48 %float_1
+         %50 = OpMatrixTimesVector %v4float %43 %49
+         %51 = OpAccessChain %_ptr_Function_v4float %v2f %int_0
+               OpStore %51 %50
+         %52 = OpAccessChain %_ptr_Function_v4float %instData %int_1
+         %53 = OpLoad %v4float %52
+         %54 = OpAccessChain %_ptr_Function_v4float %v2f %int_1
+               OpStore %54 %53
+         %55 = OpLoad %V2F %v2f
+               OpReturnValue %55
+               OpFunctionEnd

--- a/shaders/asm/vert/extract-transposed-matrix-from-struct.asm.vert
+++ b/shaders/asm/vert/extract-transposed-matrix-from-struct.asm.vert
@@ -1,0 +1,141 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 79
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %VS "main" %PosL_1 %instanceID_1 %_entryPointOutput_Position %_entryPointOutput_Color
+               OpSource HLSL 500
+               OpName %VS "VS"
+               OpName %V2F "V2F"
+               OpMemberName %V2F 0 "Position"
+               OpMemberName %V2F 1 "Color"
+               OpName %_VS_vf3_u1_ "@VS(vf3;u1;"
+               OpName %PosL "PosL"
+               OpName %instanceID "instanceID"
+               OpName %InstanceData "InstanceData"
+               OpMemberName %InstanceData 0 "MATRIX_MVP"
+               OpMemberName %InstanceData 1 "Color"
+               OpName %instData "instData"
+               OpName %InstanceData_0 "InstanceData"
+               OpMemberName %InstanceData_0 0 "MATRIX_MVP"
+               OpMemberName %InstanceData_0 1 "Color"
+               OpName %gInstanceData "gInstanceData"
+               OpMemberName %gInstanceData 0 "@data"
+               OpName %gInstanceData_0 "gInstanceData"
+               OpName %v2f "v2f"
+               OpName %PosL_0 "PosL"
+               OpName %PosL_1 "PosL"
+               OpName %instanceID_0 "instanceID"
+               OpName %instanceID_1 "instanceID"
+               OpName %flattenTemp "flattenTemp"
+               OpName %param "param"
+               OpName %param_0 "param"
+               OpName %_entryPointOutput_Position "@entryPointOutput.Position"
+               OpName %_entryPointOutput_Color "@entryPointOutput.Color"
+               OpMemberDecorate %InstanceData_0 0 RowMajor
+               OpMemberDecorate %InstanceData_0 0 Offset 0
+               OpMemberDecorate %InstanceData_0 0 MatrixStride 16
+               OpMemberDecorate %InstanceData_0 1 Offset 64
+               OpDecorate %_runtimearr_InstanceData_0 ArrayStride 80
+               OpMemberDecorate %gInstanceData 0 NonWritable
+               OpMemberDecorate %gInstanceData 0 Offset 0
+               OpDecorate %gInstanceData BufferBlock
+               OpDecorate %gInstanceData_0 DescriptorSet 1
+               OpDecorate %gInstanceData_0 Binding 0
+               OpDecorate %PosL_1 Location 0
+               OpDecorate %instanceID_1 BuiltIn InstanceIndex
+               OpDecorate %_entryPointOutput_Position BuiltIn Position
+               OpDecorate %_entryPointOutput_Color Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%_ptr_Function_v3float = OpTypePointer Function %v3float
+       %uint = OpTypeInt 32 0
+%_ptr_Function_uint = OpTypePointer Function %uint
+    %v4float = OpTypeVector %float 4
+        %V2F = OpTypeStruct %v4float %v4float
+         %13 = OpTypeFunction %V2F %_ptr_Function_v3float %_ptr_Function_uint
+%mat4v4float = OpTypeMatrix %v4float 4
+%InstanceData = OpTypeStruct %mat4v4float %v4float
+%_ptr_Function_InstanceData = OpTypePointer Function %InstanceData
+%InstanceData_0 = OpTypeStruct %mat4v4float %v4float
+%_runtimearr_InstanceData_0 = OpTypeRuntimeArray %InstanceData_0
+%gInstanceData = OpTypeStruct %_runtimearr_InstanceData_0
+%_ptr_Uniform_gInstanceData = OpTypePointer Uniform %gInstanceData
+%gInstanceData_0 = OpVariable %_ptr_Uniform_gInstanceData Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_InstanceData_0 = OpTypePointer Uniform %InstanceData_0
+%_ptr_Function_mat4v4float = OpTypePointer Function %mat4v4float
+      %int_1 = OpConstant %int 1
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+%_ptr_Function_V2F = OpTypePointer Function %V2F
+    %float_1 = OpConstant %float 1
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+     %PosL_1 = OpVariable %_ptr_Input_v3float Input
+%_ptr_Input_uint = OpTypePointer Input %uint
+%instanceID_1 = OpVariable %_ptr_Input_uint Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%_entryPointOutput_Position = OpVariable %_ptr_Output_v4float Output
+%_entryPointOutput_Color = OpVariable %_ptr_Output_v4float Output
+         %VS = OpFunction %void None %3
+          %5 = OpLabel
+     %PosL_0 = OpVariable %_ptr_Function_v3float Function
+%instanceID_0 = OpVariable %_ptr_Function_uint Function
+%flattenTemp = OpVariable %_ptr_Function_V2F Function
+      %param = OpVariable %_ptr_Function_v3float Function
+    %param_0 = OpVariable %_ptr_Function_uint Function
+         %61 = OpLoad %v3float %PosL_1
+               OpStore %PosL_0 %61
+         %65 = OpLoad %uint %instanceID_1
+               OpStore %instanceID_0 %65
+         %68 = OpLoad %v3float %PosL_0
+               OpStore %param %68
+         %70 = OpLoad %uint %instanceID_0
+               OpStore %param_0 %70
+         %71 = OpFunctionCall %V2F %_VS_vf3_u1_ %param %param_0
+               OpStore %flattenTemp %71
+         %74 = OpAccessChain %_ptr_Function_v4float %flattenTemp %int_0
+         %75 = OpLoad %v4float %74
+               OpStore %_entryPointOutput_Position %75
+         %77 = OpAccessChain %_ptr_Function_v4float %flattenTemp %int_1
+         %78 = OpLoad %v4float %77
+               OpStore %_entryPointOutput_Color %78
+               OpReturn
+               OpFunctionEnd
+%_VS_vf3_u1_ = OpFunction %V2F None %13
+       %PosL = OpFunctionParameter %_ptr_Function_v3float
+ %instanceID = OpFunctionParameter %_ptr_Function_uint
+         %17 = OpLabel
+   %instData = OpVariable %_ptr_Function_InstanceData Function
+        %v2f = OpVariable %_ptr_Function_V2F Function
+         %29 = OpLoad %uint %instanceID
+         %31 = OpAccessChain %_ptr_Uniform_InstanceData_0 %gInstanceData_0 %int_0 %29
+         %32 = OpLoad %InstanceData_0 %31
+         %33 = OpCompositeExtract %mat4v4float %32 0
+         %35 = OpAccessChain %_ptr_Function_mat4v4float %instData %int_0
+               OpStore %35 %33
+         %36 = OpCompositeExtract %v4float %32 1
+         %39 = OpAccessChain %_ptr_Function_v4float %instData %int_1
+               OpStore %39 %36
+         %42 = OpAccessChain %_ptr_Function_mat4v4float %instData %int_0
+         %43 = OpLoad %mat4v4float %42
+         %44 = OpLoad %v3float %PosL
+         %46 = OpCompositeExtract %float %44 0
+         %47 = OpCompositeExtract %float %44 1
+         %48 = OpCompositeExtract %float %44 2
+         %49 = OpCompositeConstruct %v4float %46 %47 %48 %float_1
+         %50 = OpMatrixTimesVector %v4float %43 %49
+         %51 = OpAccessChain %_ptr_Function_v4float %v2f %int_0
+               OpStore %51 %50
+         %52 = OpAccessChain %_ptr_Function_v4float %instData %int_1
+         %53 = OpLoad %v4float %52
+         %54 = OpAccessChain %_ptr_Function_v4float %v2f %int_1
+               OpStore %54 %53
+         %55 = OpLoad %V2F %v2f
+               OpReturnValue %55
+               OpFunctionEnd

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -8940,7 +8940,7 @@ bool CompilerGLSL::is_non_native_row_major_matrix(uint32_t id)
 		return false;
 
 	// Non-matrix or column-major matrix types do not need to be converted.
-	if (!ir.meta[id].decoration.decoration_flags.get(DecorationRowMajor))
+	if (!has_decoration(id, DecorationRowMajor))
 		return false;
 
 	// Only square row-major matrices can be converted at this time.
@@ -8961,7 +8961,7 @@ bool CompilerGLSL::member_is_non_native_row_major_matrix(const SPIRType &type, u
 		return false;
 
 	// Non-matrix or column-major matrix types do not need to be converted.
-	if (!combined_decoration_for_member(type, index).get(DecorationRowMajor))
+	if (!has_member_decoration(type.self, index, DecorationRowMajor))
 		return false;
 
 	// Only square row-major matrices can be converted at this time.

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -4682,7 +4682,7 @@ bool CompilerMSL::is_non_native_row_major_matrix(uint32_t id)
 		return false;
 
 	// Non-matrix or column-major matrix types do not need to be converted.
-	if (!ir.meta[id].decoration.decoration_flags.get(DecorationRowMajor))
+	if (!has_decoration(id, DecorationRowMajor))
 		return false;
 
 	// Generate a function that will swap matrix elements from row-major to column-major.
@@ -4704,7 +4704,7 @@ bool CompilerMSL::member_is_non_native_row_major_matrix(const SPIRType &type, ui
 		return false;
 
 	// Non-matrix or column-major matrix types do not need to be converted.
-	if (!combined_decoration_for_member(type, index).get(DecorationRowMajor))
+	if (!has_member_decoration(type.self, index, DecorationRowMajor))
 		return false;
 
 	// Generate a function that will swap matrix elements from row-major to column-major.


### PR DESCRIPTION
We were using combined decorations which propagated row-major information all the way from struct members up to the struct itself. The fix is to just check the immediate member when deducing transpose requirements.

Fix #861.