### PR TITLE
Support the SPV_KHR_post_depth_coverage extension.

### DIFF
--- a/reference/opt/shaders-msl/frag/post-depth-coverage.ios.msl2.frag
+++ b/reference/opt/shaders-msl/frag/post-depth-coverage.ios.msl2.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+[[ early_fragment_tests ]] fragment main0_out main0(uint gl_SampleMaskIn [[sample_mask, post_depth_coverage]])
+{
+    main0_out out = {};
+    out.FragColor = float4(float(gl_SampleMaskIn));
+    return out;
+}
+

--- a/reference/opt/shaders/frag/post-depth-coverage.frag
+++ b/reference/opt/shaders/frag/post-depth-coverage.frag
@@ -1,0 +1,11 @@
+#version 450
+#extension GL_ARB_post_depth_coverage : require
+layout(early_fragment_tests, post_depth_coverage) in;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    FragColor = vec4(float(gl_SampleMaskIn[0]));
+}
+

--- a/reference/shaders-msl/frag/post-depth-coverage.ios.msl2.frag
+++ b/reference/shaders-msl/frag/post-depth-coverage.ios.msl2.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+[[ early_fragment_tests ]] fragment main0_out main0(uint gl_SampleMaskIn [[sample_mask, post_depth_coverage]])
+{
+    main0_out out = {};
+    out.FragColor = float4(float(gl_SampleMaskIn));
+    return out;
+}
+

--- a/reference/shaders/frag/post-depth-coverage.frag
+++ b/reference/shaders/frag/post-depth-coverage.frag
@@ -1,0 +1,11 @@
+#version 450
+#extension GL_ARB_post_depth_coverage : require
+layout(early_fragment_tests, post_depth_coverage) in;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    FragColor = vec4(float(gl_SampleMaskIn[0]));
+}
+

--- a/shaders-msl/frag/post-depth-coverage.ios.msl2.frag
+++ b/shaders-msl/frag/post-depth-coverage.ios.msl2.frag
@@ -1,0 +1,11 @@
+#version 450
+#extension GL_ARB_post_depth_coverage : require
+
+layout(post_depth_coverage) in;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = vec4(gl_SampleMaskIn[0]);
+}

--- a/shaders/frag/post-depth-coverage.frag
+++ b/shaders/frag/post-depth-coverage.frag
@@ -1,0 +1,11 @@
+#version 450
+#extension GL_ARB_post_depth_coverage : require
+
+layout(post_depth_coverage) in;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = vec4(gl_SampleMaskIn[0]);
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -600,6 +600,10 @@ void CompilerGLSL::emit_header()
 			require_extension_internal("GL_ARB_shader_image_load_store");
 	}
 
+	// Needed for: layout(post_depth_coverage) in;
+	if (execution.flags.get(ExecutionModePostDepthCoverage))
+		require_extension_internal("GL_ARB_post_depth_coverage");
+
 	for (auto &ext : forced_extensions)
 	{
 		if (ext == "GL_EXT_shader_explicit_arithmetic_types_float16")
@@ -763,6 +767,8 @@ void CompilerGLSL::emit_header()
 
 		if (execution.flags.get(ExecutionModeEarlyFragmentTests))
 			inputs.push_back("early_fragment_tests");
+		if (execution.flags.get(ExecutionModePostDepthCoverage))
+			inputs.push_back("post_depth_coverage");
 
 		if (!options.es && execution.flags.get(ExecutionModeDepthGreater))
 			statement("layout(depth_greater) out float gl_FragDepth;");


### PR DESCRIPTION
Using the `PostDepthCoverage` mode specifies that the `gl_SampleMaskIn`
variable is to contain the computed coverage mask following the early
fragment tests, which this mode requires and implicitly enables.

Note that unlike Vulkan and OpenGL, Metal places this on the sample mask
input itself, and furthermore does *not* implicitly enable early
fragment testing. If it isn't enabled explicitly with an
`[[early_fragment_tests]]` attribute, the compiler will error out. So we
have to enable that mode explicitly if `PostDepthCoverage` is enabled
but `EarlyFragmentTests` isn't.

For Metal, only iOS supports this; for some reason, Apple has yet to
implement it on macOS, even though many desktop cards support it.