### PR TITLE
HLSL: Support OpArrayLength.

### DIFF
--- a/reference/opt/shaders-hlsl/comp/ssbo-array-length.comp
+++ b/reference/opt/shaders-hlsl/comp/ssbo-array-length.comp
@@ -1,0 +1,15 @@
+RWByteAddressBuffer _11 : register(u1);
+
+void comp_main()
+{
+    uint _14;
+    _11.GetDimensions(_14);
+    _14 = (_14 - 16) / 16;
+    _11.Store(0, uint(int(_14)));
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    comp_main();
+}

--- a/reference/opt/shaders/comp/ssbo-array-length.comp
+++ b/reference/opt/shaders/comp/ssbo-array-length.comp
@@ -1,0 +1,14 @@
+#version 450
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 1, std140) buffer SSBO
+{
+    uint size;
+    float v[];
+} _11;
+
+void main()
+{
+    _11.size = uint(int(_11.v.length()));
+}
+

--- a/reference/opt/shaders/comp/ssbo-array-length.comp
+++ b/reference/opt/shaders/comp/ssbo-array-length.comp
@@ -9,6 +9,6 @@ layout(binding = 1, std140) buffer SSBO
 
 void main()
 {
-    _11.size = uint(int(_11.v.length()));
+    _11.size = uint(int(uint(_11.v.length())));
 }
 

--- a/reference/shaders-hlsl/comp/ssbo-array-length.comp
+++ b/reference/shaders-hlsl/comp/ssbo-array-length.comp
@@ -1,0 +1,15 @@
+RWByteAddressBuffer _11 : register(u1);
+
+void comp_main()
+{
+    uint _14;
+    _11.GetDimensions(_14);
+    _14 = (_14 - 16) / 16;
+    _11.Store(0, uint(int(_14)));
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    comp_main();
+}

--- a/reference/shaders/comp/ssbo-array-length.comp
+++ b/reference/shaders/comp/ssbo-array-length.comp
@@ -1,0 +1,14 @@
+#version 450
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 1, std140) buffer SSBO
+{
+    uint size;
+    float v[];
+} _11;
+
+void main()
+{
+    _11.size = uint(int(_11.v.length()));
+}
+

--- a/reference/shaders/comp/ssbo-array-length.comp
+++ b/reference/shaders/comp/ssbo-array-length.comp
@@ -9,6 +9,6 @@ layout(binding = 1, std140) buffer SSBO
 
 void main()
 {
-    _11.size = uint(int(_11.v.length()));
+    _11.size = uint(int(uint(_11.v.length())));
 }
 

--- a/shaders-hlsl/comp/ssbo-array-length.comp
+++ b/shaders-hlsl/comp/ssbo-array-length.comp
@@ -1,0 +1,12 @@
+#version 450
+layout(local_size_x = 1) in;
+layout(set = 0, binding = 1, std140) buffer SSBO
+{
+	uint size;
+	float v[];
+};
+
+void main()
+{
+	size = v.length();
+}

--- a/shaders/comp/ssbo-array-length.comp
+++ b/shaders/comp/ssbo-array-length.comp
@@ -1,0 +1,12 @@
+#version 450
+layout(local_size_x = 1) in;
+layout(set = 0, binding = 1, std140) buffer SSBO
+{
+	uint size;
+	float v[];
+};
+
+void main()
+{
+	size = v.length();
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -7566,7 +7566,8 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		uint32_t result_type = ops[0];
 		uint32_t id = ops[1];
 		auto e = access_chain_internal(ops[2], &ops[3], length - 3, ACCESS_CHAIN_INDEX_IS_LITERAL_BIT, nullptr);
-		set<SPIRExpression>(id, e + ".length()", result_type, true);
+		set<SPIRExpression>(id, join(type_to_glsl(get<SPIRType>(result_type)), "(", e, ".length())"), result_type,
+		                    true);
 		break;
 	}
 


### PR DESCRIPTION
On HLSL we can query the byte size of any (RW)ByteAddressBuffer with GetDimensions, and then we compute the result.