### PR TITLE
MSL: Fix textures which are sampled and compared against.

### DIFF
--- a/reference/opt/shaders-hlsl/asm/frag/sample-and-compare.asm.frag
+++ b/reference/opt/shaders-hlsl/asm/frag/sample-and-compare.asm.frag
@@ -1,0 +1,30 @@
+Texture2D<float4> g_Texture : register(t0);
+SamplerState g_Sampler : register(s0);
+SamplerComparisonState g_CompareSampler : register(s1);
+
+static float2 in_var_TEXCOORD0;
+static float out_var_SV_Target;
+
+struct SPIRV_Cross_Input
+{
+    float2 in_var_TEXCOORD0 : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float out_var_SV_Target : SV_Target0;
+};
+
+void frag_main()
+{
+    out_var_SV_Target = g_Texture.Sample(g_Sampler, in_var_TEXCOORD0).x + g_Texture.SampleCmpLevelZero(g_CompareSampler, in_var_TEXCOORD0, 0.5f);
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    in_var_TEXCOORD0 = stage_input.in_var_TEXCOORD0;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.out_var_SV_Target = out_var_SV_Target;
+    return stage_output;
+}

--- a/reference/opt/shaders-msl/asm/frag/sample-and-compare.asm.frag
+++ b/reference/opt/shaders-msl/asm/frag/sample-and-compare.asm.frag
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float out_var_SV_Target [[color(0)]];
+};
+
+struct main0_in
+{
+    float2 in_var_TEXCOORD0 [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], depth2d<float> g_Texture [[texture(0)]], sampler g_Sampler [[sampler(0)]], sampler g_CompareSampler [[sampler(1)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = float4(g_Texture.sample(g_Sampler, in.in_var_TEXCOORD0)).x + g_Texture.sample_compare(g_CompareSampler, in.in_var_TEXCOORD0, 0.5, level(0.0));
+    return out;
+}
+

--- a/reference/opt/shaders/asm/frag/sample-and-compare.asm.frag
+++ b/reference/opt/shaders/asm/frag/sample-and-compare.asm.frag
@@ -1,0 +1,13 @@
+#version 450
+
+uniform sampler2D SPIRV_Cross_Combinedg_Textureg_Sampler;
+uniform sampler2DShadow SPIRV_Cross_Combinedg_Textureg_CompareSampler;
+
+layout(location = 0) in vec2 in_var_TEXCOORD0;
+layout(location = 0) out float out_var_SV_Target;
+
+void main()
+{
+    out_var_SV_Target = texture(SPIRV_Cross_Combinedg_Textureg_Sampler, in_var_TEXCOORD0).x + textureLod(SPIRV_Cross_Combinedg_Textureg_CompareSampler, vec3(in_var_TEXCOORD0, 0.5), 0.0);
+}
+

--- a/reference/shaders-hlsl/asm/frag/sample-and-compare.asm.frag
+++ b/reference/shaders-hlsl/asm/frag/sample-and-compare.asm.frag
@@ -1,0 +1,30 @@
+Texture2D<float4> g_Texture : register(t0);
+SamplerState g_Sampler : register(s0);
+SamplerComparisonState g_CompareSampler : register(s1);
+
+static float2 in_var_TEXCOORD0;
+static float out_var_SV_Target;
+
+struct SPIRV_Cross_Input
+{
+    float2 in_var_TEXCOORD0 : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float out_var_SV_Target : SV_Target0;
+};
+
+void frag_main()
+{
+    out_var_SV_Target = g_Texture.Sample(g_Sampler, in_var_TEXCOORD0).x + g_Texture.SampleCmpLevelZero(g_CompareSampler, in_var_TEXCOORD0, 0.5f);
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    in_var_TEXCOORD0 = stage_input.in_var_TEXCOORD0;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.out_var_SV_Target = out_var_SV_Target;
+    return stage_output;
+}

--- a/reference/shaders-msl/asm/frag/sample-and-compare.asm.frag
+++ b/reference/shaders-msl/asm/frag/sample-and-compare.asm.frag
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float out_var_SV_Target [[color(0)]];
+};
+
+struct main0_in
+{
+    float2 in_var_TEXCOORD0 [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], depth2d<float> g_Texture [[texture(0)]], sampler g_Sampler [[sampler(0)]], sampler g_CompareSampler [[sampler(1)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = float4(g_Texture.sample(g_Sampler, in.in_var_TEXCOORD0)).x + g_Texture.sample_compare(g_CompareSampler, in.in_var_TEXCOORD0, 0.5, level(0.0));
+    return out;
+}
+

--- a/reference/shaders/asm/frag/sample-and-compare.asm.frag
+++ b/reference/shaders/asm/frag/sample-and-compare.asm.frag
@@ -1,0 +1,13 @@
+#version 450
+
+uniform sampler2D SPIRV_Cross_Combinedg_Textureg_Sampler;
+uniform sampler2DShadow SPIRV_Cross_Combinedg_Textureg_CompareSampler;
+
+layout(location = 0) in vec2 in_var_TEXCOORD0;
+layout(location = 0) out float out_var_SV_Target;
+
+void main()
+{
+    out_var_SV_Target = texture(SPIRV_Cross_Combinedg_Textureg_Sampler, in_var_TEXCOORD0).x + textureLod(SPIRV_Cross_Combinedg_Textureg_CompareSampler, vec3(in_var_TEXCOORD0, 0.5), 0.0);
+}
+

--- a/shaders-hlsl/asm/frag/sample-and-compare.asm.frag
+++ b/shaders-hlsl/asm/frag/sample-and-compare.asm.frag
@@ -1,0 +1,61 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google spiregg; 0
+; Bound: 32
+; Schema: 0
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %in_var_TEXCOORD0 %out_var_SV_Target
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 600
+               OpName %type_2d_image "type.2d.image"
+               OpName %g_Texture "g_Texture"
+               OpName %type_sampler "type.sampler"
+               OpName %g_Sampler "g_Sampler"
+               OpName %g_CompareSampler "g_CompareSampler"
+               OpName %in_var_TEXCOORD0 "in.var.TEXCOORD0"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpName %main "main"
+               OpName %type_sampled_image "type.sampled.image"
+               OpDecorate %in_var_TEXCOORD0 Location 0
+               OpDecorate %out_var_SV_Target Location 0
+               OpDecorate %g_Texture DescriptorSet 0
+               OpDecorate %g_Texture Binding 0
+               OpDecorate %g_Sampler DescriptorSet 0
+               OpDecorate %g_Sampler Binding 0
+               OpDecorate %g_CompareSampler DescriptorSet 0
+               OpDecorate %g_CompareSampler Binding 1
+      %float = OpTypeFloat 32
+  %float_0_5 = OpConstant %float 0.5
+    %float_0 = OpConstant %float 0
+%type_2d_image = OpTypeImage %float 2D 2 0 0 1 Unknown
+%_ptr_UniformConstant_type_2d_image = OpTypePointer UniformConstant %type_2d_image
+%type_sampler = OpTypeSampler
+%_ptr_UniformConstant_type_sampler = OpTypePointer UniformConstant %type_sampler
+    %v2float = OpTypeVector %float 2
+%_ptr_Input_v2float = OpTypePointer Input %v2float
+%_ptr_Output_float = OpTypePointer Output %float
+       %void = OpTypeVoid
+         %19 = OpTypeFunction %void
+%type_sampled_image = OpTypeSampledImage %type_2d_image
+    %v4float = OpTypeVector %float 4
+  %g_Texture = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
+  %g_Sampler = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
+%g_CompareSampler = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
+%in_var_TEXCOORD0 = OpVariable %_ptr_Input_v2float Input
+%out_var_SV_Target = OpVariable %_ptr_Output_float Output
+       %main = OpFunction %void None %19
+         %21 = OpLabel
+         %22 = OpLoad %v2float %in_var_TEXCOORD0
+         %23 = OpLoad %type_2d_image %g_Texture
+         %24 = OpLoad %type_sampler %g_Sampler
+         %25 = OpSampledImage %type_sampled_image %23 %24
+         %26 = OpImageSampleImplicitLod %v4float %25 %22 None
+         %27 = OpCompositeExtract %float %26 0
+         %28 = OpLoad %type_sampler %g_CompareSampler
+         %29 = OpSampledImage %type_sampled_image %23 %28
+         %30 = OpImageSampleDrefExplicitLod %float %29 %22 %float_0_5 Lod %float_0
+         %31 = OpFAdd %float %27 %30
+               OpStore %out_var_SV_Target %31
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl/asm/frag/sample-and-compare.asm.frag
+++ b/shaders-msl/asm/frag/sample-and-compare.asm.frag
@@ -1,0 +1,61 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google spiregg; 0
+; Bound: 32
+; Schema: 0
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %in_var_TEXCOORD0 %out_var_SV_Target
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 600
+               OpName %type_2d_image "type.2d.image"
+               OpName %g_Texture "g_Texture"
+               OpName %type_sampler "type.sampler"
+               OpName %g_Sampler "g_Sampler"
+               OpName %g_CompareSampler "g_CompareSampler"
+               OpName %in_var_TEXCOORD0 "in.var.TEXCOORD0"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpName %main "main"
+               OpName %type_sampled_image "type.sampled.image"
+               OpDecorate %in_var_TEXCOORD0 Location 0
+               OpDecorate %out_var_SV_Target Location 0
+               OpDecorate %g_Texture DescriptorSet 0
+               OpDecorate %g_Texture Binding 0
+               OpDecorate %g_Sampler DescriptorSet 0
+               OpDecorate %g_Sampler Binding 0
+               OpDecorate %g_CompareSampler DescriptorSet 0
+               OpDecorate %g_CompareSampler Binding 1
+      %float = OpTypeFloat 32
+  %float_0_5 = OpConstant %float 0.5
+    %float_0 = OpConstant %float 0
+%type_2d_image = OpTypeImage %float 2D 2 0 0 1 Unknown
+%_ptr_UniformConstant_type_2d_image = OpTypePointer UniformConstant %type_2d_image
+%type_sampler = OpTypeSampler
+%_ptr_UniformConstant_type_sampler = OpTypePointer UniformConstant %type_sampler
+    %v2float = OpTypeVector %float 2
+%_ptr_Input_v2float = OpTypePointer Input %v2float
+%_ptr_Output_float = OpTypePointer Output %float
+       %void = OpTypeVoid
+         %19 = OpTypeFunction %void
+%type_sampled_image = OpTypeSampledImage %type_2d_image
+    %v4float = OpTypeVector %float 4
+  %g_Texture = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
+  %g_Sampler = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
+%g_CompareSampler = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
+%in_var_TEXCOORD0 = OpVariable %_ptr_Input_v2float Input
+%out_var_SV_Target = OpVariable %_ptr_Output_float Output
+       %main = OpFunction %void None %19
+         %21 = OpLabel
+         %22 = OpLoad %v2float %in_var_TEXCOORD0
+         %23 = OpLoad %type_2d_image %g_Texture
+         %24 = OpLoad %type_sampler %g_Sampler
+         %25 = OpSampledImage %type_sampled_image %23 %24
+         %26 = OpImageSampleImplicitLod %v4float %25 %22 None
+         %27 = OpCompositeExtract %float %26 0
+         %28 = OpLoad %type_sampler %g_CompareSampler
+         %29 = OpSampledImage %type_sampled_image %23 %28
+         %30 = OpImageSampleDrefExplicitLod %float %29 %22 %float_0_5 Lod %float_0
+         %31 = OpFAdd %float %27 %30
+               OpStore %out_var_SV_Target %31
+               OpReturn
+               OpFunctionEnd

--- a/shaders/asm/frag/sample-and-compare.asm.frag
+++ b/shaders/asm/frag/sample-and-compare.asm.frag
@@ -1,0 +1,61 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google spiregg; 0
+; Bound: 32
+; Schema: 0
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %in_var_TEXCOORD0 %out_var_SV_Target
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 600
+               OpName %type_2d_image "type.2d.image"
+               OpName %g_Texture "g_Texture"
+               OpName %type_sampler "type.sampler"
+               OpName %g_Sampler "g_Sampler"
+               OpName %g_CompareSampler "g_CompareSampler"
+               OpName %in_var_TEXCOORD0 "in.var.TEXCOORD0"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpName %main "main"
+               OpName %type_sampled_image "type.sampled.image"
+               OpDecorate %in_var_TEXCOORD0 Location 0
+               OpDecorate %out_var_SV_Target Location 0
+               OpDecorate %g_Texture DescriptorSet 0
+               OpDecorate %g_Texture Binding 0
+               OpDecorate %g_Sampler DescriptorSet 0
+               OpDecorate %g_Sampler Binding 0
+               OpDecorate %g_CompareSampler DescriptorSet 0
+               OpDecorate %g_CompareSampler Binding 1
+      %float = OpTypeFloat 32
+  %float_0_5 = OpConstant %float 0.5
+    %float_0 = OpConstant %float 0
+%type_2d_image = OpTypeImage %float 2D 2 0 0 1 Unknown
+%_ptr_UniformConstant_type_2d_image = OpTypePointer UniformConstant %type_2d_image
+%type_sampler = OpTypeSampler
+%_ptr_UniformConstant_type_sampler = OpTypePointer UniformConstant %type_sampler
+    %v2float = OpTypeVector %float 2
+%_ptr_Input_v2float = OpTypePointer Input %v2float
+%_ptr_Output_float = OpTypePointer Output %float
+       %void = OpTypeVoid
+         %19 = OpTypeFunction %void
+%type_sampled_image = OpTypeSampledImage %type_2d_image
+    %v4float = OpTypeVector %float 4
+  %g_Texture = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
+  %g_Sampler = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
+%g_CompareSampler = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
+%in_var_TEXCOORD0 = OpVariable %_ptr_Input_v2float Input
+%out_var_SV_Target = OpVariable %_ptr_Output_float Output
+       %main = OpFunction %void None %19
+         %21 = OpLabel
+         %22 = OpLoad %v2float %in_var_TEXCOORD0
+         %23 = OpLoad %type_2d_image %g_Texture
+         %24 = OpLoad %type_sampler %g_Sampler
+         %25 = OpSampledImage %type_sampled_image %23 %24
+         %26 = OpImageSampleImplicitLod %v4float %25 %22 None
+         %27 = OpCompositeExtract %float %26 0
+         %28 = OpLoad %type_sampler %g_CompareSampler
+         %29 = OpSampledImage %type_sampled_image %23 %28
+         %30 = OpImageSampleDrefExplicitLod %float %29 %22 %float_0_5 Lod %float_0
+         %31 = OpFAdd %float %27 %30
+               OpStore %out_var_SV_Target %31
+               OpReturn
+               OpFunctionEnd

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -401,6 +401,7 @@ protected:
 		bool supports_extensions = false;
 		bool supports_empty_struct = false;
 		bool array_is_value_type = true;
+		bool comparison_image_samples_scalar = false;
 	} backend;
 
 	void emit_struct(SPIRType &type);

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -604,6 +604,7 @@ string CompilerMSL::compile()
 	backend.boolean_mix_support = false;
 	backend.allow_truncated_access_chain = true;
 	backend.array_is_value_type = false;
+	backend.comparison_image_samples_scalar = true;
 
 	capture_output_to_buffer = msl_options.capture_output_to_buffer;
 	is_rasterization_disabled = msl_options.disable_rasterization || capture_output_to_buffer;


### PR DESCRIPTION
depth2d in MSL only returns float, not float4, even for normal sampling.
We need to conditionally remap-swizzle back to float4.

Fix #873.