### PR TITLE
Fix guard around [[noreturn]].

### DIFF
--- a/spirv_cross_error_handling.hpp
+++ b/spirv_cross_error_handling.hpp
@@ -31,7 +31,7 @@
 namespace SPIRV_CROSS_NAMESPACE
 {
 #ifdef SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) || defined(__clang__)
 [[noreturn]]
 #endif
 inline void


### PR DESCRIPTION
Clang defines _MSC_VER and supports [[noreturn]].