### PR TITLE
Support the SPV_EXT_fragment_shader_interlock extension.

### DIFF
--- a/reference/opt/shaders-hlsl/frag/pixel-interlock-ordered.sm51.fxconly.frag
+++ b/reference/opt/shaders-hlsl/frag/pixel-interlock-ordered.sm51.fxconly.frag
@@ -1,0 +1,24 @@
+RWByteAddressBuffer _9 : register(u6, space0);
+globallycoherent RasterizerOrderedByteAddressBuffer _42 : register(u3, space0);
+RasterizerOrderedByteAddressBuffer _52 : register(u4, space0);
+RWTexture2D<unorm float4> img4 : register(u5, space0);
+RasterizerOrderedTexture2D<unorm float4> img : register(u0, space0);
+RasterizerOrderedTexture2D<unorm float4> img3 : register(u2, space0);
+RasterizerOrderedTexture2D<uint> img2 : register(u1, space0);
+
+void frag_main()
+{
+    _9.Store(0, uint(0));
+    img4[int2(1, 1)] = float4(1.0f, 0.0f, 0.0f, 1.0f);
+    img[int2(0, 0)] = img3[int2(0, 0)];
+    uint _39;
+    InterlockedAdd(img2[int2(0, 0)], 1u, _39);
+    _42.Store(0, uint(int(_42.Load(0)) + 42));
+    uint _55;
+    _42.InterlockedAnd(4, _52.Load(0), _55);
+}
+
+void main()
+{
+    frag_main();
+}

--- a/reference/opt/shaders-msl/frag/pixel-interlock-ordered.msl2.argument.frag
+++ b/reference/opt/shaders-msl/frag/pixel-interlock-ordered.msl2.argument.frag
@@ -1,0 +1,43 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct Buffer3
+{
+    int baz;
+};
+
+struct Buffer
+{
+    int foo;
+    uint bar;
+};
+
+struct Buffer2
+{
+    uint quux;
+};
+
+struct spvDescriptorSetBuffer0
+{
+    device Buffer3* m_9 [[id(0)]];
+    texture2d<float, access::write> img4 [[id(1)]];
+    texture2d<float, access::write> img [[id(2), raster_order_group(0)]];
+    texture2d<float> img3 [[id(3), raster_order_group(0)]];
+    volatile device Buffer* m_34 [[id(4), raster_order_group(0)]];
+    device Buffer2* m_44 [[id(5), raster_order_group(0)]];
+};
+
+fragment void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]])
+{
+    (*spvDescriptorSet0.m_9).baz = 0;
+    spvDescriptorSet0.img4.write(float4(1.0, 0.0, 0.0, 1.0), uint2(int2(1)));
+    spvDescriptorSet0.img.write(spvDescriptorSet0.img3.read(uint2(int2(0))), uint2(int2(0)));
+    (*spvDescriptorSet0.m_34).foo += 42;
+    uint _49 = atomic_fetch_and_explicit((volatile device atomic_uint*)&(*spvDescriptorSet0.m_34).bar, (*spvDescriptorSet0.m_44).quux, memory_order_relaxed);
+}
+

--- a/reference/opt/shaders-msl/frag/pixel-interlock-ordered.msl2.frag
+++ b/reference/opt/shaders-msl/frag/pixel-interlock-ordered.msl2.frag
@@ -1,0 +1,33 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct Buffer3
+{
+    int baz;
+};
+
+struct Buffer
+{
+    int foo;
+    uint bar;
+};
+
+struct Buffer2
+{
+    uint quux;
+};
+
+fragment void main0(device Buffer3& _9 [[buffer(0)]], volatile device Buffer& _34 [[buffer(1), raster_order_group(0)]], device Buffer2& _44 [[buffer(2), raster_order_group(0)]], texture2d<float, access::write> img4 [[texture(0)]], texture2d<float, access::write> img [[texture(1), raster_order_group(0)]], texture2d<float> img3 [[texture(2), raster_order_group(0)]])
+{
+    _9.baz = 0;
+    img4.write(float4(1.0, 0.0, 0.0, 1.0), uint2(int2(1)));
+    img.write(img3.read(uint2(int2(0))), uint2(int2(0)));
+    _34.foo += 42;
+    uint _49 = atomic_fetch_and_explicit((volatile device atomic_uint*)&_34.bar, _44.quux, memory_order_relaxed);
+}
+

--- a/reference/opt/shaders/frag/pixel-interlock-ordered.frag
+++ b/reference/opt/shaders/frag/pixel-interlock-ordered.frag
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(pixel_interlock_ordered) in;
+
+layout(binding = 2, std430) coherent buffer Buffer
+{
+    int foo;
+    uint bar;
+} _30;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+
+void main()
+{
+    beginInvocationInterlockARB();
+    imageStore(img, ivec2(0), vec4(1.0, 0.0, 0.0, 1.0));
+    uint _27 = imageAtomicAdd(img2, ivec2(0), 1u);
+    _30.foo += 42;
+    uint _41 = atomicAnd(_30.bar, 255u);
+    endInvocationInterlockARB();
+}
+

--- a/reference/opt/shaders/frag/pixel-interlock-unordered.frag
+++ b/reference/opt/shaders/frag/pixel-interlock-unordered.frag
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(pixel_interlock_unordered) in;
+
+layout(binding = 2, std430) coherent buffer Buffer
+{
+    int foo;
+    uint bar;
+} _30;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+
+void main()
+{
+    beginInvocationInterlockARB();
+    imageStore(img, ivec2(0), vec4(1.0, 0.0, 0.0, 1.0));
+    uint _27 = imageAtomicAdd(img2, ivec2(0), 1u);
+    _30.foo += 42;
+    uint _41 = atomicAnd(_30.bar, 255u);
+    endInvocationInterlockARB();
+}
+

--- a/reference/opt/shaders/frag/sample-interlock-ordered.frag
+++ b/reference/opt/shaders/frag/sample-interlock-ordered.frag
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(sample_interlock_ordered) in;
+
+layout(binding = 2, std430) coherent buffer Buffer
+{
+    int foo;
+    uint bar;
+} _30;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+
+void main()
+{
+    beginInvocationInterlockARB();
+    imageStore(img, ivec2(0), vec4(1.0, 0.0, 0.0, 1.0));
+    uint _27 = imageAtomicAdd(img2, ivec2(0), 1u);
+    _30.foo += 42;
+    uint _47 = atomicAnd(_30.bar, uint(gl_SampleMaskIn[0]));
+    endInvocationInterlockARB();
+}
+

--- a/reference/opt/shaders/frag/sample-interlock-unordered.frag
+++ b/reference/opt/shaders/frag/sample-interlock-unordered.frag
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(sample_interlock_unordered) in;
+
+layout(binding = 2, std430) coherent buffer Buffer
+{
+    int foo;
+    uint bar;
+} _30;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+
+void main()
+{
+    beginInvocationInterlockARB();
+    imageStore(img, ivec2(0), vec4(1.0, 0.0, 0.0, 1.0));
+    uint _27 = imageAtomicAdd(img2, ivec2(0), 1u);
+    _30.foo += 42;
+    uint _41 = atomicAnd(_30.bar, 255u);
+    endInvocationInterlockARB();
+}
+

--- a/reference/shaders-hlsl/frag/pixel-interlock-ordered.sm51.fxconly.frag
+++ b/reference/shaders-hlsl/frag/pixel-interlock-ordered.sm51.fxconly.frag
@@ -1,0 +1,24 @@
+RWByteAddressBuffer _9 : register(u6, space0);
+globallycoherent RasterizerOrderedByteAddressBuffer _42 : register(u3, space0);
+RasterizerOrderedByteAddressBuffer _52 : register(u4, space0);
+RWTexture2D<unorm float4> img4 : register(u5, space0);
+RasterizerOrderedTexture2D<unorm float4> img : register(u0, space0);
+RasterizerOrderedTexture2D<unorm float4> img3 : register(u2, space0);
+RasterizerOrderedTexture2D<uint> img2 : register(u1, space0);
+
+void frag_main()
+{
+    _9.Store(0, uint(0));
+    img4[int2(1, 1)] = float4(1.0f, 0.0f, 0.0f, 1.0f);
+    img[int2(0, 0)] = img3[int2(0, 0)];
+    uint _39;
+    InterlockedAdd(img2[int2(0, 0)], 1u, _39);
+    _42.Store(0, uint(int(_42.Load(0)) + 42));
+    uint _55;
+    _42.InterlockedAnd(4, _52.Load(0), _55);
+}
+
+void main()
+{
+    frag_main();
+}

--- a/reference/shaders-msl/frag/pixel-interlock-ordered.msl2.argument.frag
+++ b/reference/shaders-msl/frag/pixel-interlock-ordered.msl2.argument.frag
@@ -1,0 +1,43 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct Buffer3
+{
+    int baz;
+};
+
+struct Buffer
+{
+    int foo;
+    uint bar;
+};
+
+struct Buffer2
+{
+    uint quux;
+};
+
+struct spvDescriptorSetBuffer0
+{
+    device Buffer3* m_9 [[id(0)]];
+    texture2d<float, access::write> img4 [[id(1)]];
+    texture2d<float, access::write> img [[id(2), raster_order_group(0)]];
+    texture2d<float> img3 [[id(3), raster_order_group(0)]];
+    volatile device Buffer* m_34 [[id(4), raster_order_group(0)]];
+    device Buffer2* m_44 [[id(5), raster_order_group(0)]];
+};
+
+fragment void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]])
+{
+    (*spvDescriptorSet0.m_9).baz = 0;
+    spvDescriptorSet0.img4.write(float4(1.0, 0.0, 0.0, 1.0), uint2(int2(1)));
+    spvDescriptorSet0.img.write(spvDescriptorSet0.img3.read(uint2(int2(0))), uint2(int2(0)));
+    (*spvDescriptorSet0.m_34).foo += 42;
+    uint _49 = atomic_fetch_and_explicit((volatile device atomic_uint*)&(*spvDescriptorSet0.m_34).bar, (*spvDescriptorSet0.m_44).quux, memory_order_relaxed);
+}
+

--- a/reference/shaders-msl/frag/pixel-interlock-ordered.msl2.frag
+++ b/reference/shaders-msl/frag/pixel-interlock-ordered.msl2.frag
@@ -1,0 +1,33 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct Buffer3
+{
+    int baz;
+};
+
+struct Buffer
+{
+    int foo;
+    uint bar;
+};
+
+struct Buffer2
+{
+    uint quux;
+};
+
+fragment void main0(device Buffer3& _9 [[buffer(0)]], volatile device Buffer& _34 [[buffer(1), raster_order_group(0)]], device Buffer2& _44 [[buffer(2), raster_order_group(0)]], texture2d<float, access::write> img4 [[texture(0)]], texture2d<float, access::write> img [[texture(1), raster_order_group(0)]], texture2d<float> img3 [[texture(2), raster_order_group(0)]])
+{
+    _9.baz = 0;
+    img4.write(float4(1.0, 0.0, 0.0, 1.0), uint2(int2(1)));
+    img.write(img3.read(uint2(int2(0))), uint2(int2(0)));
+    _34.foo += 42;
+    uint _49 = atomic_fetch_and_explicit((volatile device atomic_uint*)&_34.bar, _44.quux, memory_order_relaxed);
+}
+

--- a/reference/shaders/frag/pixel-interlock-ordered.frag
+++ b/reference/shaders/frag/pixel-interlock-ordered.frag
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(pixel_interlock_ordered) in;
+
+layout(binding = 2, std430) coherent buffer Buffer
+{
+    int foo;
+    uint bar;
+} _30;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+
+void main()
+{
+    beginInvocationInterlockARB();
+    imageStore(img, ivec2(0), vec4(1.0, 0.0, 0.0, 1.0));
+    uint _27 = imageAtomicAdd(img2, ivec2(0), 1u);
+    _30.foo += 42;
+    uint _41 = atomicAnd(_30.bar, 255u);
+    endInvocationInterlockARB();
+}
+

--- a/reference/shaders/frag/pixel-interlock-unordered.frag
+++ b/reference/shaders/frag/pixel-interlock-unordered.frag
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(pixel_interlock_unordered) in;
+
+layout(binding = 2, std430) coherent buffer Buffer
+{
+    int foo;
+    uint bar;
+} _30;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+
+void main()
+{
+    beginInvocationInterlockARB();
+    imageStore(img, ivec2(0), vec4(1.0, 0.0, 0.0, 1.0));
+    uint _27 = imageAtomicAdd(img2, ivec2(0), 1u);
+    _30.foo += 42;
+    uint _41 = atomicAnd(_30.bar, 255u);
+    endInvocationInterlockARB();
+}
+

--- a/reference/shaders/frag/sample-interlock-ordered.frag
+++ b/reference/shaders/frag/sample-interlock-ordered.frag
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(sample_interlock_ordered) in;
+
+layout(binding = 2, std430) coherent buffer Buffer
+{
+    int foo;
+    uint bar;
+} _30;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+
+void main()
+{
+    beginInvocationInterlockARB();
+    imageStore(img, ivec2(0), vec4(1.0, 0.0, 0.0, 1.0));
+    uint _27 = imageAtomicAdd(img2, ivec2(0), 1u);
+    _30.foo += 42;
+    uint _47 = atomicAnd(_30.bar, uint(gl_SampleMaskIn[0]));
+    endInvocationInterlockARB();
+}
+

--- a/reference/shaders/frag/sample-interlock-unordered.frag
+++ b/reference/shaders/frag/sample-interlock-unordered.frag
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(sample_interlock_unordered) in;
+
+layout(binding = 2, std430) coherent buffer Buffer
+{
+    int foo;
+    uint bar;
+} _30;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+
+void main()
+{
+    beginInvocationInterlockARB();
+    imageStore(img, ivec2(0), vec4(1.0, 0.0, 0.0, 1.0));
+    uint _27 = imageAtomicAdd(img2, ivec2(0), 1u);
+    _30.foo += 42;
+    uint _41 = atomicAnd(_30.bar, 255u);
+    endInvocationInterlockARB();
+}
+

--- a/shaders-hlsl/frag/pixel-interlock-ordered.sm51.fxconly.frag
+++ b/shaders-hlsl/frag/pixel-interlock-ordered.sm51.fxconly.frag
@@ -1,0 +1,36 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+
+layout(pixel_interlock_ordered) in;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+layout(binding = 2, rgba8) uniform readonly image2D img3;
+layout(binding = 3) coherent buffer Buffer
+{
+	int foo;
+	uint bar;
+};
+layout(binding = 4) buffer Buffer2
+{
+	uint quux;
+};
+
+layout(binding = 5, rgba8) uniform writeonly image2D img4;
+layout(binding = 6) buffer Buffer3
+{
+	int baz;
+};
+
+void main()
+{
+	// Deliberately outside the critical section to test usage tracking.
+	baz = 0;
+	imageStore(img4, ivec2(1, 1), vec4(1.0, 0.0, 0.0, 1.0));
+	beginInvocationInterlockARB();
+	imageStore(img, ivec2(0, 0), imageLoad(img3, ivec2(0, 0)));
+	imageAtomicAdd(img2, ivec2(0, 0), 1u);
+	foo += 42;
+	atomicAnd(bar, quux);
+	endInvocationInterlockARB();
+}

--- a/shaders-msl/frag/pixel-interlock-ordered.msl2.argument.frag
+++ b/shaders-msl/frag/pixel-interlock-ordered.msl2.argument.frag
@@ -1,0 +1,36 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+
+layout(pixel_interlock_ordered) in;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+//layout(binding = 1, r32ui) uniform uimage2D img2;
+layout(binding = 2, rgba8) uniform readonly image2D img3;
+layout(binding = 3) coherent buffer Buffer
+{
+	int foo;
+	uint bar;
+};
+layout(binding = 4) buffer Buffer2
+{
+	uint quux;
+};
+
+layout(binding = 5, rgba8) uniform writeonly image2D img4;
+layout(binding = 6) buffer Buffer3
+{
+	int baz;
+};
+
+void main()
+{
+	// Deliberately outside the critical section to test usage tracking.
+	baz = 0;
+	imageStore(img4, ivec2(1, 1), vec4(1.0, 0.0, 0.0, 1.0));
+	beginInvocationInterlockARB();
+	imageStore(img, ivec2(0, 0), imageLoad(img3, ivec2(0, 0)));
+	//imageAtomicAdd(img2, ivec2(0, 0), 1u);
+	foo += 42;
+	atomicAnd(bar, quux);
+	endInvocationInterlockARB();
+}

--- a/shaders-msl/frag/pixel-interlock-ordered.msl2.frag
+++ b/shaders-msl/frag/pixel-interlock-ordered.msl2.frag
@@ -1,0 +1,36 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+
+layout(pixel_interlock_ordered) in;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+//layout(binding = 1, r32ui) uniform uimage2D img2;
+layout(binding = 2, rgba8) uniform readonly image2D img3;
+layout(binding = 3) coherent buffer Buffer
+{
+	int foo;
+	uint bar;
+};
+layout(binding = 4) buffer Buffer2
+{
+	uint quux;
+};
+
+layout(binding = 5, rgba8) uniform writeonly image2D img4;
+layout(binding = 6) buffer Buffer3
+{
+	int baz;
+};
+
+void main()
+{
+	// Deliberately outside the critical section to test usage tracking.
+	baz = 0;
+	imageStore(img4, ivec2(1, 1), vec4(1.0, 0.0, 0.0, 1.0));
+	beginInvocationInterlockARB();
+	imageStore(img, ivec2(0, 0), imageLoad(img3, ivec2(0, 0)));
+	//imageAtomicAdd(img2, ivec2(0, 0), 1u);
+	foo += 42;
+	atomicAnd(bar, quux);
+	endInvocationInterlockARB();
+}

--- a/shaders/frag/pixel-interlock-ordered.frag
+++ b/shaders/frag/pixel-interlock-ordered.frag
@@ -1,0 +1,22 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+
+layout(pixel_interlock_ordered) in;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+layout(binding = 2) coherent buffer Buffer
+{
+	int foo;
+	uint bar;
+};
+
+void main()
+{
+	beginInvocationInterlockARB();
+	imageStore(img, ivec2(0, 0), vec4(1.0, 0.0, 0.0, 1.0));
+	imageAtomicAdd(img2, ivec2(0, 0), 1u);
+	foo += 42;
+	atomicAnd(bar, 0xff);
+	endInvocationInterlockARB();
+}

--- a/shaders/frag/pixel-interlock-unordered.frag
+++ b/shaders/frag/pixel-interlock-unordered.frag
@@ -1,0 +1,22 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+
+layout(pixel_interlock_unordered) in;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+layout(binding = 2) coherent buffer Buffer
+{
+	int foo;
+	uint bar;
+};
+
+void main()
+{
+	beginInvocationInterlockARB();
+	imageStore(img, ivec2(0, 0), vec4(1.0, 0.0, 0.0, 1.0));
+	imageAtomicAdd(img2, ivec2(0, 0), 1u);
+	foo += 42;
+	atomicAnd(bar, 0xff);
+	endInvocationInterlockARB();
+}

--- a/shaders/frag/sample-interlock-ordered.frag
+++ b/shaders/frag/sample-interlock-ordered.frag
@@ -1,0 +1,22 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+
+layout(sample_interlock_ordered) in;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+layout(binding = 2) coherent buffer Buffer
+{
+	int foo;
+	uint bar;
+};
+
+void main()
+{
+	beginInvocationInterlockARB();
+	imageStore(img, ivec2(0, 0), vec4(1.0, 0.0, 0.0, 1.0));
+	imageAtomicAdd(img2, ivec2(0, 0), 1u);
+	foo += 42;
+	atomicAnd(bar, gl_SampleMaskIn[0]);
+	endInvocationInterlockARB();
+}

--- a/shaders/frag/sample-interlock-unordered.frag
+++ b/shaders/frag/sample-interlock-unordered.frag
@@ -1,0 +1,22 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+
+layout(sample_interlock_unordered) in;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+layout(binding = 2) coherent buffer Buffer
+{
+	int foo;
+	uint bar;
+};
+
+void main()
+{
+	beginInvocationInterlockARB();
+	imageStore(img, ivec2(0, 0), vec4(1.0, 0.0, 0.0, 1.0));
+	imageAtomicAdd(img2, ivec2(0, 0), 1u);
+	foo += 42;
+	atomicAnd(bar, 0xff);
+	endInvocationInterlockARB();
+}

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -945,6 +945,27 @@ protected:
 	                              bool single_function);
 	bool may_read_undefined_variable_in_block(const SPIRBlock &block, uint32_t var);
 
+	// Finds all resources that are written to from inside the critical section, if present.
+	// The critical section is delimited by OpBeginInvocationInterlockEXT and
+	// OpEndInvocationInterlockEXT instructions. In MSL and HLSL, any resources written
+	// while inside the critical section must be placed in a raster order group.
+	struct InterlockedResourceAccessHandler : OpcodeHandler
+	{
+		InterlockedResourceAccessHandler(Compiler &compiler_)
+		    : compiler(compiler_)
+		{
+		}
+
+		bool handle(spv::Op op, const uint32_t *args, uint32_t length) override;
+
+		Compiler &compiler;
+		bool in_crit_sec = false;
+	};
+
+	void analyze_interlocked_resource_usage();
+	// The set of all resources written while inside the critical section, if present.
+	std::unordered_set<uint32_t> interlocked_resources;
+
 	void make_constant_null(uint32_t id, uint32_t type);
 
 	std::unordered_map<uint32_t, std::string> declared_block_names;

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -852,6 +852,12 @@ string CompilerMSL::compile()
 	update_active_builtins();
 	analyze_image_and_sampler_usage();
 	analyze_sampled_image_usage();
+	if (get_execution_model() == ExecutionModelFragment &&
+	    (get_entry_point().flags.get(ExecutionModePixelInterlockOrderedEXT) ||
+	     get_entry_point().flags.get(ExecutionModePixelInterlockUnorderedEXT) ||
+	     get_entry_point().flags.get(ExecutionModeSampleInterlockOrderedEXT) ||
+	     get_entry_point().flags.get(ExecutionModeSampleInterlockUnorderedEXT)))
+		analyze_interlocked_resource_usage();
 	preprocess_op_codes();
 	build_implicit_builtins();
 
@@ -5541,6 +5547,12 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		emit_op(ops[0], ops[1], "simd_is_helper_thread()", false);
 		break;
 
+	case OpBeginInvocationInterlockEXT:
+	case OpEndInvocationInterlockEXT:
+		if (!msl_options.supports_msl_version(2, 0))
+			SPIRV_CROSS_THROW("Raster order groups require MSL 2.0.");
+		break; // Nothing to do in the body
+
 	default:
 		CompilerGLSL::emit_instruction(instruction);
 		break;
@@ -7436,8 +7448,15 @@ string CompilerMSL::member_attribute_qualifier(const SPIRType &type, uint32_t in
 	bool is_builtin = is_member_builtin(type, index, &builtin);
 
 	if (has_extended_member_decoration(type.self, index, SPIRVCrossDecorationResourceIndexPrimary))
-		return join(" [[id(",
-		            get_extended_member_decoration(type.self, index, SPIRVCrossDecorationResourceIndexPrimary), ")]]");
+	{
+		string quals = join(
+		    " [[id(", get_extended_member_decoration(type.self, index, SPIRVCrossDecorationResourceIndexPrimary), ")");
+		if (interlocked_resources.count(
+		        get_extended_member_decoration(type.self, index, SPIRVCrossDecorationInterfaceOrigID)))
+			quals += ", raster_order_group(0)";
+		quals += "]]";
+		return quals;
+	}
 
 	// Vertex function inputs
 	if (execution.model == ExecutionModelVertex && type.storage == StorageClassInput)
@@ -8239,7 +8258,10 @@ void CompilerMSL::entry_point_args_discrete_descriptors(string &ep_args)
 						ep_args += ", ";
 					ep_args += get_argument_address_space(var) + " " + type_to_glsl(type) + "* " + to_restrict(var_id) +
 					           r.name + "_" + convert_to_string(i);
-					ep_args += " [[buffer(" + convert_to_string(r.index + i) + ")]]";
+					ep_args += " [[buffer(" + convert_to_string(r.index + i) + ")";
+					if (interlocked_resources.count(var_id))
+						ep_args += ", raster_order_group(0)";
+					ep_args += "]]";
 				}
 			}
 			else
@@ -8248,7 +8270,10 @@ void CompilerMSL::entry_point_args_discrete_descriptors(string &ep_args)
 					ep_args += ", ";
 				ep_args +=
 				    get_argument_address_space(var) + " " + type_to_glsl(type) + "& " + to_restrict(var_id) + r.name;
-				ep_args += " [[buffer(" + convert_to_string(r.index) + ")]]";
+				ep_args += " [[buffer(" + convert_to_string(r.index) + ")";
+				if (interlocked_resources.count(var_id))
+					ep_args += ", raster_order_group(0)";
+				ep_args += "]]";
 			}
 			break;
 		}
@@ -8264,7 +8289,10 @@ void CompilerMSL::entry_point_args_discrete_descriptors(string &ep_args)
 			ep_args += image_type_glsl(type, var_id) + " " + r.name;
 			if (r.plane > 0)
 				ep_args += join(plane_name_suffix, r.plane);
-			ep_args += " [[texture(" + convert_to_string(r.index) + ")]]";
+			ep_args += " [[texture(" + convert_to_string(r.index) + ")";
+			if (interlocked_resources.count(var_id))
+				ep_args += ", raster_order_group(0)";
+			ep_args += "]]";
 			break;
 		default:
 			if (!ep_args.empty())
@@ -8274,7 +8302,10 @@ void CompilerMSL::entry_point_args_discrete_descriptors(string &ep_args)
 				           type_to_glsl(type, var_id) + "& " + r.name;
 			else
 				ep_args += type_to_glsl(type, var_id) + " " + r.name;
-			ep_args += " [[buffer(" + convert_to_string(r.index) + ")]]";
+			ep_args += " [[buffer(" + convert_to_string(r.index) + ")";
+			if (interlocked_resources.count(var_id))
+				ep_args += ", raster_order_group(0)";
+			ep_args += "]]";
 			break;
 		}
 	}


### PR DESCRIPTION
This was straightforward to implement in GLSL. The
`ShadingRateInterlockOrderedEXT` and `ShadingRateInterlockUnorderedEXT`
modes aren't implemented yet, because we don't support
`SPV_NV_shading_rate` or `SPV_EXT_fragment_invocation_density` yet.

HLSL and MSL were more interesting. They don't support this directly,
but they do support marking resources as "rasterizer ordered," which
does roughly the same thing. So this implementation scans all accesses
inside the critical section and marks all storage resources found
therein as rasterizer ordered. They also don't support the fine-grained
controls on pixel- vs. sample-level interlock and disabling ordering
guarantees that GLSL and SPIR-V do, but that's OK. "Unordered" here
merely means the order is undefined; that it just so happens to be the
same as rasterizer order is immaterial. As for pixel- vs. sample-level
interlock, Vulkan explicitly states:

> With sample shading enabled, [the `PixelInterlockOrderedEXT` and
> `PixelInterlockUnorderedEXT`] execution modes are treated like
> `SampleInterlockOrderedEXT` or `SampleInterlockUnorderedEXT`
> respectively.

and:

> If [the `SampleInterlockOrderedEXT` or `SampleInterlockUnorderedEXT`]
> execution modes are used in single-sample mode they are treated like
> `PixelInterlockOrderedEXT` or `PixelInterlockUnorderedEXT`
> respectively.

So this will DTRT for MoltenVK and gfx-rs, at least.

MSL additionally supports multiple raster order groups; resources that
are not accessed together can be placed in different ROGs to allow them
to be synchronized separately. A more sophisticated analysis might be
able to place resources optimally, but that's outside the scope of this
change. For now, we assign all resources to group 0, which should do for
our purposes.

`glslang` doesn't support the `RasterizerOrdered` UAVs this
implementation produces for HLSL, so the test case needs `fxc.exe`.

It also insists on GLSL 4.50 for `GL_ARB_fragment_shader_interlock`,
even though the spec says it needs either 4.20 or
`GL_ARB_shader_image_load_store`; and it doesn't support the
`GL_NV_fragment_shader_interlock` extension at all. So I haven't been
able to test those code paths.

Fixes #1002.