### PR TITLE
TestShaders now looks for spirvcross, and fix clone time-out error in checkout_glslang_spirv_tools.sh

### DIFF
--- a/checkout_glslang_spirv_tools.sh
+++ b/checkout_glslang_spirv_tools.sh
@@ -13,7 +13,7 @@ else
 	echo "Cloning glslang revision $GLSLANG_REV."
 	mkdir -p external
 	cd external
-	git clone git://github.com/KhronosGroup/glslang.git
+	git clone https://github.com/KhronosGroup/glslang.git
 	cd glslang
 	git checkout $GLSLANG_REV
 fi
@@ -28,7 +28,7 @@ else
 	echo "Cloning SPIRV-Tools revision $SPIRV_TOOLS_REV."
 	mkdir -p external
 	cd external
-	git clone git://github.com/KhronosGroup/SPIRV-Tools.git spirv-tools
+	git clone https://github.com/KhronosGroup/SPIRV-Tools.git spirv-tools
 	cd spirv-tools
 	git checkout $SPIRV_TOOLS_REV
 fi
@@ -39,7 +39,7 @@ if [ -d external/spirv-headers ]; then
 	git checkout $SPIRV_HEADERS_REV
 	cd ../..
 else
-	git clone git://github.com/KhronosGroup/SPIRV-Headers.git external/spirv-headers
+	git clone https://github.com/KhronosGroup/SPIRV-Headers.git external/spirv-headers
 	cd external/spirv-headers
 	git checkout $SPIRV_HEADERS_REV
 	cd ../..

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -16,6 +16,26 @@ import multiprocessing
 import errno
 from functools import partial
 
+spirv_cross_paths = [
+  './spirv-cross',
+  'msvc/x64/Release/SPIRV-Cross.exe',
+  'msvc/x64/Debug/SPIRV-Cross.exe',
+  'msvc/Debug/SPIRV-Cross.exe',
+  'msvc/Release/SPIRV-Cross.exe']
+
+def find_spirv_cross():
+    spirv_cross_path = None
+      
+    for file in spirv_cross_paths:
+      if os.path.exists(file):
+        spirv_cross_path = file
+        break
+        
+    if (spirv_cross_path is None):
+      print("Can't find SPIRV-Cross! (Have you built it?)")
+      sys.exit(1)
+    return spirv_cross_path
+  
 def remove_file(path):
     #print('Removing file:', path)
     os.remove(path)
@@ -143,7 +163,7 @@ def cross_compile_msl(shader, spirv, opt):
     if opt:
         subprocess.check_call(['spirv-opt', '--skip-validation', '-O', '-o', spirv_path, spirv_path])
 
-    spirv_cross_path = './spirv-cross'
+    spirv_cross_path = find_spirv_cross()
 
     msl_args = [spirv_cross_path, '--entry', 'main', '--output', msl_path, spirv_path, '--msl']
     msl_args.append('--msl-version')
@@ -230,8 +250,8 @@ def cross_compile_hlsl(shader, spirv, opt, force_no_external_validation):
     if opt:
         subprocess.check_call(['spirv-opt', '--skip-validation', '-O', '-o', spirv_path, spirv_path])
 
-    spirv_cross_path = './spirv-cross'
-
+    spirv_cross_path = find_spirv_cross()
+    
     sm = shader_to_sm(shader)
     subprocess.check_call([spirv_cross_path, '--entry', 'main', '--output', hlsl_path, spirv_path, '--hlsl-enable-compat', '--hlsl', '--shader-model', sm])
 
@@ -254,7 +274,7 @@ def cross_compile_reflect(shader, spirv, opt):
     if opt:
         subprocess.check_call(['spirv-opt', '--skip-validation', '-O', '-o', spirv_path, spirv_path])
 
-    spirv_cross_path = './spirv-cross'
+    spirv_cross_path = find_spirv_cross()
 
     sm = shader_to_sm(shader)
     subprocess.check_call([spirv_cross_path, '--entry', 'main', '--output', reflect_path, spirv_path, '--reflect'])
@@ -296,8 +316,8 @@ def cross_compile(shader, vulkan, spirv, invalid_spirv, eliminate, is_legacy, fl
     if flatten_dim:
         extra_args += ['--flatten-multidimensional-arrays']
 
-    spirv_cross_path = './spirv-cross'
-
+    spirv_cross_path = find_spirv_cross()
+        
     # A shader might not be possible to make valid GLSL from, skip validation for this case.
     if not ('nocompat' in glsl_path):
         subprocess.check_call([spirv_cross_path, '--entry', 'main', '--output', glsl_path, spirv_path] + extra_args)


### PR DESCRIPTION
These are some changes I had to make to the testing scripts to get the tests running:

So "git clone git://github.com/KhronosGroup/glslang.git" and friends times out on my machine. Changing it to https gets it working for me. Since the path github first gives on the web interface is the https one, I'm assuming it's preferred. 

test_shaders.py looks for a ./spirv-cross in the current directory to execute. This appears to need to be a symlink, it appears you need to manually create it, and the need for this isn't referenced in the documentation, and it fails messily if it can't find it. I've changed the script so that if it can't find this symlink, it falls back to the output paths for the visual studio project.
