### PR TITLE
MSL: Stop exiting early from extra tesc instances.

### DIFF
--- a/reference/opt/shaders-msl/asm/tesc/tess-fixed-input-array-builtin-array.invalid.asm.tesc
+++ b/reference/opt/shaders-msl/asm/tesc/tess-fixed-input-array-builtin-array.invalid.asm.tesc
@@ -52,22 +52,38 @@ kernel void main0(main0_in in [[stage_in]], uint gl_InvocationID [[thread_index_
     if (gl_InvocationID < spvIndirectParams[0])
         gl_in[gl_InvocationID] = in;
     threadgroup_barrier(mem_flags::mem_threadgroup);
-    if (gl_InvocationID >= 3)
-        return;
     VertexOutput _223[3] = { VertexOutput{ gl_in[0].gl_Position, gl_in[0].VertexOutput_uv }, VertexOutput{ gl_in[1].gl_Position, gl_in[1].VertexOutput_uv }, VertexOutput{ gl_in[2].gl_Position, gl_in[2].VertexOutput_uv } };
     VertexOutput param[3];
     spvArrayCopyFromStack1(param, _223);
-    gl_out[gl_InvocationID].gl_Position = param[gl_InvocationID].pos;
-    gl_out[gl_InvocationID]._entryPointOutput.uv = param[gl_InvocationID].uv;
+    if (gl_InvocationID < 3)
+    {
+        gl_out[gl_InvocationID].gl_Position = param[gl_InvocationID].pos;
+    }
+    if (gl_InvocationID < 3)
+    {
+        gl_out[gl_InvocationID]._entryPointOutput.uv = param[gl_InvocationID].uv;
+    }
     threadgroup_barrier(mem_flags::mem_device);
     if (int(gl_InvocationID) == 0)
     {
         float2 _174 = float2(1.0) + gl_in[0].VertexOutput_uv;
         float _175 = _174.x;
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(_175);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(_175);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(_175);
-        spvTessLevel[gl_PrimitiveID].insideTessellationFactor = half(_175);
+        if (gl_InvocationID < 3)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(_175);
+        }
+        if (gl_InvocationID < 3)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(_175);
+        }
+        if (gl_InvocationID < 3)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(_175);
+        }
+        if (gl_InvocationID < 3)
+        {
+            spvTessLevel[gl_PrimitiveID].insideTessellationFactor = half(_175);
+        }
     }
 }
 

--- a/reference/opt/shaders-msl/asm/tesc/tess-level-overrun.asm.tesc
+++ b/reference/opt/shaders-msl/asm/tesc/tess-level-overrun.asm.tesc
@@ -15,9 +15,21 @@ struct TessLevels
 
 kernel void main0(const device TessLevels& sb_levels [[buffer(0)]], uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], constant uint* spvIndirectParams [[buffer(29)]], device MTLTriangleTessellationFactorsHalf* spvTessLevel [[buffer(26)]])
 {
-    spvTessLevel[gl_PrimitiveID].insideTessellationFactor = half(sb_levels.inner0);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(sb_levels.outer0);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(sb_levels.outer1);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(sb_levels.outer2);
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor = half(sb_levels.inner0);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(sb_levels.outer0);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(sb_levels.outer1);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(sb_levels.outer2);
+    }
 }
 

--- a/reference/opt/shaders-msl/desktop-only/tesc/arrayed-output.desktop.sso.tesc
+++ b/reference/opt/shaders-msl/desktop-only/tesc/arrayed-output.desktop.sso.tesc
@@ -25,20 +25,45 @@ kernel void main0(main0_in in [[stage_in]], uint gl_InvocationID [[thread_index_
     if (gl_InvocationID < spvIndirectParams[0])
         gl_in[gl_InvocationID] = in;
     threadgroup_barrier(mem_flags::mem_threadgroup);
-    if (gl_InvocationID >= 4)
-        return;
-    gl_out[gl_InvocationID].vVertex = gl_in[gl_InvocationID].vInput + gl_in[gl_InvocationID ^ 1].vInput;
+    if (gl_InvocationID < 4)
+    {
+        gl_out[gl_InvocationID].vVertex = gl_in[gl_InvocationID].vInput + gl_in[gl_InvocationID ^ 1].vInput;
+    }
     threadgroup_barrier(mem_flags::mem_device);
     if (gl_InvocationID == 0)
     {
-        patchOut.vPatch[0] = float3(10.0);
-        patchOut.vPatch[1] = float3(20.0);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(1.0);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(2.0);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(3.0);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(4.0);
-        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(1.0);
-        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(2.0);
+        if (gl_InvocationID < 4)
+        {
+            patchOut.vPatch[0] = float3(10.0);
+        }
+        if (gl_InvocationID < 4)
+        {
+            patchOut.vPatch[1] = float3(20.0);
+        }
+        if (gl_InvocationID < 4)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(1.0);
+        }
+        if (gl_InvocationID < 4)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(2.0);
+        }
+        if (gl_InvocationID < 4)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(3.0);
+        }
+        if (gl_InvocationID < 4)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(4.0);
+        }
+        if (gl_InvocationID < 4)
+        {
+            spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(1.0);
+        }
+        if (gl_InvocationID < 4)
+        {
+            spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(2.0);
+        }
     }
 }
 

--- a/reference/opt/shaders-msl/desktop-only/tesc/basic.desktop.sso.tesc
+++ b/reference/opt/shaders-msl/desktop-only/tesc/basic.desktop.sso.tesc
@@ -25,15 +25,37 @@ kernel void main0(main0_in in [[stage_in]], uint gl_InvocationID [[thread_index_
     if (gl_InvocationID < spvIndirectParams[0])
         gl_in[gl_InvocationID] = in;
     threadgroup_barrier(mem_flags::mem_threadgroup);
-    if (gl_InvocationID >= 1)
-        return;
-    spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(8.8999996185302734375);
-    spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(6.900000095367431640625);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(8.8999996185302734375);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(6.900000095367431640625);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(3.900000095367431640625);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(4.900000095367431640625);
-    patchOut.vFoo = float3(1.0);
-    gl_out[gl_InvocationID].gl_Position = gl_in[0].gl_Position + gl_in[1].gl_Position;
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(8.8999996185302734375);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(6.900000095367431640625);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(8.8999996185302734375);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(6.900000095367431640625);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(3.900000095367431640625);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(4.900000095367431640625);
+    }
+    if (gl_InvocationID < 1)
+    {
+        patchOut.vFoo = float3(1.0);
+    }
+    if (gl_InvocationID < 1)
+    {
+        gl_out[gl_InvocationID].gl_Position = gl_in[0].gl_Position + gl_in[1].gl_Position;
+    }
 }
 

--- a/reference/opt/shaders-msl/desktop-only/tesc/struct-copy.desktop.sso.tesc
+++ b/reference/opt/shaders-msl/desktop-only/tesc/struct-copy.desktop.sso.tesc
@@ -26,17 +26,36 @@ kernel void main0(main0_in in [[stage_in]], uint gl_InvocationID [[thread_index_
     if (gl_InvocationID < spvIndirectParams[0])
         gl_in[gl_InvocationID] = in;
     threadgroup_barrier(mem_flags::mem_threadgroup);
-    if (gl_InvocationID >= 4)
-        return;
     Boo vInput_24;
     vInput_24.a = gl_in[gl_InvocationID].Boo_a;
     vInput_24.b = gl_in[gl_InvocationID].Boo_b;
-    gl_out[gl_InvocationID].vVertex = vInput_24;
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(1.0);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(2.0);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(3.0);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(4.0);
-    spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(1.0);
-    spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(2.0);
+    if (gl_InvocationID < 4)
+    {
+        gl_out[gl_InvocationID].vVertex = vInput_24;
+    }
+    if (gl_InvocationID < 4)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(1.0);
+    }
+    if (gl_InvocationID < 4)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(2.0);
+    }
+    if (gl_InvocationID < 4)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(3.0);
+    }
+    if (gl_InvocationID < 4)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(4.0);
+    }
+    if (gl_InvocationID < 4)
+    {
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(1.0);
+    }
+    if (gl_InvocationID < 4)
+    {
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(2.0);
+    }
 }
 

--- a/reference/opt/shaders-msl/tesc/basic.tesc
+++ b/reference/opt/shaders-msl/tesc/basic.tesc
@@ -11,12 +11,33 @@ struct main0_patchOut
 kernel void main0(uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], constant uint* spvIndirectParams [[buffer(29)]], device main0_patchOut* spvPatchOut [[buffer(27)]], device MTLQuadTessellationFactorsHalf* spvTessLevel [[buffer(26)]])
 {
     device main0_patchOut& patchOut = spvPatchOut[gl_PrimitiveID];
-    spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(8.8999996185302734375);
-    spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(6.900000095367431640625);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(8.8999996185302734375);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(6.900000095367431640625);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(3.900000095367431640625);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(4.900000095367431640625);
-    patchOut.vFoo = float3(1.0);
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(8.8999996185302734375);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(6.900000095367431640625);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(8.8999996185302734375);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(6.900000095367431640625);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(3.900000095367431640625);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(4.900000095367431640625);
+    }
+    if (gl_InvocationID < 1)
+    {
+        patchOut.vFoo = float3(1.0);
+    }
 }
 

--- a/reference/opt/shaders-msl/tesc/storage.tesc
+++ b/reference/opt/shaders-msl/tesc/storage.tesc
@@ -3,14 +3,13 @@
 
 using namespace metal;
 
-struct main0_patchOut
+struct StorageBuffer
 {
-    float3 vFoo;
+    int foo;
 };
 
-kernel void main0(uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], constant uint* spvIndirectParams [[buffer(29)]], device main0_patchOut* spvPatchOut [[buffer(27)]], device MTLQuadTessellationFactorsHalf* spvTessLevel [[buffer(26)]])
+kernel void main0(device StorageBuffer& storageBuffer [[buffer(0)]], texture2d<float, access::write> storageImage [[texture(1)]], uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], constant uint* spvIndirectParams [[buffer(29)]], device MTLQuadTessellationFactorsHalf* spvTessLevel [[buffer(26)]])
 {
-    device main0_patchOut& patchOut = spvPatchOut[gl_PrimitiveID];
     if (gl_InvocationID < 1)
     {
         spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(8.8999996185302734375);
@@ -37,7 +36,11 @@ kernel void main0(uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_
     }
     if (gl_InvocationID < 1)
     {
-        patchOut.vFoo = float3(1.0);
+        storageBuffer.foo = 0;
+    }
+    if (gl_InvocationID < 1)
+    {
+        storageImage.write(float4(0.0), uint2(int2(0)));
     }
 }
 

--- a/reference/opt/shaders-msl/tesc/water_tess.tesc
+++ b/reference/opt/shaders-msl/tesc/water_tess.tesc
@@ -30,8 +30,6 @@ kernel void main0(main0_in in [[stage_in]], constant UBO& _41 [[buffer(0)]], uin
     if (gl_InvocationID < spvIndirectParams[0])
         gl_in[gl_InvocationID] = in;
     threadgroup_barrier(mem_flags::mem_threadgroup);
-    if (gl_InvocationID >= 1)
-        return;
     float2 _430 = (gl_in[0].vPatchPosBase - float2(10.0)) * _41.uScale.xy;
     float2 _440 = ((gl_in[0].vPatchPosBase + _41.uPatchSize) + float2(10.0)) * _41.uScale.xy;
     float3 _445 = float3(_430.x, -10.0, _430.y);
@@ -50,16 +48,37 @@ kernel void main0(main0_in in [[stage_in]], constant UBO& _41 [[buffer(0)]], uin
     }
     if (!(!_525))
     {
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(-1.0);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(-1.0);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(-1.0);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(-1.0);
-        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(-1.0);
-        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(-1.0);
+        if (gl_InvocationID < 1)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(-1.0);
+        }
+        if (gl_InvocationID < 1)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(-1.0);
+        }
+        if (gl_InvocationID < 1)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(-1.0);
+        }
+        if (gl_InvocationID < 1)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(-1.0);
+        }
+        if (gl_InvocationID < 1)
+        {
+            spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(-1.0);
+        }
+        if (gl_InvocationID < 1)
+        {
+            spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(-1.0);
+        }
     }
     else
     {
-        patchOut.vOutPatchPosBase = gl_in[0].vPatchPosBase;
+        if (gl_InvocationID < 1)
+        {
+            patchOut.vOutPatchPosBase = gl_in[0].vPatchPosBase;
+        }
         float2 _678 = (gl_in[0].vPatchPosBase + (float2(-0.5) * _41.uPatchSize)) * _41.uScale.xy;
         float2 _706 = (gl_in[0].vPatchPosBase + (float2(0.5, -0.5) * _41.uPatchSize)) * _41.uScale.xy;
         float _725 = fast::clamp(log2((length(_41.uCamPos - float3(_706.x, 0.0, _706.y)) + 9.9999997473787516355514526367188e-05) * _41.uDistanceMod), 0.0, _41.uMaxTessLevel.x);
@@ -79,15 +98,36 @@ kernel void main0(main0_in in [[stage_in]], constant UBO& _41 [[buffer(0)]], uin
         float _624 = dot(float4(_725, fast::clamp(log2((length(_41.uCamPos - float3(_734.x, 0.0, _734.y)) + 9.9999997473787516355514526367188e-05) * _41.uDistanceMod), 0.0, _41.uMaxTessLevel.x), _809, _837), float4(0.25));
         float _630 = dot(float4(_809, _837, _893, fast::clamp(log2((length(_41.uCamPos - float3(_902.x, 0.0, _902.y)) + 9.9999997473787516355514526367188e-05) * _41.uDistanceMod), 0.0, _41.uMaxTessLevel.x)), float4(0.25));
         float4 _631 = float4(_612, _618, _624, _630);
-        patchOut.vPatchLods = _631;
+        if (gl_InvocationID < 1)
+        {
+            patchOut.vPatchLods = _631;
+        }
         float4 _928 = exp2(-fast::min(_631, _631.yzwx)) * _41.uMaxTessLevel.y;
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(_928.x);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(_928.y);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(_928.z);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(_928.w);
+        if (gl_InvocationID < 1)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(_928.x);
+        }
+        if (gl_InvocationID < 1)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(_928.y);
+        }
+        if (gl_InvocationID < 1)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(_928.z);
+        }
+        if (gl_InvocationID < 1)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(_928.w);
+        }
         float _935 = _41.uMaxTessLevel.y * exp2(-fast::min(fast::min(fast::min(_612, _618), fast::min(_624, _630)), _809));
-        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(_935);
-        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(_935);
+        if (gl_InvocationID < 1)
+        {
+            spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(_935);
+        }
+        if (gl_InvocationID < 1)
+        {
+            spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(_935);
+        }
     }
 }
 

--- a/reference/shaders-msl/asm/tesc/tess-fixed-input-array-builtin-array.invalid.asm.tesc
+++ b/reference/shaders-msl/asm/tesc/tess-fixed-input-array-builtin-array.invalid.asm.tesc
@@ -82,8 +82,6 @@ kernel void main0(main0_in in [[stage_in]], uint gl_InvocationID [[thread_index_
     if (gl_InvocationID < spvIndirectParams[0])
         gl_in[gl_InvocationID] = in;
     threadgroup_barrier(mem_flags::mem_threadgroup);
-    if (gl_InvocationID >= 3)
-        return;
     VertexOutput p[3];
     p[0].pos = gl_in[0].gl_Position;
     p[0].uv = gl_in[0].VertexOutput_uv;
@@ -96,18 +94,36 @@ kernel void main0(main0_in in [[stage_in]], uint gl_InvocationID [[thread_index_
     spvArrayCopyFromStack1(param, p);
     uint param_1 = i;
     HSOut flattenTemp = _hs_main(param, param_1);
-    gl_out[gl_InvocationID].gl_Position = flattenTemp.pos;
-    gl_out[gl_InvocationID]._entryPointOutput.uv = flattenTemp.uv;
+    if (gl_InvocationID < 3)
+    {
+        gl_out[gl_InvocationID].gl_Position = flattenTemp.pos;
+    }
+    if (gl_InvocationID < 3)
+    {
+        gl_out[gl_InvocationID]._entryPointOutput.uv = flattenTemp.uv;
+    }
     threadgroup_barrier(mem_flags::mem_device);
     if (int(gl_InvocationID) == 0)
     {
         VertexOutput param_2[3];
         spvArrayCopyFromStack1(param_2, p);
         HSConstantOut _patchConstantResult = PatchHS(param_2);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(_patchConstantResult.EdgeTess[0]);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(_patchConstantResult.EdgeTess[1]);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(_patchConstantResult.EdgeTess[2]);
-        spvTessLevel[gl_PrimitiveID].insideTessellationFactor = half(_patchConstantResult.InsideTess);
+        if (gl_InvocationID < 3)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(_patchConstantResult.EdgeTess[0]);
+        }
+        if (gl_InvocationID < 3)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(_patchConstantResult.EdgeTess[1]);
+        }
+        if (gl_InvocationID < 3)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(_patchConstantResult.EdgeTess[2]);
+        }
+        if (gl_InvocationID < 3)
+        {
+            spvTessLevel[gl_PrimitiveID].insideTessellationFactor = half(_patchConstantResult.InsideTess);
+        }
     }
 }
 

--- a/reference/shaders-msl/asm/tesc/tess-level-overrun.asm.tesc
+++ b/reference/shaders-msl/asm/tesc/tess-level-overrun.asm.tesc
@@ -15,9 +15,21 @@ struct TessLevels
 
 kernel void main0(const device TessLevels& sb_levels [[buffer(0)]], uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], constant uint* spvIndirectParams [[buffer(29)]], device MTLTriangleTessellationFactorsHalf* spvTessLevel [[buffer(26)]])
 {
-    spvTessLevel[gl_PrimitiveID].insideTessellationFactor = half(sb_levels.inner0);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(sb_levels.outer0);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(sb_levels.outer1);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(sb_levels.outer2);
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor = half(sb_levels.inner0);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(sb_levels.outer0);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(sb_levels.outer1);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(sb_levels.outer2);
+    }
 }
 

--- a/reference/shaders-msl/desktop-only/tesc/arrayed-output.desktop.sso.tesc
+++ b/reference/shaders-msl/desktop-only/tesc/arrayed-output.desktop.sso.tesc
@@ -25,20 +25,45 @@ kernel void main0(main0_in in [[stage_in]], uint gl_InvocationID [[thread_index_
     if (gl_InvocationID < spvIndirectParams[0])
         gl_in[gl_InvocationID] = in;
     threadgroup_barrier(mem_flags::mem_threadgroup);
-    if (gl_InvocationID >= 4)
-        return;
-    gl_out[gl_InvocationID].vVertex = gl_in[gl_InvocationID].vInput + gl_in[gl_InvocationID ^ 1].vInput;
+    if (gl_InvocationID < 4)
+    {
+        gl_out[gl_InvocationID].vVertex = gl_in[gl_InvocationID].vInput + gl_in[gl_InvocationID ^ 1].vInput;
+    }
     threadgroup_barrier(mem_flags::mem_device);
     if (gl_InvocationID == 0)
     {
-        patchOut.vPatch[0] = float3(10.0);
-        patchOut.vPatch[1] = float3(20.0);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(1.0);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(2.0);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(3.0);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(4.0);
-        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(1.0);
-        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(2.0);
+        if (gl_InvocationID < 4)
+        {
+            patchOut.vPatch[0] = float3(10.0);
+        }
+        if (gl_InvocationID < 4)
+        {
+            patchOut.vPatch[1] = float3(20.0);
+        }
+        if (gl_InvocationID < 4)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(1.0);
+        }
+        if (gl_InvocationID < 4)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(2.0);
+        }
+        if (gl_InvocationID < 4)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(3.0);
+        }
+        if (gl_InvocationID < 4)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(4.0);
+        }
+        if (gl_InvocationID < 4)
+        {
+            spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(1.0);
+        }
+        if (gl_InvocationID < 4)
+        {
+            spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(2.0);
+        }
     }
 }
 

--- a/reference/shaders-msl/desktop-only/tesc/basic.desktop.sso.tesc
+++ b/reference/shaders-msl/desktop-only/tesc/basic.desktop.sso.tesc
@@ -22,7 +22,10 @@ struct main0_in
 
 void set_position(device main0_out* thread & gl_out, thread uint& gl_InvocationID, threadgroup main0_in* thread & gl_in)
 {
-    gl_out[gl_InvocationID].gl_Position = gl_in[0].gl_Position + gl_in[1].gl_Position;
+    if (gl_InvocationID < 1)
+    {
+        gl_out[gl_InvocationID].gl_Position = gl_in[0].gl_Position + gl_in[1].gl_Position;
+    }
 }
 
 kernel void main0(main0_in in [[stage_in]], uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], device main0_out* spvOut [[buffer(28)]], constant uint* spvIndirectParams [[buffer(29)]], device main0_patchOut* spvPatchOut [[buffer(27)]], device MTLQuadTessellationFactorsHalf* spvTessLevel [[buffer(26)]], threadgroup main0_in* gl_in [[threadgroup(0)]])
@@ -32,15 +35,34 @@ kernel void main0(main0_in in [[stage_in]], uint gl_InvocationID [[thread_index_
     if (gl_InvocationID < spvIndirectParams[0])
         gl_in[gl_InvocationID] = in;
     threadgroup_barrier(mem_flags::mem_threadgroup);
-    if (gl_InvocationID >= 1)
-        return;
-    spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(8.8999996185302734375);
-    spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(6.900000095367431640625);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(8.8999996185302734375);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(6.900000095367431640625);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(3.900000095367431640625);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(4.900000095367431640625);
-    patchOut.vFoo = float3(1.0);
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(8.8999996185302734375);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(6.900000095367431640625);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(8.8999996185302734375);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(6.900000095367431640625);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(3.900000095367431640625);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(4.900000095367431640625);
+    }
+    if (gl_InvocationID < 1)
+    {
+        patchOut.vFoo = float3(1.0);
+    }
     set_position(gl_out, gl_InvocationID, gl_in);
 }
 

--- a/reference/shaders-msl/desktop-only/tesc/struct-copy.desktop.sso.tesc
+++ b/reference/shaders-msl/desktop-only/tesc/struct-copy.desktop.sso.tesc
@@ -26,17 +26,36 @@ kernel void main0(main0_in in [[stage_in]], uint gl_InvocationID [[thread_index_
     if (gl_InvocationID < spvIndirectParams[0])
         gl_in[gl_InvocationID] = in;
     threadgroup_barrier(mem_flags::mem_threadgroup);
-    if (gl_InvocationID >= 4)
-        return;
     Boo vInput_24;
     vInput_24.a = gl_in[gl_InvocationID].Boo_a;
     vInput_24.b = gl_in[gl_InvocationID].Boo_b;
-    gl_out[gl_InvocationID].vVertex = vInput_24;
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(1.0);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(2.0);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(3.0);
-    spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(4.0);
-    spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(1.0);
-    spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(2.0);
+    if (gl_InvocationID < 4)
+    {
+        gl_out[gl_InvocationID].vVertex = vInput_24;
+    }
+    if (gl_InvocationID < 4)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(1.0);
+    }
+    if (gl_InvocationID < 4)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(2.0);
+    }
+    if (gl_InvocationID < 4)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(3.0);
+    }
+    if (gl_InvocationID < 4)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(4.0);
+    }
+    if (gl_InvocationID < 4)
+    {
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(1.0);
+    }
+    if (gl_InvocationID < 4)
+    {
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(2.0);
+    }
 }
 

--- a/reference/shaders-msl/tesc/storage.tesc
+++ b/reference/shaders-msl/tesc/storage.tesc
@@ -1,0 +1,58 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct StorageBuffer
+{
+    int foo;
+};
+
+void writeToBuffer(device StorageBuffer& storageBuffer, thread uint& gl_InvocationID)
+{
+    if (gl_InvocationID < 1)
+    {
+        storageBuffer.foo = 0;
+    }
+}
+
+void writeToImage(thread texture2d<float, access::write> storageImage, thread uint& gl_InvocationID)
+{
+    if (gl_InvocationID < 1)
+    {
+        storageImage.write(float4(0.0), uint2(int2(0)));
+    }
+}
+
+kernel void main0(device StorageBuffer& storageBuffer [[buffer(0)]], texture2d<float, access::write> storageImage [[texture(1)]], uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], constant uint* spvIndirectParams [[buffer(29)]], device MTLQuadTessellationFactorsHalf* spvTessLevel [[buffer(26)]])
+{
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(8.8999996185302734375);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(6.900000095367431640625);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(8.8999996185302734375);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(6.900000095367431640625);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(3.900000095367431640625);
+    }
+    if (gl_InvocationID < 1)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(4.900000095367431640625);
+    }
+    writeToBuffer(storageBuffer, gl_InvocationID);
+    writeToImage(storageImage, gl_InvocationID);
+}
+

--- a/reference/shaders-msl/tesc/water_tess.tesc
+++ b/reference/shaders-msl/tesc/water_tess.tesc
@@ -69,9 +69,12 @@ float tess_level(thread const float& lod, constant UBO& v_41)
     return v_41.uMaxTessLevel.y * exp2(-lod);
 }
 
-void compute_tess_levels(thread const float2& p0, constant UBO& v_41, device float2& vOutPatchPosBase, device float4& vPatchLods, device half (&gl_TessLevelOuter)[4], device half (&gl_TessLevelInner)[2])
+void compute_tess_levels(thread const float2& p0, constant UBO& v_41, device float2& vOutPatchPosBase, device float4& vPatchLods, device half (&gl_TessLevelOuter)[4], device half (&gl_TessLevelInner)[2], thread uint& gl_InvocationID)
 {
-    vOutPatchPosBase = p0;
+    if (gl_InvocationID < 1)
+    {
+        vOutPatchPosBase = p0;
+    }
     float2 param = p0 + (float2(-0.5) * v_41.uPatchSize);
     float l00 = lod_factor(param, v_41);
     float2 param_1 = p0 + (float2(0.5, -0.5) * v_41.uPatchSize);
@@ -91,19 +94,40 @@ void compute_tess_levels(thread const float2& p0, constant UBO& v_41, device flo
     float2 param_8 = p0 + (float2(1.5) * v_41.uPatchSize);
     float l22 = lod_factor(param_8, v_41);
     float4 lods = float4(dot(float4(l01, l11, l02, l12), float4(0.25)), dot(float4(l00, l10, l01, l11), float4(0.25)), dot(float4(l10, l20, l11, l21), float4(0.25)), dot(float4(l11, l21, l12, l22), float4(0.25)));
-    vPatchLods = lods;
+    if (gl_InvocationID < 1)
+    {
+        vPatchLods = lods;
+    }
     float4 outer_lods = fast::min(lods, lods.yzwx);
     float4 param_9 = outer_lods;
     float4 levels = tess_level(param_9, v_41);
-    gl_TessLevelOuter[0] = half(levels.x);
-    gl_TessLevelOuter[1] = half(levels.y);
-    gl_TessLevelOuter[2] = half(levels.z);
-    gl_TessLevelOuter[3] = half(levels.w);
+    if (gl_InvocationID < 1)
+    {
+        gl_TessLevelOuter[0] = half(levels.x);
+    }
+    if (gl_InvocationID < 1)
+    {
+        gl_TessLevelOuter[1] = half(levels.y);
+    }
+    if (gl_InvocationID < 1)
+    {
+        gl_TessLevelOuter[2] = half(levels.z);
+    }
+    if (gl_InvocationID < 1)
+    {
+        gl_TessLevelOuter[3] = half(levels.w);
+    }
     float min_lod = fast::min(fast::min(lods.x, lods.y), fast::min(lods.z, lods.w));
     float param_10 = fast::min(min_lod, l11);
     float inner = tess_level(param_10, v_41);
-    gl_TessLevelInner[0] = half(inner);
-    gl_TessLevelInner[1] = half(inner);
+    if (gl_InvocationID < 1)
+    {
+        gl_TessLevelInner[0] = half(inner);
+    }
+    if (gl_InvocationID < 1)
+    {
+        gl_TessLevelInner[1] = half(inner);
+    }
 }
 
 kernel void main0(main0_in in [[stage_in]], constant UBO& v_41 [[buffer(0)]], uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], constant uint* spvIndirectParams [[buffer(29)]], device main0_patchOut* spvPatchOut [[buffer(27)]], device MTLQuadTessellationFactorsHalf* spvTessLevel [[buffer(26)]], threadgroup main0_in* gl_in [[threadgroup(0)]])
@@ -112,23 +136,39 @@ kernel void main0(main0_in in [[stage_in]], constant UBO& v_41 [[buffer(0)]], ui
     if (gl_InvocationID < spvIndirectParams[0])
         gl_in[gl_InvocationID] = in;
     threadgroup_barrier(mem_flags::mem_threadgroup);
-    if (gl_InvocationID >= 1)
-        return;
     float2 p0 = gl_in[0].vPatchPosBase;
     float2 param = p0;
     if (!frustum_cull(param, v_41))
     {
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(-1.0);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(-1.0);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(-1.0);
-        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(-1.0);
-        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(-1.0);
-        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(-1.0);
+        if (gl_InvocationID < 1)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(-1.0);
+        }
+        if (gl_InvocationID < 1)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(-1.0);
+        }
+        if (gl_InvocationID < 1)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(-1.0);
+        }
+        if (gl_InvocationID < 1)
+        {
+            spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(-1.0);
+        }
+        if (gl_InvocationID < 1)
+        {
+            spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(-1.0);
+        }
+        if (gl_InvocationID < 1)
+        {
+            spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(-1.0);
+        }
     }
     else
     {
         float2 param_1 = p0;
-        compute_tess_levels(param_1, v_41, patchOut.vOutPatchPosBase, patchOut.vPatchLods, spvTessLevel[gl_PrimitiveID].edgeTessellationFactor, spvTessLevel[gl_PrimitiveID].insideTessellationFactor);
+        compute_tess_levels(param_1, v_41, patchOut.vOutPatchPosBase, patchOut.vPatchLods, spvTessLevel[gl_PrimitiveID].edgeTessellationFactor, spvTessLevel[gl_PrimitiveID].insideTessellationFactor, gl_InvocationID);
     }
 }
 

--- a/shaders-msl/tesc/storage.tesc
+++ b/shaders-msl/tesc/storage.tesc
@@ -1,0 +1,32 @@
+#version 450
+
+layout(std430, binding = 0) buffer StorageBuffer
+{
+    int foo;
+} storageBuffer;
+
+layout(binding = 1, rgba8) uniform image2D storageImage;
+
+layout(vertices = 1) out;
+
+void writeToBuffer()
+{
+    storageBuffer.foo = 0;
+}
+
+void writeToImage()
+{
+    imageStore(storageImage, ivec2(0, 0), vec4(0));
+}
+
+void main()
+{
+    gl_TessLevelInner[0] = 8.9;
+    gl_TessLevelInner[1] = 6.9;
+    gl_TessLevelOuter[0] = 8.9;
+    gl_TessLevelOuter[1] = 6.9;
+    gl_TessLevelOuter[2] = 3.9;
+    gl_TessLevelOuter[3] = 4.9;
+    writeToBuffer();
+    writeToImage();
+}


### PR DESCRIPTION
Unfortunately, my worst fears were in fact confirmed. Some hardware,
particularly NVIDIA hardware, doesn't handle the early exits well. Upon
executing a barrier, the GPU will often hang, causing weird graphical
glitches at best and kernel panics at worst.

Instead, we'll do what I should've done and wanted to do in the first
place: guard all writes to externally visible memory with an `if` block,
to ensure the extra spawned invocations have no visible effect.
Unfortunately, this will keep the GPU busy executing code that will
ultimately have no effect, but it's necessary to prevent GPU hangs by
ensuring that every thread hits all the barriers.

The formatting is... not ideal. We really want to stick consecutive
writes in the same `if` block. But I'm not sure how to do that yet.