### PR TITLE
Support the SPV_EXT_demote_to_helper_invocation extension.

### DIFF
--- a/reference/opt/shaders-hlsl/frag/demote-to-helper.frag
+++ b/reference/opt/shaders-hlsl/frag/demote-to-helper.frag
@@ -1,0 +1,9 @@
+void frag_main()
+{
+    discard;
+}
+
+void main()
+{
+    frag_main();
+}

--- a/reference/opt/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl21.invalid.frag
+++ b/reference/opt/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl21.invalid.frag
@@ -1,0 +1,9 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+fragment void main0()
+{
+}
+

--- a/reference/opt/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl21.invalid.frag
+++ b/reference/opt/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl21.invalid.frag
@@ -5,5 +5,6 @@ using namespace metal;
 
 fragment void main0()
 {
+    bool _9 = simd_is_helper_thread();
 }
 

--- a/reference/opt/shaders/vulkan/frag/demote-to-helper-forwarding.asm.vk.nocompat.frag.vk
+++ b/reference/opt/shaders/vulkan/frag/demote-to-helper-forwarding.asm.vk.nocompat.frag.vk
@@ -1,0 +1,15 @@
+#version 450
+#extension GL_EXT_demote_to_helper_invocation : require
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    bool _15 = helperInvocationEXT();
+    demote;
+    if (!_15)
+    {
+        FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+    }
+}
+

--- a/reference/opt/shaders/vulkan/frag/demote-to-helper.vk.nocompat.frag.vk
+++ b/reference/opt/shaders/vulkan/frag/demote-to-helper.vk.nocompat.frag.vk
@@ -1,0 +1,9 @@
+#version 450
+#extension GL_EXT_demote_to_helper_invocation : require
+
+void main()
+{
+    demote;
+    bool helper = helperInvocationEXT();
+}
+

--- a/reference/opt/shaders/vulkan/frag/demote-to-helper.vk.nocompat.frag.vk
+++ b/reference/opt/shaders/vulkan/frag/demote-to-helper.vk.nocompat.frag.vk
@@ -4,6 +4,7 @@
 void main()
 {
     demote;
-    bool helper = helperInvocationEXT();
+    bool _9 = helperInvocationEXT();
+    bool helper = _9;
 }
 

--- a/reference/shaders-hlsl/frag/demote-to-helper.frag
+++ b/reference/shaders-hlsl/frag/demote-to-helper.frag
@@ -1,0 +1,9 @@
+void frag_main()
+{
+    discard;
+}
+
+void main()
+{
+    frag_main();
+}

--- a/reference/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl21.invalid.frag
+++ b/reference/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl21.invalid.frag
@@ -5,6 +5,7 @@ using namespace metal;
 
 fragment void main0()
 {
-    bool helper = simd_is_helper_thread();
+    bool _9 = simd_is_helper_thread();
+    bool helper = _9;
 }
 

--- a/reference/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl21.invalid.frag
+++ b/reference/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl21.invalid.frag
@@ -1,0 +1,10 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+fragment void main0()
+{
+    bool helper = simd_is_helper_thread();
+}
+

--- a/reference/shaders/vulkan/frag/demote-to-helper-forwarding.asm.vk.nocompat.frag.vk
+++ b/reference/shaders/vulkan/frag/demote-to-helper-forwarding.asm.vk.nocompat.frag.vk
@@ -1,0 +1,15 @@
+#version 450
+#extension GL_EXT_demote_to_helper_invocation : require
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    bool _15 = helperInvocationEXT();
+    demote;
+    if (!_15)
+    {
+        FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+    }
+}
+

--- a/reference/shaders/vulkan/frag/demote-to-helper.vk.nocompat.frag.vk
+++ b/reference/shaders/vulkan/frag/demote-to-helper.vk.nocompat.frag.vk
@@ -1,0 +1,9 @@
+#version 450
+#extension GL_EXT_demote_to_helper_invocation : require
+
+void main()
+{
+    demote;
+    bool helper = helperInvocationEXT();
+}
+

--- a/reference/shaders/vulkan/frag/demote-to-helper.vk.nocompat.frag.vk
+++ b/reference/shaders/vulkan/frag/demote-to-helper.vk.nocompat.frag.vk
@@ -4,6 +4,7 @@
 void main()
 {
     demote;
-    bool helper = helperInvocationEXT();
+    bool _9 = helperInvocationEXT();
+    bool helper = _9;
 }
 

--- a/shaders-hlsl/frag/demote-to-helper.frag
+++ b/shaders-hlsl/frag/demote-to-helper.frag
@@ -1,0 +1,7 @@
+#version 450
+#extension GL_EXT_demote_to_helper_invocation : require
+
+void main()
+{
+	demote;
+}

--- a/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl21.invalid.frag
+++ b/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl21.invalid.frag
@@ -1,0 +1,8 @@
+#version 450
+#extension GL_EXT_demote_to_helper_invocation : require
+
+void main()
+{
+	//demote;	// FIXME: Not implemented for MSL
+	bool helper = helperInvocationEXT();
+}

--- a/shaders/vulkan/frag/demote-to-helper-forwarding.asm.vk.nocompat.frag
+++ b/shaders/vulkan/frag/demote-to-helper-forwarding.asm.vk.nocompat.frag
@@ -1,0 +1,41 @@
+; SPIR-V
+; Version: 1.3
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 19
+; Schema: 0
+               OpCapability Shader
+               OpCapability DemoteToHelperInvocationEXT
+               OpExtension "SPV_EXT_demote_to_helper_invocation"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_demote_to_helper_invocation"
+               OpName %main "main"
+               OpName %FragColor "FragColor"
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %bool = OpTypeBool
+%_ptr_Function_bool = OpTypePointer Function %bool
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+    %float_1 = OpConstant %float 1
+    %float_0 = OpConstant %float 0
+         %19 = OpConstantComposite %v4float %float_1 %float_0 %float_0 %float_1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %9 = OpIsHelperInvocationEXT %bool
+               OpDemoteToHelperInvocationEXT
+         %10 = OpLogicalNot %bool %9
+               OpSelectionMerge %12 None
+               OpBranchConditional %10 %11 %12
+         %11 = OpLabel
+               OpStore %FragColor %19
+               OpBranch %12
+         %12 = OpLabel
+               OpReturn
+               OpFunctionEnd

--- a/shaders/vulkan/frag/demote-to-helper.vk.nocompat.frag
+++ b/shaders/vulkan/frag/demote-to-helper.vk.nocompat.frag
@@ -1,0 +1,8 @@
+#version 450
+#extension GL_EXT_demote_to_helper_invocation : require
+
+void main()
+{
+	demote;
+	bool helper = helperInvocationEXT();
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -9789,7 +9789,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		if (!options.vulkan_semantics)
 			SPIRV_CROSS_THROW("GL_EXT_demote_to_helper_invocation is only supported in Vulkan GLSL.");
 		require_extension_internal("GL_EXT_demote_to_helper_invocation");
-		emit_op(ops[0], ops[1], "helperInvocationEXT()", true);
+		emit_op(ops[0], ops[1], "helperInvocationEXT()", false);
 		break;
 
 	default:

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -9778,6 +9778,20 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 	case OpNoLine:
 		break;
 
+	case OpDemoteToHelperInvocationEXT:
+		if (!options.vulkan_semantics)
+			SPIRV_CROSS_THROW("GL_EXT_demote_to_helper_invocation is only supported in Vulkan GLSL.");
+		require_extension_internal("GL_EXT_demote_to_helper_invocation");
+		statement(backend.demote_literal, ";");
+		break;
+
+	case OpIsHelperInvocationEXT:
+		if (!options.vulkan_semantics)
+			SPIRV_CROSS_THROW("GL_EXT_demote_to_helper_invocation is only supported in Vulkan GLSL.");
+		require_extension_internal("GL_EXT_demote_to_helper_invocation");
+		emit_op(ops[0], ops[1], "helperInvocationEXT()", true);
+		break;
+
 	default:
 		statement("// unimplemented op ", instruction.op);
 		break;

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -369,6 +369,7 @@ protected:
 	struct BackendVariations
 	{
 		std::string discard_literal = "discard";
+		std::string demote_literal = "demote";
 		std::string null_pointer_literal = "";
 		bool float_literal_suffix = false;
 		bool double_literal_suffix = true;

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -4663,6 +4663,9 @@ void CompilerHLSL::emit_instruction(const Instruction &instruction)
 		break;
 	}
 
+	case OpIsHelperInvocationEXT:
+		SPIRV_CROSS_THROW("helperInvocationEXT() is not supported in HLSL.");
+
 	default:
 		CompilerGLSL::emit_instruction(instruction);
 		break;
@@ -4819,6 +4822,7 @@ string CompilerHLSL::compile()
 	backend.uint16_t_literal_suffix = "u";
 	backend.basic_int_type = "int";
 	backend.basic_uint_type = "uint";
+	backend.demote_literal = "discard";
 	backend.boolean_mix_function = "";
 	backend.swizzle_is_function = false;
 	backend.shared_is_implied = true;

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -757,6 +757,7 @@ string CompilerMSL::compile()
 	backend.basic_int16_type = "short";
 	backend.basic_uint16_type = "ushort";
 	backend.discard_literal = "discard_fragment()";
+	backend.demote_literal = "unsupported-demote";
 	backend.boolean_mix_function = "select";
 	backend.swizzle_is_function = false;
 	backend.shared_is_implied = false;
@@ -4466,6 +4467,14 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		inherit_expression_dependencies(id, b);
 		break;
 	}
+
+	case OpIsHelperInvocationEXT:
+		if (msl_options.is_ios())
+			SPIRV_CROSS_THROW("simd_is_helper_thread() is only supported on macOS.");
+		else if (msl_options.is_macos() && !msl_options.supports_msl_version(2, 1))
+			SPIRV_CROSS_THROW("simd_is_helper_thread() requires version 2.1 on macOS.");
+		emit_op(ops[0], ops[1], "simd_is_helper_thread()", true);
+		break;
 
 	default:
 		CompilerGLSL::emit_instruction(instruction);

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -4473,7 +4473,7 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 			SPIRV_CROSS_THROW("simd_is_helper_thread() is only supported on macOS.");
 		else if (msl_options.is_macos() && !msl_options.supports_msl_version(2, 1))
 			SPIRV_CROSS_THROW("simd_is_helper_thread() requires version 2.1 on macOS.");
-		emit_op(ops[0], ops[1], "simd_is_helper_thread()", true);
+		emit_op(ops[0], ops[1], "simd_is_helper_thread()", false);
 		break;
 
 	default:


### PR DESCRIPTION
This extension provides a new operation which causes a fragment to be
discarded without terminating the fragment shader invocation. The
invocation for the discarded fragment becomes a helper invocation, so
that derivatives will remain defined. The old `HelperInvocation` builtin
becomes undefined when this occurs, so a second new instruction queries
the current helper invocation status.

This is only fully supported for GLSL. HLSL doesn't support the
`IsHelperInvocation` operation and MSL doesn't support the
`DemoteToHelperInvocation` op.

Fixes #1052.