### PR TITLE
Properly deal with sign-dependent GLSL opcodes.

### DIFF
--- a/reference/shaders-hlsl-no-opt/asm/comp/glsl-signed-operations.asm.comp
+++ b/reference/shaders-hlsl-no-opt/asm/comp/glsl-signed-operations.asm.comp
@@ -1,0 +1,45 @@
+RWByteAddressBuffer _4 : register(u0);
+
+void comp_main()
+{
+    int4 _19 = int4(_4.Load4(0));
+    uint4 _20 = _4.Load4(16);
+    _4.Store4(0, uint4(abs(_19)));
+    _4.Store4(16, uint4(abs(_19)));
+    _4.Store4(0, uint4(abs(int4(_20))));
+    _4.Store4(16, uint4(abs(int4(_20))));
+    _4.Store4(0, uint4(sign(_19)));
+    _4.Store4(16, uint4(sign(_19)));
+    _4.Store4(0, uint4(sign(int4(_20))));
+    _4.Store4(16, uint4(sign(int4(_20))));
+    _4.Store4(0, uint4(firstbithigh(int4(_20))));
+    _4.Store4(16, uint4(firstbithigh(int4(_20))));
+    _4.Store4(0, uint4(int4(firstbithigh(uint4(_19)))));
+    _4.Store4(16, firstbithigh(uint4(_19)));
+    _4.Store4(0, uint4(min(_19, _19)));
+    _4.Store4(16, uint4(min(_19, int4(_20))));
+    _4.Store4(0, uint4(min(int4(_20), int4(_20))));
+    _4.Store4(16, uint4(min(int4(_20), _19)));
+    _4.Store4(0, uint4(int4(min(uint4(_19), _20))));
+    _4.Store4(16, min(uint4(_19), _20));
+    _4.Store4(0, uint4(int4(min(_20, uint4(_19)))));
+    _4.Store4(16, min(_20, uint4(_19)));
+    _4.Store4(0, uint4(max(_19, _19)));
+    _4.Store4(16, uint4(max(_19, _19)));
+    _4.Store4(0, uint4(max(int4(_20), _19)));
+    _4.Store4(16, uint4(max(int4(_20), _19)));
+    _4.Store4(0, uint4(int4(max(uint4(_19), _20))));
+    _4.Store4(16, max(uint4(_19), uint4(_19)));
+    _4.Store4(0, uint4(int4(max(_20, uint4(_19)))));
+    _4.Store4(16, max(_20, uint4(_19)));
+    _4.Store4(0, uint4(clamp(int4(_20), int4(_20), int4(_20))));
+    _4.Store4(16, uint4(clamp(int4(_20), int4(_20), int4(_20))));
+    _4.Store4(0, uint4(int4(clamp(uint4(_19), uint4(_19), uint4(_19)))));
+    _4.Store4(16, clamp(uint4(_19), uint4(_19), uint4(_19)));
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    comp_main();
+}

--- a/reference/shaders-hlsl-no-opt/comp/bitfield.comp
+++ b/reference/shaders-hlsl-no-opt/comp/bitfield.comp
@@ -92,7 +92,7 @@ void comp_main()
     s = reversebits(s);
     int v0 = countbits(u);
     int v1 = countbits(s);
-    int v2 = firstbithigh(u);
+    int v2 = int(firstbithigh(u));
     int v3 = firstbitlow(s);
     int3 s_1 = SPIRV_Cross_bitfieldSExtract(signed_values, 5, 20);
     uint3 u_1 = SPIRV_Cross_bitfieldUExtract(unsigned_values, 6, 21);
@@ -102,7 +102,7 @@ void comp_main()
     s_1 = reversebits(s_1);
     int3 v0_1 = countbits(u_1);
     int3 v1_1 = countbits(s_1);
-    int3 v2_1 = firstbithigh(u_1);
+    int3 v2_1 = int3(firstbithigh(u_1));
     int3 v3_1 = firstbitlow(s_1);
 }
 

--- a/reference/shaders-msl-no-opt/asm/comp/glsl-signed-operations.asm.comp
+++ b/reference/shaders-msl-no-opt/asm/comp/glsl-signed-operations.asm.comp
@@ -1,0 +1,73 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct SSBO
+{
+    int4 ints;
+    uint4 uints;
+};
+
+// Implementation of the signed GLSL findMSB() function
+template<typename T>
+T findSMSB(T x)
+{
+    T v = select(x, T(-1) - x, x < T(0));
+    return select(clz(T(0)) - (clz(v) + T(1)), T(-1), v == T(0));
+}
+
+// Implementation of the unsigned GLSL findMSB() function
+template<typename T>
+T findUMSB(T x)
+{
+    return select(clz(T(0)) - (clz(x) + T(1)), T(-1), x == T(0));
+}
+
+// Implementation of the GLSL sign() function for integer types
+template<typename T, typename E = typename enable_if<is_integral<T>::value>::type>
+T sign(T x)
+{
+    return select(select(select(x, T(0), x == T(0)), T(1), x > T(0)), T(-1), x < T(0));
+}
+
+kernel void main0(device SSBO& _4 [[buffer(0)]])
+{
+    int4 _19 = _4.ints;
+    uint4 _20 = _4.uints;
+    _4.ints = abs(_19);
+    _4.uints = uint4(abs(_19));
+    _4.ints = abs(int4(_20));
+    _4.uints = uint4(abs(int4(_20)));
+    _4.ints = sign(_19);
+    _4.uints = uint4(sign(_19));
+    _4.ints = sign(int4(_20));
+    _4.uints = uint4(sign(int4(_20)));
+    _4.ints = findSMSB(int4(_20));
+    _4.uints = uint4(findSMSB(int4(_20)));
+    _4.ints = int4(findUMSB(uint4(_19)));
+    _4.uints = findUMSB(uint4(_19));
+    _4.ints = min(_19, _19);
+    _4.uints = uint4(min(_19, int4(_20)));
+    _4.ints = min(int4(_20), int4(_20));
+    _4.uints = uint4(min(int4(_20), _19));
+    _4.ints = int4(min(uint4(_19), _20));
+    _4.uints = min(uint4(_19), _20);
+    _4.ints = int4(min(_20, uint4(_19)));
+    _4.uints = min(_20, uint4(_19));
+    _4.ints = max(_19, _19);
+    _4.uints = uint4(max(_19, _19));
+    _4.ints = max(int4(_20), _19);
+    _4.uints = uint4(max(int4(_20), _19));
+    _4.ints = int4(max(uint4(_19), _20));
+    _4.uints = max(uint4(_19), uint4(_19));
+    _4.ints = int4(max(_20, uint4(_19)));
+    _4.uints = max(_20, uint4(_19));
+    _4.ints = clamp(int4(_20), int4(_20), int4(_20));
+    _4.uints = uint4(clamp(int4(_20), int4(_20), int4(_20)));
+    _4.ints = int4(clamp(uint4(_19), uint4(_19), uint4(_19)));
+    _4.uints = clamp(uint4(_19), uint4(_19), uint4(_19));
+}
+

--- a/reference/shaders-msl-no-opt/comp/bitfield.comp
+++ b/reference/shaders-msl-no-opt/comp/bitfield.comp
@@ -39,7 +39,7 @@ kernel void main0()
     s = reverse_bits(s);
     int v0 = popcount(u);
     int v1 = popcount(s);
-    int v2 = findUMSB(u);
+    int v2 = int(findUMSB(u));
     int v3 = findSMSB(s);
     int v4 = findLSB(u);
     int v5 = findLSB(s);

--- a/reference/shaders-no-opt/asm/comp/glsl-signed-operations.asm.comp
+++ b/reference/shaders-no-opt/asm/comp/glsl-signed-operations.asm.comp
@@ -1,0 +1,47 @@
+#version 450
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0, std430) buffer SSBO
+{
+    ivec4 ints;
+    uvec4 uints;
+} _4;
+
+void main()
+{
+    ivec4 _19 = _4.ints;
+    uvec4 _20 = _4.uints;
+    _4.ints = abs(_19);
+    _4.uints = uvec4(abs(_19));
+    _4.ints = abs(ivec4(_20));
+    _4.uints = uvec4(abs(ivec4(_20)));
+    _4.ints = sign(_19);
+    _4.uints = uvec4(sign(_19));
+    _4.ints = sign(ivec4(_20));
+    _4.uints = uvec4(sign(ivec4(_20)));
+    _4.ints = findMSB(ivec4(_20));
+    _4.uints = uvec4(findMSB(ivec4(_20)));
+    _4.ints = findMSB(uvec4(_19));
+    _4.uints = uvec4(findMSB(uvec4(_19)));
+    _4.ints = min(_19, _19);
+    _4.uints = uvec4(min(_19, ivec4(_20)));
+    _4.ints = min(ivec4(_20), ivec4(_20));
+    _4.uints = uvec4(min(ivec4(_20), _19));
+    _4.ints = ivec4(min(uvec4(_19), _20));
+    _4.uints = min(uvec4(_19), _20);
+    _4.ints = ivec4(min(_20, uvec4(_19)));
+    _4.uints = min(_20, uvec4(_19));
+    _4.ints = max(_19, _19);
+    _4.uints = uvec4(max(_19, _19));
+    _4.ints = max(ivec4(_20), _19);
+    _4.uints = uvec4(max(ivec4(_20), _19));
+    _4.ints = ivec4(max(uvec4(_19), _20));
+    _4.uints = max(uvec4(_19), uvec4(_19));
+    _4.ints = ivec4(max(_20, uvec4(_19)));
+    _4.uints = max(_20, uvec4(_19));
+    _4.ints = clamp(ivec4(_20), ivec4(_20), ivec4(_20));
+    _4.uints = uvec4(clamp(ivec4(_20), ivec4(_20), ivec4(_20)));
+    _4.ints = ivec4(clamp(uvec4(_19), uvec4(_19), uvec4(_19)));
+    _4.uints = clamp(uvec4(_19), uvec4(_19), uvec4(_19));
+}
+

--- a/shaders-hlsl-no-opt/asm/comp/glsl-signed-operations.asm.comp
+++ b/shaders-hlsl-no-opt/asm/comp/glsl-signed-operations.asm.comp
@@ -1,0 +1,123 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 26
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %SSBO "SSBO"
+               OpMemberName %SSBO 0 "ints"
+               OpMemberName %SSBO 1 "uints"
+               OpName %_ ""
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpMemberDecorate %SSBO 1 Offset 16
+               OpDecorate %SSBO BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %v4int = OpTypeVector %int 4
+       %uint = OpTypeInt 32 0
+     %v4uint = OpTypeVector %uint 4
+       %SSBO = OpTypeStruct %v4int %v4uint
+%_ptr_Uniform_SSBO = OpTypePointer Uniform %SSBO
+          %_ = OpVariable %_ptr_Uniform_SSBO Uniform
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_v4int = OpTypePointer Uniform %v4int
+      %int_1 = OpConstant %int 1
+%_ptr_Uniform_v4uint = OpTypePointer Uniform %v4uint
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %ints_ptr = OpAccessChain %_ptr_Uniform_v4int %_ %int_0
+         %uints_ptr = OpAccessChain %_ptr_Uniform_v4uint %_ %int_1
+         %ints = OpLoad %v4int %ints_ptr
+         %uints = OpLoad %v4uint %uints_ptr
+
+         %int_to_int_sabs = OpExtInst %v4int %1 SAbs %ints
+         %int_to_uint_sabs = OpExtInst %v4uint %1 SAbs %ints
+         %uint_to_int_sabs = OpExtInst %v4int %1 SAbs %uints
+         %uint_to_uint_sabs = OpExtInst %v4uint %1 SAbs %uints
+
+         %int_to_int_ssign = OpExtInst %v4int %1 SSign %ints
+         %int_to_uint_ssign = OpExtInst %v4uint %1 SSign %ints
+         %uint_to_int_ssign = OpExtInst %v4int %1 SSign %uints
+         %uint_to_uint_ssign = OpExtInst %v4uint %1 SSign %uints
+
+         %int_to_int_smsb = OpExtInst %v4int %1 FindSMsb %uints
+         %int_to_uint_smsb = OpExtInst %v4uint %1 FindSMsb %uints
+         %uint_to_int_umsb = OpExtInst %v4int %1 FindUMsb %ints
+         %uint_to_uint_umsb = OpExtInst %v4uint %1 FindUMsb %ints
+
+         %int_to_int_smin = OpExtInst %v4int %1 SMin %ints %ints
+         %int_to_uint_smin = OpExtInst %v4uint %1 SMin %ints %uints
+         %uint_to_int_smin = OpExtInst %v4int %1 SMin %uints %uints
+         %uint_to_uint_smin = OpExtInst %v4uint %1 SMin %uints %ints
+
+         %int_to_int_umin = OpExtInst %v4int %1 UMin %ints %uints
+         %int_to_uint_umin = OpExtInst %v4uint %1 UMin %ints %uints
+         %uint_to_int_umin = OpExtInst %v4int %1 UMin %uints %ints
+         %uint_to_uint_umin = OpExtInst %v4uint %1 UMin %uints %ints
+
+         %int_to_int_smax = OpExtInst %v4int %1 SMax %ints %ints
+         %int_to_uint_smax = OpExtInst %v4uint %1 SMax %ints %ints
+         %uint_to_int_smax = OpExtInst %v4int %1 SMax %uints %ints
+         %uint_to_uint_smax = OpExtInst %v4uint %1 SMax %uints %ints
+
+         %int_to_int_umax = OpExtInst %v4int %1 UMax %ints %uints
+         %int_to_uint_umax = OpExtInst %v4uint %1 UMax %ints %ints
+         %uint_to_int_umax = OpExtInst %v4int %1 UMax %uints %ints
+         %uint_to_uint_umax = OpExtInst %v4uint %1 UMax %uints %ints
+
+         %int_to_int_sclamp = OpExtInst %v4int %1 SClamp %uints %uints %uints
+         %int_to_uint_sclamp = OpExtInst %v4uint %1 SClamp %uints %uints %uints
+         %uint_to_int_uclamp = OpExtInst %v4int %1 UClamp %ints %ints %ints
+         %uint_to_uint_uclamp = OpExtInst %v4uint %1 UClamp %ints %ints %ints
+
+               OpStore %ints_ptr %int_to_int_sabs
+               OpStore %uints_ptr %int_to_uint_sabs
+               OpStore %ints_ptr %uint_to_int_sabs
+               OpStore %uints_ptr %uint_to_uint_sabs
+
+               OpStore %ints_ptr %int_to_int_ssign
+               OpStore %uints_ptr %int_to_uint_ssign
+               OpStore %ints_ptr %uint_to_int_ssign
+               OpStore %uints_ptr %uint_to_uint_ssign
+
+               OpStore %ints_ptr %int_to_int_smsb
+               OpStore %uints_ptr %int_to_uint_smsb
+               OpStore %ints_ptr %uint_to_int_umsb
+               OpStore %uints_ptr %uint_to_uint_umsb
+
+               OpStore %ints_ptr %int_to_int_smin
+               OpStore %uints_ptr %int_to_uint_smin
+               OpStore %ints_ptr %uint_to_int_smin
+               OpStore %uints_ptr %uint_to_uint_smin
+
+               OpStore %ints_ptr %int_to_int_umin
+               OpStore %uints_ptr %int_to_uint_umin
+               OpStore %ints_ptr %uint_to_int_umin
+               OpStore %uints_ptr %uint_to_uint_umin
+
+               OpStore %ints_ptr %int_to_int_smax
+               OpStore %uints_ptr %int_to_uint_smax
+               OpStore %ints_ptr %uint_to_int_smax
+               OpStore %uints_ptr %uint_to_uint_smax
+
+               OpStore %ints_ptr %int_to_int_umax
+               OpStore %uints_ptr %int_to_uint_umax
+               OpStore %ints_ptr %uint_to_int_umax
+               OpStore %uints_ptr %uint_to_uint_umax
+
+               OpStore %ints_ptr %int_to_int_sclamp
+               OpStore %uints_ptr %int_to_uint_sclamp
+               OpStore %ints_ptr %uint_to_int_uclamp
+               OpStore %uints_ptr %uint_to_uint_uclamp
+
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/comp/glsl-signed-operations.asm.comp
+++ b/shaders-msl-no-opt/asm/comp/glsl-signed-operations.asm.comp
@@ -1,0 +1,123 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 26
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %SSBO "SSBO"
+               OpMemberName %SSBO 0 "ints"
+               OpMemberName %SSBO 1 "uints"
+               OpName %_ ""
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpMemberDecorate %SSBO 1 Offset 16
+               OpDecorate %SSBO BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %v4int = OpTypeVector %int 4
+       %uint = OpTypeInt 32 0
+     %v4uint = OpTypeVector %uint 4
+       %SSBO = OpTypeStruct %v4int %v4uint
+%_ptr_Uniform_SSBO = OpTypePointer Uniform %SSBO
+          %_ = OpVariable %_ptr_Uniform_SSBO Uniform
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_v4int = OpTypePointer Uniform %v4int
+      %int_1 = OpConstant %int 1
+%_ptr_Uniform_v4uint = OpTypePointer Uniform %v4uint
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %ints_ptr = OpAccessChain %_ptr_Uniform_v4int %_ %int_0
+         %uints_ptr = OpAccessChain %_ptr_Uniform_v4uint %_ %int_1
+         %ints = OpLoad %v4int %ints_ptr
+         %uints = OpLoad %v4uint %uints_ptr
+
+         %int_to_int_sabs = OpExtInst %v4int %1 SAbs %ints
+         %int_to_uint_sabs = OpExtInst %v4uint %1 SAbs %ints
+         %uint_to_int_sabs = OpExtInst %v4int %1 SAbs %uints
+         %uint_to_uint_sabs = OpExtInst %v4uint %1 SAbs %uints
+
+         %int_to_int_ssign = OpExtInst %v4int %1 SSign %ints
+         %int_to_uint_ssign = OpExtInst %v4uint %1 SSign %ints
+         %uint_to_int_ssign = OpExtInst %v4int %1 SSign %uints
+         %uint_to_uint_ssign = OpExtInst %v4uint %1 SSign %uints
+
+         %int_to_int_smsb = OpExtInst %v4int %1 FindSMsb %uints
+         %int_to_uint_smsb = OpExtInst %v4uint %1 FindSMsb %uints
+         %uint_to_int_umsb = OpExtInst %v4int %1 FindUMsb %ints
+         %uint_to_uint_umsb = OpExtInst %v4uint %1 FindUMsb %ints
+
+         %int_to_int_smin = OpExtInst %v4int %1 SMin %ints %ints
+         %int_to_uint_smin = OpExtInst %v4uint %1 SMin %ints %uints
+         %uint_to_int_smin = OpExtInst %v4int %1 SMin %uints %uints
+         %uint_to_uint_smin = OpExtInst %v4uint %1 SMin %uints %ints
+
+         %int_to_int_umin = OpExtInst %v4int %1 UMin %ints %uints
+         %int_to_uint_umin = OpExtInst %v4uint %1 UMin %ints %uints
+         %uint_to_int_umin = OpExtInst %v4int %1 UMin %uints %ints
+         %uint_to_uint_umin = OpExtInst %v4uint %1 UMin %uints %ints
+
+         %int_to_int_smax = OpExtInst %v4int %1 SMax %ints %ints
+         %int_to_uint_smax = OpExtInst %v4uint %1 SMax %ints %ints
+         %uint_to_int_smax = OpExtInst %v4int %1 SMax %uints %ints
+         %uint_to_uint_smax = OpExtInst %v4uint %1 SMax %uints %ints
+
+         %int_to_int_umax = OpExtInst %v4int %1 UMax %ints %uints
+         %int_to_uint_umax = OpExtInst %v4uint %1 UMax %ints %ints
+         %uint_to_int_umax = OpExtInst %v4int %1 UMax %uints %ints
+         %uint_to_uint_umax = OpExtInst %v4uint %1 UMax %uints %ints
+
+         %int_to_int_sclamp = OpExtInst %v4int %1 SClamp %uints %uints %uints
+         %int_to_uint_sclamp = OpExtInst %v4uint %1 SClamp %uints %uints %uints
+         %uint_to_int_uclamp = OpExtInst %v4int %1 UClamp %ints %ints %ints
+         %uint_to_uint_uclamp = OpExtInst %v4uint %1 UClamp %ints %ints %ints
+
+               OpStore %ints_ptr %int_to_int_sabs
+               OpStore %uints_ptr %int_to_uint_sabs
+               OpStore %ints_ptr %uint_to_int_sabs
+               OpStore %uints_ptr %uint_to_uint_sabs
+
+               OpStore %ints_ptr %int_to_int_ssign
+               OpStore %uints_ptr %int_to_uint_ssign
+               OpStore %ints_ptr %uint_to_int_ssign
+               OpStore %uints_ptr %uint_to_uint_ssign
+
+               OpStore %ints_ptr %int_to_int_smsb
+               OpStore %uints_ptr %int_to_uint_smsb
+               OpStore %ints_ptr %uint_to_int_umsb
+               OpStore %uints_ptr %uint_to_uint_umsb
+
+               OpStore %ints_ptr %int_to_int_smin
+               OpStore %uints_ptr %int_to_uint_smin
+               OpStore %ints_ptr %uint_to_int_smin
+               OpStore %uints_ptr %uint_to_uint_smin
+
+               OpStore %ints_ptr %int_to_int_umin
+               OpStore %uints_ptr %int_to_uint_umin
+               OpStore %ints_ptr %uint_to_int_umin
+               OpStore %uints_ptr %uint_to_uint_umin
+
+               OpStore %ints_ptr %int_to_int_smax
+               OpStore %uints_ptr %int_to_uint_smax
+               OpStore %ints_ptr %uint_to_int_smax
+               OpStore %uints_ptr %uint_to_uint_smax
+
+               OpStore %ints_ptr %int_to_int_umax
+               OpStore %uints_ptr %int_to_uint_umax
+               OpStore %ints_ptr %uint_to_int_umax
+               OpStore %uints_ptr %uint_to_uint_umax
+
+               OpStore %ints_ptr %int_to_int_sclamp
+               OpStore %uints_ptr %int_to_uint_sclamp
+               OpStore %ints_ptr %uint_to_int_uclamp
+               OpStore %uints_ptr %uint_to_uint_uclamp
+
+               OpReturn
+               OpFunctionEnd

--- a/shaders-no-opt/asm/comp/glsl-signed-operations.asm.comp
+++ b/shaders-no-opt/asm/comp/glsl-signed-operations.asm.comp
@@ -1,0 +1,123 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 26
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %SSBO "SSBO"
+               OpMemberName %SSBO 0 "ints"
+               OpMemberName %SSBO 1 "uints"
+               OpName %_ ""
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpMemberDecorate %SSBO 1 Offset 16
+               OpDecorate %SSBO BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %v4int = OpTypeVector %int 4
+       %uint = OpTypeInt 32 0
+     %v4uint = OpTypeVector %uint 4
+       %SSBO = OpTypeStruct %v4int %v4uint
+%_ptr_Uniform_SSBO = OpTypePointer Uniform %SSBO
+          %_ = OpVariable %_ptr_Uniform_SSBO Uniform
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_v4int = OpTypePointer Uniform %v4int
+      %int_1 = OpConstant %int 1
+%_ptr_Uniform_v4uint = OpTypePointer Uniform %v4uint
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %ints_ptr = OpAccessChain %_ptr_Uniform_v4int %_ %int_0
+         %uints_ptr = OpAccessChain %_ptr_Uniform_v4uint %_ %int_1
+         %ints = OpLoad %v4int %ints_ptr
+         %uints = OpLoad %v4uint %uints_ptr
+
+         %int_to_int_sabs = OpExtInst %v4int %1 SAbs %ints
+         %int_to_uint_sabs = OpExtInst %v4uint %1 SAbs %ints
+         %uint_to_int_sabs = OpExtInst %v4int %1 SAbs %uints
+         %uint_to_uint_sabs = OpExtInst %v4uint %1 SAbs %uints
+
+         %int_to_int_ssign = OpExtInst %v4int %1 SSign %ints
+         %int_to_uint_ssign = OpExtInst %v4uint %1 SSign %ints
+         %uint_to_int_ssign = OpExtInst %v4int %1 SSign %uints
+         %uint_to_uint_ssign = OpExtInst %v4uint %1 SSign %uints
+
+         %int_to_int_smsb = OpExtInst %v4int %1 FindSMsb %uints
+         %int_to_uint_smsb = OpExtInst %v4uint %1 FindSMsb %uints
+         %uint_to_int_umsb = OpExtInst %v4int %1 FindUMsb %ints
+         %uint_to_uint_umsb = OpExtInst %v4uint %1 FindUMsb %ints
+
+         %int_to_int_smin = OpExtInst %v4int %1 SMin %ints %ints
+         %int_to_uint_smin = OpExtInst %v4uint %1 SMin %ints %uints
+         %uint_to_int_smin = OpExtInst %v4int %1 SMin %uints %uints
+         %uint_to_uint_smin = OpExtInst %v4uint %1 SMin %uints %ints
+
+         %int_to_int_umin = OpExtInst %v4int %1 UMin %ints %uints
+         %int_to_uint_umin = OpExtInst %v4uint %1 UMin %ints %uints
+         %uint_to_int_umin = OpExtInst %v4int %1 UMin %uints %ints
+         %uint_to_uint_umin = OpExtInst %v4uint %1 UMin %uints %ints
+
+         %int_to_int_smax = OpExtInst %v4int %1 SMax %ints %ints
+         %int_to_uint_smax = OpExtInst %v4uint %1 SMax %ints %ints
+         %uint_to_int_smax = OpExtInst %v4int %1 SMax %uints %ints
+         %uint_to_uint_smax = OpExtInst %v4uint %1 SMax %uints %ints
+
+         %int_to_int_umax = OpExtInst %v4int %1 UMax %ints %uints
+         %int_to_uint_umax = OpExtInst %v4uint %1 UMax %ints %ints
+         %uint_to_int_umax = OpExtInst %v4int %1 UMax %uints %ints
+         %uint_to_uint_umax = OpExtInst %v4uint %1 UMax %uints %ints
+
+         %int_to_int_sclamp = OpExtInst %v4int %1 SClamp %uints %uints %uints
+         %int_to_uint_sclamp = OpExtInst %v4uint %1 SClamp %uints %uints %uints
+         %uint_to_int_uclamp = OpExtInst %v4int %1 UClamp %ints %ints %ints
+         %uint_to_uint_uclamp = OpExtInst %v4uint %1 UClamp %ints %ints %ints
+
+               OpStore %ints_ptr %int_to_int_sabs
+               OpStore %uints_ptr %int_to_uint_sabs
+               OpStore %ints_ptr %uint_to_int_sabs
+               OpStore %uints_ptr %uint_to_uint_sabs
+
+               OpStore %ints_ptr %int_to_int_ssign
+               OpStore %uints_ptr %int_to_uint_ssign
+               OpStore %ints_ptr %uint_to_int_ssign
+               OpStore %uints_ptr %uint_to_uint_ssign
+
+               OpStore %ints_ptr %int_to_int_smsb
+               OpStore %uints_ptr %int_to_uint_smsb
+               OpStore %ints_ptr %uint_to_int_umsb
+               OpStore %uints_ptr %uint_to_uint_umsb
+
+               OpStore %ints_ptr %int_to_int_smin
+               OpStore %uints_ptr %int_to_uint_smin
+               OpStore %ints_ptr %uint_to_int_smin
+               OpStore %uints_ptr %uint_to_uint_smin
+
+               OpStore %ints_ptr %int_to_int_umin
+               OpStore %uints_ptr %int_to_uint_umin
+               OpStore %ints_ptr %uint_to_int_umin
+               OpStore %uints_ptr %uint_to_uint_umin
+
+               OpStore %ints_ptr %int_to_int_smax
+               OpStore %uints_ptr %int_to_uint_smax
+               OpStore %ints_ptr %uint_to_int_smax
+               OpStore %uints_ptr %uint_to_uint_smax
+
+               OpStore %ints_ptr %int_to_int_umax
+               OpStore %uints_ptr %int_to_uint_umax
+               OpStore %ints_ptr %uint_to_int_umax
+               OpStore %uints_ptr %uint_to_uint_umax
+
+               OpStore %ints_ptr %int_to_int_sclamp
+               OpStore %uints_ptr %int_to_uint_sclamp
+               OpStore %ints_ptr %uint_to_int_uclamp
+               OpStore %uints_ptr %uint_to_uint_uclamp
+
+               OpReturn
+               OpFunctionEnd

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -429,8 +429,14 @@ protected:
 	void emit_trinary_func_op(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, uint32_t op2,
 	                          const char *op);
 	void emit_binary_func_op(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, const char *op);
+
+	void emit_unary_func_op_cast(uint32_t result_type, uint32_t result_id, uint32_t op0, const char *op,
+	                             SPIRType::BaseType input_type, SPIRType::BaseType expected_result_type);
 	void emit_binary_func_op_cast(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, const char *op,
 	                              SPIRType::BaseType input_type, bool skip_cast_if_equal_type);
+	void emit_trinary_func_op_cast(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, uint32_t op2, const char *op,
+	                               SPIRType::BaseType input_type);
+
 	void emit_unary_func_op(uint32_t result_type, uint32_t result_id, uint32_t op0, const char *op);
 	void emit_unrolled_unary_op(uint32_t result_type, uint32_t result_id, uint32_t operand, const char *op);
 	void emit_binary_op(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, const char *op);
@@ -635,6 +641,7 @@ protected:
 	virtual void emit_store_statement(uint32_t lhs_expression, uint32_t rhs_expression);
 
 	uint32_t get_integer_width_for_instruction(const Instruction &instr) const;
+	uint32_t get_integer_width_for_glsl_instruction(GLSLstd450 op, const uint32_t *arguments, uint32_t length) const;
 
 	bool variable_is_lut(const SPIRVariable &var) const;
 

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -3049,7 +3049,12 @@ string CompilerHLSL::bitcast_glsl_op(const SPIRType &out_type, const SPIRType &i
 
 void CompilerHLSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop, const uint32_t *args, uint32_t count)
 {
-	GLSLstd450 op = static_cast<GLSLstd450>(eop);
+	auto op = static_cast<GLSLstd450>(eop);
+
+	// If we need to do implicit bitcasts, make sure we do it with the correct type.
+	uint32_t integer_width = get_integer_width_for_glsl_instruction(op, args, count);
+	auto int_type = to_signed_basetype(integer_width);
+	auto uint_type = to_unsigned_basetype(integer_width);
 
 	switch (op)
 	{
@@ -3189,9 +3194,13 @@ void CompilerHLSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop,
 	case GLSLstd450FindILsb:
 		emit_unary_func_op(result_type, id, args[0], "firstbitlow");
 		break;
+
 	case GLSLstd450FindSMsb:
+		emit_unary_func_op_cast(result_type, id, args[0], "firstbithigh", int_type, int_type);
+		break;
+
 	case GLSLstd450FindUMsb:
-		emit_unary_func_op(result_type, id, args[0], "firstbithigh");
+		emit_unary_func_op_cast(result_type, id, args[0], "firstbithigh", uint_type, uint_type);
 		break;
 
 	case GLSLstd450MatrixInverse:

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -4085,7 +4085,12 @@ const char *CompilerMSL::get_memory_order(uint32_t)
 // Override for MSL-specific extension syntax instructions
 void CompilerMSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop, const uint32_t *args, uint32_t count)
 {
-	GLSLstd450 op = static_cast<GLSLstd450>(eop);
+	auto op = static_cast<GLSLstd450>(eop);
+
+	// If we need to do implicit bitcasts, make sure we do it with the correct type.
+	uint32_t integer_width = get_integer_width_for_glsl_instruction(op, args, count);
+	auto int_type = to_signed_basetype(integer_width);
+	auto uint_type = to_unsigned_basetype(integer_width);
 
 	switch (op)
 	{
@@ -4100,10 +4105,11 @@ void CompilerMSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop, 
 		break;
 
 	case GLSLstd450FindSMsb:
-		emit_unary_func_op(result_type, id, args[0], "findSMSB");
+		emit_unary_func_op_cast(result_type, id, args[0], "findSMSB", int_type, int_type);
 		break;
+
 	case GLSLstd450FindUMsb:
-		emit_unary_func_op(result_type, id, args[0], "findUMSB");
+		emit_unary_func_op_cast(result_type, id, args[0], "findUMSB", uint_type, uint_type);
 		break;
 
 	case GLSLstd450PackSnorm4x8:


### PR DESCRIPTION
The GLSLstd450 spec is very lax about input signs, so we need to do the
bitcasting dance to implement it correctly.

Fix #908.