### PR TITLE
Make build system more modular.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,14 @@ option(SPIRV_CROSS_STATIC "Build the C and C++ API as static libraries." ON)
 option(SPIRV_CROSS_CLI "Build the CLI binary. Requires SPIRV_CROSS_STATIC." ON)
 option(SPIRV_CROSS_ENABLE_TESTS "Enable SPIRV-Cross tests." ON)
 
+option(SPIRV_CROSS_ENABLE_GLSL "Enable GLSL support." ON)
+option(SPIRV_CROSS_ENABLE_HLSL "Enable HLSL target support." ON)
+option(SPIRV_CROSS_ENABLE_MSL "Enable MSL target support." ON)
+option(SPIRV_CROSS_ENABLE_CPP "Enable C++ target support." ON)
+option(SPIRV_CROSS_ENABLE_REFLECT "Enable JSON reflection target support." ON)
+option(SPIRV_CROSS_ENABLE_C_API "Enable C API wrapper support in static library." ON)
+option(SPIRV_CROSS_ENABLE_UTIL "Enable util module support." ON)
+
 option(SPIRV_CROSS_SANITIZE_ADDRESS "Sanitize address" OFF)
 option(SPIRV_CROSS_SANITIZE_MEMORY "Sanitize memory" OFF)
 option(SPIRV_CROSS_SANITIZE_THREADS "Sanitize threads" OFF)
@@ -95,124 +103,201 @@ macro(spirv_cross_add_library name config_name)
 	add_library(${name} ${ARGN})
 	extract_headers(hdrs "${ARGN}")
 	target_include_directories(${name} PUBLIC
-		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-		$<INSTALL_INTERFACE:include/spirv_cross>)
+			$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+			$<INSTALL_INTERFACE:include/spirv_cross>)
 	set_target_properties(${name} PROPERTIES
-		PUBLIC_HEADERS "${hdrs}")
+			PUBLIC_HEADERS "${hdrs}")
 	target_compile_options(${name} PRIVATE ${spirv-compiler-options})
 	target_compile_definitions(${name} PRIVATE ${spirv-compiler-defines})
 	install(TARGETS ${name}
-		EXPORT ${config_name}Config
-		RUNTIME DESTINATION bin
-		LIBRARY DESTINATION lib
-		ARCHIVE DESTINATION lib
-		PUBLIC_HEADER DESTINATION include/spirv_cross)
+			EXPORT ${config_name}Config
+			RUNTIME DESTINATION bin
+			LIBRARY DESTINATION lib
+			ARCHIVE DESTINATION lib
+			PUBLIC_HEADER DESTINATION include/spirv_cross)
 	install(FILES ${hdrs} DESTINATION include/spirv_cross)
 	install(EXPORT ${config_name}Config DESTINATION share/${config_name}/cmake)
 	export(TARGETS ${name} FILE ${config_name}Config.cmake)
 endmacro()
 
 set(spirv-cross-core-sources
-	${CMAKE_CURRENT_SOURCE_DIR}/GLSL.std.450.h
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_common.hpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv.hpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross.hpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_parser.hpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_parser.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross_parsed_ir.hpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross_parsed_ir.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_cfg.hpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_cfg.cpp)
+		${CMAKE_CURRENT_SOURCE_DIR}/GLSL.std.450.h
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_common.hpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv.hpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross.hpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_parser.hpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_parser.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross_parsed_ir.hpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross_parsed_ir.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cfg.hpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cfg.cpp)
 
 set(spirv-cross-c-sources
-	spirv.h
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross_c.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross_c.h)
+		spirv.h
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross_c.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross_c.h)
 
 set(spirv-cross-glsl-sources
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_glsl.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_glsl.hpp)
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_glsl.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_glsl.hpp)
 
 set(spirv-cross-cpp-sources
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_cpp.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_cpp.hpp)
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cpp.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cpp.hpp)
 
 set(spirv-cross-msl-sources
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_msl.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_msl.hpp)
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_msl.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_msl.hpp)
 
 set(spirv-cross-hlsl-sources
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_hlsl.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_hlsl.hpp)
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_hlsl.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_hlsl.hpp)
 
 set(spirv-cross-reflect-sources
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_reflect.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_reflect.hpp)
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_reflect.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_reflect.hpp)
 
 set(spirv-cross-util-sources
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross_util.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross_util.hpp)
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross_util.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross_util.hpp)
 
 if (SPIRV_CROSS_STATIC)
 	spirv_cross_add_library(spirv-cross-core spirv_cross_core STATIC
-		${spirv-cross-core-sources})
+			${spirv-cross-core-sources})
 
-	spirv_cross_add_library(spirv-cross-c spirv_cross_c STATIC
-		${spirv-cross-c-sources})
+	if (SPIRV_CROSS_ENABLE_GLSL)
+		spirv_cross_add_library(spirv-cross-glsl spirv_cross_glsl STATIC
+				${spirv-cross-glsl-sources})
+		target_link_libraries(spirv-cross-glsl PRIVATE spirv-cross-core)
+	endif()
 
-	spirv_cross_add_library(spirv-cross-glsl spirv_cross_glsl STATIC
-		${spirv-cross-glsl-sources})
+	if (SPIRV_CROSS_ENABLE_CPP)
+		spirv_cross_add_library(spirv-cross-cpp spirv_cross_cpp STATIC
+				${spirv-cross-cpp-sources})
 
-	spirv_cross_add_library(spirv-cross-cpp spirv_cross_cpp STATIC
-		${spirv-cross-cpp-sources})
+		if (SPIRV_CROSS_ENABLE_GLSL)
+			target_link_libraries(spirv-cross-cpp PRIVATE spirv-cross-glsl)
+		else()
+			message(FATAL_ERROR "Must enable GLSL support to enable C++ support.")
+		endif()
+	endif()
 
-	spirv_cross_add_library(spirv-cross-reflect spirv_cross_reflect STATIC
-		${spirv-cross-reflect-sources})
+	if (SPIRV_CROSS_ENABLE_REFLECT)
+		spirv_cross_add_library(spirv-cross-reflect spirv_cross_reflect STATIC
+				${spirv-cross-reflect-sources})
+	endif()
 
-	spirv_cross_add_library(spirv-cross-msl spirv_cross_msl STATIC
-		${spirv-cross-msl-sources})
+	if (SPIRV_CROSS_ENABLE_MSL)
+		spirv_cross_add_library(spirv-cross-msl spirv_cross_msl STATIC
+				${spirv-cross-msl-sources})
+		if (SPIRV_CROSS_ENABLE_GLSL)
+			target_link_libraries(spirv-cross-msl PRIVATE spirv-cross-glsl)
+		else()
+			message(FATAL_ERROR "Must enable GLSL support to enable MSL support.")
+		endif()
+	endif()
 
-	spirv_cross_add_library(spirv-cross-hlsl spirv_cross_hlsl STATIC
-		${spirv-cross-hlsl-sources})
+	if (SPIRV_CROSS_ENABLE_HLSL)
+		spirv_cross_add_library(spirv-cross-hlsl spirv_cross_hlsl STATIC
+				${spirv-cross-hlsl-sources})
+		if (SPIRV_CROSS_ENABLE_GLSL)
+			target_link_libraries(spirv-cross-hlsl PRIVATE spirv-cross-glsl)
+		else()
+			message(FATAL_ERROR "Must enable GLSL support to enable HLSL support.")
+		endif()
+	endif()
 
-	spirv_cross_add_library(spirv-cross-util spirv_cross_util STATIC
-		${spirv-cross-util-sources})
+	if (SPIRV_CROSS_ENABLE_UTIL)
+		spirv_cross_add_library(spirv-cross-util spirv_cross_util STATIC
+				${spirv-cross-util-sources})
+		target_link_libraries(spirv-cross-util PRIVATE spirv-cross-core)
+	endif()
 
-	target_link_libraries(spirv-cross-util PRIVATE spirv-cross-core)
-	target_link_libraries(spirv-cross-glsl PRIVATE spirv-cross-core)
-	target_link_libraries(spirv-cross-msl PRIVATE spirv-cross-glsl)
-	target_link_libraries(spirv-cross-hlsl PRIVATE spirv-cross-glsl)
-	target_link_libraries(spirv-cross-cpp PRIVATE spirv-cross-glsl)
-	target_link_libraries(spirv-cross-c PRIVATE
-			spirv-cross-core
-			spirv-cross-glsl
-			spirv-cross-hlsl
-			spirv-cross-msl
-			spirv-cross-cpp
-			spirv-cross-reflect)
+	if (SPIRV_CROSS_ENABLE_C_API)
+		spirv_cross_add_library(spirv-cross-c spirv_cross_c STATIC
+				${spirv-cross-c-sources})
+
+		if (SPIRV_CROSS_ENABLE_GLSL)
+			target_link_libraries(spirv-cross-c PRIVATE spirv-cross-glsl)
+			target_compile_definitions(spirv-cross-c PRIVATE SPIRV_CROSS_C_API_GLSL=1)
+		endif()
+
+		if (SPIRV_CROSS_ENABLE_HLSL)
+			target_link_libraries(spirv-cross-c PRIVATE spirv-cross-hlsl)
+			target_compile_definitions(spirv-cross-c PRIVATE SPIRV_CROSS_C_API_HLSL=1)
+		endif()
+
+		if (SPIRV_CROSS_ENABLE_MSL)
+			target_link_libraries(spirv-cross-c PRIVATE spirv-cross-msl)
+			target_compile_definitions(spirv-cross-c PRIVATE SPIRV_CROSS_C_API_MSL=1)
+		endif()
+
+		if (SPIRV_CROSS_ENABLE_CPP)
+			target_link_libraries(spirv-cross-c PRIVATE spirv-cross-cpp)
+			target_compile_definitions(spirv-cross-c PRIVATE SPIRV_CROSS_C_API_CPP=1)
+		endif()
+
+		if (SPIRV_CROSS_ENABLE_REFLECT)
+			target_link_libraries(spirv-cross-c PRIVATE spirv-cross-reflect)
+			target_compile_definitions(spirv-cross-c PRIVATE SPIRV_CROSS_C_API_REFLECT=1)
+		endif()
+	endif()
 endif()
 
 if (SPIRV_CROSS_SHARED)
 	set(spirv-cross-abi-major 0)
-	set(spirv-cross-abi-minor 4)
+	set(spirv-cross-abi-minor 5)
 	set(spirv-cross-abi-patch 0)
 	set(SPIRV_CROSS_VERSION ${spirv-cross-abi-major}.${spirv-cross-abi-minor}.${spirv-cross-abi-patch})
 	set(SPIRV_CROSS_INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib)
 	set(SPIRV_CROSS_INSTALL_INC_DIR ${CMAKE_INSTALL_PREFIX}/include/spirv_cross)
 	configure_file(
-		${CMAKE_CURRENT_SOURCE_DIR}/pkg-config/spirv-cross-c-shared.pc.in
-		${CMAKE_CURRENT_BINARY_DIR}/spirv-cross-c-shared.pc @ONLY)
+			${CMAKE_CURRENT_SOURCE_DIR}/pkg-config/spirv-cross-c-shared.pc.in
+			${CMAKE_CURRENT_BINARY_DIR}/spirv-cross-c-shared.pc @ONLY)
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/spirv-cross-c-shared.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/share/pkgconfig)
 
 	spirv_cross_add_library(spirv-cross-c-shared spirv_cross_c_shared SHARED
-		${spirv-cross-core-sources}
-		${spirv-cross-glsl-sources}
-		${spirv-cross-cpp-sources}
-		${spirv-cross-reflect-sources}
-		${spirv-cross-msl-sources}
-		${spirv-cross-hlsl-sources}
-		${spirv-cross-c-sources})
+			${spirv-cross-core-sources}
+			${spirv-cross-c-sources})
+
+	if (SPIRV_CROSS_ENABLE_GLSL)
+		target_sources(spirv-cross-c-shared PRIVATE ${spirv-cross-glsl-sources})
+		target_compile_definitions(spirv-cross-c-shared PRIVATE SPIRV_CROSS_C_API_GLSL=1)
+	endif()
+
+	if (SPIRV_CROSS_ENABLE_HLSL)
+		if (SPIRV_CROSS_ENABLE_GLSL)
+			target_sources(spirv-cross-c-shared PRIVATE ${spirv-cross-hlsl-sources})
+		else()
+			message(FATAL_ERROR "Must enable GLSL support to enable HLSL support.")
+		endif()
+		target_compile_definitions(spirv-cross-c-shared PRIVATE SPIRV_CROSS_C_API_HLSL=1)
+	endif()
+
+	if (SPIRV_CROSS_ENABLE_MSL)
+		if (SPIRV_CROSS_ENABLE_GLSL)
+			target_sources(spirv-cross-c-shared PRIVATE ${spirv-cross-msl-sources})
+		else()
+			message(FATAL_ERROR "Must enable GLSL support to enable MSL support.")
+		endif()
+		target_compile_definitions(spirv-cross-c-shared PRIVATE SPIRV_CROSS_C_API_MSL=1)
+	endif()
+
+	if (SPIRV_CROSS_ENABLE_CPP)
+		if (SPIRV_CROSS_ENABLE_GLSL)
+			target_sources(spirv-cross-c-shared PRIVATE ${spirv-cross-cpp-sources})
+		else()
+			message(FATAL_ERROR "Must enable GLSL support to enable C++ support.")
+		endif()
+		target_compile_definitions(spirv-cross-c-shared PRIVATE SPIRV_CROSS_C_API_CPP=1)
+	endif()
+
+	if (SPIRV_CROSS_ENABLE_REFLECT)
+		target_sources(spirv-cross-c-shared PRIVATE ${spirv-cross-reflect-sources})
+		target_compile_definitions(spirv-cross-c-shared PRIVATE SPIRV_CROSS_C_API_REFLECT=1)
+	endif()
+
 	if (CMAKE_COMPILER_IS_GNUCXX OR (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang"))
 		# Only export the C API.
 		target_compile_options(spirv-cross-c-shared PRIVATE -fvisibility=hidden)
@@ -224,11 +309,35 @@ if (SPIRV_CROSS_SHARED)
 	target_compile_definitions(spirv-cross-c-shared PRIVATE SPVC_EXPORT_SYMBOLS)
 
 	set_target_properties(spirv-cross-c-shared PROPERTIES
-		VERSION ${SPIRV_CROSS_VERSION}
-		SOVERSION ${spirv-cross-abi-major})
+			VERSION ${SPIRV_CROSS_VERSION}
+			SOVERSION ${spirv-cross-abi-major})
 endif()
 
 if (SPIRV_CROSS_CLI)
+	if (NOT SPIRV_CROSS_ENABLE_GLSL)
+		message(FATAL_ERROR "Must enable GLSL if building CLI.")
+	endif()
+
+	if (NOT SPIRV_CROSS_ENABLE_HLSL)
+		message(FATAL_ERROR "Must enable HLSL if building CLI.")
+	endif()
+
+	if (NOT SPIRV_CROSS_ENABLE_MSL)
+		message(FATAL_ERROR "Must enable MSL if building CLI.")
+	endif()
+
+	if (NOT SPIRV_CROSS_ENABLE_CPP)
+		message(FATAL_ERROR "Must enable C++ if building CLI.")
+	endif()
+
+	if (NOT SPIRV_CROSS_ENABLE_REFLECT)
+		message(FATAL_ERROR "Must enable reflection if building CLI.")
+	endif()
+
+	if (NOT SPIRV_CROSS_ENABLE_UTIL)
+		message(FATAL_ERROR "Must enable utils if building CLI.")
+	endif()
+
 	if (NOT SPIRV_CROSS_STATIC)
 		message(FATAL_ERROR "Must build static libraries if building CLI.")
 	endif()
@@ -238,13 +347,13 @@ if (SPIRV_CROSS_CLI)
 	set_target_properties(spirv-cross PROPERTIES LINK_FLAGS "${spirv-cross-link-flags}")
 	install(TARGETS spirv-cross RUNTIME DESTINATION bin)
 	target_link_libraries(spirv-cross PRIVATE
-		spirv-cross-glsl
-		spirv-cross-hlsl
-		spirv-cross-cpp
-		spirv-cross-reflect
-		spirv-cross-msl
-		spirv-cross-util
-		spirv-cross-core)
+			spirv-cross-glsl
+			spirv-cross-hlsl
+			spirv-cross-cpp
+			spirv-cross-reflect
+			spirv-cross-msl
+			spirv-cross-util
+			spirv-cross-core)
 
 	if (SPIRV_CROSS_ENABLE_TESTS)
 		# Set up tests, using only the simplest modes of the test_shaders
@@ -254,17 +363,17 @@ if (SPIRV_CROSS_CLI)
 		#  - Keep failing outputs
 		find_package(PythonInterp)
 		find_program(spirv-cross-glslang NAMES glslangValidator
-			PATHS ${CMAKE_CURRENT_SOURCE_DIR}/external/glslang-build/output/bin
-			NO_DEFAULT_PATH)
+				PATHS ${CMAKE_CURRENT_SOURCE_DIR}/external/glslang-build/output/bin
+				NO_DEFAULT_PATH)
 		find_program(spirv-cross-spirv-as NAMES spirv-as
-			PATHS ${CMAKE_CURRENT_SOURCE_DIR}/external/spirv-tools-build/output/bin
-			NO_DEFAULT_PATH)
+				PATHS ${CMAKE_CURRENT_SOURCE_DIR}/external/spirv-tools-build/output/bin
+				NO_DEFAULT_PATH)
 		find_program(spirv-cross-spirv-val NAMES spirv-val
-			PATHS ${CMAKE_CURRENT_SOURCE_DIR}/external/spirv-tools-build/output/bin
-			NO_DEFAULT_PATH)
+				PATHS ${CMAKE_CURRENT_SOURCE_DIR}/external/spirv-tools-build/output/bin
+				NO_DEFAULT_PATH)
 		find_program(spirv-cross-spirv-opt NAMES spirv-opt
-			PATHS ${CMAKE_CURRENT_SOURCE_DIR}/external/spirv-tools-build/output/bin
-			NO_DEFAULT_PATH)
+				PATHS ${CMAKE_CURRENT_SOURCE_DIR}/external/spirv-tools-build/output/bin
+				NO_DEFAULT_PATH)
 
 		if ((${spirv-cross-glslang} MATCHES "NOTFOUND") OR (${spirv-cross-spirv-as} MATCHES "NOTFOUND") OR (${spirv-cross-spirv-val} MATCHES "NOTFOUND") OR (${spirv-cross-spirv-opt} MATCHES "NOTFOUND"))
 			set(SPIRV_CROSS_ENABLE_TESTS OFF)
@@ -279,10 +388,10 @@ if (SPIRV_CROSS_CLI)
 		endif()
 
 		set(spirv-cross-externals
-			--glslang "${spirv-cross-glslang}"
-			--spirv-as "${spirv-cross-spirv-as}"
-			--spirv-opt "${spirv-cross-spirv-opt}"
-			--spirv-val "${spirv-cross-spirv-val}")
+				--glslang "${spirv-cross-glslang}"
+				--spirv-as "${spirv-cross-spirv-as}"
+				--spirv-opt "${spirv-cross-spirv-opt}"
+				--spirv-val "${spirv-cross-spirv-val}")
 
 		if (${PYTHONINTERP_FOUND} AND SPIRV_CROSS_ENABLE_TESTS)
 			if (${PYTHON_VERSION_MAJOR} GREATER 2)
@@ -293,61 +402,61 @@ if (SPIRV_CROSS_CLI)
 					target_compile_options(spirv-cross-c-api-test PRIVATE -std=c89 -Wall -Wextra)
 				endif()
 				add_test(NAME spirv-cross-c-api-test
-					COMMAND $<TARGET_FILE:spirv-cross-c-api-test> ${CMAKE_CURRENT_SOURCE_DIR}/tests-other/c_api_test.spv)
+						COMMAND $<TARGET_FILE:spirv-cross-c-api-test> ${CMAKE_CURRENT_SOURCE_DIR}/tests-other/c_api_test.spv)
 				add_test(NAME spirv-cross-test
-					COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --parallel
-					${spirv-cross-externals}
-					${CMAKE_CURRENT_SOURCE_DIR}/shaders
-					WORKING_DIRECTORY $<TARGET_FILE_DIR:spirv-cross>)
+						COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --parallel
+						${spirv-cross-externals}
+						${CMAKE_CURRENT_SOURCE_DIR}/shaders
+						WORKING_DIRECTORY $<TARGET_FILE_DIR:spirv-cross>)
 				add_test(NAME spirv-cross-test-no-opt
-					COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --parallel
-					${spirv-cross-externals}
-					${CMAKE_CURRENT_SOURCE_DIR}/shaders-no-opt
-					WORKING_DIRECTORY $<TARGET_FILE_DIR:spirv-cross>)
+						COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --parallel
+						${spirv-cross-externals}
+						${CMAKE_CURRENT_SOURCE_DIR}/shaders-no-opt
+						WORKING_DIRECTORY $<TARGET_FILE_DIR:spirv-cross>)
 				add_test(NAME spirv-cross-test-metal
-					COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --metal --parallel
-					${spirv-cross-externals}
-					${CMAKE_CURRENT_SOURCE_DIR}/shaders-msl
-					WORKING_DIRECTORY $<TARGET_FILE_DIR:spirv-cross>)
+						COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --metal --parallel
+						${spirv-cross-externals}
+						${CMAKE_CURRENT_SOURCE_DIR}/shaders-msl
+						WORKING_DIRECTORY $<TARGET_FILE_DIR:spirv-cross>)
 				add_test(NAME spirv-cross-test-metal-no-opt
-					COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --metal --parallel
-					${spirv-cross-externals}
-					${CMAKE_CURRENT_SOURCE_DIR}/shaders-msl-no-opt
-					WORKING_DIRECTORY $<TARGET_FILE_DIR:spirv-cross>)
+						COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --metal --parallel
+						${spirv-cross-externals}
+						${CMAKE_CURRENT_SOURCE_DIR}/shaders-msl-no-opt
+						WORKING_DIRECTORY $<TARGET_FILE_DIR:spirv-cross>)
 				add_test(NAME spirv-cross-test-hlsl
-					COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --hlsl --parallel
-					${spirv-cross-externals}
-					${CMAKE_CURRENT_SOURCE_DIR}/shaders-hlsl
-					WORKING_DIRECTORY $<TARGET_FILE_DIR:spirv-cross>)
+						COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --hlsl --parallel
+						${spirv-cross-externals}
+						${CMAKE_CURRENT_SOURCE_DIR}/shaders-hlsl
+						WORKING_DIRECTORY $<TARGET_FILE_DIR:spirv-cross>)
 				add_test(NAME spirv-cross-test-hlsl-no-opt
-					COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --hlsl --parallel
-					${spirv-cross-externals}
-					${CMAKE_CURRENT_SOURCE_DIR}/shaders-hlsl-no-opt
-					WORKING_DIRECTORY $<TARGET_FILE_DIR:spirv-cross>)
+						COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --hlsl --parallel
+						${spirv-cross-externals}
+						${CMAKE_CURRENT_SOURCE_DIR}/shaders-hlsl-no-opt
+						WORKING_DIRECTORY $<TARGET_FILE_DIR:spirv-cross>)
 				add_test(NAME spirv-cross-test-opt
-					COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --opt --parallel
-					${spirv-cross-externals}
-					${CMAKE_CURRENT_SOURCE_DIR}/shaders
-					WORKING_DIRECTORY $<TARGET_FILE_DIR:spirv-cross>)
+						COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --opt --parallel
+						${spirv-cross-externals}
+						${CMAKE_CURRENT_SOURCE_DIR}/shaders
+						WORKING_DIRECTORY $<TARGET_FILE_DIR:spirv-cross>)
 				add_test(NAME spirv-cross-test-metal-opt
-					COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --metal --opt --parallel
-					${spirv-cross-externals}
-					${CMAKE_CURRENT_SOURCE_DIR}/shaders-msl
-					WORKING_DIRECTORY $<TARGET_FILE_DIR:spirv-cross>)
+						COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --metal --opt --parallel
+						${spirv-cross-externals}
+						${CMAKE_CURRENT_SOURCE_DIR}/shaders-msl
+						WORKING_DIRECTORY $<TARGET_FILE_DIR:spirv-cross>)
 				add_test(NAME spirv-cross-test-hlsl-opt
-					COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --hlsl --opt --parallel
-					${spirv-cross-externals}
-					${CMAKE_CURRENT_SOURCE_DIR}/shaders-hlsl
-					WORKING_DIRECTORY $<TARGET_FILE_DIR:spirv-cross>)
+						COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --hlsl --opt --parallel
+						${spirv-cross-externals}
+						${CMAKE_CURRENT_SOURCE_DIR}/shaders-hlsl
+						WORKING_DIRECTORY $<TARGET_FILE_DIR:spirv-cross>)
 				add_test(NAME spirv-cross-test-reflection
-					COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --reflect --parallel
-					${spirv-cross-externals}
-					${CMAKE_CURRENT_SOURCE_DIR}/shaders-reflection
-					WORKING_DIRECTORY $<TARGET_FILE_DIR:spirv-cross>)
+						COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --reflect --parallel
+						${spirv-cross-externals}
+						${CMAKE_CURRENT_SOURCE_DIR}/shaders-reflection
+						WORKING_DIRECTORY $<TARGET_FILE_DIR:spirv-cross>)
 			endif()
 		elseif(NOT ${PYTHONINTERP_FOUND})
 			message(WARNING "Testing disabled. Could not find python3. If you have python3 installed try running "
-				"cmake with -DPYTHON_EXECUTABLE:FILEPATH=/path/to/python3 to help it find the executable")
+					"cmake with -DPYTHON_EXECUTABLE:FILEPATH=/path/to/python3 to help it find the executable")
 		endif()
 	endif()
 endif()

--- a/spirv_cross_c.cpp
+++ b/spirv_cross_c.cpp
@@ -15,12 +15,26 @@
  */
 
 #include "spirv_cross_c.h"
+
+#if SPIRV_CROSS_C_API_CPP
 #include "spirv_cpp.hpp"
+#endif
+#if SPIRV_CROSS_C_API_GLSL
 #include "spirv_glsl.hpp"
+#else
+#include "spirv_cross.hpp"
+#endif
+#if SPIRV_CROSS_C_API_HLSL
 #include "spirv_hlsl.hpp"
+#endif
+#if SPIRV_CROSS_C_API_MSL
 #include "spirv_msl.hpp"
-#include "spirv_parser.hpp"
+#endif
+#if SPIRV_CROSS_C_API_REFLECT
 #include "spirv_reflect.hpp"
+#endif
+#include "spirv_parser.hpp"
+#include <string.h>
 #include <memory>
 #include <new>
 
@@ -130,9 +144,15 @@ struct spvc_compiler_options_s : ScratchMemoryAllocation
 {
 	spvc_context context = nullptr;
 	uint32_t backend_flags = 0;
+#if SPIRV_CROSS_C_API_GLSL
 	CompilerGLSL::Options glsl;
+#endif
+#if SPIRV_CROSS_C_API_MSL
 	CompilerMSL::Options msl;
+#endif
+#if SPIRV_CROSS_C_API_HLSL
 	CompilerHLSL::Options hlsl;
+#endif
 };
 
 struct spvc_set_s : ScratchMemoryAllocation
@@ -253,40 +273,50 @@ spvc_result spvc_context_create_compiler(spvc_context context, spvc_backend back
 				comp->compiler.reset(new Compiler(parsed_ir->parsed));
 			break;
 
+#if SPIRV_CROSS_C_API_GLSL
 		case SPVC_BACKEND_GLSL:
 			if (mode == SPVC_CAPTURE_MODE_TAKE_OWNERSHIP)
 				comp->compiler.reset(new CompilerGLSL(move(parsed_ir->parsed)));
 			else if (mode == SPVC_CAPTURE_MODE_COPY)
 				comp->compiler.reset(new CompilerGLSL(parsed_ir->parsed));
 			break;
+#endif
 
+#if SPIRV_CROSS_C_API_HLSL
 		case SPVC_BACKEND_HLSL:
 			if (mode == SPVC_CAPTURE_MODE_TAKE_OWNERSHIP)
 				comp->compiler.reset(new CompilerHLSL(move(parsed_ir->parsed)));
 			else if (mode == SPVC_CAPTURE_MODE_COPY)
 				comp->compiler.reset(new CompilerHLSL(parsed_ir->parsed));
 			break;
+#endif
 
+#if SPIRV_CROSS_C_API_MSL
 		case SPVC_BACKEND_MSL:
 			if (mode == SPVC_CAPTURE_MODE_TAKE_OWNERSHIP)
 				comp->compiler.reset(new CompilerMSL(move(parsed_ir->parsed)));
 			else if (mode == SPVC_CAPTURE_MODE_COPY)
 				comp->compiler.reset(new CompilerMSL(parsed_ir->parsed));
 			break;
+#endif
 
+#if SPIRV_CROSS_C_API_CPP
 		case SPVC_BACKEND_CPP:
 			if (mode == SPVC_CAPTURE_MODE_TAKE_OWNERSHIP)
 				comp->compiler.reset(new CompilerCPP(move(parsed_ir->parsed)));
 			else if (mode == SPVC_CAPTURE_MODE_COPY)
 				comp->compiler.reset(new CompilerCPP(parsed_ir->parsed));
 			break;
+#endif
 
+#if SPIRV_CROSS_C_API_REFLECT
 		case SPVC_BACKEND_JSON:
 			if (mode == SPVC_CAPTURE_MODE_TAKE_OWNERSHIP)
 				comp->compiler.reset(new CompilerReflection(move(parsed_ir->parsed)));
 			else if (mode == SPVC_CAPTURE_MODE_COPY)
 				comp->compiler.reset(new CompilerReflection(parsed_ir->parsed));
 			break;
+#endif
 
 		default:
 			context->report_error("Invalid backend.");
@@ -315,22 +345,28 @@ spvc_result spvc_compiler_create_compiler_options(spvc_compiler compiler, spvc_c
 		opt->backend_flags = 0;
 		switch (compiler->backend)
 		{
+#if SPIRV_CROSS_C_API_MSL
 		case SPVC_BACKEND_MSL:
 			opt->backend_flags |= SPVC_COMPILER_OPTION_MSL_BIT | SPVC_COMPILER_OPTION_COMMON_BIT;
 			opt->glsl = static_cast<CompilerMSL *>(compiler->compiler.get())->get_common_options();
 			opt->msl = static_cast<CompilerMSL *>(compiler->compiler.get())->get_msl_options();
 			break;
+#endif
 
+#if SPIRV_CROSS_C_API_HLSL
 		case SPVC_BACKEND_HLSL:
 			opt->backend_flags |= SPVC_COMPILER_OPTION_HLSL_BIT | SPVC_COMPILER_OPTION_COMMON_BIT;
 			opt->glsl = static_cast<CompilerHLSL *>(compiler->compiler.get())->get_common_options();
 			opt->hlsl = static_cast<CompilerHLSL *>(compiler->compiler.get())->get_hlsl_options();
 			break;
+#endif
 
+#if SPIRV_CROSS_C_API_GLSL
 		case SPVC_BACKEND_GLSL:
 			opt->backend_flags |= SPVC_COMPILER_OPTION_GLSL_BIT | SPVC_COMPILER_OPTION_COMMON_BIT;
 			opt->glsl = static_cast<CompilerGLSL *>(compiler->compiler.get())->get_common_options();
 			break;
+#endif
 
 		default:
 			break;
@@ -351,6 +387,8 @@ spvc_result spvc_compiler_options_set_bool(spvc_compiler_options options, spvc_c
 
 spvc_result spvc_compiler_options_set_uint(spvc_compiler_options options, spvc_compiler_option option, unsigned value)
 {
+	(void)value;
+	(void)option;
 	uint32_t supported_mask = options->backend_flags;
 	uint32_t required_mask = option & SPVC_COMPILER_OPTION_LANG_BITS;
 	if ((required_mask | supported_mask) != supported_mask)
@@ -361,6 +399,7 @@ spvc_result spvc_compiler_options_set_uint(spvc_compiler_options options, spvc_c
 
 	switch (option)
 	{
+#if SPIRV_CROSS_C_API_GLSL
 	case SPVC_COMPILER_OPTION_FORCE_TEMPORARY:
 		options->glsl.force_temporary = value != 0;
 		break;
@@ -373,6 +412,7 @@ spvc_result spvc_compiler_options_set_uint(spvc_compiler_options options, spvc_c
 	case SPVC_COMPILER_OPTION_FLIP_VERTEX_Y:
 		options->glsl.vertex.flip_vert_y = value != 0;
 		break;
+
 	case SPVC_COMPILER_OPTION_GLSL_SUPPORT_NONZERO_BASE_INSTANCE:
 		options->glsl.vertex.support_nonzero_base_instance = value != 0;
 		break;
@@ -399,7 +439,12 @@ spvc_result spvc_compiler_options_set_uint(spvc_compiler_options options, spvc_c
 		options->glsl.fragment.default_int_precision =
 		    value != 0 ? CompilerGLSL::Options::Precision::Highp : CompilerGLSL::Options::Precision::Mediump;
 		break;
+	case SPVC_COMPILER_OPTION_GLSL_EMIT_PUSH_CONSTANT_AS_UNIFORM_BUFFER:
+		options->glsl.emit_push_constant_as_uniform_buffer = value != 0;
+		break;
+#endif
 
+#if SPIRV_CROSS_C_API_HLSL
 	case SPVC_COMPILER_OPTION_HLSL_SHADER_MODEL:
 		options->hlsl.shader_model = value;
 		break;
@@ -415,7 +460,9 @@ spvc_result spvc_compiler_options_set_uint(spvc_compiler_options options, spvc_c
 	case SPVC_COMPILER_OPTION_HLSL_SUPPORT_NONZERO_BASE_VERTEX_BASE_INSTANCE:
 		options->hlsl.support_nonzero_base_vertex_base_instance = value != 0;
 		break;
+#endif
 
+#if SPIRV_CROSS_C_API_MSL
 	case SPVC_COMPILER_OPTION_MSL_VERSION:
 		options->msl.msl_version = value;
 		break;
@@ -479,10 +526,7 @@ spvc_result spvc_compiler_options_set_uint(spvc_compiler_options options, spvc_c
 	case SPVC_COMPILER_OPTION_MSL_ARGUMENT_BUFFERS:
 		options->msl.argument_buffers = value != 0;
 		break;
-
-	case SPVC_COMPILER_OPTION_GLSL_EMIT_PUSH_CONSTANT_AS_UNIFORM_BUFFER:
-		options->glsl.emit_push_constant_as_uniform_buffer = value != 0;
-		break;
+#endif
 
 	default:
 		options->context->report_error("Unknown option.");
@@ -494,19 +538,29 @@ spvc_result spvc_compiler_options_set_uint(spvc_compiler_options options, spvc_c
 
 spvc_result spvc_compiler_install_compiler_options(spvc_compiler compiler, spvc_compiler_options options)
 {
+	(void)options;
 	switch (compiler->backend)
 	{
+#if SPIRV_CROSS_C_API_GLSL
 	case SPVC_BACKEND_GLSL:
 		static_cast<CompilerGLSL &>(*compiler->compiler).set_common_options(options->glsl);
 		break;
+#endif
+
+#if SPIRV_CROSS_C_API_HLSL
 	case SPVC_BACKEND_HLSL:
 		static_cast<CompilerHLSL &>(*compiler->compiler).set_common_options(options->glsl);
 		static_cast<CompilerHLSL &>(*compiler->compiler).set_hlsl_options(options->hlsl);
 		break;
+#endif
+
+#if SPIRV_CROSS_C_API_MSL
 	case SPVC_BACKEND_MSL:
 		static_cast<CompilerMSL &>(*compiler->compiler).set_common_options(options->glsl);
 		static_cast<CompilerMSL &>(*compiler->compiler).set_msl_options(options->msl);
 		break;
+#endif
+
 	default:
 		break;
 	}
@@ -516,6 +570,7 @@ spvc_result spvc_compiler_install_compiler_options(spvc_compiler compiler, spvc_
 
 spvc_result spvc_compiler_add_header_line(spvc_compiler compiler, const char *line)
 {
+#if SPIRV_CROSS_C_API_GLSL
 	if (compiler->backend == SPVC_BACKEND_NONE)
 	{
 		compiler->context->report_error("Cross-compilation related option used on NONE backend which only supports reflection.");
@@ -524,10 +579,16 @@ spvc_result spvc_compiler_add_header_line(spvc_compiler compiler, const char *li
 
 	static_cast<CompilerGLSL *>(compiler->compiler.get())->add_header_line(line);
 	return SPVC_SUCCESS;
+#else
+	(void)line;
+	compiler->context->report_error("Cross-compilation related option used on NONE backend which only supports reflection.");
+	return SPVC_ERROR_INVALID_ARGUMENT;
+#endif
 }
 
 spvc_result spvc_compiler_require_extension(spvc_compiler compiler, const char *line)
 {
+#if SPIRV_CROSS_C_API_GLSL
 	if (compiler->backend == SPVC_BACKEND_NONE)
 	{
 		compiler->context->report_error("Cross-compilation related option used on NONE backend which only supports reflection.");
@@ -536,10 +597,16 @@ spvc_result spvc_compiler_require_extension(spvc_compiler compiler, const char *
 
 	static_cast<CompilerGLSL *>(compiler->compiler.get())->require_extension(line);
 	return SPVC_SUCCESS;
+#else
+	(void)line;
+	compiler->context->report_error("Cross-compilation related option used on NONE backend which only supports reflection.");
+	return SPVC_ERROR_INVALID_ARGUMENT;
+#endif
 }
 
 spvc_result spvc_compiler_flatten_buffer_block(spvc_compiler compiler, spvc_variable_id id)
 {
+#if SPIRV_CROSS_C_API_GLSL
 	if (compiler->backend == SPVC_BACKEND_NONE)
 	{
 		compiler->context->report_error("Cross-compilation related option used on NONE backend which only supports reflection.");
@@ -548,12 +615,18 @@ spvc_result spvc_compiler_flatten_buffer_block(spvc_compiler compiler, spvc_vari
 
 	static_cast<CompilerGLSL *>(compiler->compiler.get())->flatten_buffer_block(id);
 	return SPVC_SUCCESS;
+#else
+	(void)id;
+	compiler->context->report_error("Cross-compilation related option used on NONE backend which only supports reflection.");
+	return SPVC_ERROR_INVALID_ARGUMENT;
+#endif
 }
 
 spvc_result spvc_compiler_hlsl_set_root_constants_layout(spvc_compiler compiler,
                                                          const spvc_hlsl_root_constants *constant_info,
                                                          size_t count)
 {
+#if SPIRV_CROSS_C_API_HLSL
 	if (compiler->backend != SPVC_BACKEND_HLSL)
 	{
 		compiler->context->report_error("HLSL function used on a non-HLSL backend.");
@@ -575,12 +648,19 @@ spvc_result spvc_compiler_hlsl_set_root_constants_layout(spvc_compiler compiler,
 
 	hlsl.set_root_constant_layouts(std::move(roots));
 	return SPVC_SUCCESS;
+#else
+	(void)constant_info;
+	(void)count;
+	compiler->context->report_error("HLSL function used on a non-HLSL backend.");
+	return SPVC_ERROR_INVALID_ARGUMENT;
+#endif
 }
 
 spvc_result spvc_compiler_hlsl_add_vertex_attribute_remap(spvc_compiler compiler,
                                                           const spvc_hlsl_vertex_attribute_remap *remap,
                                                           size_t count)
 {
+#if SPIRV_CROSS_C_API_HLSL
 	if (compiler->backend != SPVC_BACKEND_HLSL)
 	{
 		compiler->context->report_error("HLSL function used on a non-HLSL backend.");
@@ -597,10 +677,17 @@ spvc_result spvc_compiler_hlsl_add_vertex_attribute_remap(spvc_compiler compiler
 	}
 
 	return SPVC_SUCCESS;
+#else
+	(void)remap;
+	(void)count;
+	compiler->context->report_error("HLSL function used on a non-HLSL backend.");
+	return SPVC_ERROR_INVALID_ARGUMENT;
+#endif
 }
 
 spvc_variable_id spvc_compiler_hlsl_remap_num_workgroups_builtin(spvc_compiler compiler)
 {
+#if SPIRV_CROSS_C_API_HLSL
 	if (compiler->backend != SPVC_BACKEND_HLSL)
 	{
 		compiler->context->report_error("HLSL function used on a non-HLSL backend.");
@@ -609,10 +696,15 @@ spvc_variable_id spvc_compiler_hlsl_remap_num_workgroups_builtin(spvc_compiler c
 
 	auto &hlsl = *static_cast<CompilerHLSL *>(compiler->compiler.get());
 	return hlsl.remap_num_workgroups_builtin();
+#else
+	compiler->context->report_error("HLSL function used on a non-HLSL backend.");
+	return 0;
+#endif
 }
 
 spvc_bool spvc_compiler_msl_is_rasterization_disabled(spvc_compiler compiler)
 {
+#if SPIRV_CROSS_C_API_MSL
 	if (compiler->backend != SPVC_BACKEND_MSL)
 	{
 		compiler->context->report_error("MSL function used on a non-MSL backend.");
@@ -621,10 +713,15 @@ spvc_bool spvc_compiler_msl_is_rasterization_disabled(spvc_compiler compiler)
 
 	auto &msl = *static_cast<CompilerMSL *>(compiler->compiler.get());
 	return msl.get_is_rasterization_disabled() ? SPVC_TRUE : SPVC_FALSE;
+#else
+	compiler->context->report_error("MSL function used on a non-MSL backend.");
+	return SPVC_FALSE;
+#endif
 }
 
 spvc_bool spvc_compiler_msl_needs_aux_buffer(spvc_compiler compiler)
 {
+#if SPIRV_CROSS_C_API_MSL
 	if (compiler->backend != SPVC_BACKEND_MSL)
 	{
 		compiler->context->report_error("MSL function used on a non-MSL backend.");
@@ -633,10 +730,15 @@ spvc_bool spvc_compiler_msl_needs_aux_buffer(spvc_compiler compiler)
 
 	auto &msl = *static_cast<CompilerMSL *>(compiler->compiler.get());
 	return msl.needs_aux_buffer() ? SPVC_TRUE : SPVC_FALSE;
+#else
+	compiler->context->report_error("MSL function used on a non-MSL backend.");
+	return SPVC_FALSE;
+#endif
 }
 
 spvc_bool spvc_compiler_msl_needs_output_buffer(spvc_compiler compiler)
 {
+#if SPIRV_CROSS_C_API_MSL
 	if (compiler->backend != SPVC_BACKEND_MSL)
 	{
 		compiler->context->report_error("MSL function used on a non-MSL backend.");
@@ -645,10 +747,15 @@ spvc_bool spvc_compiler_msl_needs_output_buffer(spvc_compiler compiler)
 
 	auto &msl = *static_cast<CompilerMSL *>(compiler->compiler.get());
 	return msl.needs_output_buffer() ? SPVC_TRUE : SPVC_FALSE;
+#else
+	compiler->context->report_error("MSL function used on a non-MSL backend.");
+	return SPVC_FALSE;
+#endif
 }
 
 spvc_bool spvc_compiler_msl_needs_patch_output_buffer(spvc_compiler compiler)
 {
+#if SPIRV_CROSS_C_API_MSL
 	if (compiler->backend != SPVC_BACKEND_MSL)
 	{
 		compiler->context->report_error("MSL function used on a non-MSL backend.");
@@ -657,10 +764,15 @@ spvc_bool spvc_compiler_msl_needs_patch_output_buffer(spvc_compiler compiler)
 
 	auto &msl = *static_cast<CompilerMSL *>(compiler->compiler.get());
 	return msl.needs_patch_output_buffer() ? SPVC_TRUE : SPVC_FALSE;
+#else
+	compiler->context->report_error("MSL function used on a non-MSL backend.");
+	return SPVC_FALSE;
+#endif
 }
 
 spvc_bool spvc_compiler_msl_needs_input_threadgroup_mem(spvc_compiler compiler)
 {
+#if SPIRV_CROSS_C_API_MSL
 	if (compiler->backend != SPVC_BACKEND_MSL)
 	{
 		compiler->context->report_error("MSL function used on a non-MSL backend.");
@@ -669,10 +781,15 @@ spvc_bool spvc_compiler_msl_needs_input_threadgroup_mem(spvc_compiler compiler)
 
 	auto &msl = *static_cast<CompilerMSL *>(compiler->compiler.get());
 	return msl.needs_input_threadgroup_mem() ? SPVC_TRUE : SPVC_FALSE;
+#else
+	compiler->context->report_error("MSL function used on a non-MSL backend.");
+	return SPVC_FALSE;
+#endif
 }
 
 spvc_result spvc_compiler_msl_add_vertex_attribute(spvc_compiler compiler, const spvc_msl_vertex_attribute *va)
 {
+#if SPIRV_CROSS_C_API_MSL
 	if (compiler->backend != SPVC_BACKEND_MSL)
 	{
 		compiler->context->report_error("MSL function used on a non-MSL backend.");
@@ -690,11 +807,17 @@ spvc_result spvc_compiler_msl_add_vertex_attribute(spvc_compiler compiler, const
 	attr.per_instance = va->per_instance;
 	msl.add_msl_vertex_attribute(attr);
 	return SPVC_SUCCESS;
+#else
+	(void)va;
+	compiler->context->report_error("MSL function used on a non-MSL backend.");
+	return SPVC_ERROR_INVALID_ARGUMENT;
+#endif
 }
 
 spvc_result spvc_compiler_msl_add_resource_binding(spvc_compiler compiler,
                                                    const spvc_msl_resource_binding *binding)
 {
+#if SPIRV_CROSS_C_API_MSL
 	if (compiler->backend != SPVC_BACKEND_MSL)
 	{
 		compiler->context->report_error("MSL function used on a non-MSL backend.");
@@ -711,10 +834,16 @@ spvc_result spvc_compiler_msl_add_resource_binding(spvc_compiler compiler,
 	bind.msl_sampler = binding->msl_sampler;
 	msl.add_msl_resource_binding(bind);
 	return SPVC_SUCCESS;
+#else
+	(void)binding;
+	compiler->context->report_error("MSL function used on a non-MSL backend.");
+	return SPVC_ERROR_INVALID_ARGUMENT;
+#endif
 }
 
 spvc_result spvc_compiler_msl_add_discrete_descriptor_set(spvc_compiler compiler, unsigned desc_set)
 {
+#if SPIRV_CROSS_C_API_MSL
 	if (compiler->backend != SPVC_BACKEND_MSL)
 	{
 		compiler->context->report_error("MSL function used on a non-MSL backend.");
@@ -724,10 +853,16 @@ spvc_result spvc_compiler_msl_add_discrete_descriptor_set(spvc_compiler compiler
 	auto &msl = *static_cast<CompilerMSL *>(compiler->compiler.get());
 	msl.add_discrete_descriptor_set(desc_set);
 	return SPVC_SUCCESS;
+#else
+	(void)desc_set;
+	compiler->context->report_error("MSL function used on a non-MSL backend.");
+	return SPVC_ERROR_INVALID_ARGUMENT;
+#endif
 }
 
 spvc_bool spvc_compiler_msl_is_vertex_attribute_used(spvc_compiler compiler, unsigned location)
 {
+#if SPIRV_CROSS_C_API_MSL
 	if (compiler->backend != SPVC_BACKEND_MSL)
 	{
 		compiler->context->report_error("MSL function used on a non-MSL backend.");
@@ -736,11 +871,17 @@ spvc_bool spvc_compiler_msl_is_vertex_attribute_used(spvc_compiler compiler, uns
 
 	auto &msl = *static_cast<CompilerMSL *>(compiler->compiler.get());
 	return msl.is_msl_vertex_attribute_used(location) ? SPVC_TRUE : SPVC_FALSE;
+#else
+	(void)location;
+	compiler->context->report_error("MSL function used on a non-MSL backend.");
+	return SPVC_FALSE;
+#endif
 }
 
 spvc_bool spvc_compiler_msl_is_resource_used(spvc_compiler compiler, SpvExecutionModel model, unsigned set,
                                              unsigned binding)
 {
+#if SPIRV_CROSS_C_API_MSL
 	if (compiler->backend != SPVC_BACKEND_MSL)
 	{
 		compiler->context->report_error("MSL function used on a non-MSL backend.");
@@ -750,11 +891,19 @@ spvc_bool spvc_compiler_msl_is_resource_used(spvc_compiler compiler, SpvExecutio
 	auto &msl = *static_cast<CompilerMSL *>(compiler->compiler.get());
 	return msl.is_msl_resource_binding_used(static_cast<spv::ExecutionModel>(model), set, binding) ? SPVC_TRUE :
 	                                                                                                 SPVC_FALSE;
+#else
+	(void)model;
+	(void)set;
+	(void)binding;
+	compiler->context->report_error("MSL function used on a non-MSL backend.");
+	return SPVC_FALSE;
+#endif
 }
 
 spvc_result spvc_compiler_msl_remap_constexpr_sampler(spvc_compiler compiler, spvc_variable_id id,
                                                       const spvc_msl_constexpr_sampler *sampler)
 {
+#if SPIRV_CROSS_C_API_MSL
 	if (compiler->backend != SPVC_BACKEND_MSL)
 	{
 		compiler->context->report_error("MSL function used on a non-MSL backend.");
@@ -780,11 +929,18 @@ spvc_result spvc_compiler_msl_remap_constexpr_sampler(spvc_compiler compiler, sp
 	samp.border_color = static_cast<MSLSamplerBorderColor>(sampler->border_color);
 	msl.remap_constexpr_sampler(id, samp);
 	return SPVC_SUCCESS;
+#else
+	(void)id;
+	(void)sampler;
+	compiler->context->report_error("MSL function used on a non-MSL backend.");
+	return SPVC_ERROR_INVALID_ARGUMENT;
+#endif
 }
 
 spvc_result spvc_compiler_msl_set_fragment_output_components(spvc_compiler compiler, unsigned location,
                                                              unsigned components)
 {
+#if SPIRV_CROSS_C_API_MSL
 	if (compiler->backend != SPVC_BACKEND_MSL)
 	{
 		compiler->context->report_error("MSL function used on a non-MSL backend.");
@@ -794,6 +950,12 @@ spvc_result spvc_compiler_msl_set_fragment_output_components(spvc_compiler compi
 	auto &msl = *static_cast<CompilerMSL *>(compiler->compiler.get());
 	msl.set_fragment_output_components(location, components);
 	return SPVC_SUCCESS;
+#else
+	(void)location;
+	(void)components;
+	compiler->context->report_error("MSL function used on a non-MSL backend.");
+	return SPVC_ERROR_INVALID_ARGUMENT;
+#endif
 }
 
 spvc_result spvc_compiler_compile(spvc_compiler compiler, const char **source)
@@ -1631,6 +1793,7 @@ unsigned spvc_msl_get_aux_buffer_struct_version(void)
 
 void spvc_msl_vertex_attribute_init(spvc_msl_vertex_attribute *attr)
 {
+#if SPIRV_CROSS_C_API_MSL
 	// Crude, but works.
 	MSLVertexAttr attr_default;
 	attr->location = attr_default.location;
@@ -1640,10 +1803,14 @@ void spvc_msl_vertex_attribute_init(spvc_msl_vertex_attribute *attr)
 	attr->msl_buffer = attr_default.msl_buffer;
 	attr->msl_offset = attr_default.msl_offset;
 	attr->msl_stride = attr_default.msl_stride;
+#else
+	memset(attr, 0, sizeof(*attr));
+#endif
 }
 
 void spvc_msl_resource_binding_init(spvc_msl_resource_binding *binding)
 {
+#if SPIRV_CROSS_C_API_MSL
 	MSLResourceBinding binding_default;
 	binding->desc_set = binding_default.desc_set;
 	binding->binding = binding_default.binding;
@@ -1651,10 +1818,14 @@ void spvc_msl_resource_binding_init(spvc_msl_resource_binding *binding)
 	binding->msl_texture = binding_default.msl_texture;
 	binding->msl_sampler = binding_default.msl_sampler;
 	binding->stage = static_cast<SpvExecutionModel>(binding_default.stage);
+#else
+	memset(binding, 0, sizeof(*binding));
+#endif
 }
 
 void spvc_msl_constexpr_sampler_init(spvc_msl_constexpr_sampler *sampler)
 {
+#if SPIRV_CROSS_C_API_MSL
 	MSLConstexprSampler defaults;
 	sampler->anisotropy_enable = defaults.anisotropy_enable ? SPVC_TRUE : SPVC_FALSE;
 	sampler->border_color = static_cast<spvc_msl_sampler_border_color>(defaults.border_color);
@@ -1671,6 +1842,9 @@ void spvc_msl_constexpr_sampler_init(spvc_msl_constexpr_sampler *sampler)
 	sampler->s_address = static_cast<spvc_msl_sampler_address>(defaults.s_address);
 	sampler->t_address = static_cast<spvc_msl_sampler_address>(defaults.t_address);
 	sampler->r_address = static_cast<spvc_msl_sampler_address>(defaults.r_address);
+#else
+	memset(sampler, 0, sizeof(*sampler));
+#endif
 }
 
 unsigned spvc_compiler_get_current_id_bound(spvc_compiler compiler)

--- a/spirv_cross_c.h
+++ b/spirv_cross_c.h
@@ -33,7 +33,7 @@ extern "C" {
 /* Bumped if ABI or API breaks backwards compatibility. */
 #define SPVC_C_API_VERSION_MAJOR 0
 /* Bumped if APIs or enumerations are added in a backwards compatible way. */
-#define SPVC_C_API_VERSION_MINOR 4
+#define SPVC_C_API_VERSION_MINOR 5
 /* Bumped if internal implementation details change. */
 #define SPVC_C_API_VERSION_PATCH 0
 


### PR DESCRIPTION
Allow user to disable individual backends.
Disallow this for CLI builds for now, but should be useful for
library-only builds, and particularly for C API.

Fix #909.