### PR TITLE
Support the SPV_KHR_device_group extension.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -515,6 +515,7 @@ struct CLIArguments
 	bool msl_argument_buffers = false;
 	bool msl_texture_buffer_native = false;
 	bool msl_multiview = false;
+	bool msl_view_index_from_device_index = false;
 	bool glsl_emit_push_constant_as_ubo = false;
 	bool glsl_emit_ubo_as_plain_uniforms = false;
 	bool emit_line_directives = false;
@@ -594,6 +595,7 @@ static void print_help()
 	                "\t[--msl-texture-buffer-native]\n"
 	                "\t[--msl-discrete-descriptor-set <index>]\n"
 	                "\t[--msl-multiview]\n"
+	                "\t[--msl-view-index-from-device-index]\n"
 	                "\t[--hlsl]\n"
 	                "\t[--reflect]\n"
 	                "\t[--shader-model]\n"
@@ -753,6 +755,7 @@ static string compile_iteration(const CLIArguments &args, std::vector<uint32_t> 
 		msl_opts.argument_buffers = args.msl_argument_buffers;
 		msl_opts.texture_buffer_native = args.msl_texture_buffer_native;
 		msl_opts.multiview = args.msl_multiview;
+		msl_opts.view_index_from_device_index = args.msl_view_index_from_device_index;
 		msl_comp->set_msl_options(msl_opts);
 		for (auto &v : args.msl_discrete_descriptor_sets)
 			msl_comp->add_discrete_descriptor_set(v);
@@ -1073,6 +1076,8 @@ static int main_inner(int argc, char *argv[])
 	        [&args](CLIParser &parser) { args.msl_discrete_descriptor_sets.push_back(parser.next_uint()); });
 	cbs.add("--msl-texture-buffer-native", [&args](CLIParser &) { args.msl_texture_buffer_native = true; });
 	cbs.add("--msl-multiview", [&args](CLIParser &) { args.msl_multiview = true; });
+	cbs.add("--msl-view-index-from-device-index",
+	        [&args](CLIParser &) { args.msl_view_index_from_device_index = true; });
 	cbs.add("--extension", [&args](CLIParser &parser) { args.extensions.push_back(parser.next_string()); });
 	cbs.add("--rename-entry-point", [&args](CLIParser &parser) {
 		auto old_name = parser.next_string();

--- a/reference/opt/shaders-msl/vulkan/vert/device-group.multiview.viewfromdev.nocompat.vk.vert
+++ b/reference/opt/shaders-msl/vulkan/vert/device-group.multiview.viewfromdev.nocompat.vk.vert
@@ -1,0 +1,19 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+vertex main0_out main0()
+{
+    main0_out out = {};
+    const int gl_DeviceIndex = 0;
+    const uint gl_ViewIndex = 0;
+    out.gl_Position = float4(float(gl_DeviceIndex), float(int(gl_ViewIndex)), 0.0, 1.0);
+    return out;
+}
+

--- a/reference/opt/shaders-msl/vulkan/vert/device-group.nocompat.vk.vert
+++ b/reference/opt/shaders-msl/vulkan/vert/device-group.nocompat.vk.vert
@@ -1,0 +1,18 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+vertex main0_out main0()
+{
+    main0_out out = {};
+    const int gl_DeviceIndex = 0;
+    out.gl_Position = float4(float(gl_DeviceIndex));
+    return out;
+}
+

--- a/reference/opt/shaders/vulkan/vert/device-group.nocompat.vk.vert.vk
+++ b/reference/opt/shaders/vulkan/vert/device-group.nocompat.vk.vert.vk
@@ -1,0 +1,8 @@
+#version 450
+#extension GL_EXT_device_group : require
+
+void main()
+{
+    gl_Position = vec4(float(gl_DeviceIndex));
+}
+

--- a/reference/shaders-msl/vulkan/vert/device-group.multiview.viewfromdev.nocompat.vk.vert
+++ b/reference/shaders-msl/vulkan/vert/device-group.multiview.viewfromdev.nocompat.vk.vert
@@ -1,0 +1,19 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+vertex main0_out main0()
+{
+    main0_out out = {};
+    const int gl_DeviceIndex = 0;
+    const uint gl_ViewIndex = 0;
+    out.gl_Position = float4(float(gl_DeviceIndex), float(int(gl_ViewIndex)), 0.0, 1.0);
+    return out;
+}
+

--- a/reference/shaders-msl/vulkan/vert/device-group.nocompat.vk.vert
+++ b/reference/shaders-msl/vulkan/vert/device-group.nocompat.vk.vert
@@ -1,0 +1,18 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+vertex main0_out main0()
+{
+    main0_out out = {};
+    const int gl_DeviceIndex = 0;
+    out.gl_Position = float4(float(gl_DeviceIndex));
+    return out;
+}
+

--- a/reference/shaders/vulkan/vert/device-group.nocompat.vk.vert.vk
+++ b/reference/shaders/vulkan/vert/device-group.nocompat.vk.vert.vk
@@ -1,0 +1,8 @@
+#version 450
+#extension GL_EXT_device_group : require
+
+void main()
+{
+    gl_Position = vec4(float(gl_DeviceIndex));
+}
+

--- a/shaders-msl/vulkan/vert/device-group.multiview.viewfromdev.nocompat.vk.vert
+++ b/shaders-msl/vulkan/vert/device-group.multiview.viewfromdev.nocompat.vk.vert
@@ -1,0 +1,8 @@
+#version 450 core
+#extension GL_EXT_device_group : require
+#extension GL_EXT_multiview : require
+
+void main()
+{
+	gl_Position = vec4(gl_DeviceIndex, gl_ViewIndex, 0.0, 1.0);
+}

--- a/shaders-msl/vulkan/vert/device-group.nocompat.vk.vert
+++ b/shaders-msl/vulkan/vert/device-group.nocompat.vk.vert
@@ -1,0 +1,7 @@
+#version 450 core
+#extension GL_EXT_device_group : require
+
+void main()
+{
+	gl_Position = vec4(gl_DeviceIndex);
+}

--- a/shaders/vulkan/vert/device-group.nocompat.vk.vert
+++ b/shaders/vulkan/vert/device-group.nocompat.vk.vert
@@ -1,0 +1,7 @@
+#version 450 core
+#extension GL_EXT_device_group : require
+
+void main()
+{
+	gl_Position = vec4(gl_DeviceIndex);
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -6290,6 +6290,12 @@ string CompilerGLSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 			SPIRV_CROSS_THROW("Stencil export not supported in GLES.");
 	}
 
+	case BuiltInDeviceIndex:
+		if (!options.vulkan_semantics)
+			SPIRV_CROSS_THROW("Need Vulkan semantics for device group support.");
+		require_extension_internal("GL_EXT_device_group");
+		return "gl_DeviceIndex";
+
 	default:
 		return join("gl_BuiltIn_", convert_to_string(builtin));
 	}

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -193,12 +193,14 @@ public:
 		uint32_t buffer_size_buffer_index = 25;
 		uint32_t view_mask_buffer_index = 24;
 		uint32_t shader_input_wg_index = 0;
+		uint32_t device_index = 0;
 		bool enable_point_size_builtin = true;
 		bool disable_rasterization = false;
 		bool capture_output_to_buffer = false;
 		bool swizzle_texture_samples = false;
 		bool tess_domain_origin_lower_left = false;
 		bool multiview = false;
+		bool view_index_from_device_index = false;
 
 		// Enable use of MSL 2.0 indirect argument buffers.
 		// MSL 2.0 must also be enabled.
@@ -274,7 +276,7 @@ public:
 	// containing the view mask for the current multiview subpass.
 	bool needs_view_mask_buffer() const
 	{
-		return msl_options.multiview;
+		return msl_options.multiview && !msl_options.view_index_from_device_index;
 	}
 
 	// Provide feedback to calling API to allow it to pass an output

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -205,6 +205,8 @@ def cross_compile_msl(shader, spirv, opt, iterations, paths):
         msl_args.append('--emit-line-directives')
     if '.multiview.' in shader:
         msl_args.append('--msl-multiview')
+    if '.viewfromdev.' in shader:
+        msl_args.append('--msl-view-index-from-device-index')
 
     subprocess.check_call(msl_args)
 


### PR DESCRIPTION
The only piece added by this extension is the `DeviceIndex` builtin,
which tells the shader which device in a grouped logical device it is
running on.

Metal's pipeline state objects are owned by the `MTLDevice` that created
them. Since Metal doesn't support logical grouping of devices the way
Vulkan does, we'll thus have to create a pipeline state for each device
in a grouped logical device. The upcoming peer group support in Metal 3
will not change this. For this reason, for Metal, the device index is
supplied as a constant at pipeline compile time.

There's an interaction between `VK_KHR_device_group` and
`VK_KHR_multiview` in the
`VK_PIPELINE_CREATE_VIEW_INDEX_FROM_DEVICE_INDEX_BIT`, which defines the
view index to be the same as the device index. The new
`view_index_from_device_index` MSL option supports this functionality.