### PR TITLE
GLSL: Fix post-depth coverage for ESSL.

### DIFF
--- a/reference/opt/shaders/frag/post-depth-coverage-es.frag
+++ b/reference/opt/shaders/frag/post-depth-coverage-es.frag
@@ -1,9 +1,8 @@
-#version 450
-#if defined(GL_ARB_post_depth_coverge)
-#extension GL_ARB_post_depth_coverage : require
-#else
+#version 310 es
 #extension GL_EXT_post_depth_coverage : require
-#endif
+#extension GL_OES_sample_variables : require
+precision mediump float;
+precision highp int;
 layout(early_fragment_tests, post_depth_coverage) in;
 
 layout(location = 0) out vec4 FragColor;

--- a/reference/opt/shaders/frag/post-depth-coverage.frag
+++ b/reference/opt/shaders/frag/post-depth-coverage.frag
@@ -1,5 +1,9 @@
 #version 450
+#if defined(GL_ARB_post_depth_coverge)
 #extension GL_ARB_post_depth_coverage : require
+#else
+#extension GL_EXT_post_depth_coverage : require
+#endif
 layout(early_fragment_tests, post_depth_coverage) in;
 
 layout(location = 0) out vec4 FragColor;

--- a/reference/shaders/frag/post-depth-coverage-es.frag
+++ b/reference/shaders/frag/post-depth-coverage-es.frag
@@ -1,9 +1,8 @@
-#version 450
-#if defined(GL_ARB_post_depth_coverge)
-#extension GL_ARB_post_depth_coverage : require
-#else
+#version 310 es
 #extension GL_EXT_post_depth_coverage : require
-#endif
+#extension GL_OES_sample_variables : require
+precision mediump float;
+precision highp int;
 layout(early_fragment_tests, post_depth_coverage) in;
 
 layout(location = 0) out vec4 FragColor;

--- a/shaders/frag/post-depth-coverage-es.frag
+++ b/shaders/frag/post-depth-coverage-es.frag
@@ -1,0 +1,13 @@
+#version 310 es
+#extension GL_EXT_post_depth_coverage : require
+#extension GL_OES_sample_variables : require
+precision mediump float;
+
+layout(early_fragment_tests, post_depth_coverage) in;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = vec4(gl_SampleMaskIn[0]);
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -640,6 +640,19 @@ void CompilerGLSL::emit_header()
 				statement("#endif");
 			}
 		}
+		else if (ext == "GL_ARB_post_depth_coverage")
+		{
+			if (options.es)
+				statement("#extension GL_EXT_post_depth_coverage : require");
+			else
+			{
+				statement("#if defined(GL_ARB_post_depth_coverge)");
+				statement("#extension GL_ARB_post_depth_coverage : require");
+				statement("#else");
+				statement("#extension GL_EXT_post_depth_coverage : require");
+				statement("#endif");
+			}
+		}
 		else
 			statement("#extension ", ext, " : require");
 	}


### PR DESCRIPTION
ESSL does not support `GL_ARB_post_depth_coverage`. There, we must use
`GL_EXT_post_depth_coverage`. I've added this as a fallback for desktop
as well.

Note that `GL_EXT_post_depth_coverage` also requires the fragment shader
to set `early_fragment_tests` explicitly, while
`GL_ARB_post_depth_coverage` does not. It doesn't really matter either
way, since `SPV_KHR_post_depth_coverage` *also* requires both execution
modes to be explicitly set.