### PR TITLE
Support -1 index in OpVectorShuffle.

### DIFF
--- a/reference/shaders-hlsl-no-opt/asm/frag/vector-shuffle-undef-index.asm.frag
+++ b/reference/shaders-hlsl-no-opt/asm/frag/vector-shuffle-undef-index.asm.frag
@@ -1,0 +1,28 @@
+static float4 FragColor;
+static float4 vFloat;
+
+struct SPIRV_Cross_Input
+{
+    float4 vFloat : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+float4 undef;
+
+void frag_main()
+{
+    FragColor = float4(undef.x, vFloat.y, 0.0f, vFloat.w) + float4(vFloat.z, vFloat.y, 0.0f, vFloat.w);
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    vFloat = stage_input.vFloat;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-msl-no-opt/asm/frag/vector-shuffle-undef-index.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/vector-shuffle-undef-index.asm.frag
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+constant float4 undef = {};
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vFloat [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    out.FragColor = float4(undef.x, in.vFloat.y, 0.0, in.vFloat.w) + float4(in.vFloat.z, in.vFloat.y, 0.0, in.vFloat.w);
+    return out;
+}
+

--- a/reference/shaders-no-opt/asm/frag/vector-shuffle-undef-index.asm.frag
+++ b/reference/shaders-no-opt/asm/frag/vector-shuffle-undef-index.asm.frag
@@ -1,0 +1,12 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) in vec4 vFloat;
+
+vec4 undef;
+
+void main()
+{
+    FragColor = vec4(undef.x, vFloat.y, 0.0, vFloat.w) + vec4(vFloat.z, vFloat.y, 0.0, vFloat.w);
+}
+

--- a/shaders-hlsl-no-opt/asm/frag/vector-shuffle-undef-index.asm.frag
+++ b/shaders-hlsl-no-opt/asm/frag/vector-shuffle-undef-index.asm.frag
@@ -1,0 +1,42 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 29
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor %vFloat
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %FragColor "FragColor"
+               OpName %vFloat "vFloat"
+               OpName %undef "undef"
+               OpDecorate %FragColor Location 0
+               OpDecorate %vFloat Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+     %vFloat = OpVariable %_ptr_Input_v4float Input
+    %v2float = OpTypeVector %float 2
+%_ptr_Private_v4float = OpTypePointer Private %v4float
+      %undef = OpUndef %v4float
+       %uint = OpTypeInt 32 0
+     %uint_2 = OpConstant %uint 2
+%_ptr_Private_float = OpTypePointer Private %float
+     %uint_3 = OpConstant %uint 3
+%_ptr_Input_float = OpTypePointer Input %float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %13 = OpLoad %v4float %vFloat
+         %26 = OpVectorShuffle %v4float %13 %undef 4 1 0xffffffff 3
+         %27 = OpVectorShuffle %v4float %13 %13 2 1 0xffffffff 3
+         %28 = OpFAdd %v4float %26 %27
+               OpStore %FragColor %28
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/frag/vector-shuffle-undef-index.asm.frag
+++ b/shaders-msl-no-opt/asm/frag/vector-shuffle-undef-index.asm.frag
@@ -1,0 +1,42 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 29
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor %vFloat
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %FragColor "FragColor"
+               OpName %vFloat "vFloat"
+               OpName %undef "undef"
+               OpDecorate %FragColor Location 0
+               OpDecorate %vFloat Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+     %vFloat = OpVariable %_ptr_Input_v4float Input
+    %v2float = OpTypeVector %float 2
+%_ptr_Private_v4float = OpTypePointer Private %v4float
+      %undef = OpUndef %v4float
+       %uint = OpTypeInt 32 0
+     %uint_2 = OpConstant %uint 2
+%_ptr_Private_float = OpTypePointer Private %float
+     %uint_3 = OpConstant %uint 3
+%_ptr_Input_float = OpTypePointer Input %float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %13 = OpLoad %v4float %vFloat
+         %26 = OpVectorShuffle %v4float %13 %undef 4 1 0xffffffff 3
+         %27 = OpVectorShuffle %v4float %13 %13 2 1 0xffffffff 3
+         %28 = OpFAdd %v4float %26 %27
+               OpStore %FragColor %28
+               OpReturn
+               OpFunctionEnd

--- a/shaders-no-opt/asm/frag/vector-shuffle-undef-index.asm.frag
+++ b/shaders-no-opt/asm/frag/vector-shuffle-undef-index.asm.frag
@@ -1,0 +1,42 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 29
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor %vFloat
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %FragColor "FragColor"
+               OpName %vFloat "vFloat"
+               OpName %undef "undef"
+               OpDecorate %FragColor Location 0
+               OpDecorate %vFloat Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+     %vFloat = OpVariable %_ptr_Input_v4float Input
+    %v2float = OpTypeVector %float 2
+%_ptr_Private_v4float = OpTypePointer Private %v4float
+      %undef = OpUndef %v4float
+       %uint = OpTypeInt 32 0
+     %uint_2 = OpConstant %uint 2
+%_ptr_Private_float = OpTypePointer Private %float
+     %uint_3 = OpConstant %uint 3
+%_ptr_Input_float = OpTypePointer Input %float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %13 = OpLoad %v4float %vFloat
+         %26 = OpVectorShuffle %v4float %13 %undef 4 1 0xffffffff 3
+         %27 = OpVectorShuffle %v4float %13 %13 2 1 0xffffffff 3
+         %28 = OpFAdd %v4float %26 %27
+               OpStore %FragColor %28
+               OpReturn
+               OpFunctionEnd


### PR DESCRIPTION
-1 (0xffffffff) literal means the component should be undefined.
Since we cannot express undefined directly, just use a 0 literal in the
appropriate type.

Fix #901.