### PR TITLE
Parse SPIR-V debug information extended instructions, as well as OpNoLine

### DIFF
--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -476,6 +476,7 @@ struct SPIRExtension : IVariant
 	{
 		Unsupported,
 		GLSL,
+		SPV_debug_info,
 		SPV_AMD_shader_ballot,
 		SPV_AMD_shader_explicit_vertex_parameter,
 		SPV_AMD_shader_trinary_minmax,

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -3079,6 +3079,7 @@ bool Compiler::AnalyzeVariableScopeAccessHandler::handle(spv::Op op, const uint3
 
 	case OpArrayLength:
 	case OpLine:
+	case OpNoLine:
 		// Uses literals, but cannot be a phi variable or temporary, so ignore.
 		break;
 
@@ -4266,6 +4267,7 @@ bool Compiler::instruction_to_result_type(uint32_t &result_type, uint32_t &resul
 	case OpGroupCommitReadPipe:
 	case OpGroupCommitWritePipe:
 	case OpLine:
+	case OpNoLine:
 		return false;
 
 	default:

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -9406,6 +9406,10 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		{
 			emit_spv_amd_gcn_shader_op(ops[0], ops[1], ops[3], &ops[4], length - 4);
 		}
+		else if (get<SPIRExtension>(extension_set).ext == SPIRExtension::SPV_debug_info)
+		{
+			break; // Ignore SPIR-V debug information extended instructions.
+		}
 		else
 		{
 			statement("// unimplemented ext op ", instruction.op);
@@ -9671,6 +9675,9 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		emit_line_directive(ops[0], ops[1]);
 		break;
 	}
+
+	case OpNoLine:
+		break;
 
 	default:
 		statement("// unimplemented op ", instruction.op);

--- a/spirv_parser.cpp
+++ b/spirv_parser.cpp
@@ -162,7 +162,6 @@ void Parser::parse(const Instruction &instruction)
 	case OpSourceContinued:
 	case OpSourceExtension:
 	case OpNop:
-	case OpNoLine:
 	case OpModuleProcessed:
 		break;
 
@@ -244,6 +243,8 @@ void Parser::parse(const Instruction &instruction)
 		auto ext = extract_string(ir.spirv, instruction.offset + 1);
 		if (ext == "GLSL.std.450")
 			set<SPIRExtension>(id, SPIRExtension::GLSL);
+		else if (ext == "DebugInfo")
+			set<SPIRExtension>(id, SPIRExtension::SPV_debug_info);
 		else if (ext == "SPV_AMD_shader_ballot")
 			set<SPIRExtension>(id, SPIRExtension::SPV_AMD_shader_ballot);
 		else if (ext == "SPV_AMD_shader_explicit_vertex_parameter")
@@ -257,6 +258,14 @@ void Parser::parse(const Instruction &instruction)
 
 		// Other SPIR-V extensions which have ExtInstrs are currently not supported.
 
+		break;
+	}
+
+	case OpExtInst:
+	{
+		// The SPIR-V debug information extended instructions might come at global scope.
+		if (current_block)
+			current_block->ops.push_back(instruction);
 		break;
 	}
 
@@ -1055,6 +1064,13 @@ void Parser::parse(const Instruction &instruction)
 			}
 		}
 		break;
+	}
+
+	case OpNoLine:
+	{
+		// OpNoLine might come at global scope.
+		if (current_block)
+			current_block->ops.push_back(instruction);
 	}
 
 	// Actual opcodes.


### PR DESCRIPTION
No impact on result shader string.