### PR TITLE
Prepare for MSL 2.2 testing

### DIFF
--- a/reference/opt/shaders-msl/desktop-only/vert/clip-cull-distance.desktop.vert
+++ b/reference/opt/shaders-msl/desktop-only/vert/clip-cull-distance.desktop.vert
@@ -7,7 +7,6 @@ struct main0_out
 {
     float4 gl_Position [[position]];
     float gl_ClipDistance [[clip_distance]] [2];
-    float gl_CullDistance[2];
 };
 
 vertex main0_out main0()
@@ -16,8 +15,6 @@ vertex main0_out main0()
     out.gl_Position = float4(10.0);
     out.gl_ClipDistance[0] = 1.0;
     out.gl_ClipDistance[1] = 4.0;
-    out.gl_CullDistance[0] = 4.0;
-    out.gl_CullDistance[1] = 9.0;
     return out;
 }
 

--- a/reference/shaders-msl/desktop-only/vert/clip-cull-distance.desktop.vert
+++ b/reference/shaders-msl/desktop-only/vert/clip-cull-distance.desktop.vert
@@ -7,7 +7,6 @@ struct main0_out
 {
     float4 gl_Position [[position]];
     float gl_ClipDistance [[clip_distance]] [2];
-    float gl_CullDistance[2];
 };
 
 vertex main0_out main0()
@@ -16,8 +15,6 @@ vertex main0_out main0()
     out.gl_Position = float4(10.0);
     out.gl_ClipDistance[0] = 1.0;
     out.gl_ClipDistance[1] = 4.0;
-    out.gl_CullDistance[0] = 4.0;
-    out.gl_CullDistance[1] = 9.0;
     return out;
 }
 

--- a/shaders-msl/desktop-only/vert/clip-cull-distance.desktop.vert
+++ b/shaders-msl/desktop-only/vert/clip-cull-distance.desktop.vert
@@ -5,6 +5,6 @@ void main()
    gl_Position = vec4(10.0);
    gl_ClipDistance[0] = 1.0;
    gl_ClipDistance[1] = 4.0;
-   gl_CullDistance[0] = 4.0;
-   gl_CullDistance[1] = 9.0;
+   //gl_CullDistance[0] = 4.0;
+   //gl_CullDistance[1] = 9.0;
 }

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -90,6 +90,21 @@ def print_msl_compiler_version():
     except OSError as e:
         if (e.errno != errno.ENOENT):    # Ignore xcrun not found error
             raise
+    except subprocess.CalledProcessError:
+        pass
+
+def msl_compiler_supports_22():
+    try:
+        subprocess.check_call(['xcrun', '--sdk', 'macosx', 'metal', '-x', 'metal', '-std=macos-metal2.2', '-'],
+                stdin = subprocess.DEVNULL, stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL)
+        print('Current SDK supports MSL 2.2. Enabling validation for MSL 2.2 shaders.')
+        return True
+    except OSError as e:
+        print('Failed to check if MSL 2.2 is not supported. It probably is not.')
+        return False
+    except subprocess.CalledProcessError:
+        print('Current SDK does NOT support MSL 2.2. Disabling validation for MSL 2.2 shaders.')
+        return False
 
 def path_to_msl_standard(shader):
     if '.ios.' in shader:
@@ -578,7 +593,10 @@ def test_shader_msl(stats, shader, args, paths):
     # executable from Xcode using args: `--msl --entry main --output msl_path spirv_path`.
 #    print('SPRIV shader: ' + spirv)
 
-    if not args.force_no_external_validation:
+    shader_is_msl22 = 'msl22' in shader
+    skip_validation = shader_is_msl22 and (not args.msl22)
+
+    if (not args.force_no_external_validation) and (not skip_validation):
         validate_shader_msl(shader, args.opt)
 
     remove_file(spirv)
@@ -722,6 +740,7 @@ def main():
         
     if args.msl:
         print_msl_compiler_version()
+        args.msl22 = msl_compiler_supports_22()
 
     backend = 'glsl'
     if (args.msl or args.metal): 


### PR DESCRIPTION
- Fix a new issue from latest beta SDK.
- Make it so test_shaders.py conditionally validates MSL 2.2 depending on SDK support. Travis CI images don't have MSL 2.2 support yet, but we can test locally at least in the meantime.