### PR TITLE
MSL: Support scalar block layout.

### DIFF
--- a/reference/opt/shaders-msl/comp/struct-packing.comp
+++ b/reference/opt/shaders-msl/comp/struct-packing.comp
@@ -3,7 +3,7 @@
 
 using namespace metal;
 
-typedef float3x2 packed_float2x3;
+typedef packed_float2 packed_rm_float2x3[3];
 
 struct S0
 {
@@ -58,7 +58,7 @@ struct SSBO1
     float3x2 m3;
     float2x2 m4;
     float2x2 m5[9];
-    packed_float2x3 m6[4][2];
+    packed_rm_float2x3 m6[4][2];
     char _m10_pad[8];
     float3x2 m7;
     char _m11_pad[8];
@@ -142,6 +142,6 @@ kernel void main0(device SSBO1& ssbo_430 [[buffer(0)]], device SSBO0& ssbo_140 [
     ssbo_430.content.m3s[5].c = _60.m3s[5].c;
     ssbo_430.content.m3s[6].c = _60.m3s[6].c;
     ssbo_430.content.m3s[7].c = _60.m3s[7].c;
-    ssbo_430.content.m1.a = ssbo_430.content.m3.a * ssbo_430.m6[1][1];
+    ssbo_430.content.m1.a = ssbo_430.content.m3.a * float3x2(float2(ssbo_430.m6[1][1][0]), float2(ssbo_430.m6[1][1][1]), float2(ssbo_430.m6[1][1][2]));
 }
 

--- a/reference/opt/shaders-msl/vert/packed_matrix.vert
+++ b/reference/opt/shaders-msl/vert/packed_matrix.vert
@@ -3,12 +3,12 @@
 
 using namespace metal;
 
-typedef float3x4 packed_float4x3;
+typedef packed_float4 packed_rm_float4x3[3];
 
 struct _15
 {
-    packed_float4x3 _m0;
-    packed_float4x3 _m1;
+    packed_rm_float4x3 _m0;
+    packed_rm_float4x3 _m1;
 };
 
 struct _42
@@ -41,7 +41,7 @@ vertex main0_out main0(main0_in in [[stage_in]], constant _15& _17 [[buffer(0)]]
 {
     main0_out out = {};
     float4 _70 = _44._m0 * float4(float3(_44._m3) + (in.m_25.xyz * (_44._m6 + _44._m7)), 1.0);
-    out.m_72 = normalize(float4(in.m_25.xyz, 0.0) * _17._m1);
+    out.m_72 = normalize(float4(in.m_25.xyz, 0.0) * float3x4(float4(_17._m1[0]), float4(_17._m1[1]), float4(_17._m1[2])));
     float4 _94 = _70;
     _94.y = -_70.y;
     out.gl_Position = _94;

--- a/reference/opt/shaders-msl/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp
+++ b/reference/opt/shaders-msl/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp
@@ -3,7 +3,10 @@
 
 using namespace metal;
 
-typedef float3x2 packed_float2x3;
+typedef packed_float2 packed_float2x2[2];
+typedef packed_float2 packed_rm_float2x3[3];
+typedef packed_float3 packed_float2x3[2];
+typedef packed_float3 packed_rm_float3x2[2];
 
 struct S0
 {
@@ -58,7 +61,7 @@ struct SSBO1
     float3x2 m3;
     float2x2 m4;
     float2x2 m5[9];
-    packed_float2x3 m6[4][2];
+    packed_rm_float2x3 m6[4][2];
     float3x2 m7;
     float array[1];
 };
@@ -126,31 +129,43 @@ struct SSBO0
     float4 array[1];
 };
 
-kernel void main0(device SSBO1& ssbo_430 [[buffer(0)]], device SSBO0& ssbo_140 [[buffer(1)]])
+struct SSBO2
 {
-    ssbo_430.content.m0s[0].a[0] = ssbo_140.content.m0s[0].a[0].xy;
-    ssbo_430.content.m0s[0].b = ssbo_140.content.m0s[0].b;
-    ssbo_430.content.m1s[0].a = float3(ssbo_140.content.m1s[0].a);
-    ssbo_430.content.m1s[0].b = ssbo_140.content.m1s[0].b;
-    ssbo_430.content.m2s[0].a[0] = ssbo_140.content.m2s[0].a[0];
-    ssbo_430.content.m2s[0].b = ssbo_140.content.m2s[0].b;
-    ssbo_430.content.m0.a[0] = ssbo_140.content.m0.a[0].xy;
-    ssbo_430.content.m0.b = ssbo_140.content.m0.b;
-    ssbo_430.content.m1.a = float3(ssbo_140.content.m1.a);
-    ssbo_430.content.m1.b = ssbo_140.content.m1.b;
-    ssbo_430.content.m2.a[0] = ssbo_140.content.m2.a[0];
-    ssbo_430.content.m2.b = ssbo_140.content.m2.b;
-    ssbo_430.content.m3.a = ssbo_140.content.m3.a;
-    ssbo_430.content.m3.b = ssbo_140.content.m3.b;
-    ssbo_430.content.m4 = ssbo_140.content.m4;
-    ssbo_430.content.m3s[0].c = ssbo_140.content.m3s[0].c;
-    ssbo_430.content.m3s[1].c = ssbo_140.content.m3s[1].c;
-    ssbo_430.content.m3s[2].c = ssbo_140.content.m3s[2].c;
-    ssbo_430.content.m3s[3].c = ssbo_140.content.m3s[3].c;
-    ssbo_430.content.m3s[4].c = ssbo_140.content.m3s[4].c;
-    ssbo_430.content.m3s[5].c = ssbo_140.content.m3s[5].c;
-    ssbo_430.content.m3s[6].c = ssbo_140.content.m3s[6].c;
-    ssbo_430.content.m3s[7].c = ssbo_140.content.m3s[7].c;
-    ssbo_430.content.m1.a = float2x3(ssbo_430.m2[1]) * float2(ssbo_430.content.m0.a[0]);
+    float m0;
+    packed_float2x2 m1;
+    packed_rm_float3x2 m2;
+};
+
+kernel void main0(device SSBO1& ssbo_scalar [[buffer(0)]], device SSBO0& ssbo_140 [[buffer(1)]], device SSBO2& ssbo_scalar2 [[buffer(2)]])
+{
+    ssbo_scalar.content.m0s[0].a[0] = ssbo_140.content.m0s[0].a[0].xy;
+    ssbo_scalar.content.m0s[0].b = ssbo_140.content.m0s[0].b;
+    ssbo_scalar.content.m1s[0].a = float3(ssbo_140.content.m1s[0].a);
+    ssbo_scalar.content.m1s[0].b = ssbo_140.content.m1s[0].b;
+    ssbo_scalar.content.m2s[0].a[0] = ssbo_140.content.m2s[0].a[0];
+    ssbo_scalar.content.m2s[0].b = ssbo_140.content.m2s[0].b;
+    ssbo_scalar.content.m0.a[0] = ssbo_140.content.m0.a[0].xy;
+    ssbo_scalar.content.m0.b = ssbo_140.content.m0.b;
+    ssbo_scalar.content.m1.a = float3(ssbo_140.content.m1.a);
+    ssbo_scalar.content.m1.b = ssbo_140.content.m1.b;
+    ssbo_scalar.content.m2.a[0] = ssbo_140.content.m2.a[0];
+    ssbo_scalar.content.m2.b = ssbo_140.content.m2.b;
+    ssbo_scalar.content.m3.a = ssbo_140.content.m3.a;
+    ssbo_scalar.content.m3.b = ssbo_140.content.m3.b;
+    ssbo_scalar.content.m4 = ssbo_140.content.m4;
+    ssbo_scalar.content.m3s[0].c = ssbo_140.content.m3s[0].c;
+    ssbo_scalar.content.m3s[1].c = ssbo_140.content.m3s[1].c;
+    ssbo_scalar.content.m3s[2].c = ssbo_140.content.m3s[2].c;
+    ssbo_scalar.content.m3s[3].c = ssbo_140.content.m3s[3].c;
+    ssbo_scalar.content.m3s[4].c = ssbo_140.content.m3s[4].c;
+    ssbo_scalar.content.m3s[5].c = ssbo_140.content.m3s[5].c;
+    ssbo_scalar.content.m3s[6].c = ssbo_140.content.m3s[6].c;
+    ssbo_scalar.content.m3s[7].c = ssbo_140.content.m3s[7].c;
+    ssbo_scalar.content.m1.a = float2x3(float3(ssbo_scalar.m2[1][0]), float3(ssbo_scalar.m2[1][1])) * float2(ssbo_scalar.content.m0.a[0]);
+    ssbo_scalar.m0 = float2x2(float2(ssbo_scalar2.m1[0]), float2(ssbo_scalar2.m1[1]));
+    ssbo_scalar2.m1[0] = transpose(ssbo_scalar.m4)[0];
+    ssbo_scalar2.m1[1] = transpose(ssbo_scalar.m4)[1];
+    ssbo_scalar2.m2[0] = spvConvertFromRowMajor3x2(ssbo_scalar.m3)[0];
+    ssbo_scalar2.m2[1] = spvConvertFromRowMajor3x2(ssbo_scalar.m3)[1];
 }
 

--- a/reference/opt/shaders-msl/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp
+++ b/reference/opt/shaders-msl/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp
@@ -1,0 +1,156 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+typedef float3x2 packed_float2x3;
+
+struct S0
+{
+    packed_float2 a[1];
+    float b;
+};
+
+struct S1
+{
+    packed_float3 a;
+    float b;
+};
+
+struct S2
+{
+    packed_float3 a[1];
+    float b;
+};
+
+struct S3
+{
+    packed_float2 a;
+    float b;
+};
+
+struct S4
+{
+    float2 c;
+};
+
+struct Content
+{
+    S0 m0s[1];
+    S1 m1s[1];
+    S2 m2s[1];
+    S0 m0;
+    S1 m1;
+    S2 m2;
+    S3 m3;
+    float m4;
+    S4 m3s[8];
+};
+
+struct SSBO1
+{
+    Content content;
+    Content content1[2];
+    Content content2;
+    float2x2 m0;
+    float2x2 m1;
+    packed_float2x3 m2[4];
+    float3x2 m3;
+    float2x2 m4;
+    float2x2 m5[9];
+    packed_float2x3 m6[4][2];
+    float3x2 m7;
+    float array[1];
+};
+
+struct S0_1
+{
+    float4 a[1];
+    float b;
+};
+
+struct S1_1
+{
+    packed_float3 a;
+    float b;
+};
+
+struct S2_1
+{
+    float3 a[1];
+    float b;
+};
+
+struct S3_1
+{
+    float2 a;
+    float b;
+};
+
+struct S4_1
+{
+    float2 c;
+};
+
+struct Content_1
+{
+    S0_1 m0s[1];
+    S1_1 m1s[1];
+    S2_1 m2s[1];
+    S0_1 m0;
+    S1_1 m1;
+    S2_1 m2;
+    S3_1 m3;
+    float m4;
+    char _m8_pad[12];
+    /* FIXME: A padded struct is needed here. If you see this message, file a bug! */ S4_1 m3s[8];
+};
+
+struct SSBO0
+{
+    Content_1 content;
+    Content_1 content1[2];
+    Content_1 content2;
+    float2x2 m0;
+    char _m4_pad[16];
+    float2x2 m1;
+    char _m5_pad[16];
+    float2x3 m2[4];
+    float3x2 m3;
+    char _m7_pad[24];
+    float2x2 m4;
+    char _m8_pad[16];
+    float2x2 m5[9];
+    float2x3 m6[4][2];
+    float3x2 m7;
+    float4 array[1];
+};
+
+kernel void main0(device SSBO1& ssbo_430 [[buffer(0)]], device SSBO0& ssbo_140 [[buffer(1)]])
+{
+    ssbo_430.content.m0s[0].a[0] = ssbo_140.content.m0s[0].a[0].xy;
+    ssbo_430.content.m0s[0].b = ssbo_140.content.m0s[0].b;
+    ssbo_430.content.m1s[0].a = float3(ssbo_140.content.m1s[0].a);
+    ssbo_430.content.m1s[0].b = ssbo_140.content.m1s[0].b;
+    ssbo_430.content.m2s[0].a[0] = ssbo_140.content.m2s[0].a[0];
+    ssbo_430.content.m2s[0].b = ssbo_140.content.m2s[0].b;
+    ssbo_430.content.m0.a[0] = ssbo_140.content.m0.a[0].xy;
+    ssbo_430.content.m0.b = ssbo_140.content.m0.b;
+    ssbo_430.content.m1.a = float3(ssbo_140.content.m1.a);
+    ssbo_430.content.m1.b = ssbo_140.content.m1.b;
+    ssbo_430.content.m2.a[0] = ssbo_140.content.m2.a[0];
+    ssbo_430.content.m2.b = ssbo_140.content.m2.b;
+    ssbo_430.content.m3.a = ssbo_140.content.m3.a;
+    ssbo_430.content.m3.b = ssbo_140.content.m3.b;
+    ssbo_430.content.m4 = ssbo_140.content.m4;
+    ssbo_430.content.m3s[0].c = ssbo_140.content.m3s[0].c;
+    ssbo_430.content.m3s[1].c = ssbo_140.content.m3s[1].c;
+    ssbo_430.content.m3s[2].c = ssbo_140.content.m3s[2].c;
+    ssbo_430.content.m3s[3].c = ssbo_140.content.m3s[3].c;
+    ssbo_430.content.m3s[4].c = ssbo_140.content.m3s[4].c;
+    ssbo_430.content.m3s[5].c = ssbo_140.content.m3s[5].c;
+    ssbo_430.content.m3s[6].c = ssbo_140.content.m3s[6].c;
+    ssbo_430.content.m3s[7].c = ssbo_140.content.m3s[7].c;
+    ssbo_430.content.m1.a = float2x3(ssbo_430.m2[1]) * float2(ssbo_430.content.m0.a[0]);
+}
+

--- a/reference/opt/shaders-msl/vulkan/frag/scalar-block-layout-ubo-std430.vk.nocompat.invalid.frag
+++ b/reference/opt/shaders-msl/vulkan/frag/scalar-block-layout-ubo-std430.vk.nocompat.invalid.frag
@@ -1,0 +1,36 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBO
+{
+    float a[1];
+    float2 b[2];
+};
+
+struct UBOEnhancedLayout
+{
+    float c[1];
+    float2 d[2];
+    char _m2_pad[9976];
+    float e;
+};
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    int vIndex [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant UBO& _17 [[buffer(0)]], constant UBOEnhancedLayout& _30 [[buffer(1)]])
+{
+    main0_out out = {};
+    out.FragColor = (_17.a[in.vIndex] + _30.c[in.vIndex]) + _30.e;
+    return out;
+}
+

--- a/reference/shaders-msl/comp/struct-packing.comp
+++ b/reference/shaders-msl/comp/struct-packing.comp
@@ -3,7 +3,7 @@
 
 using namespace metal;
 
-typedef float3x2 packed_float2x3;
+typedef packed_float2 packed_rm_float2x3[3];
 
 struct S0
 {
@@ -58,7 +58,7 @@ struct SSBO1
     float3x2 m3;
     float2x2 m4;
     float2x2 m5[9];
-    packed_float2x3 m6[4][2];
+    packed_rm_float2x3 m6[4][2];
     char _m10_pad[8];
     float3x2 m7;
     char _m11_pad[8];
@@ -142,6 +142,6 @@ kernel void main0(device SSBO1& ssbo_430 [[buffer(0)]], device SSBO0& ssbo_140 [
     ssbo_430.content.m3s[5].c = _60.m3s[5].c;
     ssbo_430.content.m3s[6].c = _60.m3s[6].c;
     ssbo_430.content.m3s[7].c = _60.m3s[7].c;
-    ssbo_430.content.m1.a = ssbo_430.content.m3.a * ssbo_430.m6[1][1];
+    ssbo_430.content.m1.a = ssbo_430.content.m3.a * float3x2(float2(ssbo_430.m6[1][1][0]), float2(ssbo_430.m6[1][1][1]), float2(ssbo_430.m6[1][1][2]));
 }
 

--- a/reference/shaders-msl/vert/packed_matrix.vert
+++ b/reference/shaders-msl/vert/packed_matrix.vert
@@ -3,12 +3,12 @@
 
 using namespace metal;
 
-typedef float3x4 packed_float4x3;
+typedef packed_float4 packed_rm_float4x3[3];
 
 struct _15
 {
-    packed_float4x3 _m0;
-    packed_float4x3 _m1;
+    packed_rm_float4x3 _m0;
+    packed_rm_float4x3 _m1;
 };
 
 struct _42
@@ -44,7 +44,7 @@ vertex main0_out main0(main0_in in [[stage_in]], constant _15& _17 [[buffer(0)]]
     float3 _13;
     do
     {
-        _13 = normalize(float4(in.m_25.xyz, 0.0) * _17._m1);
+        _13 = normalize(float4(in.m_25.xyz, 0.0) * float3x4(float4(_17._m1[0]), float4(_17._m1[1]), float4(_17._m1[2])));
         break;
     } while (false);
     float4 _39 = _44._m0 * float4(float3(_44._m3) + (in.m_25.xyz * (_44._m6 + _44._m7)), 1.0);

--- a/reference/shaders-msl/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp
+++ b/reference/shaders-msl/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp
@@ -3,7 +3,10 @@
 
 using namespace metal;
 
-typedef float3x2 packed_float2x3;
+typedef packed_float2 packed_float2x2[2];
+typedef packed_float2 packed_rm_float2x3[3];
+typedef packed_float3 packed_float2x3[2];
+typedef packed_float3 packed_rm_float3x2[2];
 
 struct S0
 {
@@ -58,7 +61,7 @@ struct SSBO1
     float3x2 m3;
     float2x2 m4;
     float2x2 m5[9];
-    packed_float2x3 m6[4][2];
+    packed_rm_float2x3 m6[4][2];
     float3x2 m7;
     float array[1];
 };
@@ -126,31 +129,43 @@ struct SSBO0
     float4 array[1];
 };
 
-kernel void main0(device SSBO1& ssbo_430 [[buffer(0)]], device SSBO0& ssbo_140 [[buffer(1)]])
+struct SSBO2
 {
-    ssbo_430.content.m0s[0].a[0] = ssbo_140.content.m0s[0].a[0].xy;
-    ssbo_430.content.m0s[0].b = ssbo_140.content.m0s[0].b;
-    ssbo_430.content.m1s[0].a = float3(ssbo_140.content.m1s[0].a);
-    ssbo_430.content.m1s[0].b = ssbo_140.content.m1s[0].b;
-    ssbo_430.content.m2s[0].a[0] = ssbo_140.content.m2s[0].a[0];
-    ssbo_430.content.m2s[0].b = ssbo_140.content.m2s[0].b;
-    ssbo_430.content.m0.a[0] = ssbo_140.content.m0.a[0].xy;
-    ssbo_430.content.m0.b = ssbo_140.content.m0.b;
-    ssbo_430.content.m1.a = float3(ssbo_140.content.m1.a);
-    ssbo_430.content.m1.b = ssbo_140.content.m1.b;
-    ssbo_430.content.m2.a[0] = ssbo_140.content.m2.a[0];
-    ssbo_430.content.m2.b = ssbo_140.content.m2.b;
-    ssbo_430.content.m3.a = ssbo_140.content.m3.a;
-    ssbo_430.content.m3.b = ssbo_140.content.m3.b;
-    ssbo_430.content.m4 = ssbo_140.content.m4;
-    ssbo_430.content.m3s[0].c = ssbo_140.content.m3s[0].c;
-    ssbo_430.content.m3s[1].c = ssbo_140.content.m3s[1].c;
-    ssbo_430.content.m3s[2].c = ssbo_140.content.m3s[2].c;
-    ssbo_430.content.m3s[3].c = ssbo_140.content.m3s[3].c;
-    ssbo_430.content.m3s[4].c = ssbo_140.content.m3s[4].c;
-    ssbo_430.content.m3s[5].c = ssbo_140.content.m3s[5].c;
-    ssbo_430.content.m3s[6].c = ssbo_140.content.m3s[6].c;
-    ssbo_430.content.m3s[7].c = ssbo_140.content.m3s[7].c;
-    ssbo_430.content.m1.a = float2x3(ssbo_430.m2[1]) * float2(ssbo_430.content.m0.a[0]);
+    float m0;
+    packed_float2x2 m1;
+    packed_rm_float3x2 m2;
+};
+
+kernel void main0(device SSBO1& ssbo_scalar [[buffer(0)]], device SSBO0& ssbo_140 [[buffer(1)]], device SSBO2& ssbo_scalar2 [[buffer(2)]])
+{
+    ssbo_scalar.content.m0s[0].a[0] = ssbo_140.content.m0s[0].a[0].xy;
+    ssbo_scalar.content.m0s[0].b = ssbo_140.content.m0s[0].b;
+    ssbo_scalar.content.m1s[0].a = float3(ssbo_140.content.m1s[0].a);
+    ssbo_scalar.content.m1s[0].b = ssbo_140.content.m1s[0].b;
+    ssbo_scalar.content.m2s[0].a[0] = ssbo_140.content.m2s[0].a[0];
+    ssbo_scalar.content.m2s[0].b = ssbo_140.content.m2s[0].b;
+    ssbo_scalar.content.m0.a[0] = ssbo_140.content.m0.a[0].xy;
+    ssbo_scalar.content.m0.b = ssbo_140.content.m0.b;
+    ssbo_scalar.content.m1.a = float3(ssbo_140.content.m1.a);
+    ssbo_scalar.content.m1.b = ssbo_140.content.m1.b;
+    ssbo_scalar.content.m2.a[0] = ssbo_140.content.m2.a[0];
+    ssbo_scalar.content.m2.b = ssbo_140.content.m2.b;
+    ssbo_scalar.content.m3.a = ssbo_140.content.m3.a;
+    ssbo_scalar.content.m3.b = ssbo_140.content.m3.b;
+    ssbo_scalar.content.m4 = ssbo_140.content.m4;
+    ssbo_scalar.content.m3s[0].c = ssbo_140.content.m3s[0].c;
+    ssbo_scalar.content.m3s[1].c = ssbo_140.content.m3s[1].c;
+    ssbo_scalar.content.m3s[2].c = ssbo_140.content.m3s[2].c;
+    ssbo_scalar.content.m3s[3].c = ssbo_140.content.m3s[3].c;
+    ssbo_scalar.content.m3s[4].c = ssbo_140.content.m3s[4].c;
+    ssbo_scalar.content.m3s[5].c = ssbo_140.content.m3s[5].c;
+    ssbo_scalar.content.m3s[6].c = ssbo_140.content.m3s[6].c;
+    ssbo_scalar.content.m3s[7].c = ssbo_140.content.m3s[7].c;
+    ssbo_scalar.content.m1.a = float2x3(float3(ssbo_scalar.m2[1][0]), float3(ssbo_scalar.m2[1][1])) * float2(ssbo_scalar.content.m0.a[0]);
+    ssbo_scalar.m0 = float2x2(float2(ssbo_scalar2.m1[0]), float2(ssbo_scalar2.m1[1]));
+    ssbo_scalar2.m1[0] = transpose(ssbo_scalar.m4)[0];
+    ssbo_scalar2.m1[1] = transpose(ssbo_scalar.m4)[1];
+    ssbo_scalar2.m2[0] = spvConvertFromRowMajor3x2(ssbo_scalar.m3)[0];
+    ssbo_scalar2.m2[1] = spvConvertFromRowMajor3x2(ssbo_scalar.m3)[1];
 }
 

--- a/reference/shaders-msl/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp
+++ b/reference/shaders-msl/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp
@@ -1,0 +1,156 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+typedef float3x2 packed_float2x3;
+
+struct S0
+{
+    packed_float2 a[1];
+    float b;
+};
+
+struct S1
+{
+    packed_float3 a;
+    float b;
+};
+
+struct S2
+{
+    packed_float3 a[1];
+    float b;
+};
+
+struct S3
+{
+    packed_float2 a;
+    float b;
+};
+
+struct S4
+{
+    float2 c;
+};
+
+struct Content
+{
+    S0 m0s[1];
+    S1 m1s[1];
+    S2 m2s[1];
+    S0 m0;
+    S1 m1;
+    S2 m2;
+    S3 m3;
+    float m4;
+    S4 m3s[8];
+};
+
+struct SSBO1
+{
+    Content content;
+    Content content1[2];
+    Content content2;
+    float2x2 m0;
+    float2x2 m1;
+    packed_float2x3 m2[4];
+    float3x2 m3;
+    float2x2 m4;
+    float2x2 m5[9];
+    packed_float2x3 m6[4][2];
+    float3x2 m7;
+    float array[1];
+};
+
+struct S0_1
+{
+    float4 a[1];
+    float b;
+};
+
+struct S1_1
+{
+    packed_float3 a;
+    float b;
+};
+
+struct S2_1
+{
+    float3 a[1];
+    float b;
+};
+
+struct S3_1
+{
+    float2 a;
+    float b;
+};
+
+struct S4_1
+{
+    float2 c;
+};
+
+struct Content_1
+{
+    S0_1 m0s[1];
+    S1_1 m1s[1];
+    S2_1 m2s[1];
+    S0_1 m0;
+    S1_1 m1;
+    S2_1 m2;
+    S3_1 m3;
+    float m4;
+    char _m8_pad[12];
+    /* FIXME: A padded struct is needed here. If you see this message, file a bug! */ S4_1 m3s[8];
+};
+
+struct SSBO0
+{
+    Content_1 content;
+    Content_1 content1[2];
+    Content_1 content2;
+    float2x2 m0;
+    char _m4_pad[16];
+    float2x2 m1;
+    char _m5_pad[16];
+    float2x3 m2[4];
+    float3x2 m3;
+    char _m7_pad[24];
+    float2x2 m4;
+    char _m8_pad[16];
+    float2x2 m5[9];
+    float2x3 m6[4][2];
+    float3x2 m7;
+    float4 array[1];
+};
+
+kernel void main0(device SSBO1& ssbo_430 [[buffer(0)]], device SSBO0& ssbo_140 [[buffer(1)]])
+{
+    ssbo_430.content.m0s[0].a[0] = ssbo_140.content.m0s[0].a[0].xy;
+    ssbo_430.content.m0s[0].b = ssbo_140.content.m0s[0].b;
+    ssbo_430.content.m1s[0].a = float3(ssbo_140.content.m1s[0].a);
+    ssbo_430.content.m1s[0].b = ssbo_140.content.m1s[0].b;
+    ssbo_430.content.m2s[0].a[0] = ssbo_140.content.m2s[0].a[0];
+    ssbo_430.content.m2s[0].b = ssbo_140.content.m2s[0].b;
+    ssbo_430.content.m0.a[0] = ssbo_140.content.m0.a[0].xy;
+    ssbo_430.content.m0.b = ssbo_140.content.m0.b;
+    ssbo_430.content.m1.a = float3(ssbo_140.content.m1.a);
+    ssbo_430.content.m1.b = ssbo_140.content.m1.b;
+    ssbo_430.content.m2.a[0] = ssbo_140.content.m2.a[0];
+    ssbo_430.content.m2.b = ssbo_140.content.m2.b;
+    ssbo_430.content.m3.a = ssbo_140.content.m3.a;
+    ssbo_430.content.m3.b = ssbo_140.content.m3.b;
+    ssbo_430.content.m4 = ssbo_140.content.m4;
+    ssbo_430.content.m3s[0].c = ssbo_140.content.m3s[0].c;
+    ssbo_430.content.m3s[1].c = ssbo_140.content.m3s[1].c;
+    ssbo_430.content.m3s[2].c = ssbo_140.content.m3s[2].c;
+    ssbo_430.content.m3s[3].c = ssbo_140.content.m3s[3].c;
+    ssbo_430.content.m3s[4].c = ssbo_140.content.m3s[4].c;
+    ssbo_430.content.m3s[5].c = ssbo_140.content.m3s[5].c;
+    ssbo_430.content.m3s[6].c = ssbo_140.content.m3s[6].c;
+    ssbo_430.content.m3s[7].c = ssbo_140.content.m3s[7].c;
+    ssbo_430.content.m1.a = float2x3(ssbo_430.m2[1]) * float2(ssbo_430.content.m0.a[0]);
+}
+

--- a/reference/shaders-msl/vulkan/frag/scalar-block-layout-ubo-std430.vk.nocompat.invalid.frag
+++ b/reference/shaders-msl/vulkan/frag/scalar-block-layout-ubo-std430.vk.nocompat.invalid.frag
@@ -1,0 +1,36 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBO
+{
+    float a[1];
+    float2 b[2];
+};
+
+struct UBOEnhancedLayout
+{
+    float c[1];
+    float2 d[2];
+    char _m2_pad[9976];
+    float e;
+};
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    int vIndex [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant UBO& _17 [[buffer(0)]], constant UBOEnhancedLayout& _30 [[buffer(1)]])
+{
+    main0_out out = {};
+    out.FragColor = (_17.a[in.vIndex] + _30.c[in.vIndex]) + _30.e;
+    return out;
+}
+

--- a/shaders-msl/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp
+++ b/shaders-msl/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp
@@ -29,7 +29,7 @@ struct S3
 
 struct S4
 {
-	vec2 c;
+    vec2 c;
 };
 
 struct Content
@@ -43,8 +43,15 @@ struct Content
     S3 m3;
     float m4;
 
-	S4 m3s[8];
+    S4 m3s[8];
 };
+
+layout(binding = 2, scalar) restrict buffer SSBO2
+{
+    float m0;
+    mat2 m1;
+    layout(row_major) mat3x2 m2;
+} ssbo_scalar2;
 
 layout(binding = 1, scalar) restrict buffer SSBO1
 {
@@ -61,7 +68,7 @@ layout(binding = 1, scalar) restrict buffer SSBO1
     layout(row_major) mat2x3 m6[4][2];
     layout(row_major) mat3x2 m7;
     float array[];
-} ssbo_430;
+} ssbo_scalar;
 
 layout(binding = 0, std140) restrict buffer SSBO0
 {
@@ -83,7 +90,10 @@ layout(binding = 0, std140) restrict buffer SSBO0
 
 void main()
 {
-    ssbo_430.content = ssbo_140.content;
-    ssbo_430.content.m1.a = ssbo_430.m2[1] * ssbo_430.content.m0.a[0];	// test packed matrix access
+    ssbo_scalar.content = ssbo_140.content;
+    ssbo_scalar.content.m1.a = ssbo_scalar.m2[1] * ssbo_scalar.content.m0.a[0];	// test packed matrix access
+    ssbo_scalar.m0 = ssbo_scalar2.m1;
+    ssbo_scalar2.m1 = ssbo_scalar.m4;
+    ssbo_scalar2.m2 = ssbo_scalar.m3;
 }
 

--- a/shaders-msl/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp
+++ b/shaders-msl/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp
@@ -1,0 +1,89 @@
+#version 310 es
+#extension GL_EXT_scalar_block_layout : require
+
+layout(local_size_x = 1) in;
+
+struct S0
+{
+    vec2 a[1];
+    float b;
+};
+
+struct S1
+{
+    vec3 a;
+    float b;
+};
+
+struct S2
+{
+    vec3 a[1];
+    float b;
+};
+
+struct S3
+{
+    vec2 a;
+    float b;
+};
+
+struct S4
+{
+	vec2 c;
+};
+
+struct Content
+{
+    S0 m0s[1];
+    S1 m1s[1];
+    S2 m2s[1];
+    S0 m0;
+    S1 m1;
+    S2 m2;
+    S3 m3;
+    float m4;
+
+	S4 m3s[8];
+};
+
+layout(binding = 1, scalar) restrict buffer SSBO1
+{
+    Content content;
+    Content content1[2];
+    Content content2;
+
+    layout(column_major) mat2 m0;
+    layout(column_major) mat2 m1;
+    layout(column_major) mat2x3 m2[4];
+    layout(column_major) mat3x2 m3;
+    layout(row_major) mat2 m4;
+    layout(row_major) mat2 m5[9];
+    layout(row_major) mat2x3 m6[4][2];
+    layout(row_major) mat3x2 m7;
+    float array[];
+} ssbo_430;
+
+layout(binding = 0, std140) restrict buffer SSBO0
+{
+    Content content;
+    Content content1[2];
+    Content content2;
+
+    layout(column_major) mat2 m0;
+    layout(column_major) mat2 m1;
+    layout(column_major) mat2x3 m2[4];
+    layout(column_major) mat3x2 m3;
+    layout(row_major) mat2 m4;
+    layout(row_major) mat2 m5[9];
+    layout(row_major) mat2x3 m6[4][2];
+    layout(row_major) mat3x2 m7;
+
+    float array[];
+} ssbo_140;
+
+void main()
+{
+    ssbo_430.content = ssbo_140.content;
+    ssbo_430.content.m1.a = ssbo_430.m2[1] * ssbo_430.content.m0.a[0];	// test packed matrix access
+}
+

--- a/shaders-msl/vulkan/frag/scalar-block-layout-ubo-std430.vk.nocompat.invalid.frag
+++ b/shaders-msl/vulkan/frag/scalar-block-layout-ubo-std430.vk.nocompat.invalid.frag
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_EXT_scalar_block_layout : require
+
+layout(std430, binding = 0) uniform UBO
+{
+	float a[1];
+	vec2 b[2];
+};
+
+layout(std430, binding = 1) uniform UBOEnhancedLayout
+{
+	float c[1];
+	vec2 d[2];
+	layout(offset = 10000) float e;
+};
+
+layout(location = 0) flat in int vIndex;
+layout(location = 0) out float FragColor;
+
+void main()
+{
+	FragColor = a[vIndex] + c[vIndex] + e;
+}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -8489,9 +8489,15 @@ size_t CompilerMSL::get_declared_struct_member_alignment(const SPIRType &struct_
 			const SPIRType *packed_type = packed_type_id != 0 ? &get<SPIRType>(packed_type_id) : nullptr;
 			if (packed_type && is_array(*packed_type) && !is_matrix(*packed_type) &&
 			    packed_type->basetype != SPIRType::Struct)
-				return (packed_type->width / 8) * 4;
+			{
+				uint32_t stride = type_struct_member_array_stride(struct_type, index);
+				if (stride == (packed_type->width / 8) * 4)
+					return stride;
+				else
+					return packed_type->width / 8;
+			}
 			else
-				return (type.width / 8) * (type.columns == 3 ? 4 : type.columns);
+				return type.width / 8;
 		}
 		else
 			return (type.width / 8) * (type.vecsize == 3 ? 4 : type.vecsize);

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -512,6 +512,7 @@ protected:
 	std::string to_component_argument(uint32_t id);
 	void align_struct(SPIRType &ib_type);
 	bool is_member_packable(SPIRType &ib_type, uint32_t index, uint32_t base_offset = 0);
+	uint32_t get_member_packed_type(SPIRType &ib_type, uint32_t index);
 	MSLStructMemberKey get_struct_member_key(uint32_t type_id, uint32_t index);
 	std::string get_argument_address_space(const SPIRVariable &argument);
 	std::string get_type_address_space(const SPIRType &type, uint32_t id);

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -511,7 +511,7 @@ protected:
 	size_t get_declared_struct_member_alignment(const SPIRType &struct_type, uint32_t index) const;
 	std::string to_component_argument(uint32_t id);
 	void align_struct(SPIRType &ib_type);
-	bool is_member_packable(SPIRType &ib_type, uint32_t index);
+	bool is_member_packable(SPIRType &ib_type, uint32_t index, uint32_t base_offset = 0);
 	MSLStructMemberKey get_struct_member_key(uint32_t type_id, uint32_t index);
 	std::string get_argument_address_space(const SPIRVariable &argument);
 	std::string get_type_address_space(const SPIRType &type, uint32_t id);


### PR DESCRIPTION
Relaxed block layout relaxed the restrictions on vector alignment,
allowing them to be aligned on scalar boundaries. Scalar block layout
relaxes this further, allowing *any* member to be aligned on a scalar
boundary. The requirement that a vector not improperly straddle a
16-byte boundary is also relaxed.

I've also added a test showing that `std430` layout works with UBOs.

I'm troubled by the dual meaning of the `Packed` extended decoration. In
some instances (struct, `float[]`, and `vec2[]` members), it actually
means the exact opposite, that the member needs extra padding. This is
especially problematic for `vec2[]`, because now we need to distinguish
the two cases by checking the array stride. I wonder if this should
actually be split into two decorations.

I also don't like that there are now four places where we set the
decoration on struct members.