### PR TITLE
Support emitting OpLine directive.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,7 +287,7 @@ if (SPIRV_CROSS_STATIC)
 endif()
 
 set(spirv-cross-abi-major 0)
-set(spirv-cross-abi-minor 11)
+set(spirv-cross-abi-minor 12)
 set(spirv-cross-abi-patch 0)
 
 if (SPIRV_CROSS_SHARED)

--- a/main.cpp
+++ b/main.cpp
@@ -516,6 +516,7 @@ struct CLIArguments
 	bool msl_texture_buffer_native = false;
 	bool glsl_emit_push_constant_as_ubo = false;
 	bool glsl_emit_ubo_as_plain_uniforms = false;
+	bool emit_line_directives = false;
 	SmallVector<uint32_t> msl_discrete_descriptor_sets;
 	SmallVector<PLSArg> pls_in;
 	SmallVector<PLSArg> pls_out;
@@ -612,6 +613,7 @@ static void print_help()
 	                "\t[--rename-entry-point <old> <new> <stage>]\n"
 	                "\t[--combined-samplers-inherit-bindings]\n"
 	                "\t[--no-support-nonzero-baseinstance]\n"
+	                "\t[--emit-line-directives]\n"
 	                "\n");
 }
 
@@ -873,6 +875,7 @@ static string compile_iteration(const CLIArguments &args, std::vector<uint32_t> 
 	opts.vertex.support_nonzero_base_instance = args.support_nonzero_baseinstance;
 	opts.emit_push_constant_as_uniform_buffer = args.glsl_emit_push_constant_as_ubo;
 	opts.emit_uniform_buffer_as_plain_uniforms = args.glsl_emit_ubo_as_plain_uniforms;
+	opts.emit_line_directives = args.emit_line_directives;
 	compiler->set_common_options(opts);
 
 	// Set HLSL specific options.
@@ -1133,6 +1136,7 @@ static int main_inner(int argc, char *argv[])
 	        [&args](CLIParser &) { args.combined_samplers_inherit_bindings = true; });
 
 	cbs.add("--no-support-nonzero-baseinstance", [&](CLIParser &) { args.support_nonzero_baseinstance = false; });
+	cbs.add("--emit-line-directives", [&args](CLIParser &) { args.emit_line_directives = true; });
 
 	cbs.default_handler = [&args](const char *value) { args.input = value; };
 	cbs.error_handler = [] { print_help(); };

--- a/reference/opt/shaders-hlsl/asm/frag/line-directive.line.asm.frag
+++ b/reference/opt/shaders-hlsl/asm/frag/line-directive.line.asm.frag
@@ -1,0 +1,88 @@
+static float FragColor;
+static float vColor;
+
+struct SPIRV_Cross_Input
+{
+    float vColor : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float FragColor : SV_Target0;
+};
+
+#line 8 "test.frag"
+void frag_main()
+{
+    float _80;
+#line 8 "test.frag"
+    FragColor = 1.0f;
+#line 9 "test.frag"
+    FragColor = 2.0f;
+#line 10 "test.frag"
+    _80 = vColor;
+    if (_80 < 0.0f)
+    {
+#line 12 "test.frag"
+        FragColor = 3.0f;
+    }
+    else
+    {
+#line 16 "test.frag"
+        FragColor = 4.0f;
+    }
+    for (int _126 = 0; float(_126) < (40.0f + _80); )
+    {
+#line 21 "test.frag"
+        FragColor += 0.20000000298023223876953125f;
+#line 22 "test.frag"
+        FragColor += 0.300000011920928955078125f;
+        _126 += (int(_80) + 5);
+        continue;
+    }
+    switch (int(_80))
+    {
+        case 0:
+        {
+#line 28 "test.frag"
+            FragColor += 0.20000000298023223876953125f;
+#line 29 "test.frag"
+            break;
+        }
+        case 1:
+        {
+#line 32 "test.frag"
+            FragColor += 0.4000000059604644775390625f;
+#line 33 "test.frag"
+            break;
+        }
+        default:
+        {
+#line 36 "test.frag"
+            FragColor += 0.800000011920928955078125f;
+#line 37 "test.frag"
+            break;
+        }
+    }
+    for (;;)
+    {
+        FragColor += (10.0f + _80);
+#line 43 "test.frag"
+        if (FragColor < 100.0f)
+        {
+        }
+        else
+        {
+            break;
+        }
+    }
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    vColor = stage_input.vColor;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/opt/shaders-msl/asm/frag/line-directive.line.asm.frag
+++ b/reference/opt/shaders-msl/asm/frag/line-directive.line.asm.frag
@@ -1,0 +1,84 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float vColor [[user(locn0)]];
+};
+
+#line 8 "test.frag"
+fragment main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    float _80;
+#line 8 "test.frag"
+    out.FragColor = 1.0;
+#line 9 "test.frag"
+    out.FragColor = 2.0;
+#line 10 "test.frag"
+    _80 = in.vColor;
+    if (_80 < 0.0)
+    {
+#line 12 "test.frag"
+        out.FragColor = 3.0;
+    }
+    else
+    {
+#line 16 "test.frag"
+        out.FragColor = 4.0;
+    }
+    for (int _126 = 0; float(_126) < (40.0 + _80); )
+    {
+#line 21 "test.frag"
+        out.FragColor += 0.20000000298023223876953125;
+#line 22 "test.frag"
+        out.FragColor += 0.300000011920928955078125;
+        _126 += (int(_80) + 5);
+        continue;
+    }
+    switch (int(_80))
+    {
+        case 0:
+        {
+#line 28 "test.frag"
+            out.FragColor += 0.20000000298023223876953125;
+#line 29 "test.frag"
+            break;
+        }
+        case 1:
+        {
+#line 32 "test.frag"
+            out.FragColor += 0.4000000059604644775390625;
+#line 33 "test.frag"
+            break;
+        }
+        default:
+        {
+#line 36 "test.frag"
+            out.FragColor += 0.800000011920928955078125;
+#line 37 "test.frag"
+            break;
+        }
+    }
+    for (;;)
+    {
+        out.FragColor += (10.0 + _80);
+#line 43 "test.frag"
+        if (out.FragColor < 100.0)
+        {
+        }
+        else
+        {
+            break;
+        }
+    }
+    return out;
+}
+

--- a/reference/opt/shaders/asm/frag/line-directive.line.asm.frag
+++ b/reference/opt/shaders/asm/frag/line-directive.line.asm.frag
@@ -1,0 +1,73 @@
+#version 450
+#extension GL_GOOGLE_cpp_style_line_directive : require
+
+layout(location = 0) out float FragColor;
+layout(location = 0) in float vColor;
+
+#line 8 "test.frag"
+void main()
+{
+    float _80;
+#line 8 "test.frag"
+    FragColor = 1.0;
+#line 9 "test.frag"
+    FragColor = 2.0;
+#line 10 "test.frag"
+    _80 = vColor;
+    if (_80 < 0.0)
+    {
+#line 12 "test.frag"
+        FragColor = 3.0;
+    }
+    else
+    {
+#line 16 "test.frag"
+        FragColor = 4.0;
+    }
+    for (int _126 = 0; float(_126) < (40.0 + _80); )
+    {
+#line 21 "test.frag"
+        FragColor += 0.20000000298023223876953125;
+#line 22 "test.frag"
+        FragColor += 0.300000011920928955078125;
+        _126 += (int(_80) + 5);
+        continue;
+    }
+    switch (int(_80))
+    {
+        case 0:
+        {
+#line 28 "test.frag"
+            FragColor += 0.20000000298023223876953125;
+#line 29 "test.frag"
+            break;
+        }
+        case 1:
+        {
+#line 32 "test.frag"
+            FragColor += 0.4000000059604644775390625;
+#line 33 "test.frag"
+            break;
+        }
+        default:
+        {
+#line 36 "test.frag"
+            FragColor += 0.800000011920928955078125;
+#line 37 "test.frag"
+            break;
+        }
+    }
+    for (;;)
+    {
+        FragColor += (10.0 + _80);
+#line 43 "test.frag"
+        if (FragColor < 100.0)
+        {
+        }
+        else
+        {
+            break;
+        }
+    }
+}
+

--- a/reference/shaders-hlsl/asm/frag/line-directive.line.asm.frag
+++ b/reference/shaders-hlsl/asm/frag/line-directive.line.asm.frag
@@ -1,0 +1,86 @@
+static float FragColor;
+static float vColor;
+
+struct SPIRV_Cross_Input
+{
+    float vColor : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float FragColor : SV_Target0;
+};
+
+#line 6 "test.frag"
+void func()
+{
+#line 8 "test.frag"
+    FragColor = 1.0f;
+#line 9 "test.frag"
+    FragColor = 2.0f;
+#line 10 "test.frag"
+    if (vColor < 0.0f)
+    {
+#line 12 "test.frag"
+        FragColor = 3.0f;
+    }
+    else
+    {
+#line 16 "test.frag"
+        FragColor = 4.0f;
+    }
+#line 19 "test.frag"
+    for (int i = 0; float(i) < (40.0f + vColor); i += (int(vColor) + 5))
+    {
+#line 21 "test.frag"
+        FragColor += 0.20000000298023223876953125f;
+#line 22 "test.frag"
+        FragColor += 0.300000011920928955078125f;
+    }
+#line 25 "test.frag"
+    switch (int(vColor))
+    {
+        case 0:
+        {
+#line 28 "test.frag"
+            FragColor += 0.20000000298023223876953125f;
+#line 29 "test.frag"
+            break;
+        }
+        case 1:
+        {
+#line 32 "test.frag"
+            FragColor += 0.4000000059604644775390625f;
+#line 33 "test.frag"
+            break;
+        }
+        default:
+        {
+#line 36 "test.frag"
+            FragColor += 0.800000011920928955078125f;
+#line 37 "test.frag"
+            break;
+        }
+    }
+    do
+    {
+#line 42 "test.frag"
+        FragColor += (10.0f + vColor);
+    } while (FragColor < 100.0f);
+}
+
+#line 46 "test.frag"
+void frag_main()
+{
+#line 48 "test.frag"
+    func();
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    vColor = stage_input.vColor;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-msl/asm/frag/line-directive.line.asm.frag
+++ b/reference/shaders-msl/asm/frag/line-directive.line.asm.frag
@@ -1,0 +1,84 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float vColor [[user(locn0)]];
+};
+
+#line 6 "test.frag"
+void func(thread float& FragColor, thread float& vColor)
+{
+#line 8 "test.frag"
+    FragColor = 1.0;
+#line 9 "test.frag"
+    FragColor = 2.0;
+#line 10 "test.frag"
+    if (vColor < 0.0)
+    {
+#line 12 "test.frag"
+        FragColor = 3.0;
+    }
+    else
+    {
+#line 16 "test.frag"
+        FragColor = 4.0;
+    }
+#line 19 "test.frag"
+    for (int i = 0; float(i) < (40.0 + vColor); i += (int(vColor) + 5))
+    {
+#line 21 "test.frag"
+        FragColor += 0.20000000298023223876953125;
+#line 22 "test.frag"
+        FragColor += 0.300000011920928955078125;
+    }
+#line 25 "test.frag"
+    switch (int(vColor))
+    {
+        case 0:
+        {
+#line 28 "test.frag"
+            FragColor += 0.20000000298023223876953125;
+#line 29 "test.frag"
+            break;
+        }
+        case 1:
+        {
+#line 32 "test.frag"
+            FragColor += 0.4000000059604644775390625;
+#line 33 "test.frag"
+            break;
+        }
+        default:
+        {
+#line 36 "test.frag"
+            FragColor += 0.800000011920928955078125;
+#line 37 "test.frag"
+            break;
+        }
+    }
+    do
+    {
+#line 42 "test.frag"
+        FragColor += (10.0 + vColor);
+    } while (FragColor < 100.0);
+}
+
+#line 46 "test.frag"
+fragment main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+#line 48 "test.frag"
+    func(out.FragColor, in.vColor);
+    return out;
+}
+

--- a/reference/shaders/asm/frag/line-directive.line.asm.frag
+++ b/reference/shaders/asm/frag/line-directive.line.asm.frag
@@ -1,0 +1,71 @@
+#version 450
+#extension GL_GOOGLE_cpp_style_line_directive : require
+
+layout(location = 0) out float FragColor;
+layout(location = 0) in float vColor;
+
+#line 6 "test.frag"
+void func()
+{
+#line 8 "test.frag"
+    FragColor = 1.0;
+#line 9 "test.frag"
+    FragColor = 2.0;
+#line 10 "test.frag"
+    if (vColor < 0.0)
+    {
+#line 12 "test.frag"
+        FragColor = 3.0;
+    }
+    else
+    {
+#line 16 "test.frag"
+        FragColor = 4.0;
+    }
+#line 19 "test.frag"
+    for (int i = 0; float(i) < (40.0 + vColor); i += (int(vColor) + 5))
+    {
+#line 21 "test.frag"
+        FragColor += 0.20000000298023223876953125;
+#line 22 "test.frag"
+        FragColor += 0.300000011920928955078125;
+    }
+#line 25 "test.frag"
+    switch (int(vColor))
+    {
+        case 0:
+        {
+#line 28 "test.frag"
+            FragColor += 0.20000000298023223876953125;
+#line 29 "test.frag"
+            break;
+        }
+        case 1:
+        {
+#line 32 "test.frag"
+            FragColor += 0.4000000059604644775390625;
+#line 33 "test.frag"
+            break;
+        }
+        default:
+        {
+#line 36 "test.frag"
+            FragColor += 0.800000011920928955078125;
+#line 37 "test.frag"
+            break;
+        }
+    }
+    do
+    {
+#line 42 "test.frag"
+        FragColor += (10.0 + vColor);
+    } while (FragColor < 100.0);
+}
+
+#line 46 "test.frag"
+void main()
+{
+#line 48 "test.frag"
+    func();
+}
+

--- a/shaders-hlsl/asm/frag/line-directive.line.asm.frag
+++ b/shaders-hlsl/asm/frag/line-directive.line.asm.frag
@@ -1,0 +1,221 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google Shaderc over Glslang; 7
+; Bound: 83
+; Schema: 0
+               OpCapability Shader
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor %vColor
+               OpExecutionMode %main OriginUpperLeft
+          %1 = OpString "test.frag"
+               OpSource GLSL 450 %1 "// OpModuleProcessed entry-point main
+// OpModuleProcessed client vulkan100
+// OpModuleProcessed target-env vulkan1.0
+// OpModuleProcessed entry-point main
+#line 1
+#version 450
+
+layout(location = 0) in float vColor;
+layout(location = 0) out float FragColor;
+
+void func()
+{
+	FragColor = 1.0;
+	FragColor = 2.0;
+	if (vColor < 0.0)
+	{
+		FragColor = 3.0;
+	}
+	else
+	{
+		FragColor = 4.0;
+	}
+
+	for (int i = 0; i < 40 + vColor; i += int(vColor) + 5)
+	{
+		FragColor += 0.2;
+		FragColor += 0.3;
+	}
+
+	switch (int(vColor))
+	{
+		case 0:
+			FragColor += 0.2;
+			break;
+
+		case 1:
+			FragColor += 0.4;
+			break;
+
+		default:
+			FragColor += 0.8;
+			break;
+	}
+
+	do
+	{
+		FragColor += 10.0 + vColor;
+	} while(FragColor < 100.0);
+}
+
+void main()
+{
+	func();
+}
+"
+               OpSourceExtension "GL_GOOGLE_cpp_style_line_directive"
+               OpSourceExtension "GL_GOOGLE_include_directive"
+               OpName %main "main"
+               OpName %func_ "func("
+               OpName %FragColor "FragColor"
+               OpName %vColor "vColor"
+               OpName %i "i"
+               OpDecorate %FragColor Location 0
+               OpDecorate %vColor Location 0
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_ptr_Output_float = OpTypePointer Output %float
+  %FragColor = OpVariable %_ptr_Output_float Output
+    %float_1 = OpConstant %float 1
+    %float_2 = OpConstant %float 2
+%_ptr_Input_float = OpTypePointer Input %float
+     %vColor = OpVariable %_ptr_Input_float Input
+    %float_0 = OpConstant %float 0
+       %bool = OpTypeBool
+    %float_3 = OpConstant %float 3
+    %float_4 = OpConstant %float 4
+        %int = OpTypeInt 32 1
+
+			   ; Should be ignored
+               OpLine %1 5 0
+
+%_ptr_Function_int = OpTypePointer Function %int
+      %int_0 = OpConstant %int 0
+   %float_40 = OpConstant %float 40
+%float_0_200000003 = OpConstant %float 0.200000003
+%float_0_300000012 = OpConstant %float 0.300000012
+      %int_5 = OpConstant %int 5
+
+			   ; Should be ignored
+               OpLine %1 5 0
+
+%float_0_400000006 = OpConstant %float 0.400000006
+%float_0_800000012 = OpConstant %float 0.800000012
+   %float_10 = OpConstant %float 10
+  %float_100 = OpConstant %float 100
+       %main = OpFunction %void None %4
+               OpLine %1 46 0
+          %6 = OpLabel
+               OpLine %1 48 0
+         %82 = OpFunctionCall %void %func_
+               OpReturn
+               OpFunctionEnd
+
+			   ; Should be ignored
+               OpLine %1 5 0
+
+      %func_ = OpFunction %void None %4
+               OpLine %1 6 0
+          %8 = OpLabel
+          %i = OpVariable %_ptr_Function_int Function
+               OpLine %1 8 0
+               OpStore %FragColor %float_1
+               OpLine %1 9 0
+               OpStore %FragColor %float_2
+               OpLine %1 10 0
+         %16 = OpLoad %float %vColor
+         %19 = OpFOrdLessThan %bool %16 %float_0
+               OpSelectionMerge %21 None
+               OpBranchConditional %19 %20 %23
+         %20 = OpLabel
+               OpLine %1 12 0
+               OpStore %FragColor %float_3
+               OpBranch %21
+         %23 = OpLabel
+               OpLine %1 16 0
+               OpStore %FragColor %float_4
+               OpBranch %21
+         %21 = OpLabel
+               OpLine %1 19 0
+               OpStore %i %int_0
+               OpBranch %29
+         %29 = OpLabel
+               OpLoopMerge %31 %32 None
+               OpBranch %33
+         %33 = OpLabel
+         %34 = OpLoad %int %i
+         %35 = OpConvertSToF %float %34
+         %37 = OpLoad %float %vColor
+         %38 = OpFAdd %float %float_40 %37
+         %39 = OpFOrdLessThan %bool %35 %38
+               OpBranchConditional %39 %30 %31
+         %30 = OpLabel
+               OpLine %1 21 0
+         %41 = OpLoad %float %FragColor
+         %42 = OpFAdd %float %41 %float_0_200000003
+               OpStore %FragColor %42
+               OpLine %1 22 0
+         %44 = OpLoad %float %FragColor
+         %45 = OpFAdd %float %44 %float_0_300000012
+               OpStore %FragColor %45
+               OpBranch %32
+         %32 = OpLabel
+               OpLine %1 19 0
+         %46 = OpLoad %float %vColor
+         %47 = OpConvertFToS %int %46
+         %49 = OpIAdd %int %47 %int_5
+         %50 = OpLoad %int %i
+         %51 = OpIAdd %int %50 %49
+               OpStore %i %51
+               OpBranch %29
+         %31 = OpLabel
+               OpLine %1 25 0
+         %52 = OpLoad %float %vColor
+         %53 = OpConvertFToS %int %52
+               OpSelectionMerge %57 None
+               OpSwitch %53 %56 0 %54 1 %55
+         %56 = OpLabel
+               OpLine %1 36 0
+         %66 = OpLoad %float %FragColor
+         %67 = OpFAdd %float %66 %float_0_800000012
+               OpStore %FragColor %67
+               OpLine %1 37 0
+               OpBranch %57
+         %54 = OpLabel
+               OpLine %1 28 0
+         %58 = OpLoad %float %FragColor
+         %59 = OpFAdd %float %58 %float_0_200000003
+               OpStore %FragColor %59
+               OpLine %1 29 0
+               OpBranch %57
+         %55 = OpLabel
+               OpLine %1 32 0
+         %62 = OpLoad %float %FragColor
+         %63 = OpFAdd %float %62 %float_0_400000006
+               OpStore %FragColor %63
+               OpLine %1 33 0
+               OpBranch %57
+         %57 = OpLabel
+               OpBranch %70
+               OpLine %1 43 0
+         %70 = OpLabel
+               OpLoopMerge %72 %73 None
+               OpBranch %71
+         %71 = OpLabel
+               OpLine %1 42 0
+         %75 = OpLoad %float %vColor
+         %76 = OpFAdd %float %float_10 %75
+         %77 = OpLoad %float %FragColor
+         %78 = OpFAdd %float %77 %76
+               OpStore %FragColor %78
+               OpBranch %73
+         %73 = OpLabel
+               OpLine %1 43 0
+         %79 = OpLoad %float %FragColor
+         %81 = OpFOrdLessThan %bool %79 %float_100
+               OpBranchConditional %81 %70 %72
+         %72 = OpLabel
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl/asm/frag/line-directive.line.asm.frag
+++ b/shaders-msl/asm/frag/line-directive.line.asm.frag
@@ -1,0 +1,221 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google Shaderc over Glslang; 7
+; Bound: 83
+; Schema: 0
+               OpCapability Shader
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor %vColor
+               OpExecutionMode %main OriginUpperLeft
+          %1 = OpString "test.frag"
+               OpSource GLSL 450 %1 "// OpModuleProcessed entry-point main
+// OpModuleProcessed client vulkan100
+// OpModuleProcessed target-env vulkan1.0
+// OpModuleProcessed entry-point main
+#line 1
+#version 450
+
+layout(location = 0) in float vColor;
+layout(location = 0) out float FragColor;
+
+void func()
+{
+	FragColor = 1.0;
+	FragColor = 2.0;
+	if (vColor < 0.0)
+	{
+		FragColor = 3.0;
+	}
+	else
+	{
+		FragColor = 4.0;
+	}
+
+	for (int i = 0; i < 40 + vColor; i += int(vColor) + 5)
+	{
+		FragColor += 0.2;
+		FragColor += 0.3;
+	}
+
+	switch (int(vColor))
+	{
+		case 0:
+			FragColor += 0.2;
+			break;
+
+		case 1:
+			FragColor += 0.4;
+			break;
+
+		default:
+			FragColor += 0.8;
+			break;
+	}
+
+	do
+	{
+		FragColor += 10.0 + vColor;
+	} while(FragColor < 100.0);
+}
+
+void main()
+{
+	func();
+}
+"
+               OpSourceExtension "GL_GOOGLE_cpp_style_line_directive"
+               OpSourceExtension "GL_GOOGLE_include_directive"
+               OpName %main "main"
+               OpName %func_ "func("
+               OpName %FragColor "FragColor"
+               OpName %vColor "vColor"
+               OpName %i "i"
+               OpDecorate %FragColor Location 0
+               OpDecorate %vColor Location 0
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_ptr_Output_float = OpTypePointer Output %float
+  %FragColor = OpVariable %_ptr_Output_float Output
+    %float_1 = OpConstant %float 1
+    %float_2 = OpConstant %float 2
+%_ptr_Input_float = OpTypePointer Input %float
+     %vColor = OpVariable %_ptr_Input_float Input
+    %float_0 = OpConstant %float 0
+       %bool = OpTypeBool
+    %float_3 = OpConstant %float 3
+    %float_4 = OpConstant %float 4
+        %int = OpTypeInt 32 1
+
+			   ; Should be ignored
+               OpLine %1 5 0
+
+%_ptr_Function_int = OpTypePointer Function %int
+      %int_0 = OpConstant %int 0
+   %float_40 = OpConstant %float 40
+%float_0_200000003 = OpConstant %float 0.200000003
+%float_0_300000012 = OpConstant %float 0.300000012
+      %int_5 = OpConstant %int 5
+
+			   ; Should be ignored
+               OpLine %1 5 0
+
+%float_0_400000006 = OpConstant %float 0.400000006
+%float_0_800000012 = OpConstant %float 0.800000012
+   %float_10 = OpConstant %float 10
+  %float_100 = OpConstant %float 100
+       %main = OpFunction %void None %4
+               OpLine %1 46 0
+          %6 = OpLabel
+               OpLine %1 48 0
+         %82 = OpFunctionCall %void %func_
+               OpReturn
+               OpFunctionEnd
+
+			   ; Should be ignored
+               OpLine %1 5 0
+
+      %func_ = OpFunction %void None %4
+               OpLine %1 6 0
+          %8 = OpLabel
+          %i = OpVariable %_ptr_Function_int Function
+               OpLine %1 8 0
+               OpStore %FragColor %float_1
+               OpLine %1 9 0
+               OpStore %FragColor %float_2
+               OpLine %1 10 0
+         %16 = OpLoad %float %vColor
+         %19 = OpFOrdLessThan %bool %16 %float_0
+               OpSelectionMerge %21 None
+               OpBranchConditional %19 %20 %23
+         %20 = OpLabel
+               OpLine %1 12 0
+               OpStore %FragColor %float_3
+               OpBranch %21
+         %23 = OpLabel
+               OpLine %1 16 0
+               OpStore %FragColor %float_4
+               OpBranch %21
+         %21 = OpLabel
+               OpLine %1 19 0
+               OpStore %i %int_0
+               OpBranch %29
+         %29 = OpLabel
+               OpLoopMerge %31 %32 None
+               OpBranch %33
+         %33 = OpLabel
+         %34 = OpLoad %int %i
+         %35 = OpConvertSToF %float %34
+         %37 = OpLoad %float %vColor
+         %38 = OpFAdd %float %float_40 %37
+         %39 = OpFOrdLessThan %bool %35 %38
+               OpBranchConditional %39 %30 %31
+         %30 = OpLabel
+               OpLine %1 21 0
+         %41 = OpLoad %float %FragColor
+         %42 = OpFAdd %float %41 %float_0_200000003
+               OpStore %FragColor %42
+               OpLine %1 22 0
+         %44 = OpLoad %float %FragColor
+         %45 = OpFAdd %float %44 %float_0_300000012
+               OpStore %FragColor %45
+               OpBranch %32
+         %32 = OpLabel
+               OpLine %1 19 0
+         %46 = OpLoad %float %vColor
+         %47 = OpConvertFToS %int %46
+         %49 = OpIAdd %int %47 %int_5
+         %50 = OpLoad %int %i
+         %51 = OpIAdd %int %50 %49
+               OpStore %i %51
+               OpBranch %29
+         %31 = OpLabel
+               OpLine %1 25 0
+         %52 = OpLoad %float %vColor
+         %53 = OpConvertFToS %int %52
+               OpSelectionMerge %57 None
+               OpSwitch %53 %56 0 %54 1 %55
+         %56 = OpLabel
+               OpLine %1 36 0
+         %66 = OpLoad %float %FragColor
+         %67 = OpFAdd %float %66 %float_0_800000012
+               OpStore %FragColor %67
+               OpLine %1 37 0
+               OpBranch %57
+         %54 = OpLabel
+               OpLine %1 28 0
+         %58 = OpLoad %float %FragColor
+         %59 = OpFAdd %float %58 %float_0_200000003
+               OpStore %FragColor %59
+               OpLine %1 29 0
+               OpBranch %57
+         %55 = OpLabel
+               OpLine %1 32 0
+         %62 = OpLoad %float %FragColor
+         %63 = OpFAdd %float %62 %float_0_400000006
+               OpStore %FragColor %63
+               OpLine %1 33 0
+               OpBranch %57
+         %57 = OpLabel
+               OpBranch %70
+               OpLine %1 43 0
+         %70 = OpLabel
+               OpLoopMerge %72 %73 None
+               OpBranch %71
+         %71 = OpLabel
+               OpLine %1 42 0
+         %75 = OpLoad %float %vColor
+         %76 = OpFAdd %float %float_10 %75
+         %77 = OpLoad %float %FragColor
+         %78 = OpFAdd %float %77 %76
+               OpStore %FragColor %78
+               OpBranch %73
+         %73 = OpLabel
+               OpLine %1 43 0
+         %79 = OpLoad %float %FragColor
+         %81 = OpFOrdLessThan %bool %79 %float_100
+               OpBranchConditional %81 %70 %72
+         %72 = OpLabel
+               OpReturn
+               OpFunctionEnd

--- a/shaders/asm/frag/line-directive.line.asm.frag
+++ b/shaders/asm/frag/line-directive.line.asm.frag
@@ -1,0 +1,221 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google Shaderc over Glslang; 7
+; Bound: 83
+; Schema: 0
+               OpCapability Shader
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor %vColor
+               OpExecutionMode %main OriginUpperLeft
+          %1 = OpString "test.frag"
+               OpSource GLSL 450 %1 "// OpModuleProcessed entry-point main
+// OpModuleProcessed client vulkan100
+// OpModuleProcessed target-env vulkan1.0
+// OpModuleProcessed entry-point main
+#line 1
+#version 450
+
+layout(location = 0) in float vColor;
+layout(location = 0) out float FragColor;
+
+void func()
+{
+	FragColor = 1.0;
+	FragColor = 2.0;
+	if (vColor < 0.0)
+	{
+		FragColor = 3.0;
+	}
+	else
+	{
+		FragColor = 4.0;
+	}
+
+	for (int i = 0; i < 40 + vColor; i += int(vColor) + 5)
+	{
+		FragColor += 0.2;
+		FragColor += 0.3;
+	}
+
+	switch (int(vColor))
+	{
+		case 0:
+			FragColor += 0.2;
+			break;
+
+		case 1:
+			FragColor += 0.4;
+			break;
+
+		default:
+			FragColor += 0.8;
+			break;
+	}
+
+	do
+	{
+		FragColor += 10.0 + vColor;
+	} while(FragColor < 100.0);
+}
+
+void main()
+{
+	func();
+}
+"
+               OpSourceExtension "GL_GOOGLE_cpp_style_line_directive"
+               OpSourceExtension "GL_GOOGLE_include_directive"
+               OpName %main "main"
+               OpName %func_ "func("
+               OpName %FragColor "FragColor"
+               OpName %vColor "vColor"
+               OpName %i "i"
+               OpDecorate %FragColor Location 0
+               OpDecorate %vColor Location 0
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_ptr_Output_float = OpTypePointer Output %float
+  %FragColor = OpVariable %_ptr_Output_float Output
+    %float_1 = OpConstant %float 1
+    %float_2 = OpConstant %float 2
+%_ptr_Input_float = OpTypePointer Input %float
+     %vColor = OpVariable %_ptr_Input_float Input
+    %float_0 = OpConstant %float 0
+       %bool = OpTypeBool
+    %float_3 = OpConstant %float 3
+    %float_4 = OpConstant %float 4
+        %int = OpTypeInt 32 1
+
+			   ; Should be ignored
+               OpLine %1 5 0
+
+%_ptr_Function_int = OpTypePointer Function %int
+      %int_0 = OpConstant %int 0
+   %float_40 = OpConstant %float 40
+%float_0_200000003 = OpConstant %float 0.200000003
+%float_0_300000012 = OpConstant %float 0.300000012
+      %int_5 = OpConstant %int 5
+
+			   ; Should be ignored
+               OpLine %1 5 0
+
+%float_0_400000006 = OpConstant %float 0.400000006
+%float_0_800000012 = OpConstant %float 0.800000012
+   %float_10 = OpConstant %float 10
+  %float_100 = OpConstant %float 100
+       %main = OpFunction %void None %4
+               OpLine %1 46 0
+          %6 = OpLabel
+               OpLine %1 48 0
+         %82 = OpFunctionCall %void %func_
+               OpReturn
+               OpFunctionEnd
+
+			   ; Should be ignored
+               OpLine %1 5 0
+
+      %func_ = OpFunction %void None %4
+               OpLine %1 6 0
+          %8 = OpLabel
+          %i = OpVariable %_ptr_Function_int Function
+               OpLine %1 8 0
+               OpStore %FragColor %float_1
+               OpLine %1 9 0
+               OpStore %FragColor %float_2
+               OpLine %1 10 0
+         %16 = OpLoad %float %vColor
+         %19 = OpFOrdLessThan %bool %16 %float_0
+               OpSelectionMerge %21 None
+               OpBranchConditional %19 %20 %23
+         %20 = OpLabel
+               OpLine %1 12 0
+               OpStore %FragColor %float_3
+               OpBranch %21
+         %23 = OpLabel
+               OpLine %1 16 0
+               OpStore %FragColor %float_4
+               OpBranch %21
+         %21 = OpLabel
+               OpLine %1 19 0
+               OpStore %i %int_0
+               OpBranch %29
+         %29 = OpLabel
+               OpLoopMerge %31 %32 None
+               OpBranch %33
+         %33 = OpLabel
+         %34 = OpLoad %int %i
+         %35 = OpConvertSToF %float %34
+         %37 = OpLoad %float %vColor
+         %38 = OpFAdd %float %float_40 %37
+         %39 = OpFOrdLessThan %bool %35 %38
+               OpBranchConditional %39 %30 %31
+         %30 = OpLabel
+               OpLine %1 21 0
+         %41 = OpLoad %float %FragColor
+         %42 = OpFAdd %float %41 %float_0_200000003
+               OpStore %FragColor %42
+               OpLine %1 22 0
+         %44 = OpLoad %float %FragColor
+         %45 = OpFAdd %float %44 %float_0_300000012
+               OpStore %FragColor %45
+               OpBranch %32
+         %32 = OpLabel
+               OpLine %1 19 0
+         %46 = OpLoad %float %vColor
+         %47 = OpConvertFToS %int %46
+         %49 = OpIAdd %int %47 %int_5
+         %50 = OpLoad %int %i
+         %51 = OpIAdd %int %50 %49
+               OpStore %i %51
+               OpBranch %29
+         %31 = OpLabel
+               OpLine %1 25 0
+         %52 = OpLoad %float %vColor
+         %53 = OpConvertFToS %int %52
+               OpSelectionMerge %57 None
+               OpSwitch %53 %56 0 %54 1 %55
+         %56 = OpLabel
+               OpLine %1 36 0
+         %66 = OpLoad %float %FragColor
+         %67 = OpFAdd %float %66 %float_0_800000012
+               OpStore %FragColor %67
+               OpLine %1 37 0
+               OpBranch %57
+         %54 = OpLabel
+               OpLine %1 28 0
+         %58 = OpLoad %float %FragColor
+         %59 = OpFAdd %float %58 %float_0_200000003
+               OpStore %FragColor %59
+               OpLine %1 29 0
+               OpBranch %57
+         %55 = OpLabel
+               OpLine %1 32 0
+         %62 = OpLoad %float %FragColor
+         %63 = OpFAdd %float %62 %float_0_400000006
+               OpStore %FragColor %63
+               OpLine %1 33 0
+               OpBranch %57
+         %57 = OpLabel
+               OpBranch %70
+               OpLine %1 43 0
+         %70 = OpLabel
+               OpLoopMerge %72 %73 None
+               OpBranch %71
+         %71 = OpLabel
+               OpLine %1 42 0
+         %75 = OpLoad %float %vColor
+         %76 = OpFAdd %float %float_10 %75
+         %77 = OpLoad %float %FragColor
+         %78 = OpFAdd %float %77 %76
+               OpStore %FragColor %78
+               OpBranch %73
+         %73 = OpLabel
+               OpLine %1 43 0
+         %79 = OpLoad %float %FragColor
+         %81 = OpFOrdLessThan %bool %79 %float_100
+               OpBranchConditional %81 %70 %72
+         %72 = OpLabel
+               OpReturn
+               OpFunctionEnd

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -299,6 +299,7 @@ enum Types
 	TypeCombinedImageSampler,
 	TypeAccessChain,
 	TypeUndef,
+	TypeString,
 	TypeCount
 };
 
@@ -316,6 +317,23 @@ struct SPIRUndef : IVariant
 	uint32_t basetype;
 
 	SPIRV_CROSS_DECLARE_CLONE(SPIRUndef)
+};
+
+struct SPIRString : IVariant
+{
+	enum
+	{
+		type = TypeString
+	};
+
+	explicit SPIRString(std::string str_)
+	    : str(std::move(str_))
+	{
+	}
+
+	std::string str;
+
+	SPIRV_CROSS_DECLARE_CLONE(SPIRString)
 };
 
 // This type is only used by backends which need to access the combined image and sampler IDs separately after
@@ -765,6 +783,13 @@ struct SPIRFunction : IVariant
 	uint32_t entry_block = 0;
 	SmallVector<uint32_t> blocks;
 	SmallVector<CombinedImageSamplerParameter> combined_parameters;
+
+	struct EntryLine
+	{
+		uint32_t file_id = 0;
+		uint32_t line_literal = 0;
+	};
+	EntryLine entry_line;
 
 	void add_local_variable(uint32_t id)
 	{

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -3036,6 +3036,7 @@ bool Compiler::AnalyzeVariableScopeAccessHandler::handle(spv::Op op, const uint3
 	}
 
 	case OpArrayLength:
+	case OpLine:
 		// Uses literals, but cannot be a phi variable or temporary, so ignore.
 		break;
 
@@ -4050,6 +4051,7 @@ bool Compiler::instruction_to_result_type(uint32_t &result_type, uint32_t &resul
 	case OpCommitWritePipe:
 	case OpGroupCommitReadPipe:
 	case OpGroupCommitWritePipe:
+	case OpLine:
 		return false;
 
 	default:

--- a/spirv_cross_c.cpp
+++ b/spirv_cross_c.cpp
@@ -417,6 +417,9 @@ spvc_result spvc_compiler_options_set_uint(spvc_compiler_options options, spvc_c
 	case SPVC_COMPILER_OPTION_FLIP_VERTEX_Y:
 		options->glsl.vertex.flip_vert_y = value != 0;
 		break;
+	case SPVC_COMPILER_OPTION_EMIT_LINE_DIRECTIVES:
+		options->glsl.emit_line_directives = value != 0;
+		break;
 
 	case SPVC_COMPILER_OPTION_GLSL_SUPPORT_NONZERO_BASE_INSTANCE:
 		options->glsl.vertex.support_nonzero_base_instance = value != 0;

--- a/spirv_cross_c.h
+++ b/spirv_cross_c.h
@@ -33,7 +33,7 @@ extern "C" {
 /* Bumped if ABI or API breaks backwards compatibility. */
 #define SPVC_C_API_VERSION_MAJOR 0
 /* Bumped if APIs or enumerations are added in a backwards compatible way. */
-#define SPVC_C_API_VERSION_MINOR 11
+#define SPVC_C_API_VERSION_MINOR 12
 /* Bumped if internal implementation details change. */
 #define SPVC_C_API_VERSION_PATCH 0
 
@@ -448,6 +448,8 @@ typedef enum spvc_compiler_option
 	SPVC_COMPILER_OPTION_GLSL_EMIT_UNIFORM_BUFFER_AS_PLAIN_UNIFORMS = 35 | SPVC_COMPILER_OPTION_GLSL_BIT,
 
 	SPVC_COMPILER_OPTION_MSL_BUFFER_SIZE_BUFFER_INDEX = 36 | SPVC_COMPILER_OPTION_MSL_BIT,
+
+	SPVC_COMPILER_OPTION_EMIT_LINE_DIRECTIVES = 37 | SPVC_COMPILER_OPTION_COMMON_BIT,
 
 	SPVC_COMPILER_OPTION_INT_MAX = 0x7fffffff
 } spvc_compiler_option;

--- a/spirv_cross_parsed_ir.cpp
+++ b/spirv_cross_parsed_ir.cpp
@@ -41,6 +41,7 @@ ParsedIR::ParsedIR()
 	pool_group->pools[TypeCombinedImageSampler].reset(new ObjectPool<SPIRCombinedImageSampler>);
 	pool_group->pools[TypeAccessChain].reset(new ObjectPool<SPIRAccessChain>);
 	pool_group->pools[TypeUndef].reset(new ObjectPool<SPIRUndef>);
+	pool_group->pools[TypeString].reset(new ObjectPool<SPIRString>);
 }
 
 // Should have been default-implemented, but need this on MSVC 2013.

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -103,6 +103,10 @@ public:
 		// Does not apply to shader storage or push constant blocks.
 		bool emit_uniform_buffer_as_plain_uniforms = false;
 
+		// Emit OpLine directives if present in the module.
+		// May not correspond exactly to original source, but should be a good approximation.
+		bool emit_line_directives = true;
+
 		enum Precision
 		{
 			DontCare,
@@ -233,6 +237,7 @@ protected:
 	virtual void emit_spv_amd_gcn_shader_op(uint32_t result_type, uint32_t result_id, uint32_t op, const uint32_t *args,
 	                                        uint32_t count);
 	virtual void emit_header();
+	void emit_line_directive(uint32_t file_id, uint32_t line_literal);
 	void build_workgroup_size(SmallVector<std::string> &arguments, const SpecializationConstant &x,
 	                          const SpecializationConstant &y, const SpecializationConstant &z);
 

--- a/spirv_parser.cpp
+++ b/spirv_parser.cpp
@@ -1038,11 +1038,14 @@ void Parser::parse(const Instruction &instruction)
 	{
 		// OpLine might come at global scope, but we don't care about those since they will not be declared in any
 		// meaningful correct order.
-		// For OpLine statements which
+		// Ignore all OpLine directives which live outside a function.
 		if (current_block)
 			current_block->ops.push_back(instruction);
 
-		if (current_function) // Line directives may arrive before first OpLabel.
+		// Line directives may arrive before first OpLabel.
+		// Treat this as the line of the function declaration,
+		// so warnings for arguments can propagate properly.
+		if (current_function)
 		{
 			// Store the first one we find and emit it before creating the function prototype.
 			if (current_function->entry_line.file_id == 0)

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -180,6 +180,8 @@ def cross_compile_msl(shader, spirv, opt, iterations, paths):
         msl_args.append('2')
         msl_args.append('--msl-discrete-descriptor-set')
         msl_args.append('3')
+    if '.line.' in shader:
+        msl_args.append('--emit-line-directives')
 
     subprocess.check_call(msl_args)
 
@@ -273,7 +275,11 @@ def cross_compile_hlsl(shader, spirv, opt, force_no_external_validation, iterati
     spirv_cross_path = paths.spirv_cross
 
     sm = shader_to_sm(shader)
-    subprocess.check_call([spirv_cross_path, '--entry', 'main', '--output', hlsl_path, spirv_path, '--hlsl-enable-compat', '--hlsl', '--shader-model', sm, '--iterations', str(iterations)])
+
+    hlsl_args = [spirv_cross_path, '--entry', 'main', '--output', hlsl_path, spirv_path, '--hlsl-enable-compat', '--hlsl', '--shader-model', sm, '--iterations', str(iterations)]
+    if '.line.' in shader:
+        hlsl_args.append('--emit-line-directives')
+    subprocess.check_call(hlsl_args)
 
     if not shader_is_invalid_spirv(hlsl_path):
         subprocess.check_call([paths.spirv_val, '--target-env', 'vulkan1.1', spirv_path])
@@ -345,6 +351,8 @@ def cross_compile(shader, vulkan, spirv, invalid_spirv, eliminate, is_legacy, fl
         extra_args += ['--flatten-multidimensional-arrays']
     if push_ubo:
         extra_args += ['--glsl-emit-push-constant-as-ubo']
+    if '.line.' in shader:
+        extra_args += ['--emit-line-directives']
 
     spirv_cross_path = paths.spirv_cross
 


### PR DESCRIPTION
Facilitates easier mapping from source language to cross-compiled output
in tooling.

Fix #989.