### PR TITLE
MSL: Support barycentrics and PrimitiveID in fragment shaders

### DIFF
--- a/reference/opt/shaders-msl/frag/barycentric-nv-nopersp.msl22.frag
+++ b/reference/opt/shaders-msl/frag/barycentric-nv-nopersp.msl22.frag
@@ -1,0 +1,28 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Vertices
+{
+    float2 uvs[1];
+};
+
+struct main0_out
+{
+    float2 value [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 gl_BaryCoordNoPerspNV [[barycentric_coord, center_no_perspective]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], const device Vertices& _19 [[buffer(0)]], uint gl_PrimitiveID [[primitive_id]])
+{
+    main0_out out = {};
+    int _23 = 3 * int(gl_PrimitiveID);
+    out.value = ((_19.uvs[_23] * in.gl_BaryCoordNoPerspNV.x) + (_19.uvs[_23 + 1] * in.gl_BaryCoordNoPerspNV.y)) + (_19.uvs[_23 + 2] * in.gl_BaryCoordNoPerspNV.z);
+    return out;
+}
+

--- a/reference/opt/shaders-msl/frag/barycentric-nv.msl22.frag
+++ b/reference/opt/shaders-msl/frag/barycentric-nv.msl22.frag
@@ -1,0 +1,28 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Vertices
+{
+    float2 uvs[1];
+};
+
+struct main0_out
+{
+    float2 value [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 gl_BaryCoordNV [[barycentric_coord, center_perspective]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], const device Vertices& _19 [[buffer(0)]], uint gl_PrimitiveID [[primitive_id]])
+{
+    main0_out out = {};
+    int _23 = 3 * int(gl_PrimitiveID);
+    out.value = ((_19.uvs[_23] * in.gl_BaryCoordNV.x) + (_19.uvs[_23 + 1] * in.gl_BaryCoordNV.y)) + (_19.uvs[_23 + 2] * in.gl_BaryCoordNV.z);
+    return out;
+}
+

--- a/reference/opt/shaders/frag/barycentric-nv.frag
+++ b/reference/opt/shaders/frag/barycentric-nv.frag
@@ -1,0 +1,19 @@
+#version 450
+#extension GL_NV_fragment_shader_barycentric : require
+
+layout(binding = 0, std430) readonly buffer Vertices
+{
+    vec2 uvs[];
+} _19;
+
+layout(location = 0) out vec2 value;
+
+void main()
+{
+    int _23 = 3 * gl_PrimitiveID;
+    int _32 = _23 + 1;
+    int _39 = _23 + 2;
+    value = ((_19.uvs[_23] * gl_BaryCoordNV.x) + (_19.uvs[_32] * gl_BaryCoordNV.y)) + (_19.uvs[_39] * gl_BaryCoordNV.z);
+    value += (((_19.uvs[_23] * gl_BaryCoordNoPerspNV.x) + (_19.uvs[_32] * gl_BaryCoordNoPerspNV.y)) + (_19.uvs[_39] * gl_BaryCoordNoPerspNV.z));
+}
+

--- a/reference/shaders-msl/frag/barycentric-nv-nopersp.msl22.frag
+++ b/reference/shaders-msl/frag/barycentric-nv-nopersp.msl22.frag
@@ -1,0 +1,31 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Vertices
+{
+    float2 uvs[1];
+};
+
+struct main0_out
+{
+    float2 value [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 gl_BaryCoordNoPerspNV [[barycentric_coord, center_no_perspective]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], const device Vertices& _19 [[buffer(0)]], uint gl_PrimitiveID [[primitive_id]])
+{
+    main0_out out = {};
+    int prim = int(gl_PrimitiveID);
+    float2 uv0 = _19.uvs[(3 * prim) + 0];
+    float2 uv1 = _19.uvs[(3 * prim) + 1];
+    float2 uv2 = _19.uvs[(3 * prim) + 2];
+    out.value = ((uv0 * in.gl_BaryCoordNoPerspNV.x) + (uv1 * in.gl_BaryCoordNoPerspNV.y)) + (uv2 * in.gl_BaryCoordNoPerspNV.z);
+    return out;
+}
+

--- a/reference/shaders-msl/frag/barycentric-nv.msl22.frag
+++ b/reference/shaders-msl/frag/barycentric-nv.msl22.frag
@@ -1,0 +1,31 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Vertices
+{
+    float2 uvs[1];
+};
+
+struct main0_out
+{
+    float2 value [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 gl_BaryCoordNV [[barycentric_coord, center_perspective]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], const device Vertices& _19 [[buffer(0)]], uint gl_PrimitiveID [[primitive_id]])
+{
+    main0_out out = {};
+    int prim = int(gl_PrimitiveID);
+    float2 uv0 = _19.uvs[(3 * prim) + 0];
+    float2 uv1 = _19.uvs[(3 * prim) + 1];
+    float2 uv2 = _19.uvs[(3 * prim) + 2];
+    out.value = ((uv0 * in.gl_BaryCoordNV.x) + (uv1 * in.gl_BaryCoordNV.y)) + (uv2 * in.gl_BaryCoordNV.z);
+    return out;
+}
+

--- a/reference/shaders/frag/barycentric-nv.frag
+++ b/reference/shaders/frag/barycentric-nv.frag
@@ -1,0 +1,20 @@
+#version 450
+#extension GL_NV_fragment_shader_barycentric : require
+
+layout(binding = 0, std430) readonly buffer Vertices
+{
+    vec2 uvs[];
+} _19;
+
+layout(location = 0) out vec2 value;
+
+void main()
+{
+    int prim = gl_PrimitiveID;
+    vec2 uv0 = _19.uvs[(3 * prim) + 0];
+    vec2 uv1 = _19.uvs[(3 * prim) + 1];
+    vec2 uv2 = _19.uvs[(3 * prim) + 2];
+    value = ((uv0 * gl_BaryCoordNV.x) + (uv1 * gl_BaryCoordNV.y)) + (uv2 * gl_BaryCoordNV.z);
+    value += (((uv0 * gl_BaryCoordNoPerspNV.x) + (uv1 * gl_BaryCoordNoPerspNV.y)) + (uv2 * gl_BaryCoordNoPerspNV.z));
+}
+

--- a/shaders-msl/frag/barycentric-nv-nopersp.msl22.frag
+++ b/shaders-msl/frag/barycentric-nv-nopersp.msl22.frag
@@ -1,0 +1,17 @@
+#version 450
+#extension GL_NV_fragment_shader_barycentric : require
+
+layout(location = 0) out vec2 value;
+
+layout(set = 0, binding = 0) readonly buffer Vertices
+{
+	vec2 uvs[];
+};
+      
+void main () {
+	int prim = gl_PrimitiveID;
+	vec2 uv0 = uvs[3 * prim + 0];
+	vec2 uv1 = uvs[3 * prim + 1];
+	vec2 uv2 = uvs[3 * prim + 2];
+    value = gl_BaryCoordNoPerspNV.x * uv0 + gl_BaryCoordNoPerspNV.y * uv1 + gl_BaryCoordNoPerspNV.z * uv2;
+}

--- a/shaders-msl/frag/barycentric-nv.msl22.frag
+++ b/shaders-msl/frag/barycentric-nv.msl22.frag
@@ -1,0 +1,17 @@
+#version 450
+#extension GL_NV_fragment_shader_barycentric : require
+
+layout(location = 0) out vec2 value;
+
+layout(set = 0, binding = 0) readonly buffer Vertices
+{
+	vec2 uvs[];
+};
+      
+void main () {
+	int prim = gl_PrimitiveID;
+	vec2 uv0 = uvs[3 * prim + 0];
+	vec2 uv1 = uvs[3 * prim + 1];
+	vec2 uv2 = uvs[3 * prim + 2];
+    value = gl_BaryCoordNV.x * uv0 + gl_BaryCoordNV.y * uv1 + gl_BaryCoordNV.z * uv2;
+}

--- a/shaders/frag/barycentric-nv.frag
+++ b/shaders/frag/barycentric-nv.frag
@@ -1,0 +1,18 @@
+#version 450
+#extension GL_NV_fragment_shader_barycentric : require
+
+layout(location = 0) out vec2 value;
+
+layout(set = 0, binding = 0) readonly buffer Vertices
+{
+	vec2 uvs[];
+};
+      
+void main () {
+	int prim = gl_PrimitiveID;
+	vec2 uv0 = uvs[3 * prim + 0];
+	vec2 uv1 = uvs[3 * prim + 1];
+	vec2 uv2 = uvs[3 * prim + 2];
+    value = gl_BaryCoordNV.x * uv0 + gl_BaryCoordNV.y * uv1 + gl_BaryCoordNV.z * uv2;
+    value += gl_BaryCoordNoPerspNV.x * uv0 + gl_BaryCoordNoPerspNV.y * uv1 + gl_BaryCoordNoPerspNV.z * uv2;
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -6156,6 +6156,26 @@ string CompilerGLSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 	case BuiltInIncomingRayFlagsNV:
 		return "gl_IncomingRayFlagsNV";
 
+	case BuiltInBaryCoordNV:
+	{
+		if (options.es && options.version < 320)
+			SPIRV_CROSS_THROW("gl_BaryCoordNV requires ESSL 320.");
+		else if (!options.es && options.version < 450)
+			SPIRV_CROSS_THROW("gl_BaryCoordNV requires GLSL 450.");
+		require_extension_internal("GL_NV_fragment_shader_barycentric");
+		return "gl_BaryCoordNV";
+	}
+
+	case BuiltInBaryCoordNoPerspNV:
+	{
+		if (options.es && options.version < 320)
+			SPIRV_CROSS_THROW("gl_BaryCoordNoPerspNV requires ESSL 320.");
+		else if (!options.es && options.version < 450)
+			SPIRV_CROSS_THROW("gl_BaryCoordNoPerspNV requires GLSL 450.");
+		require_extension_internal("GL_NV_fragment_shader_barycentric");
+		return "gl_BaryCoordNoPerspNV";
+	}
+
 	case BuiltInFragStencilRefEXT:
 	{
 		if (!options.es)

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -471,7 +471,7 @@ protected:
 	std::string to_swizzle_expression(uint32_t id);
 	std::string to_buffer_size_expression(uint32_t id);
 	std::string builtin_qualifier(spv::BuiltIn builtin);
-	std::string builtin_type_decl(spv::BuiltIn builtin);
+	std::string builtin_type_decl(spv::BuiltIn builtin, uint32_t id = 0);
 	std::string built_in_func_arg(spv::BuiltIn builtin, bool prefix_comma);
 	std::string member_attribute_qualifier(const SPIRType &type, uint32_t index);
 	std::string argument_decl(const SPIRFunction::Parameter &arg);


### PR DESCRIPTION
Was also trivial to add GLSL support for GL_NV_fragment_shader_barycentric.

Fix #1010.