### PR TITLE
Rewrite how we deal with locales and decimal point

### DIFF
--- a/spirv_cpp.cpp
+++ b/spirv_cpp.cpp
@@ -306,9 +306,6 @@ void CompilerCPP::emit_resources()
 
 string CompilerCPP::compile()
 {
-	// Force a classic "C" locale, reverts when function returns
-	ClassicLocale classic_locale;
-
 	// Do not deal with ES-isms like precision, older extensions and such.
 	options.es = false;
 	options.version = 450;

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -64,8 +64,6 @@ void Compiler::set_ir(const ParsedIR &ir_)
 
 string Compiler::compile()
 {
-	// Force a classic "C" locale, reverts when function returns
-	ClassicLocale classic_locale;
 	return "";
 }
 

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -174,7 +174,7 @@ void CompilerGLSL::init()
 		current_locale_radix_character = *conv->decimal_point;
 #else
 	// localeconv, the portable function is not MT safe ...
-	const char *decimal_point = nl_langinfo(DECIMAL_POINT);
+	const char *decimal_point = nl_langinfo(RADIXCHAR);
 	if (decimal_point && *decimal_point != '\0')
 		current_locale_radix_character = *decimal_point;
 #endif

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -21,6 +21,7 @@
 #include <assert.h>
 #include <cmath>
 #include <limits>
+#include <locale.h>
 #include <utility>
 
 using namespace spv;
@@ -147,6 +148,23 @@ string CompilerGLSL::sanitize_underscores(const string &str)
 		}
 	}
 	return res;
+}
+
+void CompilerGLSL::init()
+{
+	if (ir.source.known)
+	{
+		options.es = ir.source.es;
+		options.version = ir.source.version;
+	}
+
+	// Query the locale to see what the decimal point is.
+	// We'll rely on fixing it up ourselves in the rare case we have a comma-as-decimal locale
+	// rather than setting locales ourselves. Settings locales in a safe and isolated way is rather
+	// tricky.
+	const lconv *loc = localeconv();
+	if (loc && loc->decimal_point)
+		current_locale_radix_character = *loc->decimal_point;
 }
 
 static const char *to_pls_layout(PlsFormat format)
@@ -387,9 +405,6 @@ void CompilerGLSL::find_static_extensions()
 
 string CompilerGLSL::compile()
 {
-	// Force a classic "C" locale, reverts when function returns
-	ClassicLocale classic_locale;
-
 	if (options.vulkan_semantics)
 		backend.allow_precision_qualifiers = true;
 	backend.force_gl_in_out_block = true;
@@ -2985,7 +3000,7 @@ string CompilerGLSL::convert_half_to_string(const SPIRConstant &c, uint32_t col,
 		type.basetype = SPIRType::Half;
 		type.vecsize = 1;
 		type.columns = 1;
-		res = join(type_to_glsl(type), "(", convert_to_string(float_value), ")");
+		res = join(type_to_glsl(type), "(", convert_to_string(float_value, current_locale_radix_character), ")");
 	}
 
 	return res;
@@ -3043,7 +3058,7 @@ string CompilerGLSL::convert_float_to_string(const SPIRConstant &c, uint32_t col
 	}
 	else
 	{
-		res = convert_to_string(float_value);
+		res = convert_to_string(float_value, current_locale_radix_character);
 		if (backend.float_literal_suffix)
 			res += "f";
 	}
@@ -3115,7 +3130,7 @@ std::string CompilerGLSL::convert_double_to_string(const SPIRConstant &c, uint32
 	}
 	else
 	{
-		res = convert_to_string(double_value);
+		res = convert_to_string(double_value, current_locale_radix_character);
 		if (backend.double_literal_suffix)
 			res += "lf";
 	}

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -643,15 +643,10 @@ protected:
 
 	bool variable_is_lut(const SPIRVariable &var) const;
 
+	char current_locale_radix_character = '.';
+
 private:
-	void init()
-	{
-		if (ir.source.known)
-		{
-			options.es = ir.source.es;
-			options.version = ir.source.version;
-		}
-	}
+	void init();
 };
 } // namespace spirv_cross
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -546,8 +546,8 @@ void CompilerMSL::emit_entry_point_declarations()
 			args.push_back(join("max_anisotropy(", s.max_anisotropy, ")"));
 		if (s.lod_clamp_enable)
 		{
-			args.push_back(
-			    join("lod_clamp(", convert_to_string(s.lod_clamp_min), ", ", convert_to_string(s.lod_clamp_max), ")"));
+			args.push_back(join("lod_clamp(", convert_to_string(s.lod_clamp_min, current_locale_radix_character), ", ",
+			                    convert_to_string(s.lod_clamp_max, current_locale_radix_character), ")"));
 		}
 
 		statement("constexpr sampler ",
@@ -574,9 +574,6 @@ void CompilerMSL::emit_entry_point_declarations()
 
 string CompilerMSL::compile()
 {
-	// Force a classic "C" locale, reverts when function returns
-	ClassicLocale classic_locale;
-
 	// Do not deal with GLES-isms like precision, older extensions and such.
 	options.vulkan_semantics = true;
 	options.es = false;
@@ -1916,7 +1913,8 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage, bool patch)
 				statement("    ", input_wg_var_name, "[", to_expression(builtin_invocation_id_id), "] = ", ib_var_ref,
 				          ";");
 				statement("threadgroup_barrier(mem_flags::mem_threadgroup);");
-				statement("if (", to_expression(builtin_invocation_id_id), " >= ", get_entry_point().output_vertices, ")");
+				statement("if (", to_expression(builtin_invocation_id_id), " >= ", get_entry_point().output_vertices,
+				          ")");
 				statement("    return;");
 			});
 		}

--- a/spirv_reflect.cpp
+++ b/spirv_reflect.cpp
@@ -247,9 +247,6 @@ void CompilerReflection::set_format(const std::string &format)
 
 string CompilerReflection::compile()
 {
-	// Force a classic "C" locale, reverts when function returns
-	ClassicLocale classic_locale;
-
 	// Move constructor for this type is broken on GCC 4.9 ...
 	json_stream = std::make_shared<simple_json::Stream>();
 	json_stream->begin_json_object();


### PR DESCRIPTION
Setting locales is not thread-safe and is a process-wide operation unless we tap into OS-specific mechanisms. Instead, we just query the locale and do this fix-up ourselves. This is much safer than the alternative.

Fix #880.