### PR TITLE
Propagate NonUniformEXT to dependent expressions

### DIFF
--- a/reference/shaders-hlsl-no-opt/asm/frag/nonuniform-qualifier-propagation.nonuniformresource.sm51.asm.frag
+++ b/reference/shaders-hlsl-no-opt/asm/frag/nonuniform-qualifier-propagation.nonuniformresource.sm51.asm.frag
@@ -1,0 +1,52 @@
+struct UBO_1_1
+{
+    float4 v[64];
+};
+
+ConstantBuffer<UBO_1_1> ubos[] : register(b0, space2);
+ByteAddressBuffer ssbos[] : register(t0, space3);
+Texture2D<float4> uSamplers[] : register(t0, space0);
+SamplerState uSamps[] : register(s0, space1);
+Texture2D<float4> uCombinedSamplers[] : register(t4, space0);
+SamplerState _uCombinedSamplers_sampler[] : register(s4, space0);
+
+static int vIndex;
+static float4 FragColor;
+static float2 vUV;
+
+struct SPIRV_Cross_Input
+{
+    nointerpolation int vIndex : TEXCOORD0;
+    float2 vUV : TEXCOORD1;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    int i = vIndex;
+    int _59 = i + 10;
+    int _64 = i + 40;
+    FragColor = uSamplers[NonUniformResourceIndex(_59)].Sample(uSamps[NonUniformResourceIndex(_64)], vUV);
+    int _71 = i + 10;
+    FragColor = uCombinedSamplers[NonUniformResourceIndex(_71)].Sample(_uCombinedSamplers_sampler[NonUniformResourceIndex(_71)], vUV);
+    int _77 = i + 20;
+    int _80 = i + 40;
+    FragColor += ubos[NonUniformResourceIndex(_77)].v[_80];
+    int _87 = i + 50;
+    int _90 = i + 60;
+    FragColor += asfloat(ssbos[NonUniformResourceIndex(_87)].Load4(_90 * 16 + 0));
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    vIndex = stage_input.vIndex;
+    vUV = stage_input.vUV;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-no-opt/asm/frag/nonuniform-qualifier-propagation.vk.nocompat.asm.frag.vk
+++ b/reference/shaders-no-opt/asm/frag/nonuniform-qualifier-propagation.vk.nocompat.asm.frag.vk
@@ -1,0 +1,37 @@
+#version 450
+#extension GL_EXT_nonuniform_qualifier : require
+
+layout(set = 0, binding = 2, std140) uniform UBO
+{
+    vec4 v[64];
+} ubos[];
+
+layout(set = 0, binding = 3, std430) readonly buffer SSBO
+{
+    vec4 v[];
+} ssbos[];
+
+layout(set = 0, binding = 0) uniform texture2D uSamplers[];
+layout(set = 0, binding = 1) uniform sampler uSamps[];
+layout(set = 0, binding = 4) uniform sampler2D uCombinedSamplers[];
+
+layout(location = 0) flat in int vIndex;
+layout(location = 0) out vec4 FragColor;
+layout(location = 1) in vec2 vUV;
+
+void main()
+{
+    int i = vIndex;
+    int _59 = i + 10;
+    int _64 = i + 40;
+    FragColor = texture(sampler2D(uSamplers[nonuniformEXT(_59)], uSamps[nonuniformEXT(_64)]), vUV);
+    int _71 = i + 10;
+    FragColor = texture(uCombinedSamplers[nonuniformEXT(_71)], vUV);
+    int _77 = i + 20;
+    int _80 = i + 40;
+    FragColor += ubos[nonuniformEXT(_77)].v[_80];
+    int _87 = i + 50;
+    int _90 = i + 60;
+    FragColor += ssbos[nonuniformEXT(_87)].v[_90];
+}
+

--- a/shaders-hlsl-no-opt/asm/frag/nonuniform-qualifier-propagation.nonuniformresource.sm51.asm.frag
+++ b/shaders-hlsl-no-opt/asm/frag/nonuniform-qualifier-propagation.nonuniformresource.sm51.asm.frag
@@ -1,0 +1,159 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 93
+; Schema: 0
+               OpCapability Shader
+               OpCapability ShaderNonUniformEXT
+               OpCapability RuntimeDescriptorArrayEXT
+               OpCapability UniformBufferArrayNonUniformIndexingEXT
+               OpCapability SampledImageArrayNonUniformIndexingEXT
+               OpCapability StorageBufferArrayNonUniformIndexingEXT
+               OpExtension "SPV_EXT_descriptor_indexing"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %vIndex %FragColor %vUV
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_nonuniform_qualifier"
+               OpName %main "main"
+               OpName %i "i"
+               OpName %vIndex "vIndex"
+               OpName %FragColor "FragColor"
+               OpName %uSamplers "uSamplers"
+               OpName %uSamps "uSamps"
+               OpName %vUV "vUV"
+               OpName %uCombinedSamplers "uCombinedSamplers"
+               OpName %UBO "UBO"
+               OpMemberName %UBO 0 "v"
+               OpName %ubos "ubos"
+               OpName %SSBO "SSBO"
+               OpMemberName %SSBO 0 "v"
+               OpName %ssbos "ssbos"
+               OpDecorate %vIndex Flat
+               OpDecorate %vIndex Location 0
+               OpDecorate %FragColor Location 0
+               OpDecorate %uSamplers DescriptorSet 0
+               OpDecorate %uSamplers Binding 0
+
+               OpDecorate %sampled_image NonUniformEXT
+               OpDecorate %combined_sampler NonUniformEXT
+               OpDecorate %ubo_ptr_copy NonUniformEXT
+               OpDecorate %ssbo_ptr_copy NonUniformEXT
+
+               OpDecorate %uSamps DescriptorSet 1
+               OpDecorate %uSamps Binding 0
+               OpDecorate %vUV Location 1
+               OpDecorate %uCombinedSamplers DescriptorSet 0
+               OpDecorate %uCombinedSamplers Binding 4
+               OpDecorate %_arr_v4float_uint_64 ArrayStride 16
+               OpMemberDecorate %UBO 0 Offset 0
+               OpDecorate %UBO Block
+               OpDecorate %ubos DescriptorSet 2
+               OpDecorate %ubos Binding 0
+               OpDecorate %_runtimearr_v4float ArrayStride 16
+               OpMemberDecorate %SSBO 0 NonWritable
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpDecorate %SSBO BufferBlock
+               OpDecorate %ssbos DescriptorSet 3
+               OpDecorate %ssbos Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+%_ptr_Input_int = OpTypePointer Input %int
+     %vIndex = OpVariable %_ptr_Input_int Input
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+         %16 = OpTypeImage %float 2D 0 0 0 1 Unknown
+%_runtimearr_16 = OpTypeRuntimeArray %16
+%_ptr_UniformConstant__runtimearr_16 = OpTypePointer UniformConstant %_runtimearr_16
+  %uSamplers = OpVariable %_ptr_UniformConstant__runtimearr_16 UniformConstant
+     %int_10 = OpConstant %int 10
+%_ptr_UniformConstant_16 = OpTypePointer UniformConstant %16
+         %27 = OpTypeSampler
+%_runtimearr_27 = OpTypeRuntimeArray %27
+%_ptr_UniformConstant__runtimearr_27 = OpTypePointer UniformConstant %_runtimearr_27
+     %uSamps = OpVariable %_ptr_UniformConstant__runtimearr_27 UniformConstant
+     %int_40 = OpConstant %int 40
+%_ptr_UniformConstant_27 = OpTypePointer UniformConstant %27
+         %38 = OpTypeSampledImage %16
+    %v2float = OpTypeVector %float 2
+%_ptr_Input_v2float = OpTypePointer Input %v2float
+        %vUV = OpVariable %_ptr_Input_v2float Input
+%_runtimearr_38 = OpTypeRuntimeArray %38
+%_ptr_UniformConstant__runtimearr_38 = OpTypePointer UniformConstant %_runtimearr_38
+%uCombinedSamplers = OpVariable %_ptr_UniformConstant__runtimearr_38 UniformConstant
+%_ptr_UniformConstant_38 = OpTypePointer UniformConstant %38
+       %uint = OpTypeInt 32 0
+    %uint_64 = OpConstant %uint 64
+%_arr_v4float_uint_64 = OpTypeArray %v4float %uint_64
+        %UBO = OpTypeStruct %_arr_v4float_uint_64
+%_runtimearr_UBO = OpTypeRuntimeArray %UBO
+%_ptr_Uniform__runtimearr_UBO = OpTypePointer Uniform %_runtimearr_UBO
+       %ubos = OpVariable %_ptr_Uniform__runtimearr_UBO Uniform
+     %int_20 = OpConstant %int 20
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
+%_runtimearr_v4float = OpTypeRuntimeArray %v4float
+       %SSBO = OpTypeStruct %_runtimearr_v4float
+%_runtimearr_SSBO = OpTypeRuntimeArray %SSBO
+%_ptr_Uniform__runtimearr_SSBO = OpTypePointer Uniform %_runtimearr_SSBO
+      %ssbos = OpVariable %_ptr_Uniform__runtimearr_SSBO Uniform
+     %int_50 = OpConstant %int 50
+     %int_60 = OpConstant %int 60
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %i = OpVariable %_ptr_Function_int Function
+         %11 = OpLoad %int %vIndex
+               OpStore %i %11
+         %20 = OpLoad %int %i
+         %22 = OpIAdd %int %20 %int_10
+         %23 = OpCopyObject %int %22
+         %25 = OpAccessChain %_ptr_UniformConstant_16 %uSamplers %23
+         %26 = OpLoad %16 %25
+         %31 = OpLoad %int %i
+         %33 = OpIAdd %int %31 %int_40
+         %34 = OpCopyObject %int %33
+         %36 = OpAccessChain %_ptr_UniformConstant_27 %uSamps %34
+         %37 = OpLoad %27 %36
+         %sampled_image = OpSampledImage %38 %26 %37
+         %43 = OpLoad %v2float %vUV
+         %44 = OpImageSampleImplicitLod %v4float %sampled_image %43
+               OpStore %FragColor %44
+         %48 = OpLoad %int %i
+         %49 = OpIAdd %int %48 %int_10
+         %50 = OpCopyObject %int %49
+         %52 = OpAccessChain %_ptr_UniformConstant_38 %uCombinedSamplers %50
+         %combined_sampler = OpLoad %38 %52
+         %54 = OpLoad %v2float %vUV
+         %55 = OpImageSampleImplicitLod %v4float %combined_sampler %54
+               OpStore %FragColor %55
+         %63 = OpLoad %int %i
+         %65 = OpIAdd %int %63 %int_20
+         %66 = OpCopyObject %int %65
+         %68 = OpLoad %int %i
+         %69 = OpIAdd %int %68 %int_40
+         %70 = OpCopyObject %int %69
+         %ubo_ptr = OpAccessChain %_ptr_Uniform_v4float %ubos %66 %int_0 %70
+         %ubo_ptr_copy = OpCopyObject %_ptr_Uniform_v4float %ubo_ptr
+         %73 = OpLoad %v4float %ubo_ptr_copy
+         %74 = OpLoad %v4float %FragColor
+         %75 = OpFAdd %v4float %74 %73
+               OpStore %FragColor %75
+         %81 = OpLoad %int %i
+         %83 = OpIAdd %int %81 %int_50
+         %84 = OpCopyObject %int %83
+         %85 = OpLoad %int %i
+         %87 = OpIAdd %int %85 %int_60
+         %88 = OpCopyObject %int %87
+         %ssbo_ptr = OpAccessChain %_ptr_Uniform_v4float %ssbos %84 %int_0 %88
+         %ssbo_ptr_copy = OpCopyObject %_ptr_Uniform_v4float %ssbo_ptr
+         %90 = OpLoad %v4float %ssbo_ptr_copy
+         %91 = OpLoad %v4float %FragColor
+         %92 = OpFAdd %v4float %91 %90
+               OpStore %FragColor %92
+               OpReturn
+               OpFunctionEnd

--- a/shaders-no-opt/asm/frag/nonuniform-qualifier-propagation.vk.nocompat.asm.frag
+++ b/shaders-no-opt/asm/frag/nonuniform-qualifier-propagation.vk.nocompat.asm.frag
@@ -1,0 +1,159 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 93
+; Schema: 0
+               OpCapability Shader
+               OpCapability ShaderNonUniformEXT
+               OpCapability RuntimeDescriptorArrayEXT
+               OpCapability UniformBufferArrayNonUniformIndexingEXT
+               OpCapability SampledImageArrayNonUniformIndexingEXT
+               OpCapability StorageBufferArrayNonUniformIndexingEXT
+               OpExtension "SPV_EXT_descriptor_indexing"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %vIndex %FragColor %vUV
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_nonuniform_qualifier"
+               OpName %main "main"
+               OpName %i "i"
+               OpName %vIndex "vIndex"
+               OpName %FragColor "FragColor"
+               OpName %uSamplers "uSamplers"
+               OpName %uSamps "uSamps"
+               OpName %vUV "vUV"
+               OpName %uCombinedSamplers "uCombinedSamplers"
+               OpName %UBO "UBO"
+               OpMemberName %UBO 0 "v"
+               OpName %ubos "ubos"
+               OpName %SSBO "SSBO"
+               OpMemberName %SSBO 0 "v"
+               OpName %ssbos "ssbos"
+               OpDecorate %vIndex Flat
+               OpDecorate %vIndex Location 0
+               OpDecorate %FragColor Location 0
+               OpDecorate %uSamplers DescriptorSet 0
+               OpDecorate %uSamplers Binding 0
+
+               OpDecorate %sampled_image NonUniformEXT
+               OpDecorate %combined_sampler NonUniformEXT
+               OpDecorate %ubo_ptr_copy NonUniformEXT
+               OpDecorate %ssbo_ptr_copy NonUniformEXT
+
+               OpDecorate %uSamps DescriptorSet 0
+               OpDecorate %uSamps Binding 1
+               OpDecorate %vUV Location 1
+               OpDecorate %uCombinedSamplers DescriptorSet 0
+               OpDecorate %uCombinedSamplers Binding 4
+               OpDecorate %_arr_v4float_uint_64 ArrayStride 16
+               OpMemberDecorate %UBO 0 Offset 0
+               OpDecorate %UBO Block
+               OpDecorate %ubos DescriptorSet 0
+               OpDecorate %ubos Binding 2
+               OpDecorate %_runtimearr_v4float ArrayStride 16
+               OpMemberDecorate %SSBO 0 NonWritable
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpDecorate %SSBO BufferBlock
+               OpDecorate %ssbos DescriptorSet 0
+               OpDecorate %ssbos Binding 3
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+%_ptr_Input_int = OpTypePointer Input %int
+     %vIndex = OpVariable %_ptr_Input_int Input
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+         %16 = OpTypeImage %float 2D 0 0 0 1 Unknown
+%_runtimearr_16 = OpTypeRuntimeArray %16
+%_ptr_UniformConstant__runtimearr_16 = OpTypePointer UniformConstant %_runtimearr_16
+  %uSamplers = OpVariable %_ptr_UniformConstant__runtimearr_16 UniformConstant
+     %int_10 = OpConstant %int 10
+%_ptr_UniformConstant_16 = OpTypePointer UniformConstant %16
+         %27 = OpTypeSampler
+%_runtimearr_27 = OpTypeRuntimeArray %27
+%_ptr_UniformConstant__runtimearr_27 = OpTypePointer UniformConstant %_runtimearr_27
+     %uSamps = OpVariable %_ptr_UniformConstant__runtimearr_27 UniformConstant
+     %int_40 = OpConstant %int 40
+%_ptr_UniformConstant_27 = OpTypePointer UniformConstant %27
+         %38 = OpTypeSampledImage %16
+    %v2float = OpTypeVector %float 2
+%_ptr_Input_v2float = OpTypePointer Input %v2float
+        %vUV = OpVariable %_ptr_Input_v2float Input
+%_runtimearr_38 = OpTypeRuntimeArray %38
+%_ptr_UniformConstant__runtimearr_38 = OpTypePointer UniformConstant %_runtimearr_38
+%uCombinedSamplers = OpVariable %_ptr_UniformConstant__runtimearr_38 UniformConstant
+%_ptr_UniformConstant_38 = OpTypePointer UniformConstant %38
+       %uint = OpTypeInt 32 0
+    %uint_64 = OpConstant %uint 64
+%_arr_v4float_uint_64 = OpTypeArray %v4float %uint_64
+        %UBO = OpTypeStruct %_arr_v4float_uint_64
+%_runtimearr_UBO = OpTypeRuntimeArray %UBO
+%_ptr_Uniform__runtimearr_UBO = OpTypePointer Uniform %_runtimearr_UBO
+       %ubos = OpVariable %_ptr_Uniform__runtimearr_UBO Uniform
+     %int_20 = OpConstant %int 20
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
+%_runtimearr_v4float = OpTypeRuntimeArray %v4float
+       %SSBO = OpTypeStruct %_runtimearr_v4float
+%_runtimearr_SSBO = OpTypeRuntimeArray %SSBO
+%_ptr_Uniform__runtimearr_SSBO = OpTypePointer Uniform %_runtimearr_SSBO
+      %ssbos = OpVariable %_ptr_Uniform__runtimearr_SSBO Uniform
+     %int_50 = OpConstant %int 50
+     %int_60 = OpConstant %int 60
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %i = OpVariable %_ptr_Function_int Function
+         %11 = OpLoad %int %vIndex
+               OpStore %i %11
+         %20 = OpLoad %int %i
+         %22 = OpIAdd %int %20 %int_10
+         %23 = OpCopyObject %int %22
+         %25 = OpAccessChain %_ptr_UniformConstant_16 %uSamplers %23
+         %26 = OpLoad %16 %25
+         %31 = OpLoad %int %i
+         %33 = OpIAdd %int %31 %int_40
+         %34 = OpCopyObject %int %33
+         %36 = OpAccessChain %_ptr_UniformConstant_27 %uSamps %34
+         %37 = OpLoad %27 %36
+         %sampled_image = OpSampledImage %38 %26 %37
+         %43 = OpLoad %v2float %vUV
+         %44 = OpImageSampleImplicitLod %v4float %sampled_image %43
+               OpStore %FragColor %44
+         %48 = OpLoad %int %i
+         %49 = OpIAdd %int %48 %int_10
+         %50 = OpCopyObject %int %49
+         %52 = OpAccessChain %_ptr_UniformConstant_38 %uCombinedSamplers %50
+         %combined_sampler = OpLoad %38 %52
+         %54 = OpLoad %v2float %vUV
+         %55 = OpImageSampleImplicitLod %v4float %combined_sampler %54
+               OpStore %FragColor %55
+         %63 = OpLoad %int %i
+         %65 = OpIAdd %int %63 %int_20
+         %66 = OpCopyObject %int %65
+         %68 = OpLoad %int %i
+         %69 = OpIAdd %int %68 %int_40
+         %70 = OpCopyObject %int %69
+         %ubo_ptr = OpAccessChain %_ptr_Uniform_v4float %ubos %66 %int_0 %70
+         %ubo_ptr_copy = OpCopyObject %_ptr_Uniform_v4float %ubo_ptr
+         %73 = OpLoad %v4float %ubo_ptr_copy
+         %74 = OpLoad %v4float %FragColor
+         %75 = OpFAdd %v4float %74 %73
+               OpStore %FragColor %75
+         %81 = OpLoad %int %i
+         %83 = OpIAdd %int %81 %int_50
+         %84 = OpCopyObject %int %83
+         %85 = OpLoad %int %i
+         %87 = OpIAdd %int %85 %int_60
+         %88 = OpCopyObject %int %87
+         %ssbo_ptr = OpAccessChain %_ptr_Uniform_v4float %ssbos %84 %int_0 %88
+         %ssbo_ptr_copy = OpCopyObject %_ptr_Uniform_v4float %ssbo_ptr
+         %90 = OpLoad %v4float %ssbo_ptr_copy
+         %91 = OpLoad %v4float %FragColor
+         %92 = OpFAdd %v4float %91 %90
+               OpStore %FragColor %92
+               OpReturn
+               OpFunctionEnd

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -672,6 +672,8 @@ protected:
 	void fixup_type_alias();
 	void reorder_type_alias();
 
+	void propagate_nonuniform_qualifier(uint32_t id);
+
 private:
 	void init();
 };

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -2479,6 +2479,10 @@ void CompilerHLSL::emit_texture_op(const Instruction &i)
 
 	inherited_expressions.push_back(coord);
 
+	// Make sure non-uniform decoration is back-propagated to where it needs to be.
+	if (has_decoration(img, DecorationNonUniformEXT))
+		propagate_nonuniform_qualifier(img);
+
 	switch (op)
 	{
 	case OpImageSampleDrefImplicitLod:
@@ -3458,6 +3462,9 @@ void CompilerHLSL::emit_load(const Instruction &instruction)
 		uint32_t id = ops[1];
 		uint32_t ptr = ops[2];
 
+		if (has_decoration(ptr, DecorationNonUniformEXT))
+			propagate_nonuniform_qualifier(ptr);
+
 		auto load_expr = read_access_chain(*chain);
 
 		bool forward = should_forward(ptr) && forced_temporaries.find(id) == end(forced_temporaries);
@@ -3490,6 +3497,9 @@ void CompilerHLSL::write_access_chain(const SPIRAccessChain &chain, uint32_t val
 
 	// Make sure we trigger a read of the constituents in the access chain.
 	track_expression_read(chain.self);
+
+	if (has_decoration(chain.self, DecorationNonUniformEXT))
+		propagate_nonuniform_qualifier(chain.self);
 
 	SPIRType target_type;
 	target_type.basetype = SPIRType::UInt;


### PR DESCRIPTION
This decoration might only be present for the very last ID which is
consumed by a sampling or Load/Store instruction. To make sure our
access chains are emitted correctly, we have to back-propagate this
decoration.

Fix #1061.
