### PR TITLE
GLSL: Implement GL_EXT_buffer_reference.

### DIFF
--- a/reference/opt/shaders/vulkan/comp/array-of-buffer-reference.nocompat.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/array-of-buffer-reference.nocompat.vk.comp.vk
@@ -1,0 +1,25 @@
+#version 450
+#extension GL_EXT_buffer_reference : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(buffer_reference) buffer Block;
+layout(buffer_reference, std430) buffer Block
+{
+    float v;
+};
+
+layout(set = 0, binding = 0, std140) uniform UBO
+{
+    Block blocks[4];
+} ubo;
+
+void main()
+{
+    Block blocks[4];
+    blocks[0] = ubo.blocks[0];
+    blocks[1] = ubo.blocks[1];
+    blocks[2] = ubo.blocks[2];
+    blocks[3] = ubo.blocks[3];
+    blocks[gl_WorkGroupID.x].v = 20.0;
+}
+

--- a/reference/opt/shaders/vulkan/comp/buffer-reference.nocompat.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/buffer-reference.nocompat.vk.comp.vk
@@ -1,0 +1,45 @@
+#version 450
+#extension GL_ARB_gpu_shader_int64 : require
+#extension GL_EXT_buffer_reference : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(buffer_reference) buffer Node;
+layout(buffer_reference, std140) buffer Node
+{
+    layout(offset = 0) int value;
+    layout(offset = 16) Node next;
+    layout(offset = 32) Node prev;
+};
+
+layout(set = 0, binding = 0, std430) restrict buffer LinkedList
+{
+    Node head1;
+    Node head2;
+} _50;
+
+void main()
+{
+    Node _45;
+    if (gl_WorkGroupID.x < 4u)
+    {
+        _45 = _50.head1;
+    }
+    else
+    {
+        _45 = _50.head2;
+    }
+    restrict Node n = _45;
+    Node param = n.next;
+    Node param_1 = _50.head1;
+    Node param_2 = _50.head2;
+    param.value = param_1.value + param_2.value;
+    Node param_4 = _50.head1;
+    Node param_3 = param_4;
+    n = param_3;
+    int v = _50.head2.value;
+    n.value = 20;
+    n.value = v * 10;
+    uint64_t uptr = uint64_t(_50.head2.next);
+    Node unode = Node(uptr);
+}
+

--- a/reference/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer-2.asm.nocompat.vk.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer-2.asm.nocompat.vk.comp.vk
@@ -1,0 +1,21 @@
+#version 450
+#extension GL_ARB_gpu_shader_int64 : require
+#extension GL_EXT_buffer_reference : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(buffer_reference) buffer uintPointer
+{
+    uint value;
+};
+
+layout(push_constant, std430) uniform _4_12
+{
+    uint64_t _m0;
+} _12;
+
+void main()
+{
+    uintPointer _3 = uintPointer(_12._m0);
+    _3.value = 20u;
+}
+

--- a/reference/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer.asm.nocompat.vk.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer.asm.nocompat.vk.comp.vk
@@ -1,0 +1,21 @@
+#version 450
+#extension GL_ARB_gpu_shader_int64 : require
+#extension GL_EXT_buffer_reference : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(buffer_reference) buffer uint0_Pointer
+{
+    uint value[];
+};
+
+layout(push_constant, std430) uniform _6_14
+{
+    uint64_t _m0;
+} _14;
+
+void main()
+{
+    uint0_Pointer _5 = uint0_Pointer(_14._m0);
+    _5.value[10] = 20u;
+}
+

--- a/reference/shaders/vulkan/comp/array-of-buffer-reference.nocompat.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/array-of-buffer-reference.nocompat.vk.comp.vk
@@ -1,0 +1,25 @@
+#version 450
+#extension GL_EXT_buffer_reference : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(buffer_reference) buffer Block;
+layout(buffer_reference, std430) buffer Block
+{
+    float v;
+};
+
+layout(set = 0, binding = 0, std140) uniform UBO
+{
+    Block blocks[4];
+} ubo;
+
+void main()
+{
+    Block blocks[4];
+    blocks[0] = ubo.blocks[0];
+    blocks[1] = ubo.blocks[1];
+    blocks[2] = ubo.blocks[2];
+    blocks[3] = ubo.blocks[3];
+    blocks[gl_WorkGroupID.x].v = 20.0;
+}
+

--- a/reference/shaders/vulkan/comp/buffer-reference.nocompat.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/buffer-reference.nocompat.vk.comp.vk
@@ -1,0 +1,56 @@
+#version 450
+#extension GL_ARB_gpu_shader_int64 : require
+#extension GL_EXT_buffer_reference : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(buffer_reference) buffer Node;
+layout(buffer_reference, std140) buffer Node
+{
+    layout(offset = 0) int value;
+    layout(offset = 16) Node next;
+    layout(offset = 32) Node prev;
+};
+
+layout(set = 0, binding = 0, std430) restrict buffer LinkedList
+{
+    Node head1;
+    Node head2;
+} _50;
+
+void copy_node(restrict Node dst, restrict Node a, restrict Node b)
+{
+    dst.value = a.value + b.value;
+}
+
+void overwrite_node(out Node dst, Node src)
+{
+    dst = src;
+}
+
+void main()
+{
+    Node _45;
+    if (gl_WorkGroupID.x < 4u)
+    {
+        _45 = _50.head1;
+    }
+    else
+    {
+        _45 = _50.head2;
+    }
+    restrict Node n = _45;
+    Node param = n.next;
+    Node param_1 = _50.head1;
+    Node param_2 = _50.head2;
+    copy_node(param, param_1, param_2);
+    Node param_4 = _50.head1;
+    Node param_3;
+    overwrite_node(param_3, param_4);
+    n = param_3;
+    int v = _50.head2.value;
+    n.value = 20;
+    n.value = v * 10;
+    uint64_t uptr = uint64_t(_50.head2.next);
+    Node unode = Node(uptr);
+}
+

--- a/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer-2.asm.nocompat.vk.comp
+++ b/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer-2.asm.nocompat.vk.comp
@@ -1,0 +1,44 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 27
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int64
+               OpCapability PhysicalStorageBufferAddressesEXT
+               OpExtension "SPV_EXT_physical_storage_buffer"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel PhysicalStorageBuffer64EXT GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_gpu_shader_int64"
+               OpSourceExtension "GL_EXT_buffer_reference"
+               OpDecorate %ptr AliasedPointerEXT
+               OpMemberDecorate %Registers 0 Offset 0
+               OpDecorate %Registers Block
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%_ptr_PhysicalStorageBufferEXT_uint = OpTypePointer PhysicalStorageBufferEXT %uint
+%_ptr_Function__ptr_PhysicalStorageBufferEXT_uint = OpTypePointer Function %_ptr_PhysicalStorageBufferEXT_uint
+      %ulong = OpTypeInt 64 0
+  %Registers = OpTypeStruct %ulong
+%_ptr_PushConstant_Registers = OpTypePointer PushConstant %Registers
+  %registers = OpVariable %_ptr_PushConstant_Registers PushConstant
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_PushConstant_ulong = OpTypePointer PushConstant %ulong
+     %int_10 = OpConstant %int 10
+    %uint_20 = OpConstant %uint 20
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+        %ptr = OpVariable %_ptr_Function__ptr_PhysicalStorageBufferEXT_uint Function
+         %19 = OpAccessChain %_ptr_PushConstant_ulong %registers %int_0
+         %20 = OpLoad %ulong %19
+         %21 = OpConvertUToPtr %_ptr_PhysicalStorageBufferEXT_uint %20
+               OpStore %ptr %21
+         %22 = OpLoad %_ptr_PhysicalStorageBufferEXT_uint %ptr
+               OpStore %22 %uint_20 Aligned 4
+               OpReturn
+               OpFunctionEnd

--- a/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer.asm.nocompat.vk.comp
+++ b/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer.asm.nocompat.vk.comp
@@ -1,0 +1,51 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 27
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int64
+               OpCapability PhysicalStorageBufferAddressesEXT
+               OpExtension "SPV_EXT_physical_storage_buffer"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel PhysicalStorageBuffer64EXT GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_gpu_shader_int64"
+               OpSourceExtension "GL_EXT_buffer_reference"
+               OpDecorate %_runtimearr_uint ArrayStride 4
+               OpMemberDecorate %uintPtr 0 Offset 0
+               OpDecorate %uintPtr Block
+               OpDecorate %ptr AliasedPointerEXT
+               OpMemberDecorate %Registers 0 Offset 0
+               OpDecorate %Registers Block
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%_runtimearr_uint = OpTypeRuntimeArray %uint
+    %uintPtr = OpTypeStruct %_runtimearr_uint
+%_ptr_PhysicalStorageBufferEXT_uint_array = OpTypePointer PhysicalStorageBufferEXT %_runtimearr_uint
+%_ptr_Function__ptr_PhysicalStorageBufferEXT_uint_array = OpTypePointer Function %_ptr_PhysicalStorageBufferEXT_uint_array
+      %ulong = OpTypeInt 64 0
+  %Registers = OpTypeStruct %ulong
+%_ptr_PushConstant_Registers = OpTypePointer PushConstant %Registers
+  %registers = OpVariable %_ptr_PushConstant_Registers PushConstant
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_PushConstant_ulong = OpTypePointer PushConstant %ulong
+     %int_10 = OpConstant %int 10
+    %uint_20 = OpConstant %uint 20
+%_ptr_PhysicalStorageBufferEXT_uint = OpTypePointer PhysicalStorageBufferEXT %uint
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+        %ptr = OpVariable %_ptr_Function__ptr_PhysicalStorageBufferEXT_uint_array Function
+         %19 = OpAccessChain %_ptr_PushConstant_ulong %registers %int_0
+         %20 = OpLoad %ulong %19
+         %21 = OpConvertUToPtr %_ptr_PhysicalStorageBufferEXT_uint_array %20
+               OpStore %ptr %21
+         %22 = OpLoad %_ptr_PhysicalStorageBufferEXT_uint_array %ptr
+         %26 = OpAccessChain %_ptr_PhysicalStorageBufferEXT_uint %22 %int_10
+               OpStore %26 %uint_20 Aligned 4
+               OpReturn
+               OpFunctionEnd

--- a/shaders/vulkan/comp/array-of-buffer-reference.nocompat.vk.comp
+++ b/shaders/vulkan/comp/array-of-buffer-reference.nocompat.vk.comp
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_EXT_buffer_reference : require
+layout(local_size_x = 1) in;
+
+layout(buffer_reference) buffer Block
+{
+	float v;
+};
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+	Block blocks[4];
+} ubo;
+
+void main()
+{
+	Block blocks[4];
+	blocks[0] = ubo.blocks[0];
+	blocks[1] = ubo.blocks[1];
+	blocks[2] = ubo.blocks[2];
+	blocks[3] = ubo.blocks[3];
+	blocks[gl_WorkGroupID.x].v = 20.0;
+}

--- a/shaders/vulkan/comp/buffer-reference.nocompat.vk.comp
+++ b/shaders/vulkan/comp/buffer-reference.nocompat.vk.comp
@@ -1,0 +1,40 @@
+#version 450
+#extension GL_EXT_buffer_reference : require
+#extension GL_ARB_gpu_shader_int64 : require
+
+layout(buffer_reference) buffer Node;
+layout(buffer_reference) buffer Node
+{
+	int value;
+	layout(offset = 16) Node next;
+	layout(offset = 32) Node prev;
+};
+
+layout(std430, set = 0, binding = 0) buffer LinkedList
+{
+	restrict Node head1;
+	restrict Node head2;
+};
+
+void copy_node(restrict Node dst, restrict Node a, restrict Node b)
+{
+	dst.value = a.value + b.value;
+}
+
+void overwrite_node(out Node dst, Node src)
+{
+	dst = src;
+}
+
+void main()
+{
+	restrict Node n = gl_WorkGroupID.x < 4u ? head1 : head2;
+	copy_node(n.next, head1, head2);
+	overwrite_node(n, head1);
+	int v = head2.value;
+	n.value = 20;
+	n.value = v * 10;
+
+	uint64_t uptr = uint64_t(head2.next);
+	Node unode = Node(uptr);
+}

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -74,6 +74,7 @@ bool Compiler::variable_storage_is_aliased(const SPIRVariable &v)
 	            ir.meta[type.self].decoration.decoration_flags.get(DecorationBufferBlock);
 	bool image = type.basetype == SPIRType::Image;
 	bool counter = type.basetype == SPIRType::AtomicCounter;
+	bool buffer_reference = type.storage == StorageClassPhysicalStorageBufferEXT;
 
 	bool is_restrict;
 	if (ssbo)
@@ -81,7 +82,7 @@ bool Compiler::variable_storage_is_aliased(const SPIRVariable &v)
 	else
 		is_restrict = has_decoration(v.self, DecorationRestrict);
 
-	return !is_restrict && (ssbo || image || counter);
+	return !is_restrict && (ssbo || image || counter || buffer_reference);
 }
 
 bool Compiler::block_is_pure(const SPIRBlock &block)
@@ -300,18 +301,41 @@ void Compiler::register_write(uint32_t chain)
 
 	if (var)
 	{
+		bool check_argument_storage_qualifier = true;
+		auto &type = expression_type(chain);
+
 		// If our variable is in a storage class which can alias with other buffers,
 		// invalidate all variables which depend on aliased variables. And if this is a
 		// variable pointer, then invalidate all variables regardless.
 		if (get_variable_data_type(*var).pointer)
+		{
 			flush_all_active_variables();
-		if (variable_storage_is_aliased(*var))
+
+			if (type.pointer_depth == 1)
+			{
+				// We have a backing variable which is a pointer-to-pointer type.
+				// We are storing some data through a pointer acquired through that variable,
+				// but we are not writing to the value of the variable itself,
+				// i.e., we are not modifying the pointer directly.
+				// If we are storing a non-pointer type (pointer_depth == 1),
+				// we know that we are storing some unrelated data.
+				// A case here would be
+				// void foo(Foo * const *arg) {
+				//   Foo *bar = *arg;
+				//   bar->unrelated = 42;
+				// }
+				// arg, the argument is constant.
+				check_argument_storage_qualifier = false;
+			}
+		}
+
+		if (type.storage == StorageClassPhysicalStorageBufferEXT || variable_storage_is_aliased(*var))
 			flush_all_aliased_variables();
 		else if (var)
 			flush_dependees(*var);
 
 		// We tried to write to a parameter which is not marked with out qualifier, force a recompile.
-		if (var->parameter && var->parameter->write_count == 0)
+		if (check_argument_storage_qualifier && var->parameter && var->parameter->write_count == 0)
 		{
 			var->parameter->write_count++;
 			force_recompile();
@@ -4114,8 +4138,13 @@ Bitset Compiler::combined_decoration_for_member(const SPIRType &type, uint32_t i
 
 		// If our type is a struct, traverse all the members as well recursively.
 		flags.merge_or(dec.decoration_flags);
+
 		for (uint32_t i = 0; i < type.member_types.size(); i++)
-			flags.merge_or(combined_decoration_for_member(get<SPIRType>(type.member_types[i]), i));
+		{
+			auto &memb_type = get<SPIRType>(type.member_types[i]);
+			if (!memb_type.pointer)
+				flags.merge_or(combined_decoration_for_member(memb_type, i));
+		}
 	}
 
 	return flags;
@@ -4179,4 +4208,45 @@ bool Compiler::is_forcing_recompilation() const
 void Compiler::clear_force_recompile()
 {
 	is_force_recompile = false;
+}
+
+Compiler::PhysicalStorageBufferPointerHandler::PhysicalStorageBufferPointerHandler(Compiler &compiler_)
+    : compiler(compiler_)
+{
+}
+
+bool Compiler::PhysicalStorageBufferPointerHandler::handle(Op op, const uint32_t *args, uint32_t)
+{
+	if (op == OpConvertUToPtr)
+	{
+		auto &type = compiler.get<SPIRType>(args[0]);
+		if (type.storage == StorageClassPhysicalStorageBufferEXT && type.pointer && type.pointer_depth == 1)
+		{
+			// If we need to cast to a pointer type which is not a block, we might need to synthesize ourselves
+			// a block type which wraps this POD type.
+			if (type.basetype != SPIRType::Struct)
+				types.insert(args[0]);
+		}
+	}
+
+	return true;
+}
+
+void Compiler::analyze_non_block_pointer_types()
+{
+	PhysicalStorageBufferPointerHandler handler(*this);
+	traverse_all_reachable_opcodes(get<SPIRFunction>(ir.default_entry_point), handler);
+	physical_storage_non_block_pointer_types.reserve(handler.types.size());
+	for (auto type : handler.types)
+		physical_storage_non_block_pointer_types.push_back(type);
+	sort(begin(physical_storage_non_block_pointer_types), end(physical_storage_non_block_pointer_types));
+}
+
+bool Compiler::type_is_array_of_pointers(const SPIRType &type) const
+{
+	if (!type.pointer)
+		return false;
+
+	// If parent type has same pointer depth, we must have an array of pointers.
+	return type.pointer_depth == get<SPIRType>(type.parent_type).pointer_depth;
 }

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -932,6 +932,16 @@ protected:
 		uint32_t write_count = 0;
 	};
 
+	struct PhysicalStorageBufferPointerHandler : OpcodeHandler
+	{
+		PhysicalStorageBufferPointerHandler(Compiler &compiler_);
+		bool handle(spv::Op op, const uint32_t *args, uint32_t length) override;
+		Compiler &compiler;
+		std::unordered_set<uint32_t> types;
+	};
+	void analyze_non_block_pointer_types();
+	SmallVector<uint32_t> physical_storage_non_block_pointer_types;
+
 	void analyze_variable_scope(SPIRFunction &function, AnalyzeVariableScopeAccessHandler &handler);
 	void find_function_local_luts(SPIRFunction &function, const AnalyzeVariableScopeAccessHandler &handler,
 	                              bool single_function);
@@ -958,6 +968,8 @@ protected:
 	uint32_t get_extended_member_decoration(uint32_t type, uint32_t index, ExtendedDecorations decoration) const;
 	bool has_extended_member_decoration(uint32_t type, uint32_t index, ExtendedDecorations decoration) const;
 	void unset_extended_member_decoration(uint32_t type, uint32_t index, ExtendedDecorations decoration);
+
+	bool type_is_array_of_pointers(const SPIRType &type) const;
 
 private:
 	// Used only to implement the old deprecated get_entry_point() interface.

--- a/spirv_cross_parsed_ir.cpp
+++ b/spirv_cross_parsed_ir.cpp
@@ -66,6 +66,8 @@ ParsedIR &ParsedIR::operator=(ParsedIR &&other) SPIRV_CROSS_NOEXCEPT
 		continue_block_to_loop_header = move(other.continue_block_to_loop_header);
 		entry_points = move(other.entry_points);
 		ids = move(other.ids);
+		addressing_model = other.addressing_model;
+		memory_model = other.memory_model;
 
 		default_entry_point = other.default_entry_point;
 		source = other.source;
@@ -98,6 +100,8 @@ ParsedIR &ParsedIR::operator=(const ParsedIR &other)
 		default_entry_point = other.default_entry_point;
 		source = other.source;
 		loop_iteration_depth = other.loop_iteration_depth;
+		addressing_model = other.addressing_model;
+		memory_model = other.memory_model;
 
 		// Very deliberate copying of IDs. There is no default copy constructor, nor a simple default constructor.
 		// Construct object first so we have the correct allocator set-up, then we can copy object into our new pool group.
@@ -692,24 +696,27 @@ void ParsedIR::add_typed_id(Types type, uint32_t id)
 	if (loop_iteration_depth)
 		SPIRV_CROSS_THROW("Cannot add typed ID while looping over it.");
 
-	switch (type)
+	if (ids[id].empty() || ids[id].get_type() != type)
 	{
-	case TypeConstant:
-		ids_for_constant_or_variable.push_back(id);
-		ids_for_constant_or_type.push_back(id);
-		break;
+		switch (type)
+		{
+		case TypeConstant:
+			ids_for_constant_or_variable.push_back(id);
+			ids_for_constant_or_type.push_back(id);
+			break;
 
-	case TypeVariable:
-		ids_for_constant_or_variable.push_back(id);
-		break;
+		case TypeVariable:
+			ids_for_constant_or_variable.push_back(id);
+			break;
 
-	case TypeType:
-	case TypeConstantOp:
-		ids_for_constant_or_type.push_back(id);
-		break;
+		case TypeType:
+		case TypeConstantOp:
+			ids_for_constant_or_type.push_back(id);
+			break;
 
-	default:
-		break;
+		default:
+			break;
+		}
 	}
 
 	if (ids[id].empty())

--- a/spirv_cross_parsed_ir.hpp
+++ b/spirv_cross_parsed_ir.hpp
@@ -107,6 +107,9 @@ public:
 
 	Source source;
 
+	spv::AddressingModel addressing_model = spv::AddressingModelMax;
+	spv::MemoryModel memory_model = spv::MemoryModelMax;
+
 	// Decoration handling methods.
 	// Can be useful for simple "raw" reflection.
 	// However, most members are here because the Parser needs most of these,

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -2697,7 +2697,7 @@ string CompilerGLSL::enclose_expression(const string &expr)
 		return expr;
 }
 
-string CompilerGLSL::dereference_expression(const SPIRType &expression_type, const std::string &expr)
+string CompilerGLSL::dereference_expression(const SPIRType &expr_type, const std::string &expr)
 {
 	// If this expression starts with an address-of operator ('&'), then
 	// just return the part after the operator.
@@ -2706,8 +2706,8 @@ string CompilerGLSL::dereference_expression(const SPIRType &expression_type, con
 		return expr.substr(1);
 	else if (backend.native_pointers)
 		return join('*', expr);
-	else if (expression_type.storage == StorageClassPhysicalStorageBufferEXT &&
-	         expression_type.basetype != SPIRType::Struct && expression_type.pointer_depth == 1)
+	else if (expr_type.storage == StorageClassPhysicalStorageBufferEXT && expr_type.basetype != SPIRType::Struct &&
+	         expr_type.pointer_depth == 1)
 	{
 		return join(enclose_expression(expr), ".value");
 	}

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -392,11 +392,13 @@ protected:
 		bool supports_empty_struct = false;
 		bool array_is_value_type = true;
 		bool comparison_image_samples_scalar = false;
+		bool native_pointers = false;
 	} backend;
 
 	void emit_struct(SPIRType &type);
 	void emit_resources();
 	void emit_buffer_block_native(const SPIRVariable &var);
+	void emit_buffer_reference_block(SPIRType &type, bool forward_declaration);
 	void emit_buffer_block_legacy(const SPIRVariable &var);
 	void emit_buffer_block_flattened(const SPIRVariable &type);
 	void emit_declared_builtin_block(spv::StorageClass storage, spv::ExecutionModel model);
@@ -495,7 +497,7 @@ protected:
 	std::string to_enclosed_pointer_expression(uint32_t id, bool register_expression_read = true);
 	std::string to_extract_component_expression(uint32_t id, uint32_t index);
 	std::string enclose_expression(const std::string &expr);
-	std::string dereference_expression(const std::string &expr);
+	std::string dereference_expression(const SPIRType &expression_type, const std::string &expr);
 	std::string address_of_expression(const std::string &expr);
 	void strip_enclosed_expression(std::string &expr);
 	std::string to_member_name(const SPIRType &type, uint32_t index);
@@ -505,7 +507,7 @@ protected:
 	virtual std::string to_qualifiers_glsl(uint32_t id);
 	const char *to_precision_qualifiers_glsl(uint32_t id);
 	virtual const char *to_storage_qualifiers_glsl(const SPIRVariable &var);
-	const char *flags_to_precision_qualifiers_glsl(const SPIRType &type, const Bitset &flags);
+	const char *flags_to_qualifiers_glsl(const SPIRType &type, const Bitset &flags);
 	const char *format_to_glsl(spv::ImageFormat format);
 	virtual std::string layout_for_member(const SPIRType &type, uint32_t index);
 	virtual std::string to_interpolation_qualifiers(const Bitset &flags);
@@ -518,6 +520,8 @@ protected:
 
 	bool buffer_is_packing_standard(const SPIRType &type, BufferPackingStandard packing, uint32_t start_offset = 0,
 	                                uint32_t end_offset = ~(0u));
+	std::string buffer_to_packing_standard(const SPIRType &type);
+
 	uint32_t type_to_packed_base_size(const SPIRType &type, BufferPackingStandard packing);
 	uint32_t type_to_packed_alignment(const SPIRType &type, const Bitset &flags, BufferPackingStandard packing);
 	uint32_t type_to_packed_array_stride(const SPIRType &type, const Bitset &flags, BufferPackingStandard packing);

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -2006,7 +2006,7 @@ void CompilerHLSL::emit_function_prototype(SPIRFunction &func, const Bitset &ret
 	auto &type = get<SPIRType>(func.return_type);
 	if (type.array.empty())
 	{
-		decl += flags_to_precision_qualifiers_glsl(type, return_flags);
+		decl += flags_to_qualifiers_glsl(type, return_flags);
 		decl += type_to_glsl(type);
 		decl += " ";
 	}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -584,6 +584,7 @@ string CompilerMSL::compile()
 	backend.allow_truncated_access_chain = true;
 	backend.array_is_value_type = false;
 	backend.comparison_image_samples_scalar = true;
+	backend.native_pointers = true;
 
 	capture_output_to_buffer = msl_options.capture_output_to_buffer;
 	is_rasterization_disabled = msl_options.disable_rasterization || capture_output_to_buffer;

--- a/spirv_parser.cpp
+++ b/spirv_parser.cpp
@@ -158,7 +158,6 @@ void Parser::parse(const Instruction &instruction)
 
 	switch (op)
 	{
-	case OpMemoryModel:
 	case OpSourceContinued:
 	case OpSourceExtension:
 	case OpNop:
@@ -166,6 +165,11 @@ void Parser::parse(const Instruction &instruction)
 	case OpNoLine:
 	case OpString:
 	case OpModuleProcessed:
+		break;
+
+	case OpMemoryModel:
+		ir.addressing_model = static_cast<AddressingModel>(ops[0]);
+		ir.memory_model = static_cast<MemoryModel>(ops[1]);
 		break;
 
 	case OpSource:
@@ -595,6 +599,20 @@ void Parser::parse(const Instruction &instruction)
 		ptrbase.parent_type = ops[2];
 
 		// Do NOT set ptrbase.self!
+		break;
+	}
+
+	case OpTypeForwardPointer:
+	{
+		uint32_t id = ops[0];
+		auto &ptrbase = set<SPIRType>(id);
+		ptrbase.pointer = true;
+		ptrbase.pointer_depth++;
+		ptrbase.storage = static_cast<StorageClass>(ops[1]);
+
+		if (ptrbase.storage == StorageClassAtomicCounter)
+			ptrbase.basetype = SPIRType::AtomicCounter;
+
 		break;
 	}
 


### PR DESCRIPTION
Buffer objects can contain pointers to arbitrary data, essentially full pointer support. This might be possible to implement for MSL as well if MSL supports placing pointers in buffers.

Fix #924.