### PR TITLE
Remove unreasonable assertion for OpTypeImage Sampled parameter.

### DIFF
--- a/spirv_parser.cpp
+++ b/spirv_parser.cpp
@@ -569,10 +569,6 @@ void Parser::parse(const Instruction &instruction)
 		type.image.sampled = ops[6];
 		type.image.format = static_cast<ImageFormat>(ops[7]);
 		type.image.access = (length >= 9) ? static_cast<AccessQualifier>(ops[8]) : AccessQualifierMax;
-
-		if (type.image.sampled == 0)
-			SPIRV_CROSS_THROW("OpTypeImage Sampled parameter must not be zero.");
-
 		break;
 	}
 


### PR DESCRIPTION
**OpTypeImage** Sampled parameter must be one of the following values:
0 indicates this is only known at run time, not at compile time
1 indicates will be used with sampler
2 indicates will be used without a sampler (a storage image)