### PR TITLE
Deal with OpSwitch case fallthrough

### DIFF
--- a/reference/opt/shaders/asm/frag/switch-label-shared-block.asm.frag
+++ b/reference/opt/shaders/asm/frag/switch-label-shared-block.asm.frag
@@ -16,7 +16,6 @@ void main()
             _19 = 1.0;
             break;
         }
-        case 1:
         default:
         {
             _19 = 3.0;

--- a/reference/shaders-hlsl-no-opt/asm/frag/switch-block-case-fallthrough.asm.frag
+++ b/reference/shaders-hlsl-no-opt/asm/frag/switch-block-case-fallthrough.asm.frag
@@ -1,0 +1,79 @@
+static int vIndex;
+static float4 FragColor;
+
+struct SPIRV_Cross_Input
+{
+    nointerpolation int vIndex : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    int i = 0;
+    int j;
+    int _30;
+    int _31;
+    if (vIndex != 0 && vIndex != 1 && vIndex != 11 && vIndex != 2 && vIndex != 3 && vIndex != 4 && vIndex != 5)
+    {
+        _30 = 2;
+    }
+    if (vIndex == 1 || vIndex == 11)
+    {
+        _31 = 1;
+    }
+    switch (vIndex)
+    {
+        case 0:
+        {
+            _30 = 3;
+        }
+        default:
+        {
+            j = _30;
+            _31 = 0;
+        }
+        case 1:
+        case 11:
+        {
+            j = _31;
+        }
+        case 2:
+        {
+            break;
+        }
+        case 3:
+        {
+            if (vIndex > 3)
+            {
+                i = 0;
+                break;
+            }
+            else
+            {
+                break;
+            }
+        }
+        case 4:
+        {
+        }
+        case 5:
+        {
+            i = 0;
+            break;
+        }
+    }
+    FragColor = float(i).xxxx;
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    vIndex = stage_input.vIndex;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-msl-no-opt/asm/frag/switch-block-case-fallthrough.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/switch-block-case-fallthrough.asm.frag
@@ -1,0 +1,75 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    int vIndex [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]])
+{
+    int i = 0;
+    main0_out out = {};
+    int j;
+    int _30;
+    int _31;
+    if (in.vIndex != 0 && in.vIndex != 1 && in.vIndex != 11 && in.vIndex != 2 && in.vIndex != 3 && in.vIndex != 4 && in.vIndex != 5)
+    {
+        _30 = 2;
+    }
+    if (in.vIndex == 1 || in.vIndex == 11)
+    {
+        _31 = 1;
+    }
+    switch (in.vIndex)
+    {
+        case 0:
+        {
+            _30 = 3;
+        }
+        default:
+        {
+            j = _30;
+            _31 = 0;
+        }
+        case 1:
+        case 11:
+        {
+            j = _31;
+        }
+        case 2:
+        {
+            break;
+        }
+        case 3:
+        {
+            if (in.vIndex > 3)
+            {
+                i = 0;
+                break;
+            }
+            else
+            {
+                break;
+            }
+        }
+        case 4:
+        {
+        }
+        case 5:
+        {
+            i = 0;
+            break;
+        }
+    }
+    out.FragColor = float4(float(i));
+    return out;
+}
+

--- a/reference/shaders-no-opt/asm/frag/switch-block-case-fallthrough.asm.frag
+++ b/reference/shaders-no-opt/asm/frag/switch-block-case-fallthrough.asm.frag
@@ -1,0 +1,63 @@
+#version 450
+
+layout(location = 0) flat in int vIndex;
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    int i;
+    int j;
+    int _30;
+    int _31;
+    if (vIndex != 0 && vIndex != 1 && vIndex != 11 && vIndex != 2 && vIndex != 3 && vIndex != 4 && vIndex != 5)
+    {
+        _30 = 2;
+    }
+    if (vIndex == 1 || vIndex == 11)
+    {
+        _31 = 1;
+    }
+    switch (vIndex)
+    {
+        case 0:
+        {
+            _30 = 3;
+        }
+        default:
+        {
+            j = _30;
+            _31 = 0;
+        }
+        case 1:
+        case 11:
+        {
+            j = _31;
+        }
+        case 2:
+        {
+            break;
+        }
+        case 3:
+        {
+            if (vIndex > 3)
+            {
+                i = 0;
+                break;
+            }
+            else
+            {
+                break;
+            }
+        }
+        case 4:
+        {
+        }
+        case 5:
+        {
+            i = 0;
+            break;
+        }
+    }
+    FragColor = vec4(float(i));
+}
+

--- a/reference/shaders/asm/frag/switch-label-shared-block.asm.frag
+++ b/reference/shaders/asm/frag/switch-label-shared-block.asm.frag
@@ -16,7 +16,6 @@ void main()
             _19 = 1.0;
             break;
         }
-        case 1:
         default:
         {
             _19 = 3.0;

--- a/shaders-hlsl-no-opt/asm/frag/switch-block-case-fallthrough.asm.frag
+++ b/shaders-hlsl-no-opt/asm/frag/switch-block-case-fallthrough.asm.frag
@@ -1,0 +1,80 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 29
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %vIndex %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %vIndex "vIndex"
+               OpName %FragColor "FragColor"
+               OpName %i "i"
+               OpName %j "j"
+               OpDecorate %vIndex Flat
+               OpDecorate %vIndex Location 0
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+       %bool = OpTypeBool
+ %int_0 = OpConstant %int 0
+ %int_1 = OpConstant %int 1
+ %int_2 = OpConstant %int 2
+ %int_3 = OpConstant %int 3
+%_ptr_Input_int = OpTypePointer Input %int
+     %vIndex = OpVariable %_ptr_Input_int Input
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+%_ptr_Function_int = OpTypePointer Function %int
+       %main = OpFunction %void None %3
+          %header = OpLabel
+          %i = OpVariable %_ptr_Function_int Function %int_0
+          %j = OpVariable %_ptr_Function_int Function
+          %9 = OpLoad %int %vIndex
+               OpSelectionMerge %switch_merge None
+               OpSwitch %9 %default_case 100 %default_case 0 %case_0 1 %case_1 11 %case_1 2 %case_2 3 %case_3 4 %case_4 5 %case_5
+
+         %case_0 = OpLabel
+               OpBranch %default_case
+
+         %default_case = OpLabel
+               %default_case_phi = OpPhi %int %int_2 %header %int_3 %case_0
+               ; Test what happens when a case block dominates access to a variable.
+               OpStore %j %default_case_phi
+               OpBranch %case_1
+
+         %case_1 = OpLabel
+               ; Test phi nodes between case labels.
+               %case_1_phi = OpPhi %int %int_0 %default_case %int_1 %header
+               OpStore %j %case_1_phi
+               OpBranch %case_2
+
+         %case_2 = OpLabel
+               OpBranch %switch_merge
+
+         %case_3 = OpLabel
+            ; Conditionally branch to another case block. This is really dumb, but it is apparently legal.
+            %case_3_cond = OpSGreaterThan %bool %9 %int_3
+            OpBranchConditional %case_3_cond %case_4 %switch_merge
+
+         %case_4 = OpLabel
+            ; When emitted from case 3, we should *not* see fallthrough behavior.
+            OpBranch %case_5
+
+         %case_5 = OpLabel
+            OpStore %i %int_0
+            OpBranch %switch_merge
+
+         %switch_merge = OpLabel
+         %26 = OpLoad %int %i
+         %27 = OpConvertSToF %float %26
+         %28 = OpCompositeConstruct %v4float %27 %27 %27 %27
+               OpStore %FragColor %28
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/frag/switch-block-case-fallthrough.asm.frag
+++ b/shaders-msl-no-opt/asm/frag/switch-block-case-fallthrough.asm.frag
@@ -1,0 +1,80 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 29
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %vIndex %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %vIndex "vIndex"
+               OpName %FragColor "FragColor"
+               OpName %i "i"
+               OpName %j "j"
+               OpDecorate %vIndex Flat
+               OpDecorate %vIndex Location 0
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+       %bool = OpTypeBool
+ %int_0 = OpConstant %int 0
+ %int_1 = OpConstant %int 1
+ %int_2 = OpConstant %int 2
+ %int_3 = OpConstant %int 3
+%_ptr_Input_int = OpTypePointer Input %int
+     %vIndex = OpVariable %_ptr_Input_int Input
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+%_ptr_Function_int = OpTypePointer Function %int
+       %main = OpFunction %void None %3
+          %header = OpLabel
+          %i = OpVariable %_ptr_Function_int Function %int_0
+          %j = OpVariable %_ptr_Function_int Function
+          %9 = OpLoad %int %vIndex
+               OpSelectionMerge %switch_merge None
+               OpSwitch %9 %default_case 100 %default_case 0 %case_0 1 %case_1 11 %case_1 2 %case_2 3 %case_3 4 %case_4 5 %case_5
+
+         %case_0 = OpLabel
+               OpBranch %default_case
+
+         %default_case = OpLabel
+               %default_case_phi = OpPhi %int %int_2 %header %int_3 %case_0
+               ; Test what happens when a case block dominates access to a variable.
+               OpStore %j %default_case_phi
+               OpBranch %case_1
+
+         %case_1 = OpLabel
+               ; Test phi nodes between case labels.
+               %case_1_phi = OpPhi %int %int_0 %default_case %int_1 %header
+               OpStore %j %case_1_phi
+               OpBranch %case_2
+
+         %case_2 = OpLabel
+               OpBranch %switch_merge
+
+         %case_3 = OpLabel
+            ; Conditionally branch to another case block. This is really dumb, but it is apparently legal.
+            %case_3_cond = OpSGreaterThan %bool %9 %int_3
+            OpBranchConditional %case_3_cond %case_4 %switch_merge
+
+         %case_4 = OpLabel
+            ; When emitted from case 3, we should *not* see fallthrough behavior.
+            OpBranch %case_5
+
+         %case_5 = OpLabel
+            OpStore %i %int_0
+            OpBranch %switch_merge
+
+         %switch_merge = OpLabel
+         %26 = OpLoad %int %i
+         %27 = OpConvertSToF %float %26
+         %28 = OpCompositeConstruct %v4float %27 %27 %27 %27
+               OpStore %FragColor %28
+               OpReturn
+               OpFunctionEnd

--- a/shaders-no-opt/asm/frag/switch-block-case-fallthrough.asm.frag
+++ b/shaders-no-opt/asm/frag/switch-block-case-fallthrough.asm.frag
@@ -1,0 +1,80 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 29
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %vIndex %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %vIndex "vIndex"
+               OpName %FragColor "FragColor"
+               OpName %i "i"
+               OpName %j "j"
+               OpDecorate %vIndex Flat
+               OpDecorate %vIndex Location 0
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+       %bool = OpTypeBool
+ %int_0 = OpConstant %int 0
+ %int_1 = OpConstant %int 1
+ %int_2 = OpConstant %int 2
+ %int_3 = OpConstant %int 3
+%_ptr_Input_int = OpTypePointer Input %int
+     %vIndex = OpVariable %_ptr_Input_int Input
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+%_ptr_Function_int = OpTypePointer Function %int
+       %main = OpFunction %void None %3
+          %header = OpLabel
+          %i = OpVariable %_ptr_Function_int Function
+          %j = OpVariable %_ptr_Function_int Function
+          %9 = OpLoad %int %vIndex
+               OpSelectionMerge %switch_merge None
+               OpSwitch %9 %default_case 100 %default_case 0 %case_0 1 %case_1 11 %case_1 2 %case_2 3 %case_3 4 %case_4 5 %case_5
+
+         %case_0 = OpLabel
+               OpBranch %default_case
+
+         %default_case = OpLabel
+               %default_case_phi = OpPhi %int %int_2 %header %int_3 %case_0
+               ; Test what happens when a case block dominates access to a variable.
+               OpStore %j %default_case_phi
+               OpBranch %case_1
+
+         %case_1 = OpLabel
+               ; Test phi nodes between case labels.
+               %case_1_phi = OpPhi %int %int_0 %default_case %int_1 %header
+               OpStore %j %case_1_phi
+               OpBranch %case_2
+
+         %case_2 = OpLabel
+               OpBranch %switch_merge
+
+         %case_3 = OpLabel
+            ; Conditionally branch to another case block. This is really dumb, but it is apparently legal.
+            %case_3_cond = OpSGreaterThan %bool %9 %int_3
+            OpBranchConditional %case_3_cond %case_4 %switch_merge
+
+         %case_4 = OpLabel
+            ; When emitted from case 3, we should *not* see fallthrough behavior.
+            OpBranch %case_5
+
+         %case_5 = OpLabel
+            OpStore %i %int_0
+            OpBranch %switch_merge
+
+         %switch_merge = OpLabel
+         %26 = OpLoad %int %i
+         %27 = OpConvertSToF %float %26
+         %28 = OpCompositeConstruct %v4float %27 %27 %27 %27
+               OpStore %FragColor %28
+               OpReturn
+               OpFunctionEnd

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -183,14 +183,14 @@ std::string join(Ts &&... ts)
 	return stream.str();
 }
 
-inline std::string merge(const SmallVector<std::string> &list)
+inline std::string merge(const SmallVector<std::string> &list, const char *between = ", ")
 {
 	StringStream<> stream;
 	for (auto &elem : list)
 	{
 		stream << elem;
 		if (&elem != &list.back())
-			stream << ", ";
+			stream << between;
 	}
 	return stream.str();
 }
@@ -703,6 +703,10 @@ struct SPIRBlock : IVariant
 
 	// Do we need a ladder variable to defer breaking out of a loop construct after a switch block?
 	bool need_ladder_break = false;
+
+	// If marked, we have explicitly handled Phi from this block, so skip any flushes related to that on a branch.
+	// Used to handle an edge case with switch and case-label fallthrough where fall-through writes to Phi.
+	uint32_t ignore_phi_from_block = 0;
 
 	// The dominating block which this block might be within.
 	// Used in continue; blocks to determine if we really need to write continue.

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -1600,6 +1600,11 @@ bool Compiler::execution_is_branchless(const SPIRBlock &from, const SPIRBlock &t
 	}
 }
 
+bool Compiler::execution_is_direct_branch(const SPIRBlock &from, const SPIRBlock &to) const
+{
+	return from.terminator == SPIRBlock::Direct && from.merge == SPIRBlock::MergeNone && from.next_block == to.self;
+}
+
 SPIRBlock::ContinueBlockType Compiler::continue_block_type(const SPIRBlock &block) const
 {
 	// The block was deemed too complex during code emit, pick conservative fallback paths.
@@ -4372,3 +4377,4 @@ bool Compiler::type_is_array_of_pointers(const SPIRType &type) const
 	// If parent type has same pointer depth, we must have an array of pointers.
 	return type.pointer_depth == get<SPIRType>(type.parent_type).pointer_depth;
 }
+

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -669,6 +669,7 @@ protected:
 	bool block_is_outside_flow_control_from_block(const SPIRBlock &from, const SPIRBlock &to);
 
 	bool execution_is_branchless(const SPIRBlock &from, const SPIRBlock &to) const;
+	bool execution_is_direct_branch(const SPIRBlock &from, const SPIRBlock &to) const;
 	bool execution_is_noop(const SPIRBlock &from, const SPIRBlock &to) const;
 	SPIRBlock::ContinueBlockType continue_block_type(const SPIRBlock &continue_block) const;
 

--- a/spirv_cross_containers.hpp
+++ b/spirv_cross_containers.hpp
@@ -447,6 +447,11 @@ public:
 		}
 	}
 
+	void insert(T *itr, const T &value)
+	{
+		insert(itr, &value, &value + 1);
+	}
+
 	T *erase(T *itr)
 	{
 		std::move(itr + 1, this->end(), itr);

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -11578,8 +11578,7 @@ void CompilerGLSL::emit_block_chain(SPIRBlock &block)
 
 		size_t num_blocks = block_declaration_order.size();
 
-		// + before [] forces a reduction to pure function pointer.
-		const auto to_case_label = +[](uint32_t literal, bool is_unsigned_case) -> string {
+		const auto to_case_label = [](uint32_t literal, bool is_unsigned_case) -> string {
 			return is_unsigned_case ? convert_to_string(literal) : convert_to_string(int32_t(literal));
 		};
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -223,6 +223,7 @@ protected:
 
 	SPIRBlock *current_emitting_block = nullptr;
 	SPIRBlock *current_emitting_switch = nullptr;
+	bool current_emitting_switch_fallthrough = false;
 
 	virtual void emit_instruction(const Instruction &instr);
 	void emit_block_instructions(SPIRBlock &block);


### PR DESCRIPTION
This is rather complicated to deal with in any sensible fashion, it's kind of a restricted form of goto, and it will also impact CFG variable scope analysis a fair bit. If one case label dominates variable declarations in another case label, we need to do the good old variable hoisting outside the switch block.

Fix #1033.