### PR TITLE
Fix the signed to unsigned conversion warning

### DIFF
--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -1382,7 +1382,7 @@ struct Meta
 		{
 			uint32_t packed_type = 0;
 			bool packed = false;
-			uint32_t ib_member_index = -1;
+			uint32_t ib_member_index = static_cast<uint32_t>(-1);
 			uint32_t ib_orig_id = 0;
 		} extended;
 	};


### PR DESCRIPTION
In msvc, assigns -1 to uint32_t can cause a warning.