### PR TITLE
Support running {,update_}test_shader.sh with CMake builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,44 +415,39 @@ The reference files are stored inside the repository in order to be able to trac
 All pull requests should ensure that test output does not change unexpectedly. This can be tested with:
 
 ```
-./test_shaders.py shaders || exit 1
-./test_shaders.py shaders --opt || exit 1
-./test_shaders.py shaders-no-opt || exit 1
-./test_shaders.py shaders-msl --msl || exit 1
-./test_shaders.py shaders-msl --msl --opt || exit 1
-./test_shaders.py shaders-msl-no-opt --msl || exit 1
-./test_shaders.py shaders-hlsl --hlsl || exit 1
-./test_shaders.py shaders-hlsl --hlsl --opt || exit 1
-./test_shaders.py shaders-hlsl-no-opt --hlsl || exit 1
-./test_shaders.py shaders-reflection --reflect || exit 1
-```
-
-although there are a couple of convenience script for doing this:
-
-```
 ./checkout_glslang_spirv_tools.sh # Checks out glslang and SPIRV-Tools at a fixed revision which matches the reference output.
+                                  # NOTE: Some users have reported problems cloning from git:// paths. To use https:// instead pass in
+                                  # $ PROTOCOL=https ./checkout_glslang_spirv_tools.sh
+                                  # instead.
 ./build_glslang_spirv_tools.sh    # Builds glslang and SPIRV-Tools.
 ./test_shaders.sh                 # Runs over all changes and makes sure that there are no deltas compared to reference files.
+```
+
+`./test_shaders.sh` currently requires a Makefile setup with GCC/Clang to be set up.
+However, on Windows, this can be rather inconvenient if a MinGW environment is not set up.
+To use a spirv-cross binary you built with CMake (or otherwise), you can pass in an environment variable as such:
+
+```
+SPIRV_CROSS_PATH=path/to/custom/spirv-cross ./test_shaders.sh
 ```
 
 However, when improving SPIRV-Cross there are of course legitimate cases where reference output should change.
 In these cases, run:
 
 ```
-./update_test_shaders.sh
+./update_test_shaders.sh          # SPIRV_CROSS_PATH also works here.
 ```
 
 to update the reference files and include these changes as part of the pull request.
 Always make sure you are running the correct version of glslangValidator as well as SPIRV-Tools when updating reference files.
-See `checkout_glslang_spirv_tools.sh`.
+See `checkout_glslang_spirv_tools.sh` which revisions are currently expected. The revisions change regularly.
 
 In short, the master branch should always be able to run `./test_shaders.py shaders` and friends without failure.
 SPIRV-Cross uses Travis CI to test all pull requests, so it is not strictly needed to perform testing yourself if you have problems running it locally.
 A pull request which does not pass testing on Travis will not be accepted however.
 
 When adding support for new features to SPIRV-Cross, a new shader and reference file should be added which covers usage of the new shader features in question.
-
-Travis CI runs the test suite with the CMake, by running `ctest`. This method is compatible with MSVC.
+Travis CI runs the test suite with the CMake, by running `ctest`. This is a more straight-forward alternative to `./test_shaders.sh`.
 
 ### Licensing
 

--- a/build_glslang_spirv_tools.sh
+++ b/build_glslang_spirv_tools.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 PROFILE=Release
+
 if [ ! -z $1 ]; then
 	PROFILE=$1
 fi

--- a/checkout_glslang_spirv_tools.sh
+++ b/checkout_glslang_spirv_tools.sh
@@ -4,6 +4,12 @@ GLSLANG_REV=ef807f4bc543e061f25dbbee6cb64dd5053b2adc
 SPIRV_TOOLS_REV=12e4a7b649e6fe28683de9fc352200c82948a1f0
 SPIRV_HEADERS_REV=111a25e4ae45e2b4d7c18415e1d6884712b958c4
 
+if [ -z $PROTOCOL ]; then
+	PROTOCOL=git
+fi
+
+echo "Using protocol \"$PROTOCOL\" for checking out repositories. If this is problematic, try PROTOCOL=https $0."
+
 if [ -d external/glslang ]; then
 	echo "Updating glslang to revision $GLSLANG_REV."
 	cd external/glslang
@@ -13,7 +19,7 @@ else
 	echo "Cloning glslang revision $GLSLANG_REV."
 	mkdir -p external
 	cd external
-	git clone git://github.com/KhronosGroup/glslang.git
+	git clone $PROTOCOL://github.com/KhronosGroup/glslang.git
 	cd glslang
 	git checkout $GLSLANG_REV
 fi
@@ -28,7 +34,7 @@ else
 	echo "Cloning SPIRV-Tools revision $SPIRV_TOOLS_REV."
 	mkdir -p external
 	cd external
-	git clone git://github.com/KhronosGroup/SPIRV-Tools.git spirv-tools
+	git clone $PROTOCOL://github.com/KhronosGroup/SPIRV-Tools.git spirv-tools
 	cd spirv-tools
 	git checkout $SPIRV_TOOLS_REV
 fi
@@ -39,7 +45,7 @@ if [ -d external/spirv-headers ]; then
 	git checkout $SPIRV_HEADERS_REV
 	cd ../..
 else
-	git clone git://github.com/KhronosGroup/SPIRV-Headers.git external/spirv-headers
+	git clone $PROTOCOL://github.com/KhronosGroup/SPIRV-Headers.git external/spirv-headers
 	cd external/spirv-headers
 	git checkout $SPIRV_HEADERS_REV
 	cd ../..

--- a/test_shaders.sh
+++ b/test_shaders.sh
@@ -1,20 +1,24 @@
 #!/bin/bash
 
-echo "Building spirv-cross"
-make -j$(nproc)
+if [ -z "$SPIRV_CROSS_PATH" ]; then
+	echo "Building spirv-cross"
+	make -j$(nproc)
+	SPIRV_CROSS_PATH="./spirv-cross"
+fi
 
 export PATH="./external/glslang-build/output/bin:./external/spirv-tools-build/output/bin:.:$PATH"
 echo "Using glslangValidation in: $(which glslangValidator)."
 echo "Using spirv-opt in: $(which spirv-opt)."
+echo "Using SPIRV-Cross in: \"$SPIRV_CROSS_PATH\"."
 
-./test_shaders.py shaders || exit 1
-./test_shaders.py shaders --opt || exit 1
-./test_shaders.py shaders-no-opt || exit 1
-./test_shaders.py shaders-msl --msl || exit 1
-./test_shaders.py shaders-msl --msl --opt || exit 1
-./test_shaders.py shaders-msl-no-opt --msl || exit 1
-./test_shaders.py shaders-hlsl --hlsl || exit 1
-./test_shaders.py shaders-hlsl --hlsl --opt || exit 1
-./test_shaders.py shaders-hlsl-no-opt --hlsl || exit 1
-./test_shaders.py shaders-reflection --reflect || exit 1
+./test_shaders.py shaders --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders --opt --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-no-opt --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-msl --msl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-msl --msl --opt --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-msl-no-opt --msl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-hlsl --hlsl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-hlsl --hlsl --opt --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-hlsl-no-opt --hlsl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-reflection --reflect --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
 

--- a/update_test_shaders.sh
+++ b/update_test_shaders.sh
@@ -1,21 +1,25 @@
 #!/bin/bash
 
-echo "Building spirv-cross"
-make -j$(nproc)
+if [ -z "$SPIRV_CROSS_PATH" ]; then
+	echo "Building spirv-cross"
+	make -j$(nproc)
+	SPIRV_CROSS_PATH="./spirv-cross"
+fi
 
 export PATH="./external/glslang-build/output/bin:./external/spirv-tools-build/output/bin:.:$PATH"
 echo "Using glslangValidation in: $(which glslangValidator)."
 echo "Using spirv-opt in: $(which spirv-opt)."
+echo "Using SPIRV-Cross in: \"$SPIRV_CROSS_PATH\"."
 
-./test_shaders.py shaders --update || exit 1
-./test_shaders.py shaders --update --opt || exit 1
-./test_shaders.py shaders-no-opt --update || exit 1
-./test_shaders.py shaders-msl --update --msl || exit 1
-./test_shaders.py shaders-msl --update --msl --opt || exit 1
-./test_shaders.py shaders-msl-no-opt --update --msl || exit 1
-./test_shaders.py shaders-hlsl --update --hlsl || exit 1
-./test_shaders.py shaders-hlsl --update --hlsl --opt || exit 1
-./test_shaders.py shaders-hlsl-no-opt --update --hlsl || exit 1
-./test_shaders.py shaders-reflection --reflect --update || exit 1
+./test_shaders.py shaders --update --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders --update --opt --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-no-opt --update --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-msl --update --msl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-msl --update --msl --opt --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-msl-no-opt --update --msl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-hlsl --update --hlsl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-hlsl --update --hlsl --opt --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-hlsl-no-opt --update --hlsl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-reflection --reflect --update --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
 
 


### PR DESCRIPTION
Make path to spirv-cross configurable so we can be a bit more flexible
with build systems used to update tests.

Fix #948.