### PR TITLE
Make sure args.msl22 is set in test_shaders.py.

### DIFF
--- a/test_shaders.py
+++ b/test_shaders.py
@@ -740,6 +740,7 @@ def main():
         sys.stderr.write('Parallel execution is disabled when using the flags --update, --malisc or --force-no-external-validation\n')
         args.parallel = False
         
+    args.msl22 = False
     if args.msl:
         print_msl_compiler_version()
         args.msl22 = msl_compiler_supports_22()


### PR DESCRIPTION
Works locally, but apparently not on Travis?