### PR TITLE
MSL: Support the SPV_INTEL_shader_integer_functions2 extension.

### DIFF
--- a/reference/opt/shaders-msl/intel/shader-integer-functions2.asm.comp
+++ b/reference/opt/shaders-msl/intel/shader-integer-functions2.asm.comp
@@ -1,0 +1,31 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct foo
+{
+    uint a;
+    uint b;
+    int c;
+    int d;
+};
+
+kernel void main0(device foo& _4 [[buffer(0)]])
+{
+    _4.a = clz(_4.a);
+    _4.a = ctz(_4.a);
+    _4.a = absdiff(_4.c, _4.d);
+    _4.a = absdiff(_4.a, _4.b);
+    _4.c = addsat(_4.c, _4.d);
+    _4.a = addsat(_4.a, _4.b);
+    _4.c = hadd(_4.c, _4.d);
+    _4.a = hadd(_4.a, _4.b);
+    _4.c = rhadd(_4.c, _4.d);
+    _4.a = rhadd(_4.a, _4.b);
+    _4.c = subsat(_4.c, _4.d);
+    _4.a = subsat(_4.a, _4.b);
+    _4.c = int(short(_4.c)) * int(short(_4.d));
+    _4.a = uint(ushort(_4.a)) * uint(ushort(_4.b));
+}
+

--- a/reference/shaders-msl/intel/shader-integer-functions2.asm.comp
+++ b/reference/shaders-msl/intel/shader-integer-functions2.asm.comp
@@ -1,0 +1,31 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct foo
+{
+    uint a;
+    uint b;
+    int c;
+    int d;
+};
+
+kernel void main0(device foo& _4 [[buffer(0)]])
+{
+    _4.a = clz(_4.a);
+    _4.a = ctz(_4.a);
+    _4.a = absdiff(_4.c, _4.d);
+    _4.a = absdiff(_4.a, _4.b);
+    _4.c = addsat(_4.c, _4.d);
+    _4.a = addsat(_4.a, _4.b);
+    _4.c = hadd(_4.c, _4.d);
+    _4.a = hadd(_4.a, _4.b);
+    _4.c = rhadd(_4.c, _4.d);
+    _4.a = rhadd(_4.a, _4.b);
+    _4.c = subsat(_4.c, _4.d);
+    _4.a = subsat(_4.a, _4.b);
+    _4.c = int(short(_4.c)) * int(short(_4.d));
+    _4.a = uint(ushort(_4.a)) * uint(ushort(_4.b));
+}
+

--- a/shaders-msl/intel/shader-integer-functions2.asm.comp
+++ b/shaders-msl/intel/shader-integer-functions2.asm.comp
@@ -1,0 +1,137 @@
+; SPIR-V
+; Version: 1.4
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 97
+; Schema: 0
+               OpCapability Shader
+               OpCapability IntegerFunctions2INTEL
+               OpExtension "SPV_INTEL_shader_integer_functions2"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpName %main "main"
+               OpName %foo "foo"
+               OpMemberName %foo 0 "a"
+               OpMemberName %foo 1 "b"
+               OpMemberName %foo 2 "c"
+               OpMemberName %foo 3 "d"
+               OpName %_ ""
+               OpMemberDecorate %foo 0 Offset 0
+               OpMemberDecorate %foo 1 Offset 4
+               OpMemberDecorate %foo 2 Offset 8
+               OpMemberDecorate %foo 3 Offset 12
+               OpDecorate %foo Block
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 0
+       %void = OpTypeVoid
+          %6 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+        %int = OpTypeInt 32 1
+        %foo = OpTypeStruct %uint %uint %int %int
+%_ptr_StorageBuffer_foo = OpTypePointer StorageBuffer %foo
+          %_ = OpVariable %_ptr_StorageBuffer_foo StorageBuffer
+      %int_0 = OpConstant %int 0
+%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
+      %int_1 = OpConstant %int 1
+      %int_2 = OpConstant %int 2
+%_ptr_StorageBuffer_int = OpTypePointer StorageBuffer %int
+      %int_3 = OpConstant %int 3
+       %main = OpFunction %void None %6
+         %15 = OpLabel
+         %16 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0
+         %17 = OpLoad %uint %16
+         %18 = OpUCountLeadingZerosINTEL %uint %17
+         %19 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0
+               OpStore %19 %18
+         %20 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0
+         %21 = OpLoad %uint %20
+         %22 = OpUCountTrailingZerosINTEL %uint %21
+         %23 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0
+               OpStore %23 %22
+         %24 = OpAccessChain %_ptr_StorageBuffer_int %_ %int_2
+         %25 = OpLoad %int %24
+         %26 = OpAccessChain %_ptr_StorageBuffer_int %_ %int_3
+         %27 = OpLoad %int %26
+         %28 = OpAbsISubINTEL %uint %25 %27
+         %29 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0
+               OpStore %29 %28
+         %30 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0
+         %31 = OpLoad %uint %30
+         %32 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_1
+         %33 = OpLoad %uint %32
+         %34 = OpAbsUSubINTEL %uint %31 %33
+         %35 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0
+               OpStore %35 %34
+         %37 = OpAccessChain %_ptr_StorageBuffer_int %_ %int_2
+         %38 = OpLoad %int %37
+         %39 = OpAccessChain %_ptr_StorageBuffer_int %_ %int_3
+         %40 = OpLoad %int %39
+         %41 = OpIAddSatINTEL %int %38 %40
+         %42 = OpAccessChain %_ptr_StorageBuffer_int %_ %int_2
+               OpStore %42 %41
+         %43 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0
+         %44 = OpLoad %uint %43
+         %45 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_1
+         %46 = OpLoad %uint %45
+         %47 = OpUAddSatINTEL %uint %44 %46
+         %48 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0
+               OpStore %48 %47
+         %49 = OpAccessChain %_ptr_StorageBuffer_int %_ %int_2
+         %50 = OpLoad %int %49
+         %51 = OpAccessChain %_ptr_StorageBuffer_int %_ %int_3
+         %52 = OpLoad %int %51
+         %53 = OpIAverageINTEL %int %50 %52
+         %54 = OpAccessChain %_ptr_StorageBuffer_int %_ %int_2
+               OpStore %54 %53
+         %55 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0
+         %56 = OpLoad %uint %55
+         %57 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_1
+         %58 = OpLoad %uint %57
+         %59 = OpUAverageINTEL %uint %56 %58
+         %60 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0
+               OpStore %60 %59
+         %61 = OpAccessChain %_ptr_StorageBuffer_int %_ %int_2
+         %62 = OpLoad %int %61
+         %63 = OpAccessChain %_ptr_StorageBuffer_int %_ %int_3
+         %64 = OpLoad %int %63
+         %65 = OpIAverageRoundedINTEL %int %62 %64
+         %66 = OpAccessChain %_ptr_StorageBuffer_int %_ %int_2
+               OpStore %66 %65
+         %67 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0
+         %68 = OpLoad %uint %67
+         %69 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_1
+         %70 = OpLoad %uint %69
+         %71 = OpUAverageRoundedINTEL %uint %68 %70
+         %72 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0
+               OpStore %72 %71
+         %73 = OpAccessChain %_ptr_StorageBuffer_int %_ %int_2
+         %74 = OpLoad %int %73
+         %75 = OpAccessChain %_ptr_StorageBuffer_int %_ %int_3
+         %76 = OpLoad %int %75
+         %77 = OpISubSatINTEL %int %74 %76
+         %78 = OpAccessChain %_ptr_StorageBuffer_int %_ %int_2
+               OpStore %78 %77
+         %79 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0
+         %80 = OpLoad %uint %79
+         %81 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_1
+         %82 = OpLoad %uint %81
+         %83 = OpUSubSatINTEL %uint %80 %82
+         %84 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0
+               OpStore %84 %83
+         %85 = OpAccessChain %_ptr_StorageBuffer_int %_ %int_2
+         %86 = OpLoad %int %85
+         %87 = OpAccessChain %_ptr_StorageBuffer_int %_ %int_3
+         %88 = OpLoad %int %87
+         %89 = OpIMul32x16INTEL %int %86 %88
+         %90 = OpAccessChain %_ptr_StorageBuffer_int %_ %int_2
+               OpStore %90 %89
+         %91 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0
+         %92 = OpLoad %uint %91
+         %93 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_1
+         %94 = OpLoad %uint %93
+         %95 = OpUMul32x16INTEL %uint %92 %94
+         %96 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0
+               OpStore %96 %95
+               OpReturn
+               OpFunctionEnd

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -4397,6 +4397,66 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		break;
 	}
 
+	// SPV_INTEL_shader_integer_functions2
+	case OpUCountLeadingZerosINTEL:
+		MSL_UFOP(clz);
+		break;
+
+	case OpUCountTrailingZerosINTEL:
+		MSL_UFOP(ctz);
+		break;
+
+	case OpAbsISubINTEL:
+	case OpAbsUSubINTEL:
+		MSL_BFOP(absdiff);
+		break;
+
+	case OpIAddSatINTEL:
+	case OpUAddSatINTEL:
+		MSL_BFOP(addsat);
+		break;
+
+	case OpIAverageINTEL:
+	case OpUAverageINTEL:
+		MSL_BFOP(hadd);
+		break;
+
+	case OpIAverageRoundedINTEL:
+	case OpUAverageRoundedINTEL:
+		MSL_BFOP(rhadd);
+		break;
+
+	case OpISubSatINTEL:
+	case OpUSubSatINTEL:
+		MSL_BFOP(subsat);
+		break;
+
+	case OpIMul32x16INTEL:
+	{
+		uint32_t result_type = ops[0];
+		uint32_t id = ops[1];
+		uint32_t a = ops[2], b = ops[3];
+		bool forward = should_forward(a) && should_forward(b);
+		emit_op(result_type, id, join("int(short(", to_expression(a), ")) * int(short(", to_expression(b), "))"),
+		        forward);
+		inherit_expression_dependencies(id, a);
+		inherit_expression_dependencies(id, b);
+		break;
+	}
+
+	case OpUMul32x16INTEL:
+	{
+		uint32_t result_type = ops[0];
+		uint32_t id = ops[1];
+		uint32_t a = ops[2], b = ops[3];
+		bool forward = should_forward(a) && should_forward(b);
+		emit_op(result_type, id, join("uint(ushort(", to_expression(a), ")) * uint(ushort(", to_expression(b), "))"),
+		        forward);
+		inherit_expression_dependencies(id, a);
+		inherit_expression_dependencies(id, b);
+		break;
+	}
+
 	default:
 		CompilerGLSL::emit_instruction(instruction);
 		break;


### PR DESCRIPTION
This provides a few functions normally available in OpenCL to the SPIR-V
shader environment. These functions happen to be available in Metal as
well.

No GLSL, unfortunately. Intel has yet to publish a
`GL_INTEL_shader_integer_functions2` spec.