### PR TITLE
MSL: Add {Base,}{Vertex,Instance}Index to bitcast_from_builtin_load.

### DIFF
--- a/reference/opt/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
+++ b/reference/opt/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
@@ -11,7 +11,7 @@ struct main0_out
 vertex main0_out main0(uint gl_BaseVertex [[base_vertex]], uint gl_BaseInstance [[base_instance]])
 {
     main0_out out = {};
-    out.gl_Position = float4(float(gl_BaseVertex), float(gl_BaseInstance), 0.0, 1.0);
+    out.gl_Position = float4(float(int(gl_BaseVertex)), float(int(gl_BaseInstance)), 0.0, 1.0);
     return out;
 }
 

--- a/reference/opt/shaders-msl/vert/no_stage_out.vert
+++ b/reference/opt/shaders-msl/vert/no_stage_out.vert
@@ -15,6 +15,6 @@ struct main0_in
 
 vertex void main0(main0_in in [[stage_in]], device _10& _12 [[buffer(0)]], uint gl_VertexIndex [[vertex_id]])
 {
-    _12._m0[gl_VertexIndex] = in.m_19;
+    _12._m0[int(gl_VertexIndex)] = in.m_19;
 }
 

--- a/reference/opt/shaders-msl/vulkan/vert/vulkan-vertex.vk.vert
+++ b/reference/opt/shaders-msl/vulkan/vert/vulkan-vertex.vk.vert
@@ -11,7 +11,7 @@ struct main0_out
 vertex main0_out main0(uint gl_VertexIndex [[vertex_id]], uint gl_InstanceIndex [[instance_id]])
 {
     main0_out out = {};
-    out.gl_Position = float4(1.0, 2.0, 3.0, 4.0) * float(gl_VertexIndex + gl_InstanceIndex);
+    out.gl_Position = float4(1.0, 2.0, 3.0, 4.0) * float(int(gl_VertexIndex) + int(gl_InstanceIndex));
     return out;
 }
 

--- a/reference/shaders-msl-no-opt/vert/functions_nested.vert
+++ b/reference/shaders-msl-no-opt/vert/functions_nested.vert
@@ -136,7 +136,7 @@ float4 read_location(thread const int& location, constant VertexBuffer& v_227, t
 {
     int param = location;
     attr_desc desc = fetch_desc(param, v_227);
-    int vertex_id = gl_VertexIndex - int(v_227.vertex_base_index);
+    int vertex_id = int(gl_VertexIndex) - int(v_227.vertex_base_index);
     if (desc.is_volatile != 0)
     {
         attr_desc param_1 = desc;

--- a/reference/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
+++ b/reference/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
@@ -11,7 +11,7 @@ struct main0_out
 vertex main0_out main0(uint gl_BaseVertex [[base_vertex]], uint gl_BaseInstance [[base_instance]])
 {
     main0_out out = {};
-    out.gl_Position = float4(float(gl_BaseVertex), float(gl_BaseInstance), 0.0, 1.0);
+    out.gl_Position = float4(float(int(gl_BaseVertex)), float(int(gl_BaseInstance)), 0.0, 1.0);
     return out;
 }
 

--- a/reference/shaders-msl/vert/no_stage_out.vert
+++ b/reference/shaders-msl/vert/no_stage_out.vert
@@ -15,6 +15,6 @@ struct main0_in
 
 vertex void main0(main0_in in [[stage_in]], device _10& _12 [[buffer(0)]], uint gl_VertexIndex [[vertex_id]])
 {
-    _12._m0[gl_VertexIndex] = in.m_19;
+    _12._m0[int(gl_VertexIndex)] = in.m_19;
 }
 

--- a/reference/shaders-msl/vulkan/vert/vulkan-vertex.vk.vert
+++ b/reference/shaders-msl/vulkan/vert/vulkan-vertex.vk.vert
@@ -11,7 +11,7 @@ struct main0_out
 vertex main0_out main0(uint gl_VertexIndex [[vertex_id]], uint gl_InstanceIndex [[instance_id]])
 {
     main0_out out = {};
-    out.gl_Position = float4(1.0, 2.0, 3.0, 4.0) * float(gl_VertexIndex + gl_InstanceIndex);
+    out.gl_Position = float4(1.0, 2.0, 3.0, 4.0) * float(int(gl_VertexIndex) + int(gl_InstanceIndex));
     return out;
 }
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -9634,6 +9634,10 @@ void CompilerMSL::bitcast_from_builtin_load(uint32_t source_id, std::string &exp
 	case BuiltInSubgroupSize:
 	case BuiltInSubgroupLocalInvocationId:
 	case BuiltInViewIndex:
+	case BuiltInVertexIndex:
+	case BuiltInInstanceIndex:
+	case BuiltInBaseInstance:
+	case BuiltInBaseVertex:
 		expected_type = SPIRType::UInt;
 		break;
 


### PR DESCRIPTION
Totally missed these, so float(index) would not work correctly for
negative numbers.

Fix #1139.