### PR TITLE
GLSL: Support std430 in UBOs with scalar layout.

### DIFF
--- a/reference/opt/shaders/vulkan/frag/scalar-block-layout-ubo-std430.vk.nocompat.invalid.frag.vk
+++ b/reference/opt/shaders/vulkan/frag/scalar-block-layout-ubo-std430.vk.nocompat.invalid.frag.vk
@@ -1,0 +1,24 @@
+#version 450
+#extension GL_EXT_scalar_block_layout : require
+
+layout(set = 0, binding = 0, std430) uniform UBO
+{
+    float a[1024];
+    vec3 b[2];
+} _17;
+
+layout(set = 0, binding = 1, std430) uniform UBOEnhancedLayout
+{
+    layout(offset = 0) float c[1024];
+    layout(offset = 4096) vec3 d[2];
+    layout(offset = 10000) float e;
+} _30;
+
+layout(location = 0) out float FragColor;
+layout(location = 0) flat in int vIndex;
+
+void main()
+{
+    FragColor = (_17.a[vIndex] + _30.c[vIndex]) + _30.e;
+}
+

--- a/reference/shaders/vulkan/frag/scalar-block-layout-ubo-std430.vk.nocompat.invalid.frag.vk
+++ b/reference/shaders/vulkan/frag/scalar-block-layout-ubo-std430.vk.nocompat.invalid.frag.vk
@@ -1,0 +1,24 @@
+#version 450
+#extension GL_EXT_scalar_block_layout : require
+
+layout(set = 0, binding = 0, std430) uniform UBO
+{
+    float a[1024];
+    vec3 b[2];
+} _17;
+
+layout(set = 0, binding = 1, std430) uniform UBOEnhancedLayout
+{
+    layout(offset = 0) float c[1024];
+    layout(offset = 4096) vec3 d[2];
+    layout(offset = 10000) float e;
+} _30;
+
+layout(location = 0) out float FragColor;
+layout(location = 0) flat in int vIndex;
+
+void main()
+{
+    FragColor = (_17.a[vIndex] + _30.c[vIndex]) + _30.e;
+}
+

--- a/shaders/vulkan/frag/scalar-block-layout-ubo-std430.vk.nocompat.invalid.frag
+++ b/shaders/vulkan/frag/scalar-block-layout-ubo-std430.vk.nocompat.invalid.frag
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_EXT_scalar_block_layout : require
+
+layout(std430, binding = 0) uniform UBO
+{
+	float a[1024];
+	vec3 b[2];
+};
+
+layout(std430, binding = 1) uniform UBOEnhancedLayout
+{
+	float c[1024];
+	vec3 d[2];
+	layout(offset = 10000) float e;
+};
+
+layout(location = 0) flat in int vIndex;
+layout(location = 0) out float FragColor;
+
+void main()
+{
+	FragColor = a[vIndex] + c[vIndex] + e;
+}

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -525,7 +525,7 @@ protected:
 
 	bool buffer_is_packing_standard(const SPIRType &type, BufferPackingStandard packing, uint32_t start_offset = 0,
 	                                uint32_t end_offset = ~(0u));
-	std::string buffer_to_packing_standard(const SPIRType &type, bool enable_std430);
+	std::string buffer_to_packing_standard(const SPIRType &type, bool support_std430_without_scalar_layout);
 
 	uint32_t type_to_packed_base_size(const SPIRType &type, BufferPackingStandard packing);
 	uint32_t type_to_packed_alignment(const SPIRType &type, const Bitset &flags, BufferPackingStandard packing);


### PR DESCRIPTION
Fix #980.