### PR TITLE
MSL: Support image swizzle workaround with argument buffers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,7 +267,7 @@ endif()
 
 if (SPIRV_CROSS_SHARED)
 	set(spirv-cross-abi-major 0)
-	set(spirv-cross-abi-minor 7)
+	set(spirv-cross-abi-minor 8)
 	set(spirv-cross-abi-patch 0)
 	set(SPIRV_CROSS_VERSION ${spirv-cross-abi-major}.${spirv-cross-abi-minor}.${spirv-cross-abi-patch})
 	set(SPIRV_CROSS_INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib)

--- a/reference/opt/shaders-msl/comp/force-recompile-hooks.swizzle.comp
+++ b/reference/opt/shaders-msl/comp/force-recompile-hooks.swizzle.comp
@@ -5,11 +5,6 @@
 
 using namespace metal;
 
-struct spvAux
-{
-    uint swizzleConst[1];
-};
-
 enum class spvSwizzle : uint
 {
     none = 0,
@@ -130,9 +125,9 @@ inline vec<T, 4> spvGatherCompareSwizzle(sampler s, const thread Tex& t, Ts... p
     return t.gather_compare(s, spvForward<Ts>(params)...);
 }
 
-kernel void main0(constant spvAux& spvAuxBuffer [[buffer(30)]], texture2d<float> foo [[texture(0)]], texture2d<float, access::write> bar [[texture(1)]], sampler fooSmplr [[sampler(0)]])
+kernel void main0(constant uint* spvSwizzleConstants [[buffer(30)]], texture2d<float> foo [[texture(0)]], texture2d<float, access::write> bar [[texture(1)]], sampler fooSmplr [[sampler(0)]])
 {
-    constant uint32_t& fooSwzl = spvAuxBuffer.swizzleConst[0];
+    constant uint32_t& fooSwzl = spvSwizzleConstants[0];
     bar.write(spvTextureSwizzle(foo.sample(fooSmplr, float2(1.0), level(0.0)), fooSwzl), uint2(int2(0)));
 }
 

--- a/reference/opt/shaders-msl/frag/array-of-texture-swizzle.msl2.argument.discrete.swizzle.frag
+++ b/reference/opt/shaders-msl/frag/array-of-texture-swizzle.msl2.argument.discrete.swizzle.frag
@@ -5,6 +5,13 @@
 
 using namespace metal;
 
+struct spvDescriptorSetBuffer0
+{
+    constant uint* spvSwizzleConstants [[id(0)]];
+    array<texture2d<float>, 4> uSampler0 [[id(1)]];
+    array<sampler, 4> uSampler0Smplr [[id(5)]];
+};
+
 struct main0_out
 {
     float4 FragColor [[color(0)]];
@@ -135,22 +142,15 @@ inline vec<T, 4> spvGatherCompareSwizzle(sampler s, const thread Tex& t, Ts... p
     return t.gather_compare(s, spvForward<Ts>(params)...);
 }
 
-float4 sample_in_func(thread const array<texture2d<float>, 4> uSampler, thread const array<sampler, 4> uSamplerSmplr, constant uint32_t* uSamplerSwzl, thread float2& vUV)
-{
-    return spvTextureSwizzle(uSampler[2].sample(uSamplerSmplr[2], vUV), uSamplerSwzl[2]);
-}
-
-float4 sample_single_in_func(thread const texture2d<float> s, thread const sampler sSmplr, constant uint32_t& sSwzl, thread float2& vUV)
-{
-    return spvTextureSwizzle(s.sample(sSmplr, vUV), sSwzl);
-}
-
-fragment main0_out main0(main0_in in [[stage_in]], constant uint* spvSwizzleConstants [[buffer(30)]], array<texture2d<float>, 4> uSampler [[texture(0)]], array<sampler, 4> uSamplerSmplr [[sampler(0)]])
+fragment main0_out main0(main0_in in [[stage_in]], constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], constant uint* spvSwizzleConstants [[buffer(30)]], texture2d<float> uSampler1 [[texture(0)]], sampler uSampler1Smplr [[sampler(0)]])
 {
     main0_out out = {};
-    constant uint32_t* uSamplerSwzl = &spvSwizzleConstants[0];
-    out.FragColor = sample_in_func(uSampler, uSamplerSmplr, uSamplerSwzl, in.vUV);
-    out.FragColor += sample_single_in_func(uSampler[1], uSamplerSmplr[1], uSamplerSwzl[1], in.vUV);
+    constant uint32_t* spvDescriptorSet0_uSampler0Swzl = &spvDescriptorSet0.spvSwizzleConstants[1];
+    constant uint32_t& uSampler1Swzl = spvSwizzleConstants[0];
+    out.FragColor = spvTextureSwizzle(spvDescriptorSet0.uSampler0[2].sample(spvDescriptorSet0.uSampler0Smplr[2], in.vUV), spvDescriptorSet0_uSampler0Swzl[2]);
+    out.FragColor += spvTextureSwizzle(uSampler1.sample(uSampler1Smplr, in.vUV), uSampler1Swzl);
+    out.FragColor += spvTextureSwizzle(spvDescriptorSet0.uSampler0[1].sample(spvDescriptorSet0.uSampler0Smplr[1], in.vUV), spvDescriptorSet0_uSampler0Swzl[1]);
+    out.FragColor += spvTextureSwizzle(uSampler1.sample(uSampler1Smplr, in.vUV), uSampler1Swzl);
     return out;
 }
 

--- a/reference/opt/shaders-msl/frag/array-of-texture-swizzle.msl2.swizzle.frag
+++ b/reference/opt/shaders-msl/frag/array-of-texture-swizzle.msl2.swizzle.frag
@@ -5,11 +5,6 @@
 
 using namespace metal;
 
-struct spvAux
-{
-    uint swizzleConst[1];
-};
-
 struct main0_out
 {
     float4 FragColor [[color(0)]];
@@ -140,10 +135,10 @@ inline vec<T, 4> spvGatherCompareSwizzle(sampler s, const thread Tex& t, Ts... p
     return t.gather_compare(s, spvForward<Ts>(params)...);
 }
 
-fragment main0_out main0(main0_in in [[stage_in]], constant spvAux& spvAuxBuffer [[buffer(30)]], array<texture2d<float>, 4> uSampler [[texture(0)]], array<sampler, 4> uSamplerSmplr [[sampler(0)]])
+fragment main0_out main0(main0_in in [[stage_in]], constant uint* spvSwizzleConstants [[buffer(30)]], array<texture2d<float>, 4> uSampler [[texture(0)]], array<sampler, 4> uSamplerSmplr [[sampler(0)]])
 {
     main0_out out = {};
-    constant uint32_t* uSamplerSwzl = &spvAuxBuffer.swizzleConst[0];
+    constant uint32_t* uSamplerSwzl = &spvSwizzleConstants[0];
     out.FragColor = spvTextureSwizzle(uSampler[2].sample(uSamplerSmplr[2], in.vUV), uSamplerSwzl[2]);
     out.FragColor += spvTextureSwizzle(uSampler[1].sample(uSamplerSmplr[1], in.vUV), uSamplerSwzl[1]);
     return out;

--- a/reference/shaders-msl-no-opt/asm/frag/texture-access.swizzle.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/texture-access.swizzle.asm.frag
@@ -5,11 +5,6 @@
 
 using namespace metal;
 
-struct spvAux
-{
-    uint swizzleConst[1];
-};
-
 // Returns 2D texture coords corresponding to 1D texel buffer coords
 uint2 spvTexelBufferCoord(uint tc)
 {
@@ -136,18 +131,18 @@ inline vec<T, 4> spvGatherCompareSwizzle(sampler s, const thread Tex& t, Ts... p
     return t.gather_compare(s, spvForward<Ts>(params)...);
 }
 
-fragment void main0(constant spvAux& spvAuxBuffer [[buffer(30)]], texture1d<float> tex1d [[texture(0)]], texture2d<float> tex2d [[texture(1)]], texture3d<float> tex3d [[texture(2)]], texturecube<float> texCube [[texture(3)]], texture2d_array<float> tex2dArray [[texture(4)]], texturecube_array<float> texCubeArray [[texture(5)]], texture2d<float> texBuffer [[texture(6)]], depth2d<float> depth2d [[texture(7)]], depthcube<float> depthCube [[texture(8)]], depth2d_array<float> depth2dArray [[texture(9)]], depthcube_array<float> depthCubeArray [[texture(10)]], sampler tex1dSamp [[sampler(0)]], sampler tex2dSamp [[sampler(1)]], sampler tex3dSamp [[sampler(2)]], sampler texCubeSamp [[sampler(3)]], sampler tex2dArraySamp [[sampler(4)]], sampler texCubeArraySamp [[sampler(5)]], sampler depth2dSamp [[sampler(7)]], sampler depthCubeSamp [[sampler(8)]], sampler depth2dArraySamp [[sampler(9)]], sampler depthCubeArraySamp [[sampler(10)]])
+fragment void main0(constant uint* spvSwizzleConstants [[buffer(30)]], texture1d<float> tex1d [[texture(0)]], texture2d<float> tex2d [[texture(1)]], texture3d<float> tex3d [[texture(2)]], texturecube<float> texCube [[texture(3)]], texture2d_array<float> tex2dArray [[texture(4)]], texturecube_array<float> texCubeArray [[texture(5)]], texture2d<float> texBuffer [[texture(6)]], depth2d<float> depth2d [[texture(7)]], depthcube<float> depthCube [[texture(8)]], depth2d_array<float> depth2dArray [[texture(9)]], depthcube_array<float> depthCubeArray [[texture(10)]], sampler tex1dSamp [[sampler(0)]], sampler tex2dSamp [[sampler(1)]], sampler tex3dSamp [[sampler(2)]], sampler texCubeSamp [[sampler(3)]], sampler tex2dArraySamp [[sampler(4)]], sampler texCubeArraySamp [[sampler(5)]], sampler depth2dSamp [[sampler(7)]], sampler depthCubeSamp [[sampler(8)]], sampler depth2dArraySamp [[sampler(9)]], sampler depthCubeArraySamp [[sampler(10)]])
 {
-    constant uint32_t& tex1dSwzl = spvAuxBuffer.swizzleConst[0];
-    constant uint32_t& tex2dSwzl = spvAuxBuffer.swizzleConst[1];
-    constant uint32_t& tex3dSwzl = spvAuxBuffer.swizzleConst[2];
-    constant uint32_t& texCubeSwzl = spvAuxBuffer.swizzleConst[3];
-    constant uint32_t& tex2dArraySwzl = spvAuxBuffer.swizzleConst[4];
-    constant uint32_t& texCubeArraySwzl = spvAuxBuffer.swizzleConst[5];
-    constant uint32_t& depth2dSwzl = spvAuxBuffer.swizzleConst[7];
-    constant uint32_t& depthCubeSwzl = spvAuxBuffer.swizzleConst[8];
-    constant uint32_t& depth2dArraySwzl = spvAuxBuffer.swizzleConst[9];
-    constant uint32_t& depthCubeArraySwzl = spvAuxBuffer.swizzleConst[10];
+    constant uint32_t& tex1dSwzl = spvSwizzleConstants[0];
+    constant uint32_t& tex2dSwzl = spvSwizzleConstants[1];
+    constant uint32_t& tex3dSwzl = spvSwizzleConstants[2];
+    constant uint32_t& texCubeSwzl = spvSwizzleConstants[3];
+    constant uint32_t& tex2dArraySwzl = spvSwizzleConstants[4];
+    constant uint32_t& texCubeArraySwzl = spvSwizzleConstants[5];
+    constant uint32_t& depth2dSwzl = spvSwizzleConstants[7];
+    constant uint32_t& depthCubeSwzl = spvSwizzleConstants[8];
+    constant uint32_t& depth2dArraySwzl = spvSwizzleConstants[9];
+    constant uint32_t& depthCubeArraySwzl = spvSwizzleConstants[10];
     float4 c = spvTextureSwizzle(tex1d.sample(tex1dSamp, 0.0), tex1dSwzl);
     c = spvTextureSwizzle(tex2d.sample(tex2dSamp, float2(0.0)), tex2dSwzl);
     c = spvTextureSwizzle(tex3d.sample(tex3dSamp, float3(0.0)), tex3dSwzl);

--- a/reference/shaders-msl-no-opt/frag/texture-access-int.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access-int.swizzle.frag
@@ -5,11 +5,6 @@
 
 using namespace metal;
 
-struct spvAux
-{
-    uint swizzleConst[1];
-};
-
 // Returns 2D texture coords corresponding to 1D texel buffer coords
 uint2 spvTexelBufferCoord(uint tc)
 {
@@ -136,14 +131,14 @@ inline vec<T, 4> spvGatherCompareSwizzle(sampler s, const thread Tex& t, Ts... p
     return t.gather_compare(s, spvForward<Ts>(params)...);
 }
 
-fragment void main0(constant spvAux& spvAuxBuffer [[buffer(30)]], texture1d<int> tex1d [[texture(0)]], texture2d<int> tex2d [[texture(1)]], texture3d<int> tex3d [[texture(2)]], texturecube<int> texCube [[texture(3)]], texture2d_array<int> tex2dArray [[texture(4)]], texturecube_array<int> texCubeArray [[texture(5)]], texture2d<int> texBuffer [[texture(6)]], sampler tex1dSmplr [[sampler(0)]], sampler tex2dSmplr [[sampler(1)]], sampler tex3dSmplr [[sampler(2)]], sampler texCubeSmplr [[sampler(3)]], sampler tex2dArraySmplr [[sampler(4)]], sampler texCubeArraySmplr [[sampler(5)]])
+fragment void main0(constant uint* spvSwizzleConstants [[buffer(30)]], texture1d<int> tex1d [[texture(0)]], texture2d<int> tex2d [[texture(1)]], texture3d<int> tex3d [[texture(2)]], texturecube<int> texCube [[texture(3)]], texture2d_array<int> tex2dArray [[texture(4)]], texturecube_array<int> texCubeArray [[texture(5)]], texture2d<int> texBuffer [[texture(6)]], sampler tex1dSmplr [[sampler(0)]], sampler tex2dSmplr [[sampler(1)]], sampler tex3dSmplr [[sampler(2)]], sampler texCubeSmplr [[sampler(3)]], sampler tex2dArraySmplr [[sampler(4)]], sampler texCubeArraySmplr [[sampler(5)]])
 {
-    constant uint32_t& tex1dSwzl = spvAuxBuffer.swizzleConst[0];
-    constant uint32_t& tex2dSwzl = spvAuxBuffer.swizzleConst[1];
-    constant uint32_t& tex3dSwzl = spvAuxBuffer.swizzleConst[2];
-    constant uint32_t& texCubeSwzl = spvAuxBuffer.swizzleConst[3];
-    constant uint32_t& tex2dArraySwzl = spvAuxBuffer.swizzleConst[4];
-    constant uint32_t& texCubeArraySwzl = spvAuxBuffer.swizzleConst[5];
+    constant uint32_t& tex1dSwzl = spvSwizzleConstants[0];
+    constant uint32_t& tex2dSwzl = spvSwizzleConstants[1];
+    constant uint32_t& tex3dSwzl = spvSwizzleConstants[2];
+    constant uint32_t& texCubeSwzl = spvSwizzleConstants[3];
+    constant uint32_t& tex2dArraySwzl = spvSwizzleConstants[4];
+    constant uint32_t& texCubeArraySwzl = spvSwizzleConstants[5];
     float4 c = float4(spvTextureSwizzle(tex1d.sample(tex1dSmplr, 0.0), tex1dSwzl));
     c = float4(spvTextureSwizzle(tex2d.sample(tex2dSmplr, float2(0.0)), tex2dSwzl));
     c = float4(spvTextureSwizzle(tex3d.sample(tex3dSmplr, float3(0.0)), tex3dSwzl));

--- a/reference/shaders-msl-no-opt/frag/texture-access-leaf.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access-leaf.swizzle.frag
@@ -5,11 +5,6 @@
 
 using namespace metal;
 
-struct spvAux
-{
-    uint swizzleConst[1];
-};
-
 // Returns 2D texture coords corresponding to 1D texel buffer coords
 uint2 spvTexelBufferCoord(uint tc)
 {
@@ -183,18 +178,18 @@ float4 doSwizzle(thread texture1d<float> tex1d, thread const sampler tex1dSmplr,
     return c;
 }
 
-fragment void main0(constant spvAux& spvAuxBuffer [[buffer(30)]], texture1d<float> tex1d [[texture(0)]], texture2d<float> tex2d [[texture(1)]], texture3d<float> tex3d [[texture(2)]], texturecube<float> texCube [[texture(3)]], texture2d_array<float> tex2dArray [[texture(4)]], texturecube_array<float> texCubeArray [[texture(5)]], texture2d<float> texBuffer [[texture(6)]], depth2d<float> depth2d [[texture(7)]], depthcube<float> depthCube [[texture(8)]], depth2d_array<float> depth2dArray [[texture(9)]], depthcube_array<float> depthCubeArray [[texture(10)]], sampler tex1dSmplr [[sampler(0)]], sampler tex2dSmplr [[sampler(1)]], sampler tex3dSmplr [[sampler(2)]], sampler texCubeSmplr [[sampler(3)]], sampler tex2dArraySmplr [[sampler(4)]], sampler texCubeArraySmplr [[sampler(5)]], sampler depth2dSmplr [[sampler(7)]], sampler depthCubeSmplr [[sampler(8)]], sampler depth2dArraySmplr [[sampler(9)]], sampler depthCubeArraySmplr [[sampler(10)]])
+fragment void main0(constant uint* spvSwizzleConstants [[buffer(30)]], texture1d<float> tex1d [[texture(0)]], texture2d<float> tex2d [[texture(1)]], texture3d<float> tex3d [[texture(2)]], texturecube<float> texCube [[texture(3)]], texture2d_array<float> tex2dArray [[texture(4)]], texturecube_array<float> texCubeArray [[texture(5)]], texture2d<float> texBuffer [[texture(6)]], depth2d<float> depth2d [[texture(7)]], depthcube<float> depthCube [[texture(8)]], depth2d_array<float> depth2dArray [[texture(9)]], depthcube_array<float> depthCubeArray [[texture(10)]], sampler tex1dSmplr [[sampler(0)]], sampler tex2dSmplr [[sampler(1)]], sampler tex3dSmplr [[sampler(2)]], sampler texCubeSmplr [[sampler(3)]], sampler tex2dArraySmplr [[sampler(4)]], sampler texCubeArraySmplr [[sampler(5)]], sampler depth2dSmplr [[sampler(7)]], sampler depthCubeSmplr [[sampler(8)]], sampler depth2dArraySmplr [[sampler(9)]], sampler depthCubeArraySmplr [[sampler(10)]])
 {
-    constant uint32_t& tex1dSwzl = spvAuxBuffer.swizzleConst[0];
-    constant uint32_t& tex2dSwzl = spvAuxBuffer.swizzleConst[1];
-    constant uint32_t& tex3dSwzl = spvAuxBuffer.swizzleConst[2];
-    constant uint32_t& texCubeSwzl = spvAuxBuffer.swizzleConst[3];
-    constant uint32_t& tex2dArraySwzl = spvAuxBuffer.swizzleConst[4];
-    constant uint32_t& texCubeArraySwzl = spvAuxBuffer.swizzleConst[5];
-    constant uint32_t& depth2dSwzl = spvAuxBuffer.swizzleConst[7];
-    constant uint32_t& depthCubeSwzl = spvAuxBuffer.swizzleConst[8];
-    constant uint32_t& depth2dArraySwzl = spvAuxBuffer.swizzleConst[9];
-    constant uint32_t& depthCubeArraySwzl = spvAuxBuffer.swizzleConst[10];
+    constant uint32_t& tex1dSwzl = spvSwizzleConstants[0];
+    constant uint32_t& tex2dSwzl = spvSwizzleConstants[1];
+    constant uint32_t& tex3dSwzl = spvSwizzleConstants[2];
+    constant uint32_t& texCubeSwzl = spvSwizzleConstants[3];
+    constant uint32_t& tex2dArraySwzl = spvSwizzleConstants[4];
+    constant uint32_t& texCubeArraySwzl = spvSwizzleConstants[5];
+    constant uint32_t& depth2dSwzl = spvSwizzleConstants[7];
+    constant uint32_t& depthCubeSwzl = spvSwizzleConstants[8];
+    constant uint32_t& depth2dArraySwzl = spvSwizzleConstants[9];
+    constant uint32_t& depthCubeArraySwzl = spvSwizzleConstants[10];
     float4 c = doSwizzle(tex1d, tex1dSmplr, tex1dSwzl, tex2d, tex2dSmplr, tex2dSwzl, tex3d, tex3dSmplr, tex3dSwzl, texCube, texCubeSmplr, texCubeSwzl, tex2dArray, tex2dArraySmplr, tex2dArraySwzl, texCubeArray, texCubeArraySmplr, texCubeArraySwzl, depth2d, depth2dSmplr, depth2dSwzl, depthCube, depthCubeSmplr, depthCubeSwzl, depth2dArray, depth2dArraySmplr, depth2dArraySwzl, depthCubeArray, depthCubeArraySmplr, depthCubeArraySwzl, texBuffer);
 }
 

--- a/reference/shaders-msl-no-opt/frag/texture-access-uint.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access-uint.swizzle.frag
@@ -5,11 +5,6 @@
 
 using namespace metal;
 
-struct spvAux
-{
-    uint swizzleConst[1];
-};
-
 // Returns 2D texture coords corresponding to 1D texel buffer coords
 uint2 spvTexelBufferCoord(uint tc)
 {
@@ -136,14 +131,14 @@ inline vec<T, 4> spvGatherCompareSwizzle(sampler s, const thread Tex& t, Ts... p
     return t.gather_compare(s, spvForward<Ts>(params)...);
 }
 
-fragment void main0(constant spvAux& spvAuxBuffer [[buffer(30)]], texture1d<uint> tex1d [[texture(0)]], texture2d<uint> tex2d [[texture(1)]], texture3d<uint> tex3d [[texture(2)]], texturecube<uint> texCube [[texture(3)]], texture2d_array<uint> tex2dArray [[texture(4)]], texturecube_array<uint> texCubeArray [[texture(5)]], texture2d<uint> texBuffer [[texture(6)]], sampler tex1dSmplr [[sampler(0)]], sampler tex2dSmplr [[sampler(1)]], sampler tex3dSmplr [[sampler(2)]], sampler texCubeSmplr [[sampler(3)]], sampler tex2dArraySmplr [[sampler(4)]], sampler texCubeArraySmplr [[sampler(5)]])
+fragment void main0(constant uint* spvSwizzleConstants [[buffer(30)]], texture1d<uint> tex1d [[texture(0)]], texture2d<uint> tex2d [[texture(1)]], texture3d<uint> tex3d [[texture(2)]], texturecube<uint> texCube [[texture(3)]], texture2d_array<uint> tex2dArray [[texture(4)]], texturecube_array<uint> texCubeArray [[texture(5)]], texture2d<uint> texBuffer [[texture(6)]], sampler tex1dSmplr [[sampler(0)]], sampler tex2dSmplr [[sampler(1)]], sampler tex3dSmplr [[sampler(2)]], sampler texCubeSmplr [[sampler(3)]], sampler tex2dArraySmplr [[sampler(4)]], sampler texCubeArraySmplr [[sampler(5)]])
 {
-    constant uint32_t& tex1dSwzl = spvAuxBuffer.swizzleConst[0];
-    constant uint32_t& tex2dSwzl = spvAuxBuffer.swizzleConst[1];
-    constant uint32_t& tex3dSwzl = spvAuxBuffer.swizzleConst[2];
-    constant uint32_t& texCubeSwzl = spvAuxBuffer.swizzleConst[3];
-    constant uint32_t& tex2dArraySwzl = spvAuxBuffer.swizzleConst[4];
-    constant uint32_t& texCubeArraySwzl = spvAuxBuffer.swizzleConst[5];
+    constant uint32_t& tex1dSwzl = spvSwizzleConstants[0];
+    constant uint32_t& tex2dSwzl = spvSwizzleConstants[1];
+    constant uint32_t& tex3dSwzl = spvSwizzleConstants[2];
+    constant uint32_t& texCubeSwzl = spvSwizzleConstants[3];
+    constant uint32_t& tex2dArraySwzl = spvSwizzleConstants[4];
+    constant uint32_t& texCubeArraySwzl = spvSwizzleConstants[5];
     float4 c = float4(spvTextureSwizzle(tex1d.sample(tex1dSmplr, 0.0), tex1dSwzl));
     c = float4(spvTextureSwizzle(tex2d.sample(tex2dSmplr, float2(0.0)), tex2dSwzl));
     c = float4(spvTextureSwizzle(tex3d.sample(tex3dSmplr, float3(0.0)), tex3dSwzl));

--- a/reference/shaders-msl-no-opt/frag/texture-access.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access.swizzle.frag
@@ -5,11 +5,6 @@
 
 using namespace metal;
 
-struct spvAux
-{
-    uint swizzleConst[1];
-};
-
 // Returns 2D texture coords corresponding to 1D texel buffer coords
 uint2 spvTexelBufferCoord(uint tc)
 {
@@ -136,18 +131,18 @@ inline vec<T, 4> spvGatherCompareSwizzle(sampler s, const thread Tex& t, Ts... p
     return t.gather_compare(s, spvForward<Ts>(params)...);
 }
 
-fragment void main0(constant spvAux& spvAuxBuffer [[buffer(30)]], texture1d<float> tex1d [[texture(0)]], texture2d<float> tex2d [[texture(1)]], texture3d<float> tex3d [[texture(2)]], texturecube<float> texCube [[texture(3)]], texture2d_array<float> tex2dArray [[texture(4)]], texturecube_array<float> texCubeArray [[texture(5)]], texture2d<float> texBuffer [[texture(6)]], depth2d<float> depth2d [[texture(7)]], depthcube<float> depthCube [[texture(8)]], depth2d_array<float> depth2dArray [[texture(9)]], depthcube_array<float> depthCubeArray [[texture(10)]], sampler tex1dSmplr [[sampler(0)]], sampler tex2dSmplr [[sampler(1)]], sampler tex3dSmplr [[sampler(2)]], sampler texCubeSmplr [[sampler(3)]], sampler tex2dArraySmplr [[sampler(4)]], sampler texCubeArraySmplr [[sampler(5)]], sampler depth2dSmplr [[sampler(7)]], sampler depthCubeSmplr [[sampler(8)]], sampler depth2dArraySmplr [[sampler(9)]], sampler depthCubeArraySmplr [[sampler(10)]])
+fragment void main0(constant uint* spvSwizzleConstants [[buffer(30)]], texture1d<float> tex1d [[texture(0)]], texture2d<float> tex2d [[texture(1)]], texture3d<float> tex3d [[texture(2)]], texturecube<float> texCube [[texture(3)]], texture2d_array<float> tex2dArray [[texture(4)]], texturecube_array<float> texCubeArray [[texture(5)]], texture2d<float> texBuffer [[texture(6)]], depth2d<float> depth2d [[texture(7)]], depthcube<float> depthCube [[texture(8)]], depth2d_array<float> depth2dArray [[texture(9)]], depthcube_array<float> depthCubeArray [[texture(10)]], sampler tex1dSmplr [[sampler(0)]], sampler tex2dSmplr [[sampler(1)]], sampler tex3dSmplr [[sampler(2)]], sampler texCubeSmplr [[sampler(3)]], sampler tex2dArraySmplr [[sampler(4)]], sampler texCubeArraySmplr [[sampler(5)]], sampler depth2dSmplr [[sampler(7)]], sampler depthCubeSmplr [[sampler(8)]], sampler depth2dArraySmplr [[sampler(9)]], sampler depthCubeArraySmplr [[sampler(10)]])
 {
-    constant uint32_t& tex1dSwzl = spvAuxBuffer.swizzleConst[0];
-    constant uint32_t& tex2dSwzl = spvAuxBuffer.swizzleConst[1];
-    constant uint32_t& tex3dSwzl = spvAuxBuffer.swizzleConst[2];
-    constant uint32_t& texCubeSwzl = spvAuxBuffer.swizzleConst[3];
-    constant uint32_t& tex2dArraySwzl = spvAuxBuffer.swizzleConst[4];
-    constant uint32_t& texCubeArraySwzl = spvAuxBuffer.swizzleConst[5];
-    constant uint32_t& depth2dSwzl = spvAuxBuffer.swizzleConst[7];
-    constant uint32_t& depthCubeSwzl = spvAuxBuffer.swizzleConst[8];
-    constant uint32_t& depth2dArraySwzl = spvAuxBuffer.swizzleConst[9];
-    constant uint32_t& depthCubeArraySwzl = spvAuxBuffer.swizzleConst[10];
+    constant uint32_t& tex1dSwzl = spvSwizzleConstants[0];
+    constant uint32_t& tex2dSwzl = spvSwizzleConstants[1];
+    constant uint32_t& tex3dSwzl = spvSwizzleConstants[2];
+    constant uint32_t& texCubeSwzl = spvSwizzleConstants[3];
+    constant uint32_t& tex2dArraySwzl = spvSwizzleConstants[4];
+    constant uint32_t& texCubeArraySwzl = spvSwizzleConstants[5];
+    constant uint32_t& depth2dSwzl = spvSwizzleConstants[7];
+    constant uint32_t& depthCubeSwzl = spvSwizzleConstants[8];
+    constant uint32_t& depth2dArraySwzl = spvSwizzleConstants[9];
+    constant uint32_t& depthCubeArraySwzl = spvSwizzleConstants[10];
     float4 c = spvTextureSwizzle(tex1d.sample(tex1dSmplr, 0.0), tex1dSwzl);
     c = spvTextureSwizzle(tex2d.sample(tex2dSmplr, float2(0.0)), tex2dSwzl);
     c = spvTextureSwizzle(tex3d.sample(tex3dSmplr, float3(0.0)), tex3dSwzl);

--- a/reference/shaders-msl-no-opt/vulkan/frag/texture-access-function.swizzle.vk.frag
+++ b/reference/shaders-msl-no-opt/vulkan/frag/texture-access-function.swizzle.vk.frag
@@ -5,11 +5,6 @@
 
 using namespace metal;
 
-struct spvAux
-{
-    uint swizzleConst[1];
-};
-
 struct main0_out
 {
     float4 fragColor [[color(0)]];
@@ -188,19 +183,19 @@ float4 do_samples(thread const texture1d<float> t1, thread const sampler t1Smplr
     return c;
 }
 
-fragment main0_out main0(constant spvAux& spvAuxBuffer [[buffer(30)]], texture1d<float> tex1d [[texture(0)]], texture2d<float> tex2d [[texture(1)]], texture3d<float> tex3d [[texture(2)]], texturecube<float> texCube [[texture(3)]], texture2d_array<float> tex2dArray [[texture(4)]], texturecube_array<float> texCubeArray [[texture(5)]], texture2d<float> texBuffer [[texture(6)]], depth2d<float> depth2d [[texture(7)]], depthcube<float> depthCube [[texture(8)]], depth2d_array<float> depth2dArray [[texture(9)]], depthcube_array<float> depthCubeArray [[texture(10)]], sampler tex1dSmplr [[sampler(0)]], sampler tex3dSmplr [[sampler(2)]], sampler tex2dArraySmplr [[sampler(4)]], sampler texCubeArraySmplr [[sampler(5)]], sampler depth2dSmplr [[sampler(7)]], sampler depthCubeSmplr [[sampler(8)]], sampler depthCubeArraySmplr [[sampler(10)]], sampler defaultSampler [[sampler(11)]], sampler shadowSampler [[sampler(12)]])
+fragment main0_out main0(constant uint* spvSwizzleConstants [[buffer(30)]], texture1d<float> tex1d [[texture(0)]], texture2d<float> tex2d [[texture(1)]], texture3d<float> tex3d [[texture(2)]], texturecube<float> texCube [[texture(3)]], texture2d_array<float> tex2dArray [[texture(4)]], texturecube_array<float> texCubeArray [[texture(5)]], texture2d<float> texBuffer [[texture(6)]], depth2d<float> depth2d [[texture(7)]], depthcube<float> depthCube [[texture(8)]], depth2d_array<float> depth2dArray [[texture(9)]], depthcube_array<float> depthCubeArray [[texture(10)]], sampler tex1dSmplr [[sampler(0)]], sampler tex3dSmplr [[sampler(2)]], sampler tex2dArraySmplr [[sampler(4)]], sampler texCubeArraySmplr [[sampler(5)]], sampler depth2dSmplr [[sampler(7)]], sampler depthCubeSmplr [[sampler(8)]], sampler depthCubeArraySmplr [[sampler(10)]], sampler defaultSampler [[sampler(11)]], sampler shadowSampler [[sampler(12)]])
 {
     main0_out out = {};
-    constant uint32_t& tex1dSwzl = spvAuxBuffer.swizzleConst[0];
-    constant uint32_t& tex2dSwzl = spvAuxBuffer.swizzleConst[1];
-    constant uint32_t& tex3dSwzl = spvAuxBuffer.swizzleConst[2];
-    constant uint32_t& texCubeSwzl = spvAuxBuffer.swizzleConst[3];
-    constant uint32_t& tex2dArraySwzl = spvAuxBuffer.swizzleConst[4];
-    constant uint32_t& texCubeArraySwzl = spvAuxBuffer.swizzleConst[5];
-    constant uint32_t& depth2dSwzl = spvAuxBuffer.swizzleConst[7];
-    constant uint32_t& depthCubeSwzl = spvAuxBuffer.swizzleConst[8];
-    constant uint32_t& depth2dArraySwzl = spvAuxBuffer.swizzleConst[9];
-    constant uint32_t& depthCubeArraySwzl = spvAuxBuffer.swizzleConst[10];
+    constant uint32_t& tex1dSwzl = spvSwizzleConstants[0];
+    constant uint32_t& tex2dSwzl = spvSwizzleConstants[1];
+    constant uint32_t& tex3dSwzl = spvSwizzleConstants[2];
+    constant uint32_t& texCubeSwzl = spvSwizzleConstants[3];
+    constant uint32_t& tex2dArraySwzl = spvSwizzleConstants[4];
+    constant uint32_t& texCubeArraySwzl = spvSwizzleConstants[5];
+    constant uint32_t& depth2dSwzl = spvSwizzleConstants[7];
+    constant uint32_t& depthCubeSwzl = spvSwizzleConstants[8];
+    constant uint32_t& depth2dArraySwzl = spvSwizzleConstants[9];
+    constant uint32_t& depthCubeArraySwzl = spvSwizzleConstants[10];
     out.fragColor = do_samples(tex1d, tex1dSmplr, tex1dSwzl, tex2d, tex2dSwzl, tex3d, tex3dSmplr, tex3dSwzl, texCube, texCubeSwzl, tex2dArray, tex2dArraySmplr, tex2dArraySwzl, texCubeArray, texCubeArraySmplr, texCubeArraySwzl, texBuffer, depth2d, depth2dSmplr, depth2dSwzl, depthCube, depthCubeSmplr, depthCubeSwzl, depth2dArray, depth2dArraySwzl, depthCubeArray, depthCubeArraySmplr, depthCubeArraySwzl, defaultSampler, shadowSampler);
     return out;
 }

--- a/reference/shaders-msl/comp/force-recompile-hooks.swizzle.comp
+++ b/reference/shaders-msl/comp/force-recompile-hooks.swizzle.comp
@@ -5,11 +5,6 @@
 
 using namespace metal;
 
-struct spvAux
-{
-    uint swizzleConst[1];
-};
-
 enum class spvSwizzle : uint
 {
     none = 0,
@@ -130,9 +125,9 @@ inline vec<T, 4> spvGatherCompareSwizzle(sampler s, const thread Tex& t, Ts... p
     return t.gather_compare(s, spvForward<Ts>(params)...);
 }
 
-kernel void main0(constant spvAux& spvAuxBuffer [[buffer(30)]], texture2d<float> foo [[texture(0)]], texture2d<float, access::write> bar [[texture(1)]], sampler fooSmplr [[sampler(0)]])
+kernel void main0(constant uint* spvSwizzleConstants [[buffer(30)]], texture2d<float> foo [[texture(0)]], texture2d<float, access::write> bar [[texture(1)]], sampler fooSmplr [[sampler(0)]])
 {
-    constant uint32_t& fooSwzl = spvAuxBuffer.swizzleConst[0];
+    constant uint32_t& fooSwzl = spvSwizzleConstants[0];
     float4 a = spvTextureSwizzle(foo.sample(fooSmplr, float2(1.0), level(0.0)), fooSwzl);
     bar.write(a, uint2(int2(0)));
 }

--- a/reference/shaders-msl/frag/array-of-texture-swizzle.msl2.argument.discrete.swizzle.frag
+++ b/reference/shaders-msl/frag/array-of-texture-swizzle.msl2.argument.discrete.swizzle.frag
@@ -5,6 +5,13 @@
 
 using namespace metal;
 
+struct spvDescriptorSetBuffer0
+{
+    constant uint* spvSwizzleConstants [[id(0)]];
+    array<texture2d<float>, 4> uSampler0 [[id(1)]];
+    array<sampler, 4> uSampler0Smplr [[id(5)]];
+};
+
 struct main0_out
 {
     float4 FragColor [[color(0)]];
@@ -135,9 +142,14 @@ inline vec<T, 4> spvGatherCompareSwizzle(sampler s, const thread Tex& t, Ts... p
     return t.gather_compare(s, spvForward<Ts>(params)...);
 }
 
-float4 sample_in_func(thread const array<texture2d<float>, 4> uSampler, thread const array<sampler, 4> uSamplerSmplr, constant uint32_t* uSamplerSwzl, thread float2& vUV)
+float4 sample_in_func_1(thread const array<texture2d<float>, 4> uSampler0, thread const array<sampler, 4> uSampler0Smplr, constant uint32_t* uSampler0Swzl, thread float2& vUV)
 {
-    return spvTextureSwizzle(uSampler[2].sample(uSamplerSmplr[2], vUV), uSamplerSwzl[2]);
+    return spvTextureSwizzle(uSampler0[2].sample(uSampler0Smplr[2], vUV), uSampler0Swzl[2]);
+}
+
+float4 sample_in_func_2(thread float2& vUV, thread texture2d<float> uSampler1, thread const sampler uSampler1Smplr, constant uint32_t& uSampler1Swzl)
+{
+    return spvTextureSwizzle(uSampler1.sample(uSampler1Smplr, vUV), uSampler1Swzl);
 }
 
 float4 sample_single_in_func(thread const texture2d<float> s, thread const sampler sSmplr, constant uint32_t& sSwzl, thread float2& vUV)
@@ -145,12 +157,15 @@ float4 sample_single_in_func(thread const texture2d<float> s, thread const sampl
     return spvTextureSwizzle(s.sample(sSmplr, vUV), sSwzl);
 }
 
-fragment main0_out main0(main0_in in [[stage_in]], constant uint* spvSwizzleConstants [[buffer(30)]], array<texture2d<float>, 4> uSampler [[texture(0)]], array<sampler, 4> uSamplerSmplr [[sampler(0)]])
+fragment main0_out main0(main0_in in [[stage_in]], constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], constant uint* spvSwizzleConstants [[buffer(30)]], texture2d<float> uSampler1 [[texture(0)]], sampler uSampler1Smplr [[sampler(0)]])
 {
     main0_out out = {};
-    constant uint32_t* uSamplerSwzl = &spvSwizzleConstants[0];
-    out.FragColor = sample_in_func(uSampler, uSamplerSmplr, uSamplerSwzl, in.vUV);
-    out.FragColor += sample_single_in_func(uSampler[1], uSamplerSmplr[1], uSamplerSwzl[1], in.vUV);
+    constant uint32_t* spvDescriptorSet0_uSampler0Swzl = &spvDescriptorSet0.spvSwizzleConstants[1];
+    constant uint32_t& uSampler1Swzl = spvSwizzleConstants[0];
+    out.FragColor = sample_in_func_1(spvDescriptorSet0.uSampler0, spvDescriptorSet0.uSampler0Smplr, spvDescriptorSet0_uSampler0Swzl, in.vUV);
+    out.FragColor += sample_in_func_2(in.vUV, uSampler1, uSampler1Smplr, uSampler1Swzl);
+    out.FragColor += sample_single_in_func(spvDescriptorSet0.uSampler0[1], spvDescriptorSet0.uSampler0Smplr[1], spvDescriptorSet0_uSampler0Swzl[1], in.vUV);
+    out.FragColor += sample_single_in_func(uSampler1, uSampler1Smplr, uSampler1Swzl, in.vUV);
     return out;
 }
 

--- a/shaders-msl/frag/array-of-texture-swizzle.msl2.argument.discrete.swizzle.frag
+++ b/shaders-msl/frag/array-of-texture-swizzle.msl2.argument.discrete.swizzle.frag
@@ -1,0 +1,31 @@
+#version 450
+
+layout(set = 0, binding = 1) uniform sampler2D uSampler0[4];
+layout(set = 2, binding = 0) uniform sampler2D uSampler1;
+layout(set = 1, binding = 4) uniform sampler2D uSamp;
+layout(location = 0) in vec2 vUV;
+
+layout(location = 0) out vec4 FragColor;
+
+vec4 sample_in_func_1()
+{
+	return texture(uSampler0[2], vUV);
+}
+
+vec4 sample_in_func_2()
+{
+	return texture(uSampler1, vUV);
+}
+
+vec4 sample_single_in_func(sampler2D s)
+{
+	return texture(s, vUV);
+}
+
+void main()
+{
+	FragColor = sample_in_func_1();
+	FragColor += sample_in_func_2();
+	FragColor += sample_single_in_func(uSampler0[1]);
+	FragColor += sample_single_in_func(uSampler1);
+}

--- a/spirv_cross_c.cpp
+++ b/spirv_cross_c.cpp
@@ -474,8 +474,8 @@ spvc_result spvc_compiler_options_set_uint(spvc_compiler_options options, spvc_c
 		options->msl.texel_buffer_texture_width = value;
 		break;
 
-	case SPVC_COMPILER_OPTION_MSL_AUX_BUFFER_INDEX:
-		options->msl.aux_buffer_index = value;
+	case SPVC_COMPILER_OPTION_MSL_SWIZZLE_BUFFER_INDEX:
+		options->msl.swizzle_buffer_index = value;
 		break;
 
 	case SPVC_COMPILER_OPTION_MSL_INDIRECT_PARAMS_BUFFER_INDEX:
@@ -726,7 +726,7 @@ spvc_bool spvc_compiler_msl_is_rasterization_disabled(spvc_compiler compiler)
 #endif
 }
 
-spvc_bool spvc_compiler_msl_needs_aux_buffer(spvc_compiler compiler)
+spvc_bool spvc_compiler_msl_needs_swizzle_buffer(spvc_compiler compiler)
 {
 #if SPIRV_CROSS_C_API_MSL
 	if (compiler->backend != SPVC_BACKEND_MSL)
@@ -736,11 +736,16 @@ spvc_bool spvc_compiler_msl_needs_aux_buffer(spvc_compiler compiler)
 	}
 
 	auto &msl = *static_cast<CompilerMSL *>(compiler->compiler.get());
-	return msl.needs_aux_buffer() ? SPVC_TRUE : SPVC_FALSE;
+	return msl.needs_swizzle_buffer() ? SPVC_TRUE : SPVC_FALSE;
 #else
 	compiler->context->report_error("MSL function used on a non-MSL backend.");
 	return SPVC_FALSE;
 #endif
+}
+
+spvc_bool spvc_compiler_msl_needs_aux_buffer(spvc_compiler compiler)
+{
+	return spvc_compiler_msl_needs_swizzle_buffer(compiler);
 }
 
 spvc_bool spvc_compiler_msl_needs_output_buffer(spvc_compiler compiler)

--- a/spirv_cross_c.h
+++ b/spirv_cross_c.h
@@ -33,7 +33,7 @@ extern "C" {
 /* Bumped if ABI or API breaks backwards compatibility. */
 #define SPVC_C_API_VERSION_MAJOR 0
 /* Bumped if APIs or enumerations are added in a backwards compatible way. */
-#define SPVC_C_API_VERSION_MINOR 7
+#define SPVC_C_API_VERSION_MINOR 8
 /* Bumped if internal implementation details change. */
 #define SPVC_C_API_VERSION_PATCH 0
 
@@ -290,9 +290,12 @@ SPVC_PUBLIC_API void spvc_msl_resource_binding_init(spvc_msl_resource_binding *b
 
 #define SPVC_MSL_PUSH_CONSTANT_DESC_SET (~(0u))
 #define SPVC_MSL_PUSH_CONSTANT_BINDING (0)
+#define SPVC_MSL_SWIZZLE_BUFFER_BINDING (~(1u))
+
+/* Obsolete. Sticks around for backwards compatibility. */
 #define SPVC_MSL_AUX_BUFFER_STRUCT_VERSION 1
 
-/* Runtime check for incompatibility. */
+/* Runtime check for incompatibility. Obsolete. */
 SPVC_PUBLIC_API unsigned spvc_msl_get_aux_buffer_struct_version(void);
 
 /* Maps to C++ API. */
@@ -407,7 +410,11 @@ typedef enum spvc_compiler_option
 
 	SPVC_COMPILER_OPTION_MSL_VERSION = 17 | SPVC_COMPILER_OPTION_MSL_BIT,
 	SPVC_COMPILER_OPTION_MSL_TEXEL_BUFFER_TEXTURE_WIDTH = 18 | SPVC_COMPILER_OPTION_MSL_BIT,
+
+	/* Obsolete, use SWIZZLE_BUFFER_INDEX instead. */
 	SPVC_COMPILER_OPTION_MSL_AUX_BUFFER_INDEX = 19 | SPVC_COMPILER_OPTION_MSL_BIT,
+	SPVC_COMPILER_OPTION_MSL_SWIZZLE_BUFFER_INDEX = 19 | SPVC_COMPILER_OPTION_MSL_BIT,
+
 	SPVC_COMPILER_OPTION_MSL_INDIRECT_PARAMS_BUFFER_INDEX = 20 | SPVC_COMPILER_OPTION_MSL_BIT,
 	SPVC_COMPILER_OPTION_MSL_SHADER_OUTPUT_BUFFER_INDEX = 21 | SPVC_COMPILER_OPTION_MSL_BIT,
 	SPVC_COMPILER_OPTION_MSL_SHADER_PATCH_OUTPUT_BUFFER_INDEX = 22 | SPVC_COMPILER_OPTION_MSL_BIT,
@@ -505,7 +512,11 @@ SPVC_PUBLIC_API spvc_variable_id spvc_compiler_hlsl_remap_num_workgroups_builtin
  * Maps to C++ API.
  */
 SPVC_PUBLIC_API spvc_bool spvc_compiler_msl_is_rasterization_disabled(spvc_compiler compiler);
+
+/* Obsolete. Renamed to needs_swizzle_buffer. */
 SPVC_PUBLIC_API spvc_bool spvc_compiler_msl_needs_aux_buffer(spvc_compiler compiler);
+SPVC_PUBLIC_API spvc_bool spvc_compiler_msl_needs_swizzle_buffer(spvc_compiler compiler);
+
 SPVC_PUBLIC_API spvc_bool spvc_compiler_msl_needs_output_buffer(spvc_compiler compiler);
 SPVC_PUBLIC_API spvc_bool spvc_compiler_msl_needs_patch_output_buffer(spvc_compiler compiler);
 SPVC_PUBLIC_API spvc_bool spvc_compiler_msl_needs_input_threadgroup_mem(spvc_compiler compiler);

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -152,11 +152,11 @@ static const uint32_t kPushConstDescSet = ~(0u);
 // element to indicate the bindings for the push constants.
 static const uint32_t kPushConstBinding = 0;
 
-static const uint32_t kMaxArgumentBuffers = 8;
+// Special constant used in a MSLResourceBinding binding
+// element to indicate the buffer binding for swizzle buffers.
+static const uint32_t kSwizzleBufferBinding = ~(1u);
 
-// The current version of the aux buffer structure. It must be incremented any time a
-// new field is added to the aux buffer.
-#define SPIRV_CROSS_MSL_AUX_BUFFER_STRUCT_VERSION 1
+static const uint32_t kMaxArgumentBuffers = 8;
 
 // Decompiles SPIR-V to Metal Shading Language
 class CompilerMSL : public CompilerGLSL
@@ -174,7 +174,7 @@ public:
 		Platform platform = macOS;
 		uint32_t msl_version = make_msl_version(1, 2);
 		uint32_t texel_buffer_texture_width = 4096; // Width of 2D Metal textures used as 1D texel buffers
-		uint32_t aux_buffer_index = 30;
+		uint32_t swizzle_buffer_index = 30;
 		uint32_t indirect_params_buffer_index = 29;
 		uint32_t shader_output_buffer_index = 28;
 		uint32_t shader_patch_output_buffer_index = 27;
@@ -243,10 +243,10 @@ public:
 	}
 
 	// Provide feedback to calling API to allow it to pass an auxiliary
-	// buffer if the shader needs it.
-	bool needs_aux_buffer() const
+	// swizzle buffer if the shader needs it.
+	bool needs_swizzle_buffer() const
 	{
-		return used_aux_buffer;
+		return used_swizzle_buffer;
 	}
 
 	// Provide feedback to calling API to allow it to pass an output
@@ -486,7 +486,7 @@ protected:
 	uint32_t builtin_primitive_id_id = 0;
 	uint32_t builtin_subgroup_invocation_id_id = 0;
 	uint32_t builtin_subgroup_size_id = 0;
-	uint32_t aux_buffer_id = 0;
+	uint32_t swizzle_buffer_id = 0;
 
 	void bitcast_to_builtin_store(uint32_t target_id, std::string &expr, const SPIRType &expr_type) override;
 	void bitcast_from_builtin_load(uint32_t source_id, std::string &expr, const SPIRType &expr_type) override;
@@ -524,8 +524,8 @@ protected:
 	bool needs_instance_idx_arg = false;
 	bool is_rasterization_disabled = false;
 	bool capture_output_to_buffer = false;
-	bool needs_aux_buffer_def = false;
-	bool used_aux_buffer = false;
+	bool needs_swizzle_buffer_def = false;
+	bool used_swizzle_buffer = false;
 	bool added_builtin_tess_level = false;
 	bool needs_subgroup_invocation_id = false;
 	std::string qual_pos_var_name;


### PR DESCRIPTION
There is no good reason to expand the aux buffer, so name it
appropriately.

Make the code cleaner by emitting a straight pointer to uint rather than
a dummy struct which only contains a single unsized array member anyways.

Implement support for argument buffers when using image swizzle workaround.

Fix #972.