### PR TITLE
Employ heuristics to figure out how to emit SSBO/UAV reflection names.

### DIFF
--- a/reference/shaders-reflection/asm/op-source-glsl-ssbo-1.asm.comp.json
+++ b/reference/shaders-reflection/asm/op-source-glsl-ssbo-1.asm.comp.json
@@ -1,0 +1,32 @@
+{
+    "entryPoints" : [
+        {
+            "name" : "main",
+            "mode" : "comp"
+        }
+    ],
+    "types" : {
+        "_5" : {
+            "name" : "SSBO0",
+            "members" : [
+                {
+                    "name" : "a",
+                    "type" : "vec4",
+                    "array" : [
+                        0
+                    ],
+                    "offset" : 0
+                }
+            ]
+        }
+    },
+    "ssbos" : [
+        {
+            "type" : "_5",
+            "name" : "SSBO0",
+            "block_size" : 0,
+            "set" : 0,
+            "binding" : 0
+        }
+    ]
+}

--- a/reference/shaders-reflection/asm/op-source-glsl-ssbo-2.asm.comp.json
+++ b/reference/shaders-reflection/asm/op-source-glsl-ssbo-2.asm.comp.json
@@ -1,0 +1,52 @@
+{
+    "entryPoints" : [
+        {
+            "name" : "main",
+            "mode" : "comp"
+        }
+    ],
+    "types" : {
+        "_4" : {
+            "name" : "SSBO0",
+            "members" : [
+                {
+                    "name" : "a",
+                    "type" : "vec4",
+                    "array" : [
+                        0
+                    ],
+                    "offset" : 0
+                }
+            ]
+        },
+        "_6" : {
+            "name" : "SSBO1",
+            "members" : [
+                {
+                    "name" : "b",
+                    "type" : "vec4",
+                    "array" : [
+                        0
+                    ],
+                    "offset" : 0
+                }
+            ]
+        }
+    },
+    "ssbos" : [
+        {
+            "type" : "_4",
+            "name" : "SSBO0",
+            "block_size" : 0,
+            "set" : 0,
+            "binding" : 0
+        },
+        {
+            "type" : "_6",
+            "name" : "SSBO1",
+            "block_size" : 0,
+            "set" : 0,
+            "binding" : 1
+        }
+    ]
+}

--- a/reference/shaders-reflection/asm/op-source-hlsl-uav-1.asm.comp.json
+++ b/reference/shaders-reflection/asm/op-source-hlsl-uav-1.asm.comp.json
@@ -1,0 +1,32 @@
+{
+    "entryPoints" : [
+        {
+            "name" : "main",
+            "mode" : "comp"
+        }
+    ],
+    "types" : {
+        "_4" : {
+            "name" : "UAV0",
+            "members" : [
+                {
+                    "name" : "_data",
+                    "type" : "vec4",
+                    "array" : [
+                        0
+                    ],
+                    "offset" : 0
+                }
+            ]
+        }
+    },
+    "ssbos" : [
+        {
+            "type" : "_4",
+            "name" : "UAV0",
+            "block_size" : 0,
+            "set" : 0,
+            "binding" : 0
+        }
+    ]
+}

--- a/reference/shaders-reflection/asm/op-source-hlsl-uav-2.asm.comp.json
+++ b/reference/shaders-reflection/asm/op-source-hlsl-uav-2.asm.comp.json
@@ -1,0 +1,39 @@
+{
+    "entryPoints" : [
+        {
+            "name" : "main",
+            "mode" : "comp"
+        }
+    ],
+    "types" : {
+        "_4" : {
+            "name" : "UAV0",
+            "members" : [
+                {
+                    "name" : "_data",
+                    "type" : "vec4",
+                    "array" : [
+                        0
+                    ],
+                    "offset" : 0
+                }
+            ]
+        }
+    },
+    "ssbos" : [
+        {
+            "type" : "_4",
+            "name" : "UAV0",
+            "block_size" : 0,
+            "set" : 0,
+            "binding" : 0
+        },
+        {
+            "type" : "_4",
+            "name" : "UAV1",
+            "block_size" : 0,
+            "set" : 0,
+            "binding" : 1
+        }
+    ]
+}

--- a/reference/shaders-reflection/asm/op-source-none-ssbo-1.asm.comp.json
+++ b/reference/shaders-reflection/asm/op-source-none-ssbo-1.asm.comp.json
@@ -1,0 +1,32 @@
+{
+    "entryPoints" : [
+        {
+            "name" : "main",
+            "mode" : "comp"
+        }
+    ],
+    "types" : {
+        "_5" : {
+            "name" : "SSBO0",
+            "members" : [
+                {
+                    "name" : "a",
+                    "type" : "vec4",
+                    "array" : [
+                        0
+                    ],
+                    "offset" : 0
+                }
+            ]
+        }
+    },
+    "ssbos" : [
+        {
+            "type" : "_5",
+            "name" : "SSBO0",
+            "block_size" : 0,
+            "set" : 0,
+            "binding" : 0
+        }
+    ]
+}

--- a/reference/shaders-reflection/asm/op-source-none-ssbo-2.asm.comp.json
+++ b/reference/shaders-reflection/asm/op-source-none-ssbo-2.asm.comp.json
@@ -1,0 +1,52 @@
+{
+    "entryPoints" : [
+        {
+            "name" : "main",
+            "mode" : "comp"
+        }
+    ],
+    "types" : {
+        "_4" : {
+            "name" : "SSBO0",
+            "members" : [
+                {
+                    "name" : "a",
+                    "type" : "vec4",
+                    "array" : [
+                        0
+                    ],
+                    "offset" : 0
+                }
+            ]
+        },
+        "_6" : {
+            "name" : "SSBO1",
+            "members" : [
+                {
+                    "name" : "b",
+                    "type" : "vec4",
+                    "array" : [
+                        0
+                    ],
+                    "offset" : 0
+                }
+            ]
+        }
+    },
+    "ssbos" : [
+        {
+            "type" : "_4",
+            "name" : "SSBO0",
+            "block_size" : 0,
+            "set" : 0,
+            "binding" : 0
+        },
+        {
+            "type" : "_6",
+            "name" : "SSBO1",
+            "block_size" : 0,
+            "set" : 0,
+            "binding" : 1
+        }
+    ]
+}

--- a/reference/shaders-reflection/asm/op-source-none-uav-1.asm.comp.json
+++ b/reference/shaders-reflection/asm/op-source-none-uav-1.asm.comp.json
@@ -1,0 +1,32 @@
+{
+    "entryPoints" : [
+        {
+            "name" : "main",
+            "mode" : "comp"
+        }
+    ],
+    "types" : {
+        "_4" : {
+            "name" : "UAV0",
+            "members" : [
+                {
+                    "name" : "_data",
+                    "type" : "vec4",
+                    "array" : [
+                        0
+                    ],
+                    "offset" : 0
+                }
+            ]
+        }
+    },
+    "ssbos" : [
+        {
+            "type" : "_4",
+            "name" : "UAV0",
+            "block_size" : 0,
+            "set" : 0,
+            "binding" : 0
+        }
+    ]
+}

--- a/reference/shaders-reflection/asm/op-source-none-uav-2.asm.comp.json
+++ b/reference/shaders-reflection/asm/op-source-none-uav-2.asm.comp.json
@@ -1,0 +1,39 @@
+{
+    "entryPoints" : [
+        {
+            "name" : "main",
+            "mode" : "comp"
+        }
+    ],
+    "types" : {
+        "_4" : {
+            "name" : "UAV0",
+            "members" : [
+                {
+                    "name" : "_data",
+                    "type" : "vec4",
+                    "array" : [
+                        0
+                    ],
+                    "offset" : 0
+                }
+            ]
+        }
+    },
+    "ssbos" : [
+        {
+            "type" : "_4",
+            "name" : "UAV0",
+            "block_size" : 0,
+            "set" : 0,
+            "binding" : 0
+        },
+        {
+            "type" : "_4",
+            "name" : "UAV1",
+            "block_size" : 0,
+            "set" : 0,
+            "binding" : 1
+        }
+    ]
+}

--- a/shaders-reflection/asm/op-source-glsl-ssbo-1.asm.comp
+++ b/shaders-reflection/asm/op-source-glsl-ssbo-1.asm.comp
@@ -1,0 +1,53 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 35
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %gl_GlobalInvocationID %_
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %SSBO0 "SSBO0"
+               OpMemberName %SSBO0 0 "a"
+               OpName %_ ""
+               OpName %gl_GlobalInvocationID "gl_GlobalInvocationID"
+               OpDecorate %_runtimearr_v4float ArrayStride 16
+               OpMemberDecorate %SSBO0 0 Offset 0
+               OpDecorate %SSBO0 BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 0
+               OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
+               OpDecorate %_runtimearr_v4float_0 ArrayStride 16
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_runtimearr_v4float = OpTypeRuntimeArray %v4float
+      %SSBO0 = OpTypeStruct %_runtimearr_v4float
+%_ptr_Uniform_SSBO0 = OpTypePointer Uniform %SSBO0
+          %_ = OpVariable %_ptr_Uniform_SSBO0 Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+       %uint = OpTypeInt 32 0
+     %v3uint = OpTypeVector %uint 3
+%_ptr_Input_v3uint = OpTypePointer Input %v3uint
+%gl_GlobalInvocationID = OpVariable %_ptr_Input_v3uint Input
+     %uint_0 = OpConstant %uint 0
+%_ptr_Input_uint = OpTypePointer Input %uint
+    %float_1 = OpConstant %float 1
+         %23 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
+%_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
+%_runtimearr_v4float_0 = OpTypeRuntimeArray %v4float
+    %float_2 = OpConstant %float 2
+         %33 = OpConstantComposite %v4float %float_2 %float_2 %float_2 %float_2
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %20 = OpAccessChain %_ptr_Input_uint %gl_GlobalInvocationID %uint_0
+         %21 = OpLoad %uint %20
+         %25 = OpAccessChain %_ptr_Uniform_v4float %_ %int_0 %21
+               OpStore %25 %23
+               OpReturn
+               OpFunctionEnd

--- a/shaders-reflection/asm/op-source-glsl-ssbo-2.asm.comp
+++ b/shaders-reflection/asm/op-source-glsl-ssbo-2.asm.comp
@@ -1,0 +1,65 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 35
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %gl_GlobalInvocationID
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %SSBO0 "SSBO0"
+               OpMemberName %SSBO0 0 "a"
+               OpName %_ ""
+               OpName %gl_GlobalInvocationID "gl_GlobalInvocationID"
+               OpName %SSBO1 "SSBO1"
+               OpMemberName %SSBO1 0 "b"
+               OpName %__0 ""
+               OpDecorate %_runtimearr_v4float ArrayStride 16
+               OpMemberDecorate %SSBO0 0 Offset 0
+               OpDecorate %SSBO0 BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 0
+               OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
+               OpDecorate %_runtimearr_v4float_0 ArrayStride 16
+               OpMemberDecorate %SSBO1 0 Offset 0
+               OpDecorate %SSBO1 BufferBlock
+               OpDecorate %__0 DescriptorSet 0
+               OpDecorate %__0 Binding 1
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_runtimearr_v4float = OpTypeRuntimeArray %v4float
+      %SSBO0 = OpTypeStruct %_runtimearr_v4float
+%_ptr_Uniform_SSBO0 = OpTypePointer Uniform %SSBO0
+          %_ = OpVariable %_ptr_Uniform_SSBO0 Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+       %uint = OpTypeInt 32 0
+     %v3uint = OpTypeVector %uint 3
+%_ptr_Input_v3uint = OpTypePointer Input %v3uint
+%gl_GlobalInvocationID = OpVariable %_ptr_Input_v3uint Input
+     %uint_0 = OpConstant %uint 0
+%_ptr_Input_uint = OpTypePointer Input %uint
+    %float_1 = OpConstant %float 1
+         %23 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
+%_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
+%_runtimearr_v4float_0 = OpTypeRuntimeArray %v4float
+      %SSBO1 = OpTypeStruct %_runtimearr_v4float_0
+%_ptr_Uniform_SSBO1 = OpTypePointer Uniform %SSBO1
+        %__0 = OpVariable %_ptr_Uniform_SSBO1 Uniform
+    %float_2 = OpConstant %float 2
+         %33 = OpConstantComposite %v4float %float_2 %float_2 %float_2 %float_2
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %20 = OpAccessChain %_ptr_Input_uint %gl_GlobalInvocationID %uint_0
+         %21 = OpLoad %uint %20
+         %25 = OpAccessChain %_ptr_Uniform_v4float %_ %int_0 %21
+               OpStore %25 %23
+         %34 = OpAccessChain %_ptr_Uniform_v4float %__0 %int_0 %21
+               OpStore %34 %33
+               OpReturn
+               OpFunctionEnd

--- a/shaders-reflection/asm/op-source-hlsl-uav-1.asm.comp
+++ b/shaders-reflection/asm/op-source-hlsl-uav-1.asm.comp
@@ -1,0 +1,48 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 48
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %threadId
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource HLSL 500
+               OpName %main "main"
+               OpName %UAV0 "UAV0"
+               OpMemberName %UAV0 0 "@data"
+               OpName %UAV0_0 "UAV0"
+               OpName %threadId "threadId"
+               OpDecorate %_runtimearr_v4float ArrayStride 16
+               OpMemberDecorate %UAV0 0 Offset 0
+               OpDecorate %UAV0 BufferBlock
+               OpDecorate %UAV0_0 DescriptorSet 0
+               OpDecorate %UAV0_0 Binding 0
+               OpDecorate %threadId BuiltIn GlobalInvocationId
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %v3int = OpTypeVector %int 3
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_runtimearr_v4float = OpTypeRuntimeArray %v4float
+       %UAV0 = OpTypeStruct %_runtimearr_v4float
+%_ptr_Uniform_UAV0 = OpTypePointer Uniform %UAV0
+     %UAV0_0 = OpVariable %_ptr_Uniform_UAV0 Uniform
+      %int_0 = OpConstant %int 0
+    %float_1 = OpConstant %float 1
+         %26 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
+%_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
+    %float_2 = OpConstant %float 2
+         %33 = OpConstantComposite %v4float %float_2 %float_2 %float_2 %float_2
+%_ptr_Input_v3int = OpTypePointer Input %v3int
+   %threadId = OpVariable %_ptr_Input_v3int Input
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %38 = OpLoad %v3int %threadId
+         %43 = OpCompositeExtract %int %38 0
+         %44 = OpAccessChain %_ptr_Uniform_v4float %UAV0_0 %int_0 %43
+               OpStore %44 %26
+               OpReturn
+               OpFunctionEnd

--- a/shaders-reflection/asm/op-source-hlsl-uav-2.asm.comp
+++ b/shaders-reflection/asm/op-source-hlsl-uav-2.asm.comp
@@ -1,0 +1,54 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 48
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %threadId
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource HLSL 500
+               OpName %main "main"
+               OpName %UAV0 "UAV0"
+               OpMemberName %UAV0 0 "@data"
+               OpName %UAV0_0 "UAV0"
+               OpName %UAV1 "UAV1"
+               OpName %threadId "threadId"
+               OpDecorate %_runtimearr_v4float ArrayStride 16
+               OpMemberDecorate %UAV0 0 Offset 0
+               OpDecorate %UAV0 BufferBlock
+               OpDecorate %UAV0_0 DescriptorSet 0
+               OpDecorate %UAV0_0 Binding 0
+               OpDecorate %UAV1 DescriptorSet 0
+               OpDecorate %UAV1 Binding 1
+               OpDecorate %threadId BuiltIn GlobalInvocationId
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %v3int = OpTypeVector %int 3
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_runtimearr_v4float = OpTypeRuntimeArray %v4float
+       %UAV0 = OpTypeStruct %_runtimearr_v4float
+%_ptr_Uniform_UAV0 = OpTypePointer Uniform %UAV0
+     %UAV0_0 = OpVariable %_ptr_Uniform_UAV0 Uniform
+      %int_0 = OpConstant %int 0
+    %float_1 = OpConstant %float 1
+         %26 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
+%_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
+       %UAV1 = OpVariable %_ptr_Uniform_UAV0 Uniform
+    %float_2 = OpConstant %float 2
+         %33 = OpConstantComposite %v4float %float_2 %float_2 %float_2 %float_2
+%_ptr_Input_v3int = OpTypePointer Input %v3int
+   %threadId = OpVariable %_ptr_Input_v3int Input
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %38 = OpLoad %v3int %threadId
+         %43 = OpCompositeExtract %int %38 0
+         %44 = OpAccessChain %_ptr_Uniform_v4float %UAV0_0 %int_0 %43
+               OpStore %44 %26
+         %47 = OpAccessChain %_ptr_Uniform_v4float %UAV1 %int_0 %43
+               OpStore %47 %33
+               OpReturn
+               OpFunctionEnd

--- a/shaders-reflection/asm/op-source-none-ssbo-1.asm.comp
+++ b/shaders-reflection/asm/op-source-none-ssbo-1.asm.comp
@@ -1,0 +1,52 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 35
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %gl_GlobalInvocationID %_
+               OpExecutionMode %main LocalSize 1 1 1
+               OpName %main "main"
+               OpName %SSBO0 "SSBO0"
+               OpMemberName %SSBO0 0 "a"
+               OpName %_ ""
+               OpName %gl_GlobalInvocationID "gl_GlobalInvocationID"
+               OpDecorate %_runtimearr_v4float ArrayStride 16
+               OpMemberDecorate %SSBO0 0 Offset 0
+               OpDecorate %SSBO0 BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 0
+               OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
+               OpDecorate %_runtimearr_v4float_0 ArrayStride 16
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_runtimearr_v4float = OpTypeRuntimeArray %v4float
+      %SSBO0 = OpTypeStruct %_runtimearr_v4float
+%_ptr_Uniform_SSBO0 = OpTypePointer Uniform %SSBO0
+          %_ = OpVariable %_ptr_Uniform_SSBO0 Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+       %uint = OpTypeInt 32 0
+     %v3uint = OpTypeVector %uint 3
+%_ptr_Input_v3uint = OpTypePointer Input %v3uint
+%gl_GlobalInvocationID = OpVariable %_ptr_Input_v3uint Input
+     %uint_0 = OpConstant %uint 0
+%_ptr_Input_uint = OpTypePointer Input %uint
+    %float_1 = OpConstant %float 1
+         %23 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
+%_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
+%_runtimearr_v4float_0 = OpTypeRuntimeArray %v4float
+    %float_2 = OpConstant %float 2
+         %33 = OpConstantComposite %v4float %float_2 %float_2 %float_2 %float_2
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %20 = OpAccessChain %_ptr_Input_uint %gl_GlobalInvocationID %uint_0
+         %21 = OpLoad %uint %20
+         %25 = OpAccessChain %_ptr_Uniform_v4float %_ %int_0 %21
+               OpStore %25 %23
+               OpReturn
+               OpFunctionEnd

--- a/shaders-reflection/asm/op-source-none-ssbo-2.asm.comp
+++ b/shaders-reflection/asm/op-source-none-ssbo-2.asm.comp
@@ -1,0 +1,64 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 35
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %gl_GlobalInvocationID
+               OpExecutionMode %main LocalSize 1 1 1
+               OpName %main "main"
+               OpName %SSBO0 "SSBO0"
+               OpMemberName %SSBO0 0 "a"
+               OpName %_ ""
+               OpName %gl_GlobalInvocationID "gl_GlobalInvocationID"
+               OpName %SSBO1 "SSBO1"
+               OpMemberName %SSBO1 0 "b"
+               OpName %__0 ""
+               OpDecorate %_runtimearr_v4float ArrayStride 16
+               OpMemberDecorate %SSBO0 0 Offset 0
+               OpDecorate %SSBO0 BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 0
+               OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
+               OpDecorate %_runtimearr_v4float_0 ArrayStride 16
+               OpMemberDecorate %SSBO1 0 Offset 0
+               OpDecorate %SSBO1 BufferBlock
+               OpDecorate %__0 DescriptorSet 0
+               OpDecorate %__0 Binding 1
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_runtimearr_v4float = OpTypeRuntimeArray %v4float
+      %SSBO0 = OpTypeStruct %_runtimearr_v4float
+%_ptr_Uniform_SSBO0 = OpTypePointer Uniform %SSBO0
+          %_ = OpVariable %_ptr_Uniform_SSBO0 Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+       %uint = OpTypeInt 32 0
+     %v3uint = OpTypeVector %uint 3
+%_ptr_Input_v3uint = OpTypePointer Input %v3uint
+%gl_GlobalInvocationID = OpVariable %_ptr_Input_v3uint Input
+     %uint_0 = OpConstant %uint 0
+%_ptr_Input_uint = OpTypePointer Input %uint
+    %float_1 = OpConstant %float 1
+         %23 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
+%_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
+%_runtimearr_v4float_0 = OpTypeRuntimeArray %v4float
+      %SSBO1 = OpTypeStruct %_runtimearr_v4float_0
+%_ptr_Uniform_SSBO1 = OpTypePointer Uniform %SSBO1
+        %__0 = OpVariable %_ptr_Uniform_SSBO1 Uniform
+    %float_2 = OpConstant %float 2
+         %33 = OpConstantComposite %v4float %float_2 %float_2 %float_2 %float_2
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %20 = OpAccessChain %_ptr_Input_uint %gl_GlobalInvocationID %uint_0
+         %21 = OpLoad %uint %20
+         %25 = OpAccessChain %_ptr_Uniform_v4float %_ %int_0 %21
+               OpStore %25 %23
+         %34 = OpAccessChain %_ptr_Uniform_v4float %__0 %int_0 %21
+               OpStore %34 %33
+               OpReturn
+               OpFunctionEnd

--- a/shaders-reflection/asm/op-source-none-uav-1.asm.comp
+++ b/shaders-reflection/asm/op-source-none-uav-1.asm.comp
@@ -1,0 +1,47 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 48
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %threadId
+               OpExecutionMode %main LocalSize 1 1 1
+               OpName %main "main"
+               OpName %UAV0 "UAV0"
+               OpMemberName %UAV0 0 "@data"
+               OpName %UAV0_0 "UAV0"
+               OpName %threadId "threadId"
+               OpDecorate %_runtimearr_v4float ArrayStride 16
+               OpMemberDecorate %UAV0 0 Offset 0
+               OpDecorate %UAV0 BufferBlock
+               OpDecorate %UAV0_0 DescriptorSet 0
+               OpDecorate %UAV0_0 Binding 0
+               OpDecorate %threadId BuiltIn GlobalInvocationId
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %v3int = OpTypeVector %int 3
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_runtimearr_v4float = OpTypeRuntimeArray %v4float
+       %UAV0 = OpTypeStruct %_runtimearr_v4float
+%_ptr_Uniform_UAV0 = OpTypePointer Uniform %UAV0
+     %UAV0_0 = OpVariable %_ptr_Uniform_UAV0 Uniform
+      %int_0 = OpConstant %int 0
+    %float_1 = OpConstant %float 1
+         %26 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
+%_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
+    %float_2 = OpConstant %float 2
+         %33 = OpConstantComposite %v4float %float_2 %float_2 %float_2 %float_2
+%_ptr_Input_v3int = OpTypePointer Input %v3int
+   %threadId = OpVariable %_ptr_Input_v3int Input
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %38 = OpLoad %v3int %threadId
+         %43 = OpCompositeExtract %int %38 0
+         %44 = OpAccessChain %_ptr_Uniform_v4float %UAV0_0 %int_0 %43
+               OpStore %44 %26
+               OpReturn
+               OpFunctionEnd

--- a/shaders-reflection/asm/op-source-none-uav-2.asm.comp
+++ b/shaders-reflection/asm/op-source-none-uav-2.asm.comp
@@ -1,0 +1,53 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 48
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %threadId
+               OpExecutionMode %main LocalSize 1 1 1
+               OpName %main "main"
+               OpName %UAV0 "UAV0"
+               OpMemberName %UAV0 0 "@data"
+               OpName %UAV0_0 "UAV0"
+               OpName %UAV1 "UAV1"
+               OpName %threadId "threadId"
+               OpDecorate %_runtimearr_v4float ArrayStride 16
+               OpMemberDecorate %UAV0 0 Offset 0
+               OpDecorate %UAV0 BufferBlock
+               OpDecorate %UAV0_0 DescriptorSet 0
+               OpDecorate %UAV0_0 Binding 0
+               OpDecorate %UAV1 DescriptorSet 0
+               OpDecorate %UAV1 Binding 1
+               OpDecorate %threadId BuiltIn GlobalInvocationId
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %v3int = OpTypeVector %int 3
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_runtimearr_v4float = OpTypeRuntimeArray %v4float
+       %UAV0 = OpTypeStruct %_runtimearr_v4float
+%_ptr_Uniform_UAV0 = OpTypePointer Uniform %UAV0
+     %UAV0_0 = OpVariable %_ptr_Uniform_UAV0 Uniform
+      %int_0 = OpConstant %int 0
+    %float_1 = OpConstant %float 1
+         %26 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
+%_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
+       %UAV1 = OpVariable %_ptr_Uniform_UAV0 Uniform
+    %float_2 = OpConstant %float 2
+         %33 = OpConstantComposite %v4float %float_2 %float_2 %float_2 %float_2
+%_ptr_Input_v3int = OpTypePointer Input %v3int
+   %threadId = OpVariable %_ptr_Input_v3int Input
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %38 = OpLoad %v3int %threadId
+         %43 = OpCompositeExtract %int %38 0
+         %44 = OpAccessChain %_ptr_Uniform_v4float %UAV0_0 %int_0 %43
+               OpStore %44 %26
+         %47 = OpAccessChain %_ptr_Uniform_v4float %UAV1 %int_0 %43
+               OpStore %47 %33
+               OpReturn
+               OpFunctionEnd

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -976,6 +976,9 @@ protected:
 	bool type_is_block_like(const SPIRType &type) const;
 	bool type_is_opaque_value(const SPIRType &type) const;
 
+	bool reflection_ssbo_instance_name_is_significant() const;
+	std::string get_remapped_declared_block_name(uint32_t id, bool fallback_prefer_instance_name) const;
+
 private:
 	// Used only to implement the old deprecated get_entry_point() interface.
 	const SPIREntryPoint &get_first_entry_point(const std::string &name) const;


### PR DESCRIPTION
This is rather shaky, but we don't have many choices here except add a
lot of awkward and unintuitive options. Try to deduce this from OpSource
and fallback to heuristic.

Fix #1018.