### PR TITLE
Move check for structured OpSwitch to CompilerGLSL.

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -10747,6 +10747,9 @@ void CompilerGLSL::emit_block_chain(SPIRBlock &block)
 		auto &type = expression_type(block.condition);
 		bool unsigned_case = type.basetype == SPIRType::UInt || type.basetype == SPIRType::UShort;
 
+		if (block.merge == SPIRBlock::MergeNone)
+			SPIRV_CROSS_THROW("Switch statement is not structured");
+
 		if (type.basetype == SPIRType::UInt64 || type.basetype == SPIRType::Int64)
 		{
 			// SPIR-V spec suggests this is allowed, but we cannot support it in higher level languages.

--- a/spirv_parser.cpp
+++ b/spirv_parser.cpp
@@ -879,9 +879,6 @@ void Parser::parse(const Instruction &instruction)
 		if (!current_block)
 			SPIRV_CROSS_THROW("Trying to end a non-existing block.");
 
-		if (current_block->merge == SPIRBlock::MergeNone)
-			SPIRV_CROSS_THROW("Switch statement is not structured");
-
 		current_block->terminator = SPIRBlock::MultiSelect;
 
 		current_block->condition = ops[0];


### PR DESCRIPTION
Can still parse correctly.

Fix #895.