### PR TITLE
Deal with case where a variable is dominated by inner part of a loop.

### DIFF
--- a/reference/opt/shaders/frag/inside-loop-dominated-variable-preservation.frag
+++ b/reference/opt/shaders/frag/inside-loop-dominated-variable-preservation.frag
@@ -1,0 +1,11 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    FragColor = vec4(1.0);
+}
+

--- a/reference/opt/shaders/vulkan/rgen/execute_callable.nocompat.vk.rgen.vk
+++ b/reference/opt/shaders/vulkan/rgen/execute_callable.nocompat.vk.rgen.vk
@@ -1,0 +1,15 @@
+#version 460
+#extension GL_NV_ray_tracing : require
+
+layout(set = 0, binding = 0) uniform accelerationStructureNV as;
+layout(set = 0, binding = 1, rgba32f) uniform writeonly image2D image;
+layout(location = 0) rayPayloadNV vec4 payload;
+layout(location = 0) callableDataNV float blend;
+
+void main()
+{
+    traceNV(as, 1u, 255u, 0u, 0u, 0u, vec3(0.0), 0.0, vec3(0.0, 0.0, -1.0), 100.0, 0);
+    executeCallableNV(0u, 0);
+    imageStore(image, ivec2(gl_LaunchIDNV.xy), payload + vec4(blend));
+}
+

--- a/reference/opt/shaders/vulkan/rgen/shader_record_buffer.nocompat.vk.rgen.vk
+++ b/reference/opt/shaders/vulkan/rgen/shader_record_buffer.nocompat.vk.rgen.vk
@@ -1,0 +1,16 @@
+#version 460
+#extension GL_NV_ray_tracing : require
+
+layout(shaderRecordNV, std430) buffer sbt
+{
+    vec3 direction;
+    float tmax;
+} _20;
+
+layout(set = 0, binding = 0) uniform accelerationStructureNV as;
+
+void main()
+{
+    traceNV(as, 0u, 255u, 0u, 1u, 0u, vec3(0.0), 0.0, _20.direction, _20.tmax, 0);
+}
+

--- a/reference/shaders-msl-no-opt/vert/functions_nested.vert
+++ b/reference/shaders-msl-no-opt/vert/functions_nested.vert
@@ -69,13 +69,13 @@ float4 fetch_attr(thread const attr_desc& desc, thread const int& vertex_id, thr
     float4 result = float4(0.0, 0.0, 0.0, 1.0);
     bool reverse_order = false;
     int first_byte = (vertex_id * desc.stride) + desc.starting_offset;
+    uint4 tmp;
     for (int n = 0; n < 4; n++)
     {
         if (n == desc.attribute_size)
         {
             break;
         }
-        uint4 tmp;
         switch (desc.type)
         {
             case 0:

--- a/reference/shaders-msl/vert/copy.flatten.vert
+++ b/reference/shaders-msl/vert/copy.flatten.vert
@@ -40,9 +40,9 @@ vertex main0_out main0(main0_in in [[stage_in]], constant UBO& _21 [[buffer(0)]]
     main0_out out = {};
     out.gl_Position = _21.uMVP * in.aVertex;
     out.vColor = float4(0.0);
+    Light_1 light;
     for (int i = 0; i < 4; i++)
     {
-        Light_1 light;
         light.Position = float3(_21.lights[i].Position);
         light.Radius = _21.lights[i].Radius;
         light.Color = _21.lights[i].Color;

--- a/reference/shaders/asm/geom/unroll-glposition-load.asm.geom
+++ b/reference/shaders/asm/geom/unroll-glposition-load.asm.geom
@@ -9,9 +9,9 @@ struct SceneOut
 
 void _main(vec4 positions[3], SceneOut OUT)
 {
+    SceneOut o;
     for (int i = 0; i < 3; i++)
     {
-        SceneOut o;
         o.pos = positions[i];
         gl_Position = o.pos;
         EmitVertex();

--- a/reference/shaders/flatten/copy.flatten.vert
+++ b/reference/shaders/flatten/copy.flatten.vert
@@ -16,10 +16,10 @@ void main()
 {
     gl_Position = mat4(UBO[0], UBO[1], UBO[2], UBO[3]) * aVertex;
     vColor = vec4(0.0);
+    Light light;
     for (int i = 0; i < 4; i++)
     {
         Light _52 = Light(UBO[i * 2 + 4].xyz, UBO[i * 2 + 4].w, UBO[i * 2 + 5]);
-        Light light;
         light.Position = _52.Position;
         light.Radius = _52.Radius;
         light.Color = _52.Color;

--- a/reference/shaders/frag/inside-loop-dominated-variable-preservation.frag
+++ b/reference/shaders/frag/inside-loop-dominated-variable-preservation.frag
@@ -1,0 +1,27 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    bool written = false;
+    float v;
+    for (mediump int i = 0; i < 4; i++)
+    {
+        float w = 0.0;
+        if (written)
+        {
+            w += v;
+        }
+        else
+        {
+            v = 20.0;
+        }
+        v += float(i);
+        written = true;
+    }
+    FragColor = vec4(1.0);
+}
+

--- a/reference/shaders/frag/inside-loop-dominated-variable-preservation.frag
+++ b/reference/shaders/frag/inside-loop-dominated-variable-preservation.frag
@@ -8,19 +8,22 @@ void main()
 {
     bool written = false;
     float v;
-    for (mediump int i = 0; i < 4; i++)
+    for (mediump int j = 0; j < 10; j++)
     {
-        float w = 0.0;
-        if (written)
+        for (mediump int i = 0; i < 4; i++)
         {
-            w += v;
+            float w = 0.0;
+            if (written)
+            {
+                w += v;
+            }
+            else
+            {
+                v = 20.0;
+            }
+            v += float(i);
+            written = true;
         }
-        else
-        {
-            v = 20.0;
-        }
-        v += float(i);
-        written = true;
     }
     FragColor = vec4(1.0);
 }

--- a/shaders/frag/inside-loop-dominated-variable-preservation.frag
+++ b/shaders/frag/inside-loop-dominated-variable-preservation.frag
@@ -6,16 +6,19 @@ void main()
 {
 	float v;
 	bool written = false;
-	for (int i = 0; i < 4; i++)
+	for (int j = 0; j < 10; j++)
 	{
-		float w = 0.0;
-		if (written)
-			w += v;
-		else
-			v = 20.0;
+		for (int i = 0; i < 4; i++)
+		{
+			float w = 0.0;
+			if (written)
+				w += v;
+			else
+				v = 20.0;
 
-		v += float(i);
-		written = true;
+			v += float(i);
+			written = true;
+		}
 	}
 	FragColor = vec4(1.0);
 }

--- a/shaders/frag/inside-loop-dominated-variable-preservation.frag
+++ b/shaders/frag/inside-loop-dominated-variable-preservation.frag
@@ -1,0 +1,21 @@
+#version 310 es
+precision mediump float;
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	float v;
+	bool written = false;
+	for (int i = 0; i < 4; i++)
+	{
+		float w = 0.0;
+		if (written)
+			w += v;
+		else
+			v = 20.0;
+
+		v += float(i);
+		written = true;
+	}
+	FragColor = vec4(1.0);
+}

--- a/spirv_cfg.hpp
+++ b/spirv_cfg.hpp
@@ -93,6 +93,8 @@ public:
 			walk_from(seen_blocks, b, op);
 	}
 
+	uint32_t find_loop_dominator(uint32_t block) const;
+
 private:
 	struct VisitOrder
 	{

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -3361,13 +3361,13 @@ void Compiler::analyze_variable_scope(SPIRFunction &entry, AnalyzeVariableScopeA
 			auto &variable = get<SPIRVariable>(var.first);
 			if (!variable.phi_variable)
 			{
-				bool preserve = may_read_undefined_variable_in_block(get<SPIRBlock>(dominating_block), var.first);
+				auto &block = get<SPIRBlock>(dominating_block);
+				bool preserve = may_read_undefined_variable_in_block(block, var.first);
 				if (preserve)
 				{
-					uint32_t loop_dominator = cfg.find_loop_dominator(dominating_block);
-					if (loop_dominator != SPIRBlock::NoDominator)
+					if (block.loop_dominator != SPIRBlock::NoDominator)
 					{
-						builder.add_block(loop_dominator);
+						builder.add_block(block.loop_dominator);
 						dominating_block = builder.get_dominator();
 					}
 				}

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -947,6 +947,7 @@ protected:
 	void analyze_variable_scope(SPIRFunction &function, AnalyzeVariableScopeAccessHandler &handler);
 	void find_function_local_luts(SPIRFunction &function, const AnalyzeVariableScopeAccessHandler &handler,
 	                              bool single_function);
+	bool may_read_undefined_variable_in_block(const SPIRBlock &block, uint32_t var);
 
 	void make_constant_null(uint32_t id, uint32_t type);
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -423,7 +423,6 @@ protected:
 	void emit_specialization_constant_op(const SPIRConstantOp &constant);
 	std::string emit_continue_block(uint32_t continue_block, bool follow_true_block, bool follow_false_block);
 	bool attempt_emit_loop_header(SPIRBlock &block, SPIRBlock::Method method);
-	void propagate_loop_dominators(const SPIRBlock &block);
 
 	void branch(uint32_t from, uint32_t to);
 	void branch_to_continue(uint32_t from, uint32_t to);


### PR DESCRIPTION
There is a risk that we try to preserve a loop variable through multiple
iterations, even though the dominating block is inside a loop.
    
Fix this by analyzing if a block starts off by writing to a variable. In
that case, there cannot be any preservation going on. If we don't, pretend the
loop header is reading the variable, which moves the variable to an
appropriate scope.

Rewrite how loop dominators are propagated.
Do this analysis in the CFG stage rather than last minute with the
ad-hoc algorithm we had in place before CFG was introduced.

Some un-submitted RT shaders snuck in as well.

Fix #1007. 
Fix #423.

