### PR TITLE
Add some missing features for NV_ray_tracing

### DIFF
--- a/reference/shaders/vulkan/rgen/execute_callable.nocompat.vk.rgen.vk
+++ b/reference/shaders/vulkan/rgen/execute_callable.nocompat.vk.rgen.vk
@@ -1,0 +1,17 @@
+#version 460
+#extension GL_NV_ray_tracing : require
+
+layout(set = 0, binding = 0) uniform accelerationStructureNV as;
+layout(set = 0, binding = 1, rgba32f) uniform writeonly image2D image;
+layout(location = 0) rayPayloadNV vec4 payload;
+layout(location = 0) callableDataNV float blend;
+
+void main()
+{
+    vec3 origin = vec3(0.0);
+    vec3 direction = vec3(0.0, 0.0, -1.0);
+    traceNV(as, 1u, 255u, 0u, 0u, 0u, origin, 0.0, direction, 100.0, 0);
+    executeCallableNV(0u, 0);
+    imageStore(image, ivec2(gl_LaunchIDNV.xy), payload + vec4(blend));
+}
+

--- a/reference/shaders/vulkan/rgen/shader_record_buffer.nocompat.vk.rgen.vk
+++ b/reference/shaders/vulkan/rgen/shader_record_buffer.nocompat.vk.rgen.vk
@@ -1,7 +1,7 @@
 #version 460
 #extension GL_NV_ray_tracing : require
 
-layout(shaderRecordNV) buffer sbt
+layout(shaderRecordNV, std430) buffer sbt
 {
     vec3 direction;
     float tmax;

--- a/reference/shaders/vulkan/rgen/shader_record_buffer.nocompat.vk.rgen.vk
+++ b/reference/shaders/vulkan/rgen/shader_record_buffer.nocompat.vk.rgen.vk
@@ -1,0 +1,17 @@
+#version 460
+#extension GL_NV_ray_tracing : require
+
+layout(shaderRecordNV) buffer sbt
+{
+    vec3 direction;
+    float tmax;
+} _20;
+
+layout(set = 0, binding = 0) uniform accelerationStructureNV as;
+layout(location = 0) rayPayloadNV float payload;
+
+void main()
+{
+    traceNV(as, 0u, 255u, 0u, 1u, 0u, vec3(0.0), 0.0, _20.direction, _20.tmax, 0);
+}
+

--- a/shaders/vulkan/rgen/execute_callable.nocompat.vk.rgen
+++ b/shaders/vulkan/rgen/execute_callable.nocompat.vk.rgen
@@ -1,0 +1,16 @@
+#version 460
+#extension GL_NV_ray_tracing : require
+
+layout(set = 0, binding = 0) uniform accelerationStructureNV as;
+layout(set = 0, binding = 1, rgba32f) uniform writeonly image2D image;
+layout(location = 0) rayPayloadNV vec4 payload;
+layout(location = 0) callableDataNV float blend;
+
+void main()
+{
+    vec3 origin = vec3(0.0);
+    vec3 direction = vec3(0.0, 0.0, -1.0);
+    traceNV(as, gl_RayFlagsOpaqueNV, 0xFF, 0u, 0u, 0u, origin, 0.0, direction, 100.0f, 0);
+    executeCallableNV(0u, 0);
+    imageStore(image, ivec2(gl_LaunchIDNV.xy), payload + vec4(blend));
+}

--- a/shaders/vulkan/rgen/shader_record_buffer.nocompat.vk.rgen
+++ b/shaders/vulkan/rgen/shader_record_buffer.nocompat.vk.rgen
@@ -1,7 +1,7 @@
 #version 460
 #extension GL_NV_ray_tracing : require
 
-layout(shaderRecordNV) buffer sbt
+layout(shaderRecordNV, std430) buffer sbt
 {
     vec3 direction;
     float tmax;

--- a/shaders/vulkan/rgen/shader_record_buffer.nocompat.vk.rgen
+++ b/shaders/vulkan/rgen/shader_record_buffer.nocompat.vk.rgen
@@ -1,0 +1,16 @@
+#version 460
+#extension GL_NV_ray_tracing : require
+
+layout(shaderRecordNV) buffer sbt
+{
+    vec3 direction;
+    float tmax;
+};
+
+layout(set = 0, binding = 0) uniform accelerationStructureNV as;
+layout(location = 0) rayPayloadNV float payload;
+
+void main()
+{
+    traceNV(as, 0u, 255u, 0u, 1u, 0u, vec3(0.0), 0.0, direction, tmax, 0);
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1457,14 +1457,14 @@ string CompilerGLSL::layout_for_variable(const SPIRVariable &var)
 
 	// Do not emit set = decoration in regular GLSL output, but
 	// we need to preserve it in Vulkan GLSL mode.
-	if (var.storage != StorageClassPushConstant)
+	if (var.storage != StorageClassPushConstant && var.storage != StorageClassShaderRecordBufferNV)
 	{
 		if (flags.get(DecorationDescriptorSet) && options.vulkan_semantics)
 			attr.push_back(join("set = ", dec.set));
 	}
 
 	bool push_constant_block = options.vulkan_semantics && var.storage == StorageClassPushConstant;
-	bool ssbo_block = var.storage == StorageClassStorageBuffer ||
+	bool ssbo_block = var.storage == StorageClassStorageBuffer || var.storage == StorageClassShaderRecordBufferNV ||
 	                  (var.storage == StorageClassUniform && typeflags.get(DecorationBufferBlock));
 	bool emulated_ubo = var.storage == StorageClassPushConstant && options.emit_push_constant_as_uniform_buffer;
 	bool ubo_block = var.storage == StorageClassUniform && typeflags.get(DecorationBlock);
@@ -1484,6 +1484,9 @@ string CompilerGLSL::layout_for_variable(const SPIRVariable &var)
 
 	// Make sure we don't emit binding layout for a classic uniform on GLSL 1.30.
 	if (!can_use_buffer_blocks && var.storage == StorageClassUniform)
+		can_use_binding = false;
+
+	if (var.storage == StorageClassShaderRecordBufferNV)
 		can_use_binding = false;
 
 	if (can_use_binding && flags.get(DecorationBinding))

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1866,11 +1866,11 @@ const char *CompilerGLSL::to_storage_qualifiers_glsl(const SPIRVariable &var)
 	}
 	else if (var.storage == StorageClassCallableDataNV)
 	{
-		return "callableDataNV";
+		return "callableDataNV ";
 	}
 	else if (var.storage == StorageClassIncomingCallableDataNV)
 	{
-		return "callableDataInNV";
+		return "callableDataInNV ";
 	}
 
 	return "";
@@ -2614,8 +2614,9 @@ void CompilerGLSL::emit_resources()
 
 		if (var.storage != StorageClassFunction && type.pointer &&
 		    (type.storage == StorageClassUniformConstant || type.storage == StorageClassAtomicCounter ||
-		     type.storage == StorageClassRayPayloadNV || type.storage == StorageClassHitAttributeNV ||
-		     type.storage == StorageClassIncomingRayPayloadNV) &&
+		     type.storage == StorageClassRayPayloadNV || type.storage == StorageClassIncomingRayPayloadNV ||
+		     type.storage == StorageClassCallableDataNV || type.storage == StorageClassIncomingCallableDataNV ||
+		     type.storage == StorageClassHitAttributeNV) &&
 		    !is_hidden_variable(var))
 		{
 			emit_uniform(var);


### PR DESCRIPTION
This should fix #999 and add all the remaining features from GLSL_NV_ray_tracing, with the exception of ray flags (which are just printed as integer constants, rather than as a combination of named flags).