### PR TITLE
MSL: Support OpImageQueryLod.

### DIFF
--- a/reference/opt/shaders-msl/frag/image-query-lod.msl22.frag
+++ b/reference/opt/shaders-msl/frag/image-query-lod.msl22.frag
@@ -1,0 +1,70 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float2 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 vUV [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> uSampler2D [[texture(0)]], texture3d<float> uSampler3D [[texture(1)]], texturecube<float> uSamplerCube [[texture(2)]], texture2d<float> uTexture2D [[texture(4)]], texture3d<float> uTexture3D [[texture(5)]], texturecube<float> uTextureCube [[texture(6)]], sampler uSampler2DSmplr [[sampler(0)]], sampler uSampler3DSmplr [[sampler(1)]], sampler uSamplerCubeSmplr [[sampler(2)]], sampler uSampler [[sampler(3)]])
+{
+    main0_out out = {};
+    out.FragColor = float2(0.0);
+    float2 _79;
+    _79.x = uSampler2D.calculate_clamped_lod(uSampler2DSmplr, in.vUV.xy);
+    _79.y = uSampler2D.calculate_unclamped_lod(uSampler2DSmplr, in.vUV.xy);
+    out.FragColor += _79;
+    float2 _84;
+    _84.x = uSampler3D.calculate_clamped_lod(uSampler3DSmplr, in.vUV);
+    _84.y = uSampler3D.calculate_unclamped_lod(uSampler3DSmplr, in.vUV);
+    out.FragColor += _84;
+    float2 _89;
+    _89.x = uSamplerCube.calculate_clamped_lod(uSamplerCubeSmplr, in.vUV);
+    _89.y = uSamplerCube.calculate_unclamped_lod(uSamplerCubeSmplr, in.vUV);
+    out.FragColor += _89;
+    float2 _97;
+    _97.x = uTexture2D.calculate_clamped_lod(uSampler, in.vUV.xy);
+    _97.y = uTexture2D.calculate_unclamped_lod(uSampler, in.vUV.xy);
+    out.FragColor += _97;
+    float2 _104;
+    _104.x = uTexture3D.calculate_clamped_lod(uSampler, in.vUV);
+    _104.y = uTexture3D.calculate_unclamped_lod(uSampler, in.vUV);
+    out.FragColor += _104;
+    float2 _111;
+    _111.x = uTextureCube.calculate_clamped_lod(uSampler, in.vUV);
+    _111.y = uTextureCube.calculate_unclamped_lod(uSampler, in.vUV);
+    out.FragColor += _111;
+    float2 _118;
+    _118.x = uSampler2D.calculate_clamped_lod(uSampler2DSmplr, in.vUV.xy);
+    _118.y = uSampler2D.calculate_unclamped_lod(uSampler2DSmplr, in.vUV.xy);
+    out.FragColor += _118;
+    float2 _123;
+    _123.x = uSampler3D.calculate_clamped_lod(uSampler3DSmplr, in.vUV);
+    _123.y = uSampler3D.calculate_unclamped_lod(uSampler3DSmplr, in.vUV);
+    out.FragColor += _123;
+    float2 _128;
+    _128.x = uSamplerCube.calculate_clamped_lod(uSamplerCubeSmplr, in.vUV);
+    _128.y = uSamplerCube.calculate_unclamped_lod(uSamplerCubeSmplr, in.vUV);
+    out.FragColor += _128;
+    float2 _136;
+    _136.x = uTexture2D.calculate_clamped_lod(uSampler, in.vUV.xy);
+    _136.y = uTexture2D.calculate_unclamped_lod(uSampler, in.vUV.xy);
+    out.FragColor += _136;
+    float2 _143;
+    _143.x = uTexture3D.calculate_clamped_lod(uSampler, in.vUV);
+    _143.y = uTexture3D.calculate_unclamped_lod(uSampler, in.vUV);
+    out.FragColor += _143;
+    float2 _150;
+    _150.x = uTextureCube.calculate_clamped_lod(uSampler, in.vUV);
+    _150.y = uTextureCube.calculate_unclamped_lod(uSampler, in.vUV);
+    out.FragColor += _150;
+    return out;
+}
+

--- a/reference/shaders-msl/frag/image-query-lod.msl22.frag
+++ b/reference/shaders-msl/frag/image-query-lod.msl22.frag
@@ -1,0 +1,77 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float2 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 vUV [[user(locn0)]];
+};
+
+void from_function(thread float2& FragColor, thread texture2d<float> uSampler2D, thread const sampler uSampler2DSmplr, thread float3& vUV, thread texture3d<float> uSampler3D, thread const sampler uSampler3DSmplr, thread texturecube<float> uSamplerCube, thread const sampler uSamplerCubeSmplr, thread texture2d<float> uTexture2D, thread sampler uSampler, thread texture3d<float> uTexture3D, thread texturecube<float> uTextureCube)
+{
+    float2 _22;
+    _22.x = uSampler2D.calculate_clamped_lod(uSampler2DSmplr, vUV.xy);
+    _22.y = uSampler2D.calculate_unclamped_lod(uSampler2DSmplr, vUV.xy);
+    FragColor += _22;
+    float2 _31;
+    _31.x = uSampler3D.calculate_clamped_lod(uSampler3DSmplr, vUV);
+    _31.y = uSampler3D.calculate_unclamped_lod(uSampler3DSmplr, vUV);
+    FragColor += _31;
+    float2 _40;
+    _40.x = uSamplerCube.calculate_clamped_lod(uSamplerCubeSmplr, vUV);
+    _40.y = uSamplerCube.calculate_unclamped_lod(uSamplerCubeSmplr, vUV);
+    FragColor += _40;
+    float2 _53;
+    _53.x = uTexture2D.calculate_clamped_lod(uSampler, vUV.xy);
+    _53.y = uTexture2D.calculate_unclamped_lod(uSampler, vUV.xy);
+    FragColor += _53;
+    float2 _62;
+    _62.x = uTexture3D.calculate_clamped_lod(uSampler, vUV);
+    _62.y = uTexture3D.calculate_unclamped_lod(uSampler, vUV);
+    FragColor += _62;
+    float2 _71;
+    _71.x = uTextureCube.calculate_clamped_lod(uSampler, vUV);
+    _71.y = uTextureCube.calculate_unclamped_lod(uSampler, vUV);
+    FragColor += _71;
+}
+
+fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> uSampler2D [[texture(0)]], texture3d<float> uSampler3D [[texture(1)]], texturecube<float> uSamplerCube [[texture(2)]], texture2d<float> uTexture2D [[texture(4)]], texture3d<float> uTexture3D [[texture(5)]], texturecube<float> uTextureCube [[texture(6)]], sampler uSampler2DSmplr [[sampler(0)]], sampler uSampler3DSmplr [[sampler(1)]], sampler uSamplerCubeSmplr [[sampler(2)]], sampler uSampler [[sampler(3)]])
+{
+    main0_out out = {};
+    out.FragColor = float2(0.0);
+    float2 _79;
+    _79.x = uSampler2D.calculate_clamped_lod(uSampler2DSmplr, in.vUV.xy);
+    _79.y = uSampler2D.calculate_unclamped_lod(uSampler2DSmplr, in.vUV.xy);
+    out.FragColor += _79;
+    float2 _84;
+    _84.x = uSampler3D.calculate_clamped_lod(uSampler3DSmplr, in.vUV);
+    _84.y = uSampler3D.calculate_unclamped_lod(uSampler3DSmplr, in.vUV);
+    out.FragColor += _84;
+    float2 _89;
+    _89.x = uSamplerCube.calculate_clamped_lod(uSamplerCubeSmplr, in.vUV);
+    _89.y = uSamplerCube.calculate_unclamped_lod(uSamplerCubeSmplr, in.vUV);
+    out.FragColor += _89;
+    float2 _97;
+    _97.x = uTexture2D.calculate_clamped_lod(uSampler, in.vUV.xy);
+    _97.y = uTexture2D.calculate_unclamped_lod(uSampler, in.vUV.xy);
+    out.FragColor += _97;
+    float2 _104;
+    _104.x = uTexture3D.calculate_clamped_lod(uSampler, in.vUV);
+    _104.y = uTexture3D.calculate_unclamped_lod(uSampler, in.vUV);
+    out.FragColor += _104;
+    float2 _111;
+    _111.x = uTextureCube.calculate_clamped_lod(uSampler, in.vUV);
+    _111.y = uTextureCube.calculate_unclamped_lod(uSampler, in.vUV);
+    out.FragColor += _111;
+    from_function(out.FragColor, uSampler2D, uSampler2DSmplr, in.vUV, uSampler3D, uSampler3DSmplr, uSamplerCube, uSamplerCubeSmplr, uTexture2D, uSampler, uTexture3D, uTextureCube);
+    return out;
+}
+

--- a/shaders-msl/frag/image-query-lod.msl22.frag
+++ b/shaders-msl/frag/image-query-lod.msl22.frag
@@ -1,0 +1,33 @@
+#version 450
+
+layout(location = 0) out vec2 FragColor;
+layout(set = 0, binding = 0) uniform sampler2D uSampler2D;
+layout(set = 0, binding = 1) uniform sampler3D uSampler3D;
+layout(set = 0, binding = 2) uniform samplerCube uSamplerCube;
+layout(set = 0, binding = 3) uniform sampler uSampler;
+layout(set = 0, binding = 4) uniform texture2D uTexture2D;
+layout(set = 0, binding = 5) uniform texture3D uTexture3D;
+layout(set = 0, binding = 6) uniform textureCube uTextureCube;
+layout(location = 0) in vec3 vUV;
+
+void from_function()
+{
+	FragColor += textureQueryLod(uSampler2D, vUV.xy);
+	FragColor += textureQueryLod(uSampler3D, vUV);
+	FragColor += textureQueryLod(uSamplerCube, vUV);
+	FragColor += textureQueryLod(sampler2D(uTexture2D, uSampler), vUV.xy);
+	FragColor += textureQueryLod(sampler3D(uTexture3D, uSampler), vUV);
+	FragColor += textureQueryLod(samplerCube(uTextureCube, uSampler), vUV);
+}
+
+void main()
+{
+	FragColor = vec2(0.0);
+	FragColor += textureQueryLod(uSampler2D, vUV.xy);
+	FragColor += textureQueryLod(uSampler3D, vUV);
+	FragColor += textureQueryLod(uSamplerCube, vUV);
+	FragColor += textureQueryLod(sampler2D(uTexture2D, uSampler), vUV.xy);
+	FragColor += textureQueryLod(sampler3D(uTexture3D, uSampler), vUV);
+	FragColor += textureQueryLod(samplerCube(uTextureCube, uSampler), vUV);
+	from_function();
+}


### PR DESCRIPTION
Correctness is a bit unclear at the moment. The spec document for 2.2 is
not updated for query-lod, but this is the best we can do anyways.

Fix #1013.