### PR TITLE
MSL: Support the SPV_AMD_shader_trinary_minmax extension.

### DIFF
--- a/reference/opt/shaders-msl/amd/shader_trinary_minmax.msl21.comp
+++ b/reference/opt/shaders-msl/amd/shader_trinary_minmax.msl21.comp
@@ -1,0 +1,11 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(64u, 1u, 1u);
+
+kernel void main0()
+{
+}
+

--- a/reference/shaders-msl/amd/shader_trinary_minmax.msl21.comp
+++ b/reference/shaders-msl/amd/shader_trinary_minmax.msl21.comp
@@ -1,0 +1,14 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(64u, 1u, 1u);
+
+kernel void main0()
+{
+    int t11 = min3(0, 3, 2);
+    int t12 = max3(0, 3, 2);
+    int t13 = median3(0, 3, 2);
+}
+

--- a/shaders-msl/amd/shader_trinary_minmax.msl21.comp
+++ b/shaders-msl/amd/shader_trinary_minmax.msl21.comp
@@ -1,0 +1,11 @@
+#version 450
+#extension GL_AMD_shader_trinary_minmax : require
+
+layout (local_size_x = 64) in;
+
+void main ()
+{
+    int t11 = min3(0, 3, 2);
+    int t12 = max3(0, 3, 2);
+    int t13 = mid3(0, 3, 2);
+}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -4884,6 +4884,40 @@ void CompilerMSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop, 
 	}
 }
 
+void CompilerMSL::emit_spv_amd_shader_trinary_minmax_op(uint32_t result_type, uint32_t id, uint32_t eop,
+                                                        const uint32_t *args, uint32_t count)
+{
+	enum AMDShaderTrinaryMinMax
+	{
+		FMin3AMD = 1,
+		UMin3AMD = 2,
+		SMin3AMD = 3,
+		FMax3AMD = 4,
+		UMax3AMD = 5,
+		SMax3AMD = 6,
+		FMid3AMD = 7,
+		UMid3AMD = 8,
+		SMid3AMD = 9
+	};
+
+	if (!msl_options.supports_msl_version(2, 1))
+		SPIRV_CROSS_THROW("Trinary min/max functions require MSL 2.1.");
+
+	auto op = static_cast<AMDShaderTrinaryMinMax>(eop);
+
+	switch (op)
+	{
+	case FMid3AMD:
+	case UMid3AMD:
+	case SMid3AMD:
+		emit_trinary_func_op(result_type, id, args[0], args[1], args[2], "median3");
+		break;
+	default:
+		CompilerGLSL::emit_spv_amd_shader_trinary_minmax_op(result_type, id, eop, args, count);
+		break;
+	}
+}
+
 // Emit a structure declaration for the specified interface variable.
 void CompilerMSL::emit_interface_block(uint32_t ib_var_id)
 {

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -410,6 +410,8 @@ protected:
 	void emit_instruction(const Instruction &instr) override;
 	void emit_glsl_op(uint32_t result_type, uint32_t result_id, uint32_t op, const uint32_t *args,
 	                  uint32_t count) override;
+	void emit_spv_amd_shader_trinary_minmax_op(uint32_t result_type, uint32_t result_id, uint32_t op,
+	                                           const uint32_t *args, uint32_t count) override;
 	void emit_header() override;
 	void emit_function_prototype(SPIRFunction &func, const Bitset &return_flags) override;
 	void emit_sampled_image_op(uint32_t result_type, uint32_t result_id, uint32_t image_id, uint32_t samp_id) override;


### PR DESCRIPTION
This requires MSL 2.1.