### PR TITLE
MSL: Fix declaration of unused input variables.

### DIFF
--- a/reference/opt/shaders-msl/asm/comp/global-parameter-name-alias.asm.comp
+++ b/reference/opt/shaders-msl/asm/comp/global-parameter-name-alias.asm.comp
@@ -3,7 +3,7 @@
 
 using namespace metal;
 
-kernel void main0(uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0()
 {
 }
 

--- a/reference/opt/shaders-msl/asm/vert/fake-builtin-input.asm.vert
+++ b/reference/opt/shaders-msl/asm/vert/fake-builtin-input.asm.vert
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float2 in_var_POSITION [[attribute(0)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    out.gl_Position = float4(in.in_var_POSITION, 0.0, 1.0);
+    return out;
+}
+

--- a/reference/opt/shaders-msl/comp/access-private-workgroup-in-function.comp
+++ b/reference/opt/shaders-msl/comp/access-private-workgroup-in-function.comp
@@ -3,7 +3,7 @@
 
 using namespace metal;
 
-kernel void main0(uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]])
+kernel void main0()
 {
 }
 

--- a/reference/opt/shaders-msl/comp/builtins.comp
+++ b/reference/opt/shaders-msl/comp/builtins.comp
@@ -5,7 +5,7 @@ using namespace metal;
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(8u, 4u, 2u);
 
-kernel void main0(uint3 gl_LocalInvocationID [[thread_position_in_threadgroup]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]], uint3 gl_NumWorkGroups [[threadgroups_per_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
+kernel void main0()
 {
 }
 

--- a/reference/opt/shaders-msl/frag/packing-test-3.frag
+++ b/reference/opt/shaders-msl/frag/packing-test-3.frag
@@ -19,7 +19,7 @@ struct main0_out
     float4 _entryPointOutput [[color(0)]];
 };
 
-fragment main0_out main0(constant CB0& _26 [[buffer(0)]], float4 gl_FragCoord [[position]])
+fragment main0_out main0(constant CB0& _26 [[buffer(0)]])
 {
     main0_out out = {};
     out._entryPointOutput = float4(_26.CB0[1].position[0], _26.CB0[1].position[1], _26.CB0[1].position[2], _26.CB0[1].radius);

--- a/reference/shaders-msl-no-opt/asm/comp/variable-pointers.asm.comp
+++ b/reference/shaders-msl-no-opt/asm/comp/variable-pointers.asm.comp
@@ -37,7 +37,7 @@ threadgroup int* select_tgsm(constant bar& cb, threadgroup int (&tgsm)[128])
     return (cb.d != 0) ? &tgsm[0u] : nullptr;
 }
 
-kernel void main0(device foo& buf [[buffer(0)]], constant bar& cb [[buffer(3)]], device baz& buf2 [[buffer(4)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(device foo& buf [[buffer(0)]], constant bar& cb [[buffer(3)]], device baz& buf2 [[buffer(4)]])
 {
     threadgroup int tgsm[128];
     device int* sbuf = select_buffer(buf, buf2, cb);

--- a/reference/shaders-msl/asm/vert/fake-builtin-input.asm.vert
+++ b/reference/shaders-msl/asm/vert/fake-builtin-input.asm.vert
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float2 in_var_POSITION [[attribute(0)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    out.gl_Position = float4(in.in_var_POSITION, 0.0, 1.0);
+    return out;
+}
+

--- a/shaders-msl/asm/vert/fake-builtin-input.asm.vert
+++ b/shaders-msl/asm/vert/fake-builtin-input.asm.vert
@@ -1,0 +1,55 @@
+; SPIR-V
+; Version: 1.3
+; Generator: Google spiregg; 0
+; Bound: 29
+; Schema: 0
+               OpCapability Shader
+               OpCapability Float16
+               OpCapability StorageInputOutput16
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %vertexShader "main" %in_var_POSITION %gl_Position %gl_FragCoord %out_var_SV_Target
+               OpEntryPoint Fragment %fragmentShader "fragmentShader" %in_var_POSITION %gl_Position %gl_FragCoord %out_var_SV_Target
+               OpExecutionMode %fragmentShader OriginUpperLeft
+               OpSource HLSL 640
+               OpName %in_var_POSITION "in.var.POSITION"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpName %vertexShader "vertexShader"
+               OpName %fragmentShader "fragmentShader"
+               OpDecorate %gl_Position BuiltIn Position
+               OpDecorate %gl_FragCoord BuiltIn FragCoord
+               OpDecorate %in_var_POSITION Location 0
+               OpDecorate %out_var_SV_Target Location 0
+      %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+    %float_1 = OpConstant %float 1
+       %half = OpTypeFloat 16
+%half_0x1p_0 = OpConstant %half 0x1p+0
+%half_0x0p_0 = OpConstant %half 0x0p+0
+     %v4half = OpTypeVector %half 4
+         %14 = OpConstantComposite %v4half %half_0x1p_0 %half_0x0p_0 %half_0x1p_0 %half_0x1p_0
+    %v2float = OpTypeVector %float 2
+%_ptr_Input_v2float = OpTypePointer Input %v2float
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%_ptr_Output_v4half = OpTypePointer Output %v4half
+       %void = OpTypeVoid
+         %22 = OpTypeFunction %void
+%in_var_POSITION = OpVariable %_ptr_Input_v2float Input
+%gl_Position = OpVariable %_ptr_Output_v4float Output
+%gl_FragCoord = OpVariable %_ptr_Input_v4float Input
+%out_var_SV_Target = OpVariable %_ptr_Output_v4half Output
+%vertexShader = OpFunction %void None %22
+         %23 = OpLabel
+         %24 = OpLoad %v2float %in_var_POSITION
+         %25 = OpCompositeExtract %float %24 0
+         %26 = OpCompositeExtract %float %24 1
+         %27 = OpCompositeConstruct %v4float %25 %26 %float_0 %float_1
+               OpStore %gl_Position %27
+               OpReturn
+               OpFunctionEnd
+%fragmentShader = OpFunction %void None %22
+         %28 = OpLabel
+               OpStore %out_var_SV_Target %14
+               OpReturn
+               OpFunctionEnd

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -512,6 +512,8 @@ protected:
 	bool emit_tessellation_access_chain(const uint32_t *ops, uint32_t length);
 	bool is_out_of_bounds_tessellation_level(uint32_t id_lhs);
 
+	void mark_implicit_builtin(spv::StorageClass storage, spv::BuiltIn builtin, uint32_t id);
+
 	Options msl_options;
 	std::set<SPVFuncImpl> spv_function_implementations;
 	std::unordered_map<uint32_t, MSLVertexAttr> vtx_attrs_by_location;


### PR DESCRIPTION
In multiple-entry-point modules, we declared builtin inputs which were
not supposed to be used for that entry point.

Fix this, by being more strict when checking which builtins to emit.

Fix #998.