### PR TITLE
MSL: Use the select() function for OpSelect.

### DIFF
--- a/reference/shaders-msl/frag/fp16.desktop.invalid.frag
+++ b/reference/shaders-msl/frag/fp16.desktop.invalid.frag
@@ -119,8 +119,7 @@ void test_builtins(thread half4& v4, thread half3& v3, thread half& v1)
     res = max(v4, v4);
     res = clamp(v4, v4, v4);
     res = mix(v4, v4, v4);
-    bool4 _243 = v4 < v4;
-    res = half4(_243.x ? v4.x : v4.x, _243.y ? v4.y : v4.y, _243.z ? v4.z : v4.z, _243.w ? v4.w : v4.w);
+    res = select(v4, v4, v4 < v4);
     res = step(v4, v4);
     res = smoothstep(v4, v4, v4);
     bool4 btmp = isnan(v4);

--- a/reference/shaders-msl/frag/mix.frag
+++ b/reference/shaders-msl/frag/mix.frag
@@ -20,11 +20,10 @@ fragment main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
     bool4 l = bool4(false, true, false, false);
-    out.FragColor = float4(l.x ? in.vIn1.x : in.vIn0.x, l.y ? in.vIn1.y : in.vIn0.y, l.z ? in.vIn1.z : in.vIn0.z, l.w ? in.vIn1.w : in.vIn0.w);
+    out.FragColor = select(in.vIn0, in.vIn1, l);
     bool f = true;
     out.FragColor = float4(f ? in.vIn3 : in.vIn2);
-    bool4 _37 = bool4(f);
-    out.FragColor = float4(_37.x ? in.vIn0.x : in.vIn1.x, _37.y ? in.vIn0.y : in.vIn1.y, _37.z ? in.vIn0.z : in.vIn1.z, _37.w ? in.vIn0.w : in.vIn1.w);
+    out.FragColor = select(in.vIn1, in.vIn0, bool4(f));
     out.FragColor = float4(f ? in.vIn2 : in.vIn3);
     return out;
 }

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -4493,7 +4493,7 @@ void CompilerGLSL::emit_mix_op(uint32_t result_type, uint32_t id, uint32_t left,
 	}
 
 	string mix_op;
-	bool has_boolean_mix = backend.boolean_mix_support &&
+	bool has_boolean_mix = *backend.boolean_mix_function &&
 	                       ((options.es && options.version >= 310) || (!options.es && options.version >= 450));
 	bool trivial_mix = to_trivial_mix_op(restype, mix_op, left, right, lerp);
 
@@ -4523,6 +4523,8 @@ void CompilerGLSL::emit_mix_op(uint32_t result_type, uint32_t id, uint32_t left,
 		inherit_expression_dependencies(id, right);
 		inherit_expression_dependencies(id, lerp);
 	}
+	else if (lerptype.basetype == SPIRType::Boolean)
+		emit_trinary_func_op(result_type, id, left, right, lerp, backend.boolean_mix_function);
 	else
 		emit_trinary_func_op(result_type, id, left, right, lerp, "mix");
 }

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -383,6 +383,7 @@ protected:
 		const char *int16_t_literal_suffix = "s";
 		const char *uint16_t_literal_suffix = "us";
 		const char *nonuniform_qualifier = "nonuniformEXT";
+		const char *boolean_mix_function = "mix";
 		bool swizzle_is_function = false;
 		bool shared_is_implied = false;
 		bool unsized_array_supported = true;
@@ -393,7 +394,6 @@ protected:
 		bool can_declare_arrays_inline = true;
 		bool native_row_major_matrix = true;
 		bool use_constructor_splatting = true;
-		bool boolean_mix_support = true;
 		bool allow_precision_qualifiers = false;
 		bool can_swizzle_scalar = false;
 		bool force_gl_in_out_block = false;

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -4792,13 +4792,13 @@ string CompilerHLSL::compile()
 	backend.uint16_t_literal_suffix = "u";
 	backend.basic_int_type = "int";
 	backend.basic_uint_type = "uint";
+	backend.boolean_mix_function = "";
 	backend.swizzle_is_function = false;
 	backend.shared_is_implied = true;
 	backend.unsized_array_supported = true;
 	backend.explicit_struct_type = false;
 	backend.use_initializer_list = true;
 	backend.use_constructor_splatting = false;
-	backend.boolean_mix_support = false;
 	backend.can_swizzle_scalar = true;
 	backend.can_declare_struct_inline = false;
 	backend.can_declare_arrays_inline = false;

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -757,6 +757,7 @@ string CompilerMSL::compile()
 	backend.basic_int16_type = "short";
 	backend.basic_uint16_type = "ushort";
 	backend.discard_literal = "discard_fragment()";
+	backend.boolean_mix_function = "select";
 	backend.swizzle_is_function = false;
 	backend.shared_is_implied = false;
 	backend.use_initializer_list = true;
@@ -765,7 +766,6 @@ string CompilerMSL::compile()
 	backend.unsized_array_supported = false;
 	backend.can_declare_arrays_inline = false;
 	backend.can_return_array = false;
-	backend.boolean_mix_support = false;
 	backend.allow_truncated_access_chain = true;
 	backend.array_is_value_type = false;
 	backend.comparison_image_samples_scalar = true;


### PR DESCRIPTION
This significantly improves codegen for vector `OpSelect` in MSL.