### PR TITLE
MSL: Inline all non-entry-point functions

### DIFF
--- a/reference/opt/shaders-msl/asm/comp/atomic-decrement.asm.comp
+++ b/reference/opt/shaders-msl/asm/comp/atomic-decrement.asm.comp
@@ -13,7 +13,7 @@ struct u0_counters
 };
 
 // Returns 2D texture coords corresponding to 1D texel buffer coords
-uint2 spvTexelBufferCoord(uint tc)
+inline uint2 spvTexelBufferCoord(uint tc)
 {
     return uint2(tc % 4096, tc / 4096);
 }

--- a/reference/opt/shaders-msl/asm/comp/atomic-increment.asm.comp
+++ b/reference/opt/shaders-msl/asm/comp/atomic-increment.asm.comp
@@ -13,7 +13,7 @@ struct u0_counters
 };
 
 // Returns 2D texture coords corresponding to 1D texel buffer coords
-uint2 spvTexelBufferCoord(uint tc)
+inline uint2 spvTexelBufferCoord(uint tc)
 {
     return uint2(tc % 4096, tc / 4096);
 }

--- a/reference/opt/shaders-msl/asm/comp/buffer-write-relative-addr.asm.comp
+++ b/reference/opt/shaders-msl/asm/comp/buffer-write-relative-addr.asm.comp
@@ -11,7 +11,7 @@ struct cb5_struct
 };
 
 // Returns 2D texture coords corresponding to 1D texel buffer coords
-uint2 spvTexelBufferCoord(uint tc)
+inline uint2 spvTexelBufferCoord(uint tc)
 {
     return uint2(tc % 4096, tc / 4096);
 }

--- a/reference/opt/shaders-msl/asm/comp/buffer-write.asm.comp
+++ b/reference/opt/shaders-msl/asm/comp/buffer-write.asm.comp
@@ -11,7 +11,7 @@ struct cb
 };
 
 // Returns 2D texture coords corresponding to 1D texel buffer coords
-uint2 spvTexelBufferCoord(uint tc)
+inline uint2 spvTexelBufferCoord(uint tc)
 {
     return uint2(tc % 4096, tc / 4096);
 }

--- a/reference/opt/shaders-msl/asm/frag/lut-promotion-initializer.asm.frag
+++ b/reference/opt/shaders-msl/asm/frag/lut-promotion-initializer.asm.frag
@@ -20,7 +20,7 @@ struct main0_in
 };
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -29,7 +29,7 @@ void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -38,7 +38,7 @@ void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T 
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -47,7 +47,7 @@ void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -56,7 +56,7 @@ void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -65,7 +65,7 @@ void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {

--- a/reference/opt/shaders-msl/asm/frag/single-function-private-lut.asm.frag
+++ b/reference/opt/shaders-msl/asm/frag/single-function-private-lut.asm.frag
@@ -19,7 +19,7 @@ struct main0_out
 
 // Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
-Tx mod(Tx x, Ty y)
+inline Tx mod(Tx x, Ty y)
 {
     return x - y * floor(x / y);
 }

--- a/reference/opt/shaders-msl/asm/tesc/tess-fixed-input-array-builtin-array.invalid.asm.tesc
+++ b/reference/opt/shaders-msl/asm/tesc/tess-fixed-input-array-builtin-array.invalid.asm.tesc
@@ -34,7 +34,7 @@ struct main0_in
 };
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -43,7 +43,7 @@ void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -52,7 +52,7 @@ void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T 
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -61,7 +61,7 @@ void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -70,7 +70,7 @@ void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -79,7 +79,7 @@ void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {

--- a/reference/opt/shaders-msl/comp/composite-array-initialization.comp
+++ b/reference/opt/shaders-msl/comp/composite-array-initialization.comp
@@ -30,7 +30,7 @@ constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(2u, 1u, 1u);
 constant Data _25[2] = { Data{ 1.0, 2.0 }, Data{ 3.0, 4.0 } };
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -39,7 +39,7 @@ void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -48,7 +48,7 @@ void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T 
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -57,7 +57,7 @@ void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -66,7 +66,7 @@ void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -75,7 +75,7 @@ void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {

--- a/reference/opt/shaders-msl/comp/composite-construct.comp
+++ b/reference/opt/shaders-msl/comp/composite-construct.comp
@@ -16,7 +16,7 @@ struct SSBO1
 };
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -25,7 +25,7 @@ void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -34,7 +34,7 @@ void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T 
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -43,7 +43,7 @@ void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -52,7 +52,7 @@ void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -61,7 +61,7 @@ void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {

--- a/reference/opt/shaders-msl/comp/global-invocation-id-writable-ssbo-in-function.comp
+++ b/reference/opt/shaders-msl/comp/global-invocation-id-writable-ssbo-in-function.comp
@@ -13,7 +13,7 @@ struct myBlock
 
 // Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
-Tx mod(Tx x, Ty y)
+inline Tx mod(Tx x, Ty y)
 {
     return x - y * floor(x / y);
 }

--- a/reference/opt/shaders-msl/comp/global-invocation-id.comp
+++ b/reference/opt/shaders-msl/comp/global-invocation-id.comp
@@ -13,7 +13,7 @@ struct myBlock
 
 // Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
-Tx mod(Tx x, Ty y)
+inline Tx mod(Tx x, Ty y)
 {
     return x - y * floor(x / y);
 }

--- a/reference/opt/shaders-msl/comp/inverse.comp
+++ b/reference/opt/shaders-msl/comp/inverse.comp
@@ -33,7 +33,7 @@ inline float spvDet3x3(float a1, float a2, float a3, float b1, float b2, float b
 
 // Returns the inverse of a matrix, by using the algorithm of calculating the classical
 // adjoint and dividing by the determinant. The contents of the matrix are changed.
-float4x4 spvInverse4x4(float4x4 m)
+inline float4x4 spvInverse4x4(float4x4 m)
 {
     float4x4 adj;	// The adjoint matrix (inverse after dividing by determinant)
 
@@ -68,7 +68,7 @@ float4x4 spvInverse4x4(float4x4 m)
 
 // Returns the inverse of a matrix, by using the algorithm of calculating the classical
 // adjoint and dividing by the determinant. The contents of the matrix are changed.
-float3x3 spvInverse3x3(float3x3 m)
+inline float3x3 spvInverse3x3(float3x3 m)
 {
     float3x3 adj;	// The adjoint matrix (inverse after dividing by determinant)
 
@@ -95,7 +95,7 @@ float3x3 spvInverse3x3(float3x3 m)
 
 // Returns the inverse of a matrix, by using the algorithm of calculating the classical
 // adjoint and dividing by the determinant. The contents of the matrix are changed.
-float2x2 spvInverse2x2(float2x2 m)
+inline float2x2 spvInverse2x2(float2x2 m)
 {
     float2x2 adj;	// The adjoint matrix (inverse after dividing by determinant)
 

--- a/reference/opt/shaders-msl/comp/local-invocation-id.comp
+++ b/reference/opt/shaders-msl/comp/local-invocation-id.comp
@@ -13,7 +13,7 @@ struct myBlock
 
 // Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
-Tx mod(Tx x, Ty y)
+inline Tx mod(Tx x, Ty y)
 {
     return x - y * floor(x / y);
 }

--- a/reference/opt/shaders-msl/comp/local-invocation-index.comp
+++ b/reference/opt/shaders-msl/comp/local-invocation-index.comp
@@ -13,7 +13,7 @@ struct myBlock
 
 // Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
-Tx mod(Tx x, Ty y)
+inline Tx mod(Tx x, Ty y)
 {
     return x - y * floor(x / y);
 }

--- a/reference/opt/shaders-msl/comp/mod.comp
+++ b/reference/opt/shaders-msl/comp/mod.comp
@@ -17,7 +17,7 @@ struct SSBO2
 
 // Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
-Tx mod(Tx x, Ty y)
+inline Tx mod(Tx x, Ty y)
 {
     return x - y * floor(x / y);
 }

--- a/reference/opt/shaders-msl/comp/writable-ssbo.comp
+++ b/reference/opt/shaders-msl/comp/writable-ssbo.comp
@@ -13,7 +13,7 @@ struct myBlock
 
 // Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
-Tx mod(Tx x, Ty y)
+inline Tx mod(Tx x, Ty y)
 {
     return x - y * floor(x / y);
 }

--- a/reference/opt/shaders-msl/frag/buffer-read-write.frag
+++ b/reference/opt/shaders-msl/frag/buffer-read-write.frag
@@ -11,7 +11,7 @@ struct main0_out
 };
 
 // Returns 2D texture coords corresponding to 1D texel buffer coords
-uint2 spvTexelBufferCoord(uint tc)
+inline uint2 spvTexelBufferCoord(uint tc)
 {
     return uint2(tc % 4096, tc / 4096);
 }

--- a/reference/opt/shaders-msl/frag/lut-promotion.frag
+++ b/reference/opt/shaders-msl/frag/lut-promotion.frag
@@ -20,7 +20,7 @@ struct main0_in
 };
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -29,7 +29,7 @@ void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -38,7 +38,7 @@ void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T 
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -47,7 +47,7 @@ void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -56,7 +56,7 @@ void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -65,7 +65,7 @@ void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {

--- a/reference/opt/shaders-msl/frag/mrt-array.frag
+++ b/reference/opt/shaders-msl/frag/mrt-array.frag
@@ -21,7 +21,7 @@ struct main0_in
 
 // Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
-Tx mod(Tx x, Ty y)
+inline Tx mod(Tx x, Ty y)
 {
     return x - y * floor(x / y);
 }

--- a/reference/opt/shaders-msl/vert/functions.vert
+++ b/reference/opt/shaders-msl/vert/functions.vert
@@ -31,28 +31,28 @@ struct main0_in
 
 // Implementation of the GLSL radians() function
 template<typename T>
-T radians(T d)
+inline T radians(T d)
 {
     return d * T(0.01745329251);
 }
 
 // Implementation of the GLSL degrees() function
 template<typename T>
-T degrees(T r)
+inline T degrees(T r)
 {
     return r * T(57.2957795131);
 }
 
 // Implementation of the GLSL findLSB() function
 template<typename T>
-T spvFindLSB(T x)
+inline T spvFindLSB(T x)
 {
     return select(ctz(x), T(-1), x == T(0));
 }
 
 // Implementation of the signed GLSL findMSB() function
 template<typename T>
-T spvFindSMSB(T x)
+inline T spvFindSMSB(T x)
 {
     T v = select(x, T(-1) - x, x < T(0));
     return select(clz(T(0)) - (clz(v) + T(1)), T(-1), v == T(0));
@@ -72,7 +72,7 @@ inline float spvDet3x3(float a1, float a2, float a3, float b1, float b2, float b
 
 // Returns the inverse of a matrix, by using the algorithm of calculating the classical
 // adjoint and dividing by the determinant. The contents of the matrix are changed.
-float4x4 spvInverse4x4(float4x4 m)
+inline float4x4 spvInverse4x4(float4x4 m)
 {
     float4x4 adj;	// The adjoint matrix (inverse after dividing by determinant)
 

--- a/reference/opt/shaders-msl/vert/sign-int-types.vert
+++ b/reference/opt/shaders-msl/vert/sign-int-types.vert
@@ -38,7 +38,7 @@ struct main0_in
 
 // Implementation of the GLSL sign() function for integer types
 template<typename T, typename E = typename enable_if<is_integral<T>::value>::type>
-T sign(T x)
+inline T sign(T x)
 {
     return select(select(select(x, T(0), x == T(0)), T(1), x > T(0)), T(-1), x < T(0));
 }

--- a/reference/opt/shaders-msl/vert/texture_buffer.vert
+++ b/reference/opt/shaders-msl/vert/texture_buffer.vert
@@ -11,7 +11,7 @@ struct main0_out
 };
 
 // Returns 2D texture coords corresponding to 1D texel buffer coords
-uint2 spvTexelBufferCoord(uint tc)
+inline uint2 spvTexelBufferCoord(uint tc)
 {
     return uint2(tc % 4096, tc / 4096);
 }

--- a/reference/shaders-msl-no-opt/asm/comp/bitscan.asm.comp
+++ b/reference/shaders-msl-no-opt/asm/comp/bitscan.asm.comp
@@ -13,14 +13,14 @@ struct SSBO
 
 // Implementation of the GLSL findLSB() function
 template<typename T>
-T spvFindLSB(T x)
+inline T spvFindLSB(T x)
 {
     return select(ctz(x), T(-1), x == T(0));
 }
 
 // Implementation of the signed GLSL findMSB() function
 template<typename T>
-T spvFindSMSB(T x)
+inline T spvFindSMSB(T x)
 {
     T v = select(x, T(-1) - x, x < T(0));
     return select(clz(T(0)) - (clz(v) + T(1)), T(-1), v == T(0));
@@ -28,7 +28,7 @@ T spvFindSMSB(T x)
 
 // Implementation of the unsigned GLSL findMSB() function
 template<typename T>
-T spvFindUMSB(T x)
+inline T spvFindUMSB(T x)
 {
     return select(clz(T(0)) - (clz(x) + T(1)), T(-1), x == T(0));
 }

--- a/reference/shaders-msl-no-opt/asm/comp/glsl-signed-operations.asm.comp
+++ b/reference/shaders-msl-no-opt/asm/comp/glsl-signed-operations.asm.comp
@@ -13,7 +13,7 @@ struct SSBO
 
 // Implementation of the signed GLSL findMSB() function
 template<typename T>
-T spvFindSMSB(T x)
+inline T spvFindSMSB(T x)
 {
     T v = select(x, T(-1) - x, x < T(0));
     return select(clz(T(0)) - (clz(v) + T(1)), T(-1), v == T(0));
@@ -21,14 +21,14 @@ T spvFindSMSB(T x)
 
 // Implementation of the unsigned GLSL findMSB() function
 template<typename T>
-T spvFindUMSB(T x)
+inline T spvFindUMSB(T x)
 {
     return select(clz(T(0)) - (clz(x) + T(1)), T(-1), x == T(0));
 }
 
 // Implementation of the GLSL sign() function for integer types
 template<typename T, typename E = typename enable_if<is_integral<T>::value>::type>
-T sign(T x)
+inline T sign(T x)
 {
     return select(select(select(x, T(0), x == T(0)), T(1), x > T(0)), T(-1), x < T(0));
 }

--- a/reference/shaders-msl-no-opt/asm/comp/storage-buffer-pointer-argument.asm.comp
+++ b/reference/shaders-msl-no-opt/asm/comp/storage-buffer-pointer-argument.asm.comp
@@ -15,7 +15,7 @@ struct SSBORead
     float b;
 };
 
-void copy_out(device float& A, device const float& B)
+inline void copy_out(device float& A, device const float& B)
 {
     A = B;
 }

--- a/reference/shaders-msl-no-opt/asm/comp/variable-pointers.asm.comp
+++ b/reference/shaders-msl-no-opt/asm/comp/variable-pointers.asm.comp
@@ -22,17 +22,17 @@ struct baz
     int e[128];
 };
 
-device int* select_buffer(device foo& buf, device baz& buf2, constant bar& cb)
+inline device int* select_buffer(device foo& buf, device baz& buf2, constant bar& cb)
 {
     return (cb.d != 0) ? &buf.a[0u] : &buf2.e[0u];
 }
 
-device int* select_buffer_null(device foo& buf, constant bar& cb)
+inline device int* select_buffer_null(device foo& buf, constant bar& cb)
 {
     return (cb.d != 0) ? &buf.a[0u] : nullptr;
 }
 
-threadgroup int* select_tgsm(constant bar& cb, threadgroup int (&tgsm)[128])
+inline threadgroup int* select_tgsm(constant bar& cb, threadgroup int (&tgsm)[128])
 {
     return (cb.d != 0) ? &tgsm[0u] : nullptr;
 }

--- a/reference/shaders-msl-no-opt/asm/frag/texture-access.swizzle.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/texture-access.swizzle.asm.frag
@@ -6,7 +6,7 @@
 using namespace metal;
 
 // Returns 2D texture coords corresponding to 1D texel buffer coords
-uint2 spvTexelBufferCoord(uint tc)
+inline uint2 spvTexelBufferCoord(uint tc)
 {
     return uint2(tc % 4096, tc / 4096);
 }

--- a/reference/shaders-msl-no-opt/comp/array-copy-threadgroup-memory.comp
+++ b/reference/shaders-msl-no-opt/comp/array-copy-threadgroup-memory.comp
@@ -8,7 +8,7 @@ using namespace metal;
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(8u, 1u, 1u);
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -17,7 +17,7 @@ void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -26,7 +26,7 @@ void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T 
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -35,7 +35,7 @@ void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -44,7 +44,7 @@ void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -53,7 +53,7 @@ void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {

--- a/reference/shaders-msl-no-opt/comp/bitfield.comp
+++ b/reference/shaders-msl-no-opt/comp/bitfield.comp
@@ -7,14 +7,14 @@ using namespace metal;
 
 // Implementation of the GLSL findLSB() function
 template<typename T>
-T spvFindLSB(T x)
+inline T spvFindLSB(T x)
 {
     return select(ctz(x), T(-1), x == T(0));
 }
 
 // Implementation of the signed GLSL findMSB() function
 template<typename T>
-T spvFindSMSB(T x)
+inline T spvFindSMSB(T x)
 {
     T v = select(x, T(-1) - x, x < T(0));
     return select(clz(T(0)) - (clz(v) + T(1)), T(-1), v == T(0));
@@ -22,7 +22,7 @@ T spvFindSMSB(T x)
 
 // Implementation of the unsigned GLSL findMSB() function
 template<typename T>
-T spvFindUMSB(T x)
+inline T spvFindUMSB(T x)
 {
     return select(clz(T(0)) - (clz(x) + T(1)), T(-1), x == T(0));
 }

--- a/reference/shaders-msl-no-opt/comp/glsl.std450.comp
+++ b/reference/shaders-msl-no-opt/comp/glsl.std450.comp
@@ -26,28 +26,28 @@ struct ResType
 
 // Implementation of the GLSL radians() function
 template<typename T>
-T radians(T d)
+inline T radians(T d)
 {
     return d * T(0.01745329251);
 }
 
 // Implementation of the GLSL degrees() function
 template<typename T>
-T degrees(T r)
+inline T degrees(T r)
 {
     return r * T(57.2957795131);
 }
 
 // Implementation of the GLSL findLSB() function
 template<typename T>
-T spvFindLSB(T x)
+inline T spvFindLSB(T x)
 {
     return select(ctz(x), T(-1), x == T(0));
 }
 
 // Implementation of the signed GLSL findMSB() function
 template<typename T>
-T spvFindSMSB(T x)
+inline T spvFindSMSB(T x)
 {
     T v = select(x, T(-1) - x, x < T(0));
     return select(clz(T(0)) - (clz(v) + T(1)), T(-1), v == T(0));
@@ -55,14 +55,14 @@ T spvFindSMSB(T x)
 
 // Implementation of the unsigned GLSL findMSB() function
 template<typename T>
-T spvFindUMSB(T x)
+inline T spvFindUMSB(T x)
 {
     return select(clz(T(0)) - (clz(x) + T(1)), T(-1), x == T(0));
 }
 
 // Implementation of the GLSL sign() function for integer types
 template<typename T, typename E = typename enable_if<is_integral<T>::value>::type>
-T sign(T x)
+inline T sign(T x)
 {
     return select(select(select(x, T(0), x == T(0)), T(1), x > T(0)), T(-1), x < T(0));
 }
@@ -81,7 +81,7 @@ inline float spvDet3x3(float a1, float a2, float a3, float b1, float b2, float b
 
 // Returns the inverse of a matrix, by using the algorithm of calculating the classical
 // adjoint and dividing by the determinant. The contents of the matrix are changed.
-float4x4 spvInverse4x4(float4x4 m)
+inline float4x4 spvInverse4x4(float4x4 m)
 {
     float4x4 adj;	// The adjoint matrix (inverse after dividing by determinant)
 
@@ -116,7 +116,7 @@ float4x4 spvInverse4x4(float4x4 m)
 
 // Returns the inverse of a matrix, by using the algorithm of calculating the classical
 // adjoint and dividing by the determinant. The contents of the matrix are changed.
-float3x3 spvInverse3x3(float3x3 m)
+inline float3x3 spvInverse3x3(float3x3 m)
 {
     float3x3 adj;	// The adjoint matrix (inverse after dividing by determinant)
 
@@ -143,7 +143,7 @@ float3x3 spvInverse3x3(float3x3 m)
 
 // Returns the inverse of a matrix, by using the algorithm of calculating the classical
 // adjoint and dividing by the determinant. The contents of the matrix are changed.
-float2x2 spvInverse2x2(float2x2 m)
+inline float2x2 spvInverse2x2(float2x2 m)
 {
     float2x2 adj;	// The adjoint matrix (inverse after dividing by determinant)
 

--- a/reference/shaders-msl-no-opt/frag/texture-access-int.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access-int.swizzle.frag
@@ -6,7 +6,7 @@
 using namespace metal;
 
 // Returns 2D texture coords corresponding to 1D texel buffer coords
-uint2 spvTexelBufferCoord(uint tc)
+inline uint2 spvTexelBufferCoord(uint tc)
 {
     return uint2(tc % 4096, tc / 4096);
 }

--- a/reference/shaders-msl-no-opt/frag/texture-access-leaf.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access-leaf.swizzle.frag
@@ -6,7 +6,7 @@
 using namespace metal;
 
 // Returns 2D texture coords corresponding to 1D texel buffer coords
-uint2 spvTexelBufferCoord(uint tc)
+inline uint2 spvTexelBufferCoord(uint tc)
 {
     return uint2(tc % 4096, tc / 4096);
 }
@@ -131,7 +131,7 @@ inline vec<T, 4> spvGatherCompareSwizzle(sampler s, const thread Tex& t, Ts... p
     return t.gather_compare(s, spvForward<Ts>(params)...);
 }
 
-float4 doSwizzle(thread texture1d<float> tex1d, thread const sampler tex1dSmplr, constant uint& tex1dSwzl, thread texture2d<float> tex2d, thread const sampler tex2dSmplr, constant uint& tex2dSwzl, thread texture3d<float> tex3d, thread const sampler tex3dSmplr, constant uint& tex3dSwzl, thread texturecube<float> texCube, thread const sampler texCubeSmplr, constant uint& texCubeSwzl, thread texture2d_array<float> tex2dArray, thread const sampler tex2dArraySmplr, constant uint& tex2dArraySwzl, thread texturecube_array<float> texCubeArray, thread const sampler texCubeArraySmplr, constant uint& texCubeArraySwzl, thread depth2d<float> depth2d, thread const sampler depth2dSmplr, constant uint& depth2dSwzl, thread depthcube<float> depthCube, thread const sampler depthCubeSmplr, constant uint& depthCubeSwzl, thread depth2d_array<float> depth2dArray, thread const sampler depth2dArraySmplr, constant uint& depth2dArraySwzl, thread depthcube_array<float> depthCubeArray, thread const sampler depthCubeArraySmplr, constant uint& depthCubeArraySwzl, thread texture2d<float> texBuffer)
+inline float4 doSwizzle(thread texture1d<float> tex1d, thread const sampler tex1dSmplr, constant uint& tex1dSwzl, thread texture2d<float> tex2d, thread const sampler tex2dSmplr, constant uint& tex2dSwzl, thread texture3d<float> tex3d, thread const sampler tex3dSmplr, constant uint& tex3dSwzl, thread texturecube<float> texCube, thread const sampler texCubeSmplr, constant uint& texCubeSwzl, thread texture2d_array<float> tex2dArray, thread const sampler tex2dArraySmplr, constant uint& tex2dArraySwzl, thread texturecube_array<float> texCubeArray, thread const sampler texCubeArraySmplr, constant uint& texCubeArraySwzl, thread depth2d<float> depth2d, thread const sampler depth2dSmplr, constant uint& depth2dSwzl, thread depthcube<float> depthCube, thread const sampler depthCubeSmplr, constant uint& depthCubeSwzl, thread depth2d_array<float> depth2dArray, thread const sampler depth2dArraySmplr, constant uint& depth2dArraySwzl, thread depthcube_array<float> depthCubeArray, thread const sampler depthCubeArraySmplr, constant uint& depthCubeArraySwzl, thread texture2d<float> texBuffer)
 {
     float4 c = spvTextureSwizzle(tex1d.sample(tex1dSmplr, 0.0), tex1dSwzl);
     c = spvTextureSwizzle(tex2d.sample(tex2dSmplr, float2(0.0)), tex2dSwzl);

--- a/reference/shaders-msl-no-opt/frag/texture-access-uint.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access-uint.swizzle.frag
@@ -6,7 +6,7 @@
 using namespace metal;
 
 // Returns 2D texture coords corresponding to 1D texel buffer coords
-uint2 spvTexelBufferCoord(uint tc)
+inline uint2 spvTexelBufferCoord(uint tc)
 {
     return uint2(tc % 4096, tc / 4096);
 }

--- a/reference/shaders-msl-no-opt/frag/texture-access.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access.swizzle.frag
@@ -6,7 +6,7 @@
 using namespace metal;
 
 // Returns 2D texture coords corresponding to 1D texel buffer coords
-uint2 spvTexelBufferCoord(uint tc)
+inline uint2 spvTexelBufferCoord(uint tc)
 {
     return uint2(tc % 4096, tc / 4096);
 }

--- a/reference/shaders-msl-no-opt/packing/matrix-2x2-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-2x2-scalar.comp
@@ -17,46 +17,46 @@ struct SSBORow
     float2x2 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float2x2 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float2x2 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(v_29.col_major0);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(v_41.row_major0);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
     v_41.row_major0[1][1] = v_29.col_major0[1].y;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-2x2-std140.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-2x2-std140.comp
@@ -17,52 +17,52 @@ struct SSBORow
     float2x4 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float2x2 loaded = float2x2(v_29.col_major0[0].xy, v_29.col_major0[1].xy);
     v_29.col_major1[0].xy = loaded[0];
     v_29.col_major1[1].xy = loaded[1];
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float2x2 loaded = transpose(float2x2(v_41.row_major0[0].xy, v_41.row_major0[1].xy));
     v_41.row_major0[0].xy = float2(loaded[0][0], loaded[1][0]);
     v_41.row_major0[1].xy = float2(loaded[0][1], loaded[1][1]);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0[0].xy = float2x2(v_29.col_major1[0].xy, v_29.col_major1[1].xy)[0];
     v_29.col_major0[1].xy = float2x2(v_29.col_major1[0].xy, v_29.col_major1[1].xy)[1];
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0[0].xy = float2(float2x2(v_29.col_major0[0].xy, v_29.col_major0[1].xy)[0][0], float2x2(v_29.col_major0[0].xy, v_29.col_major0[1].xy)[1][0]);
     v_41.row_major0[1].xy = float2(float2x2(v_29.col_major0[0].xy, v_29.col_major0[1].xy)[0][1], float2x2(v_29.col_major0[0].xy, v_29.col_major0[1].xy)[1][1]);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].xy = float2(float2x2(v_41.row_major0[0].xy, v_41.row_major0[1].xy)[0][0], float2x2(v_41.row_major0[0].xy, v_41.row_major0[1].xy)[1][0]);
     v_29.col_major0[1].xy = float2(float2x2(v_41.row_major0[0].xy, v_41.row_major0[1].xy)[0][1], float2x2(v_41.row_major0[0].xy, v_41.row_major0[1].xy)[1][1]);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0[0].xy = float2x2(v_41.row_major1[0].xy, v_41.row_major1[1].xy)[0];
     v_41.row_major0[1].xy = float2x2(v_41.row_major1[0].xy, v_41.row_major1[1].xy)[1];
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1].xy = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
     v_41.row_major0[1][1] = v_29.col_major0[1].y;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-2x2-std430.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-2x2-std430.comp
@@ -17,46 +17,46 @@ struct SSBORow
     float2x2 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float2x2 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float2x2 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(v_29.col_major0);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(v_41.row_major0);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
     v_41.row_major0[1][1] = v_29.col_major0[1].y;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-2x3-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-2x3-scalar.comp
@@ -19,42 +19,42 @@ struct SSBORow
     float3x2 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float2x3 loaded = float2x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]));
     v_29.col_major1[0] = loaded[0];
     v_29.col_major1[1] = loaded[1];
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float2x3 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0[0] = float2x3(float3(v_29.col_major1[0]), float3(v_29.col_major1[1]))[0];
     v_29.col_major0[1] = float2x3(float3(v_29.col_major1[0]), float3(v_29.col_major1[1]))[1];
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(float2x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1])));
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0] = float3(v_41.row_major0[0][0], v_41.row_major0[1][0], v_41.row_major0[2][0]);
     v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1][0];
@@ -62,7 +62,7 @@ void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
     v_41.row_major0[2][1] = v_29.col_major0[1][2];
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0][1u] = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0][1u];

--- a/reference/shaders-msl-no-opt/packing/matrix-2x3-std140.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-2x3-std140.comp
@@ -17,13 +17,13 @@ struct SSBORow
     float3x4 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float2x3 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float2x3 loaded = transpose(float3x2(v_41.row_major0[0].xy, v_41.row_major0[1].xy, v_41.row_major0[2].xy));
     v_41.row_major0[0].xy = float2(loaded[0][0], loaded[1][0]);
@@ -31,31 +31,31 @@ void load_store_to_variable_row_major(device SSBORow& v_41)
     v_41.row_major0[2].xy = float2(loaded[0][2], loaded[1][2]);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0[0].xy = float2(v_29.col_major0[0][0], v_29.col_major0[1][0]);
     v_41.row_major0[1].xy = float2(v_29.col_major0[0][1], v_29.col_major0[1][1]);
     v_41.row_major0[2].xy = float2(v_29.col_major0[0][2], v_29.col_major0[1][2]);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(float3x2(v_41.row_major0[0].xy, v_41.row_major0[1].xy, v_41.row_major0[2].xy));
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0[0].xy = float3x2(v_41.row_major1[0].xy, v_41.row_major1[1].xy, v_41.row_major1[2].xy)[0];
     v_41.row_major0[1].xy = float3x2(v_41.row_major1[0].xy, v_41.row_major1[1].xy, v_41.row_major1[2].xy)[1];
     v_41.row_major0[2].xy = float3x2(v_41.row_major1[0].xy, v_41.row_major1[1].xy, v_41.row_major1[2].xy)[2];
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
@@ -63,7 +63,7 @@ void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
     v_41.row_major0[2][1] = v_29.col_major0[1].z;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-2x3-std430.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-2x3-std430.comp
@@ -17,39 +17,39 @@ struct SSBORow
     float3x2 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float2x3 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float2x3 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(v_29.col_major0);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(v_41.row_major0);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
@@ -57,7 +57,7 @@ void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
     v_41.row_major0[2][1] = v_29.col_major0[1].z;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-2x4-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-2x4-scalar.comp
@@ -17,39 +17,39 @@ struct SSBORow
     float4x2 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float2x4 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float2x4 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(v_29.col_major0);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(v_41.row_major0);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float4(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1], v_41.row_major0[3][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
@@ -58,7 +58,7 @@ void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
     v_41.row_major0[3][1] = v_29.col_major0[1].w;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-2x4-std140.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-2x4-std140.comp
@@ -17,13 +17,13 @@ struct SSBORow
     float4x4 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float2x4 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float2x4 loaded = transpose(float4x2(v_41.row_major0[0].xy, v_41.row_major0[1].xy, v_41.row_major0[2].xy, v_41.row_major0[3].xy));
     v_41.row_major0[0].xy = float2(loaded[0][0], loaded[1][0]);
@@ -32,12 +32,12 @@ void load_store_to_variable_row_major(device SSBORow& v_41)
     v_41.row_major0[3].xy = float2(loaded[0][3], loaded[1][3]);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0[0].xy = float2(v_29.col_major0[0][0], v_29.col_major0[1][0]);
     v_41.row_major0[1].xy = float2(v_29.col_major0[0][1], v_29.col_major0[1][1]);
@@ -45,12 +45,12 @@ void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
     v_41.row_major0[3].xy = float2(v_29.col_major0[0][3], v_29.col_major0[1][3]);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(float4x2(v_41.row_major0[0].xy, v_41.row_major0[1].xy, v_41.row_major0[2].xy, v_41.row_major0[3].xy));
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0[0].xy = float4x2(v_41.row_major1[0].xy, v_41.row_major1[1].xy, v_41.row_major1[2].xy, v_41.row_major1[3].xy)[0];
     v_41.row_major0[1].xy = float4x2(v_41.row_major1[0].xy, v_41.row_major1[1].xy, v_41.row_major1[2].xy, v_41.row_major1[3].xy)[1];
@@ -58,7 +58,7 @@ void copy_row_major_to_row_major(device SSBORow& v_41)
     v_41.row_major0[3].xy = float4x2(v_41.row_major1[0].xy, v_41.row_major1[1].xy, v_41.row_major1[2].xy, v_41.row_major1[3].xy)[3];
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float4(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1], v_41.row_major0[3][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
@@ -67,7 +67,7 @@ void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
     v_41.row_major0[3][1] = v_29.col_major0[1].w;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-2x4-std430.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-2x4-std430.comp
@@ -17,39 +17,39 @@ struct SSBORow
     float4x2 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float2x4 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float2x4 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(v_29.col_major0);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(v_41.row_major0);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float4(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1], v_41.row_major0[3][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
@@ -58,7 +58,7 @@ void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
     v_41.row_major0[3][1] = v_29.col_major0[1].w;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-3x2-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x2-scalar.comp
@@ -19,49 +19,49 @@ struct SSBORow
     packed_rm_float3x2 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float3x2 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float3x2 loaded = transpose(float2x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1])));
     v_41.row_major0[0] = float3(loaded[0][0], loaded[1][0], loaded[2][0]);
     v_41.row_major0[1] = float3(loaded[0][1], loaded[1][1], loaded[2][1]);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0[0] = float3(v_29.col_major0[0][0], v_29.col_major0[1][0], v_29.col_major0[2][0]);
     v_41.row_major0[1] = float3(v_29.col_major0[0][1], v_29.col_major0[1][1], v_29.col_major0[2][1]);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(float2x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1])));
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0[0] = float2x3(float3(v_41.row_major1[0]), float3(v_41.row_major1[1]))[0];
     v_41.row_major0[1] = float2x3(float3(v_41.row_major1[0]), float3(v_41.row_major1[1]))[1];
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
     v_41.row_major0[1][1] = v_29.col_major0[1].y;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-3x2-std140.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x2-std140.comp
@@ -17,7 +17,7 @@ struct SSBORow
     float2x3 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float3x2 loaded = float3x2(v_29.col_major0[0].xy, v_29.col_major0[1].xy, v_29.col_major0[2].xy);
     v_29.col_major1[0].xy = loaded[0];
@@ -25,44 +25,44 @@ void load_store_to_variable_col_major(device SSBOCol& v_29)
     v_29.col_major1[2].xy = loaded[2];
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float3x2 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0[0].xy = float3x2(v_29.col_major1[0].xy, v_29.col_major1[1].xy, v_29.col_major1[2].xy)[0];
     v_29.col_major0[1].xy = float3x2(v_29.col_major1[0].xy, v_29.col_major1[1].xy, v_29.col_major1[2].xy)[1];
     v_29.col_major0[2].xy = float3x2(v_29.col_major1[0].xy, v_29.col_major1[1].xy, v_29.col_major1[2].xy)[2];
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(float3x2(v_29.col_major0[0].xy, v_29.col_major0[1].xy, v_29.col_major0[2].xy));
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].xy = float2(v_41.row_major0[0][0], v_41.row_major0[1][0]);
     v_29.col_major0[1].xy = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
     v_29.col_major0[2].xy = float2(v_41.row_major0[0][2], v_41.row_major0[1][2]);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1].xy = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
     v_41.row_major0[1][1] = v_29.col_major0[1].y;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-3x2-std430.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x2-std430.comp
@@ -17,46 +17,46 @@ struct SSBORow
     float2x3 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float3x2 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float3x2 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(v_29.col_major0);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(v_41.row_major0);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
     v_41.row_major0[1][1] = v_29.col_major0[1].y;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-3x3-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x3-scalar.comp
@@ -20,7 +20,7 @@ struct SSBORow
     packed_rm_float3x3 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float3x3 loaded = float3x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]));
     v_29.col_major1[0] = loaded[0];
@@ -28,7 +28,7 @@ void load_store_to_variable_col_major(device SSBOCol& v_29)
     v_29.col_major1[2] = loaded[2];
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float3x3 loaded = transpose(float3x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2])));
     v_41.row_major0[0] = float3(loaded[0][0], loaded[1][0], loaded[2][0]);
@@ -36,35 +36,35 @@ void load_store_to_variable_row_major(device SSBORow& v_41)
     v_41.row_major0[2] = float3(loaded[0][2], loaded[1][2], loaded[2][2]);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0[0] = float3x3(float3(v_29.col_major1[0]), float3(v_29.col_major1[1]), float3(v_29.col_major1[2]))[0];
     v_29.col_major0[1] = float3x3(float3(v_29.col_major1[0]), float3(v_29.col_major1[1]), float3(v_29.col_major1[2]))[1];
     v_29.col_major0[2] = float3x3(float3(v_29.col_major1[0]), float3(v_29.col_major1[1]), float3(v_29.col_major1[2]))[2];
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0[0] = float3(float3x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]))[0][0], float3x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]))[1][0], float3x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]))[2][0]);
     v_41.row_major0[1] = float3(float3x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]))[0][1], float3x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]))[1][1], float3x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]))[2][1]);
     v_41.row_major0[2] = float3(float3x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]))[0][2], float3x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]))[1][2], float3x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]))[2][2]);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0] = float3(float3x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]))[0][0], float3x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]))[1][0], float3x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]))[2][0]);
     v_29.col_major0[1] = float3(float3x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]))[0][1], float3x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]))[1][1], float3x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]))[2][1]);
     v_29.col_major0[2] = float3(float3x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]))[0][2], float3x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]))[1][2], float3x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]))[2][2]);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0[0] = float3x3(float3(v_41.row_major1[0]), float3(v_41.row_major1[1]), float3(v_41.row_major1[2]))[0];
     v_41.row_major0[1] = float3x3(float3(v_41.row_major1[0]), float3(v_41.row_major1[1]), float3(v_41.row_major1[2]))[1];
     v_41.row_major0[2] = float3x3(float3(v_41.row_major1[0]), float3(v_41.row_major1[1]), float3(v_41.row_major1[2]))[2];
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1][0];
@@ -72,7 +72,7 @@ void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
     v_41.row_major0[2][1] = v_29.col_major0[1][2];
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0][1u] = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0][1u];

--- a/reference/shaders-msl-no-opt/packing/matrix-3x3-std140.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x3-std140.comp
@@ -17,39 +17,39 @@ struct SSBORow
     float3x3 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float3x3 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float3x3 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(v_29.col_major0);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(v_41.row_major0);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
@@ -57,7 +57,7 @@ void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
     v_41.row_major0[2][1] = v_29.col_major0[1].z;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-3x3-std430.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x3-std430.comp
@@ -17,39 +17,39 @@ struct SSBORow
     float3x3 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float3x3 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float3x3 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(v_29.col_major0);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(v_41.row_major0);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
@@ -57,7 +57,7 @@ void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
     v_41.row_major0[2][1] = v_29.col_major0[1].z;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-3x4-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x4-scalar.comp
@@ -19,13 +19,13 @@ struct SSBORow
     packed_rm_float3x4 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float3x4 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float3x4 loaded = transpose(float4x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]), float3(v_41.row_major0[3])));
     v_41.row_major0[0] = float3(loaded[0][0], loaded[1][0], loaded[2][0]);
@@ -34,12 +34,12 @@ void load_store_to_variable_row_major(device SSBORow& v_41)
     v_41.row_major0[3] = float3(loaded[0][3], loaded[1][3], loaded[2][3]);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0[0] = float3(v_29.col_major0[0][0], v_29.col_major0[1][0], v_29.col_major0[2][0]);
     v_41.row_major0[1] = float3(v_29.col_major0[0][1], v_29.col_major0[1][1], v_29.col_major0[2][1]);
@@ -47,12 +47,12 @@ void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
     v_41.row_major0[3] = float3(v_29.col_major0[0][3], v_29.col_major0[1][3], v_29.col_major0[2][3]);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(float4x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]), float3(v_41.row_major0[3])));
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0[0] = float4x3(float3(v_41.row_major1[0]), float3(v_41.row_major1[1]), float3(v_41.row_major1[2]), float3(v_41.row_major1[3]))[0];
     v_41.row_major0[1] = float4x3(float3(v_41.row_major1[0]), float3(v_41.row_major1[1]), float3(v_41.row_major1[2]), float3(v_41.row_major1[3]))[1];
@@ -60,7 +60,7 @@ void copy_row_major_to_row_major(device SSBORow& v_41)
     v_41.row_major0[3] = float4x3(float3(v_41.row_major1[0]), float3(v_41.row_major1[1]), float3(v_41.row_major1[2]), float3(v_41.row_major1[3]))[3];
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float4(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1], v_41.row_major0[3][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
@@ -69,7 +69,7 @@ void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
     v_41.row_major0[3][1] = v_29.col_major0[1].w;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-3x4-std140.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x4-std140.comp
@@ -17,39 +17,39 @@ struct SSBORow
     float4x3 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float3x4 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float3x4 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(v_29.col_major0);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(v_41.row_major0);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float4(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1], v_41.row_major0[3][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
@@ -58,7 +58,7 @@ void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
     v_41.row_major0[3][1] = v_29.col_major0[1].w;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-3x4-std430.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x4-std430.comp
@@ -17,39 +17,39 @@ struct SSBORow
     float4x3 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float3x4 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float3x4 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(v_29.col_major0);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(v_41.row_major0);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float4(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1], v_41.row_major0[3][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
@@ -58,7 +58,7 @@ void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
     v_41.row_major0[3][1] = v_29.col_major0[1].w;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-4x2-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-4x2-scalar.comp
@@ -17,46 +17,46 @@ struct SSBORow
     float2x4 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float4x2 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float4x2 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(v_29.col_major0);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(v_41.row_major0);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
     v_41.row_major0[1][1] = v_29.col_major0[1].y;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-4x2-std140.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-4x2-std140.comp
@@ -17,7 +17,7 @@ struct SSBORow
     float2x4 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float4x2 loaded = float4x2(v_29.col_major0[0].xy, v_29.col_major0[1].xy, v_29.col_major0[2].xy, v_29.col_major0[3].xy);
     v_29.col_major1[0].xy = loaded[0];
@@ -26,13 +26,13 @@ void load_store_to_variable_col_major(device SSBOCol& v_29)
     v_29.col_major1[3].xy = loaded[3];
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float4x2 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0[0].xy = float4x2(v_29.col_major1[0].xy, v_29.col_major1[1].xy, v_29.col_major1[2].xy, v_29.col_major1[3].xy)[0];
     v_29.col_major0[1].xy = float4x2(v_29.col_major1[0].xy, v_29.col_major1[1].xy, v_29.col_major1[2].xy, v_29.col_major1[3].xy)[1];
@@ -40,12 +40,12 @@ void copy_col_major_to_col_major(device SSBOCol& v_29)
     v_29.col_major0[3].xy = float4x2(v_29.col_major1[0].xy, v_29.col_major1[1].xy, v_29.col_major1[2].xy, v_29.col_major1[3].xy)[3];
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(float4x2(v_29.col_major0[0].xy, v_29.col_major0[1].xy, v_29.col_major0[2].xy, v_29.col_major0[3].xy));
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].xy = float2(v_41.row_major0[0][0], v_41.row_major0[1][0]);
     v_29.col_major0[1].xy = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
@@ -53,19 +53,19 @@ void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
     v_29.col_major0[3].xy = float2(v_41.row_major0[0][3], v_41.row_major0[1][3]);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1].xy = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
     v_41.row_major0[1][1] = v_29.col_major0[1].y;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-4x2-std430.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-4x2-std430.comp
@@ -17,46 +17,46 @@ struct SSBORow
     float2x4 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float4x2 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float4x2 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(v_29.col_major0);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(v_41.row_major0);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
     v_41.row_major0[1][1] = v_29.col_major0[1].y;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-4x3-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-4x3-scalar.comp
@@ -19,7 +19,7 @@ struct SSBORow
     float3x4 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float4x3 loaded = float4x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]), float3(v_29.col_major0[3]));
     v_29.col_major1[0] = loaded[0];
@@ -28,13 +28,13 @@ void load_store_to_variable_col_major(device SSBOCol& v_29)
     v_29.col_major1[3] = loaded[3];
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float4x3 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0[0] = float4x3(float3(v_29.col_major1[0]), float3(v_29.col_major1[1]), float3(v_29.col_major1[2]), float3(v_29.col_major1[3]))[0];
     v_29.col_major0[1] = float4x3(float3(v_29.col_major1[0]), float3(v_29.col_major1[1]), float3(v_29.col_major1[2]), float3(v_29.col_major1[3]))[1];
@@ -42,12 +42,12 @@ void copy_col_major_to_col_major(device SSBOCol& v_29)
     v_29.col_major0[3] = float4x3(float3(v_29.col_major1[0]), float3(v_29.col_major1[1]), float3(v_29.col_major1[2]), float3(v_29.col_major1[3]))[3];
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(float4x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]), float3(v_29.col_major0[3])));
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0] = float3(v_41.row_major0[0][0], v_41.row_major0[1][0], v_41.row_major0[2][0]);
     v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
@@ -55,12 +55,12 @@ void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
     v_29.col_major0[3] = float3(v_41.row_major0[0][3], v_41.row_major0[1][3], v_41.row_major0[2][3]);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1][0];
@@ -68,7 +68,7 @@ void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
     v_41.row_major0[2][1] = v_29.col_major0[1][2];
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0][1u] = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0][1u];

--- a/reference/shaders-msl-no-opt/packing/matrix-4x3-std140.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-4x3-std140.comp
@@ -17,39 +17,39 @@ struct SSBORow
     float3x4 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float4x3 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float4x3 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(v_29.col_major0);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(v_41.row_major0);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
@@ -57,7 +57,7 @@ void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
     v_41.row_major0[2][1] = v_29.col_major0[1].z;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-4x3-std430.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-4x3-std430.comp
@@ -17,39 +17,39 @@ struct SSBORow
     float3x4 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float4x3 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float4x3 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(v_29.col_major0);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(v_41.row_major0);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
@@ -57,7 +57,7 @@ void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
     v_41.row_major0[2][1] = v_29.col_major0[1].z;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-4x4-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-4x4-scalar.comp
@@ -17,39 +17,39 @@ struct SSBORow
     float4x4 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float4x4 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float4x4 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(v_29.col_major0);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(v_41.row_major0);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float4(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1], v_41.row_major0[3][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
@@ -58,7 +58,7 @@ void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
     v_41.row_major0[3][1] = v_29.col_major0[1].w;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-4x4-std140.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-4x4-std140.comp
@@ -17,39 +17,39 @@ struct SSBORow
     float4x4 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float4x4 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float4x4 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(v_29.col_major0);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(v_41.row_major0);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float4(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1], v_41.row_major0[3][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
@@ -58,7 +58,7 @@ void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
     v_41.row_major0[3][1] = v_29.col_major0[1].w;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/packing/matrix-4x4-std430.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-4x4-std430.comp
@@ -17,39 +17,39 @@ struct SSBORow
     float4x4 row_major1;
 };
 
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+inline void load_store_to_variable_col_major(device SSBOCol& v_29)
 {
     float4x4 loaded = v_29.col_major0;
     v_29.col_major1 = loaded;
 }
 
-void load_store_to_variable_row_major(device SSBORow& v_41)
+inline void load_store_to_variable_row_major(device SSBORow& v_41)
 {
     float4x4 loaded = transpose(v_41.row_major0);
     v_41.row_major0 = transpose(loaded);
 }
 
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+inline void copy_col_major_to_col_major(device SSBOCol& v_29)
 {
     v_29.col_major0 = v_29.col_major1;
 }
 
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_41.row_major0 = transpose(v_29.col_major0);
 }
 
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0 = transpose(v_41.row_major0);
 }
 
-void copy_row_major_to_row_major(device SSBORow& v_41)
+inline void copy_row_major_to_row_major(device SSBORow& v_41)
 {
     v_41.row_major0 = v_41.row_major1;
 }
 
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[1] = float4(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1], v_41.row_major0[3][1]);
     v_41.row_major0[0][1] = v_29.col_major0[1].x;
@@ -58,7 +58,7 @@ void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
     v_41.row_major0[3][1] = v_29.col_major0[1].w;
 }
 
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+inline void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
 {
     v_29.col_major0[0].y = v_41.row_major0[1u][0];
     v_41.row_major0[1u][0] = v_29.col_major0[0].y;

--- a/reference/shaders-msl-no-opt/vert/functions_nested.vert
+++ b/reference/shaders-msl-no-opt/vert/functions_nested.vert
@@ -37,12 +37,12 @@ struct main0_out
 };
 
 // Returns 2D texture coords corresponding to 1D texel buffer coords
-uint2 spvTexelBufferCoord(uint tc)
+inline uint2 spvTexelBufferCoord(uint tc)
 {
     return uint2(tc % 4096, tc / 4096);
 }
 
-attr_desc fetch_desc(thread const int& location, constant VertexBuffer& v_227)
+inline attr_desc fetch_desc(thread const int& location, constant VertexBuffer& v_227)
 {
     int attribute_flags = v_227.input_attributes[location].w;
     attr_desc result;
@@ -55,7 +55,7 @@ attr_desc fetch_desc(thread const int& location, constant VertexBuffer& v_227)
     return result;
 }
 
-uint get_bits(thread const uint4& v, thread const int& swap)
+inline uint get_bits(thread const uint4& v, thread const int& swap)
 {
     if (swap != 0)
     {
@@ -64,7 +64,7 @@ uint get_bits(thread const uint4& v, thread const int& swap)
     return ((v.x | (v.y << uint(8))) | (v.z << uint(16))) | (v.w << uint(24));
 }
 
-float4 fetch_attr(thread const attr_desc& desc, thread const int& vertex_id, thread const texture2d<uint> input_stream)
+inline float4 fetch_attr(thread const attr_desc& desc, thread const int& vertex_id, thread const texture2d<uint> input_stream)
 {
     float4 result = float4(0.0, 0.0, 0.0, 1.0);
     bool reverse_order = false;
@@ -132,7 +132,7 @@ float4 fetch_attr(thread const attr_desc& desc, thread const int& vertex_id, thr
     return _210;
 }
 
-float4 read_location(thread const int& location, constant VertexBuffer& v_227, thread uint& gl_VertexIndex, thread texture2d<uint> buff_in_2, thread texture2d<uint> buff_in_1)
+inline float4 read_location(thread const int& location, constant VertexBuffer& v_227, thread uint& gl_VertexIndex, thread texture2d<uint> buff_in_2, thread texture2d<uint> buff_in_1)
 {
     int param = location;
     attr_desc desc = fetch_desc(param, v_227);
@@ -151,7 +151,7 @@ float4 read_location(thread const int& location, constant VertexBuffer& v_227, t
     }
 }
 
-void vs_adjust(thread float4& dst_reg0, thread float4& dst_reg1, thread float4& dst_reg7, constant VertexBuffer& v_227, thread uint& gl_VertexIndex, thread texture2d<uint> buff_in_2, thread texture2d<uint> buff_in_1, constant VertexConstantsBuffer& v_309)
+inline void vs_adjust(thread float4& dst_reg0, thread float4& dst_reg1, thread float4& dst_reg7, constant VertexBuffer& v_227, thread uint& gl_VertexIndex, thread texture2d<uint> buff_in_2, thread texture2d<uint> buff_in_1, constant VertexConstantsBuffer& v_309)
 {
     int param = 3;
     float4 in_diff_color = read_location(param, v_227, gl_VertexIndex, buff_in_2, buff_in_1);

--- a/reference/shaders-msl-no-opt/vert/pass-array-by-value.vert
+++ b/reference/shaders-msl-no-opt/vert/pass-array-by-value.vert
@@ -19,7 +19,7 @@ struct main0_in
 };
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -28,7 +28,7 @@ void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -37,7 +37,7 @@ void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T 
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -46,7 +46,7 @@ void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -55,7 +55,7 @@ void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -64,7 +64,7 @@ void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -72,7 +72,7 @@ void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgr
     }
 }
 
-float4 consume_constant_arrays2(thread const float4 (&positions)[4], thread const float4 (&positions2)[4], thread int& Index1, thread int& Index2)
+inline float4 consume_constant_arrays2(thread const float4 (&positions)[4], thread const float4 (&positions2)[4], thread int& Index1, thread int& Index2)
 {
     float4 indexable[4];
     spvArrayCopyFromStackToStack1(indexable, positions);
@@ -81,7 +81,7 @@ float4 consume_constant_arrays2(thread const float4 (&positions)[4], thread cons
     return indexable[Index1] + indexable_1[Index2];
 }
 
-float4 consume_constant_arrays(thread const float4 (&positions)[4], thread const float4 (&positions2)[4], thread int& Index1, thread int& Index2)
+inline float4 consume_constant_arrays(thread const float4 (&positions)[4], thread const float4 (&positions2)[4], thread int& Index1, thread int& Index2)
 {
     return consume_constant_arrays2(positions, positions2, Index1, Index2);
 }

--- a/reference/shaders-msl-no-opt/vulkan/frag/texture-access-function.swizzle.vk.frag
+++ b/reference/shaders-msl-no-opt/vulkan/frag/texture-access-function.swizzle.vk.frag
@@ -11,7 +11,7 @@ struct main0_out
 };
 
 // Returns 2D texture coords corresponding to 1D texel buffer coords
-uint2 spvTexelBufferCoord(uint tc)
+inline uint2 spvTexelBufferCoord(uint tc)
 {
     return uint2(tc % 4096, tc / 4096);
 }
@@ -136,7 +136,7 @@ inline vec<T, 4> spvGatherCompareSwizzle(sampler s, const thread Tex& t, Ts... p
     return t.gather_compare(s, spvForward<Ts>(params)...);
 }
 
-float4 do_samples(thread const texture1d<float> t1, thread const sampler t1Smplr, constant uint& t1Swzl, thread const texture2d<float> t2, constant uint& t2Swzl, thread const texture3d<float> t3, thread const sampler t3Smplr, constant uint& t3Swzl, thread const texturecube<float> tc, constant uint& tcSwzl, thread const texture2d_array<float> t2a, thread const sampler t2aSmplr, constant uint& t2aSwzl, thread const texturecube_array<float> tca, thread const sampler tcaSmplr, constant uint& tcaSwzl, thread const texture2d<float> tb, thread const depth2d<float> d2, thread const sampler d2Smplr, constant uint& d2Swzl, thread const depthcube<float> dc, thread const sampler dcSmplr, constant uint& dcSwzl, thread const depth2d_array<float> d2a, constant uint& d2aSwzl, thread const depthcube_array<float> dca, thread const sampler dcaSmplr, constant uint& dcaSwzl, thread sampler defaultSampler, thread sampler shadowSampler)
+inline float4 do_samples(thread const texture1d<float> t1, thread const sampler t1Smplr, constant uint& t1Swzl, thread const texture2d<float> t2, constant uint& t2Swzl, thread const texture3d<float> t3, thread const sampler t3Smplr, constant uint& t3Swzl, thread const texturecube<float> tc, constant uint& tcSwzl, thread const texture2d_array<float> t2a, thread const sampler t2aSmplr, constant uint& t2aSwzl, thread const texturecube_array<float> tca, thread const sampler tcaSmplr, constant uint& tcaSwzl, thread const texture2d<float> tb, thread const depth2d<float> d2, thread const sampler d2Smplr, constant uint& d2Swzl, thread const depthcube<float> dc, thread const sampler dcSmplr, constant uint& dcSwzl, thread const depth2d_array<float> d2a, constant uint& d2aSwzl, thread const depthcube_array<float> dca, thread const sampler dcaSmplr, constant uint& dcaSwzl, thread sampler defaultSampler, thread sampler shadowSampler)
 {
     float4 c = spvTextureSwizzle(t1.sample(t1Smplr, 0.0), t1Swzl);
     c = spvTextureSwizzle(t2.sample(defaultSampler, float2(0.0)), t2Swzl);

--- a/reference/shaders-msl/asm/comp/atomic-decrement.asm.comp
+++ b/reference/shaders-msl/asm/comp/atomic-decrement.asm.comp
@@ -13,7 +13,7 @@ struct u0_counters
 };
 
 // Returns 2D texture coords corresponding to 1D texel buffer coords
-uint2 spvTexelBufferCoord(uint tc)
+inline uint2 spvTexelBufferCoord(uint tc)
 {
     return uint2(tc % 4096, tc / 4096);
 }

--- a/reference/shaders-msl/asm/comp/atomic-increment.asm.comp
+++ b/reference/shaders-msl/asm/comp/atomic-increment.asm.comp
@@ -13,7 +13,7 @@ struct u0_counters
 };
 
 // Returns 2D texture coords corresponding to 1D texel buffer coords
-uint2 spvTexelBufferCoord(uint tc)
+inline uint2 spvTexelBufferCoord(uint tc)
 {
     return uint2(tc % 4096, tc / 4096);
 }

--- a/reference/shaders-msl/asm/comp/buffer-write-relative-addr.asm.comp
+++ b/reference/shaders-msl/asm/comp/buffer-write-relative-addr.asm.comp
@@ -11,7 +11,7 @@ struct cb5_struct
 };
 
 // Returns 2D texture coords corresponding to 1D texel buffer coords
-uint2 spvTexelBufferCoord(uint tc)
+inline uint2 spvTexelBufferCoord(uint tc)
 {
     return uint2(tc % 4096, tc / 4096);
 }

--- a/reference/shaders-msl/asm/comp/buffer-write.asm.comp
+++ b/reference/shaders-msl/asm/comp/buffer-write.asm.comp
@@ -11,7 +11,7 @@ struct cb
 };
 
 // Returns 2D texture coords corresponding to 1D texel buffer coords
-uint2 spvTexelBufferCoord(uint tc)
+inline uint2 spvTexelBufferCoord(uint tc)
 {
     return uint2(tc % 4096, tc / 4096);
 }

--- a/reference/shaders-msl/asm/comp/global-parameter-name-alias.asm.comp
+++ b/reference/shaders-msl/asm/comp/global-parameter-name-alias.asm.comp
@@ -10,13 +10,13 @@ struct ssbo
     uint _data[1];
 };
 
-void Load(thread const uint& size, const device ssbo& ssbo_1)
+inline void Load(thread const uint& size, const device ssbo& ssbo_1)
 {
     int byteAddrTemp = int(size >> uint(2));
     uint4 data = uint4(ssbo_1._data[byteAddrTemp], ssbo_1._data[byteAddrTemp + 1], ssbo_1._data[byteAddrTemp + 2], ssbo_1._data[byteAddrTemp + 3]);
 }
 
-void _main(thread const uint3& id, const device ssbo& ssbo_1)
+inline void _main(thread const uint3& id, const device ssbo& ssbo_1)
 {
     uint param = 4u;
     Load(param, ssbo_1);

--- a/reference/shaders-msl/asm/comp/image-load-store-short-vector.asm.comp
+++ b/reference/shaders-msl/asm/comp/image-load-store-short-vector.asm.comp
@@ -5,7 +5,7 @@
 
 using namespace metal;
 
-void _main(thread const uint3& id, thread texture2d<float, access::read_write> TargetTexture)
+inline void _main(thread const uint3& id, thread texture2d<float, access::read_write> TargetTexture)
 {
     float2 loaded = TargetTexture.read(uint2(id.xy)).xy;
     float2 storeTemp = loaded + float2(1.0);

--- a/reference/shaders-msl/asm/comp/struct-resource-name-aliasing.asm.comp
+++ b/reference/shaders-msl/asm/comp/struct-resource-name-aliasing.asm.comp
@@ -10,7 +10,7 @@ struct bufA
     uint _data[1];
 };
 
-void _main(device bufA& bufA_1, device bufA& bufB)
+inline void _main(device bufA& bufA_1, device bufA& bufB)
 {
     bufA_1._data[0] = 0u;
     bufB._data[0] = 0u;

--- a/reference/shaders-msl/asm/comp/variable-pointers-2.asm.comp
+++ b/reference/shaders-msl/asm/comp/variable-pointers-2.asm.comp
@@ -17,12 +17,12 @@ struct bar
     int d;
 };
 
-device foo* select_buffer(device foo& a, constant bar& cb)
+inline device foo* select_buffer(device foo& a, constant bar& cb)
 {
     return (cb.d != 0) ? &a : nullptr;
 }
 
-thread uint3* select_input(thread uint3& gl_GlobalInvocationID, thread uint3& gl_LocalInvocationID, constant bar& cb)
+inline thread uint3* select_input(thread uint3& gl_GlobalInvocationID, thread uint3& gl_LocalInvocationID, constant bar& cb)
 {
     return (cb.d != 0) ? &gl_GlobalInvocationID : &gl_LocalInvocationID;
 }

--- a/reference/shaders-msl/asm/comp/variable-pointers-store-forwarding.asm.comp
+++ b/reference/shaders-msl/asm/comp/variable-pointers-store-forwarding.asm.comp
@@ -15,7 +15,7 @@ struct bar
     int b;
 };
 
-device int* _24(device foo& a, device bar& b, thread uint3& gl_GlobalInvocationID)
+inline device int* _24(device foo& a, device bar& b, thread uint3& gl_GlobalInvocationID)
 {
     return (gl_GlobalInvocationID.x != 0u) ? &a.a : &b.b;
 }

--- a/reference/shaders-msl/asm/comp/vector-builtin-type-cast-func.asm.comp
+++ b/reference/shaders-msl/asm/comp/vector-builtin-type-cast-func.asm.comp
@@ -12,7 +12,7 @@ struct cb1_struct
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(16u, 16u, 1u);
 
-int2 get_texcoord(thread const int2& base, thread const int2& index, thread uint3& gl_LocalInvocationID)
+inline int2 get_texcoord(thread const int2& base, thread const int2& index, thread uint3& gl_LocalInvocationID)
 {
     return (base * int3(gl_LocalInvocationID).xy) + index;
 }

--- a/reference/shaders-msl/asm/frag/empty-struct.asm.frag
+++ b/reference/shaders-msl/asm/frag/empty-struct.asm.frag
@@ -10,12 +10,12 @@ struct EmptyStructTest
     int empty_struct_member;
 };
 
-float GetValue(thread const EmptyStructTest& self)
+inline float GetValue(thread const EmptyStructTest& self)
 {
     return 0.0;
 }
 
-float GetValue_1(EmptyStructTest self)
+inline float GetValue_1(EmptyStructTest self)
 {
     return 0.0;
 }

--- a/reference/shaders-msl/asm/frag/extract-packed-from-composite.asm.frag
+++ b/reference/shaders-msl/asm/frag/extract-packed-from-composite.asm.frag
@@ -28,7 +28,7 @@ struct main0_out
     float4 _entryPointOutput [[color(0)]];
 };
 
-float4 _main(thread const float4& pos, constant buf& v_11)
+inline float4 _main(thread const float4& pos, constant buf& v_11)
 {
     int _46 = int(pos.x) % 16;
     Foo foo;

--- a/reference/shaders-msl/asm/frag/function-overload-alias.asm.frag
+++ b/reference/shaders-msl/asm/frag/function-overload-alias.asm.frag
@@ -10,22 +10,22 @@ struct main0_out
     float4 FragColor [[color(0)]];
 };
 
-float4 foo(thread const float4& foo_1)
+inline float4 foo(thread const float4& foo_1)
 {
     return foo_1 + float4(1.0);
 }
 
-float4 foo(thread const float3& foo_1)
+inline float4 foo(thread const float3& foo_1)
 {
     return foo_1.xyzz + float4(1.0);
 }
 
-float4 foo_1(thread const float4& foo_2)
+inline float4 foo_1(thread const float4& foo_2)
 {
     return foo_2 + float4(2.0);
 }
 
-float4 foo(thread const float2& foo_2)
+inline float4 foo(thread const float2& foo_2)
 {
     return foo_2.xyxy + float4(2.0);
 }

--- a/reference/shaders-msl/asm/frag/line-directive.line.asm.frag
+++ b/reference/shaders-msl/asm/frag/line-directive.line.asm.frag
@@ -16,7 +16,7 @@ struct main0_in
 };
 
 #line 6 "test.frag"
-void func(thread float& FragColor, thread float& vColor)
+inline void func(thread float& FragColor, thread float& vColor)
 {
 #line 8 "test.frag"
     FragColor = 1.0;

--- a/reference/shaders-msl/asm/frag/lut-promotion-initializer.asm.frag
+++ b/reference/shaders-msl/asm/frag/lut-promotion-initializer.asm.frag
@@ -20,7 +20,7 @@ struct main0_in
 };
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -29,7 +29,7 @@ void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -38,7 +38,7 @@ void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T 
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -47,7 +47,7 @@ void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -56,7 +56,7 @@ void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -65,7 +65,7 @@ void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {

--- a/reference/shaders-msl/asm/frag/pass-by-value.asm.frag
+++ b/reference/shaders-msl/asm/frag/pass-by-value.asm.frag
@@ -15,7 +15,7 @@ struct main0_out
     float FragColor [[color(0)]];
 };
 
-float add_value(float v, float w)
+inline float add_value(float v, float w)
 {
     return v + w;
 }

--- a/reference/shaders-msl/asm/frag/single-function-private-lut.asm.frag
+++ b/reference/shaders-msl/asm/frag/single-function-private-lut.asm.frag
@@ -19,13 +19,13 @@ struct main0_out
 
 // Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
-Tx mod(Tx x, Ty y)
+inline Tx mod(Tx x, Ty y)
 {
     return x - y * floor(x / y);
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -34,7 +34,7 @@ void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -43,7 +43,7 @@ void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T 
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -52,7 +52,7 @@ void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -61,7 +61,7 @@ void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -70,7 +70,7 @@ void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {

--- a/reference/shaders-msl/asm/frag/unknown-depth-state.asm.frag
+++ b/reference/shaders-msl/asm/frag/unknown-depth-state.asm.frag
@@ -15,12 +15,12 @@ struct main0_in
     float3 vUV [[user(locn0)]];
 };
 
-float sample_combined(thread float3& vUV, thread depth2d<float> uShadow, thread const sampler uShadowSmplr)
+inline float sample_combined(thread float3& vUV, thread depth2d<float> uShadow, thread const sampler uShadowSmplr)
 {
     return uShadow.sample_compare(uShadowSmplr, vUV.xy, vUV.z);
 }
 
-float sample_separate(thread float3& vUV, thread depth2d<float> uTexture, thread sampler uSampler)
+inline float sample_separate(thread float3& vUV, thread depth2d<float> uTexture, thread sampler uSampler)
 {
     return uTexture.sample_compare(uSampler, vUV.xy, vUV.z);
 }

--- a/reference/shaders-msl/asm/tesc/tess-fixed-input-array-builtin-array.invalid.asm.tesc
+++ b/reference/shaders-msl/asm/tesc/tess-fixed-input-array-builtin-array.invalid.asm.tesc
@@ -46,7 +46,7 @@ struct main0_in
 };
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -55,7 +55,7 @@ void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -64,7 +64,7 @@ void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T 
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -73,7 +73,7 @@ void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -82,7 +82,7 @@ void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -91,7 +91,7 @@ void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -99,7 +99,7 @@ void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgr
     }
 }
 
-HSOut _hs_main(thread const VertexOutput (&p)[3], thread const uint& i)
+inline HSOut _hs_main(thread const VertexOutput (&p)[3], thread const uint& i)
 {
     HSOut _output;
     _output.pos = p[i].pos;
@@ -107,7 +107,7 @@ HSOut _hs_main(thread const VertexOutput (&p)[3], thread const uint& i)
     return _output;
 }
 
-HSConstantOut PatchHS(thread const VertexOutput (&_patch)[3])
+inline HSConstantOut PatchHS(thread const VertexOutput (&_patch)[3])
 {
     HSConstantOut _output;
     _output.EdgeTess[0] = (float2(1.0) + _patch[0].uv).x;

--- a/reference/shaders-msl/asm/vert/extract-transposed-matrix-from-struct.asm.vert
+++ b/reference/shaders-msl/asm/vert/extract-transposed-matrix-from-struct.asm.vert
@@ -39,7 +39,7 @@ struct main0_in
     float3 PosL [[attribute(0)]];
 };
 
-V2F _VS(thread const float3& PosL, thread const uint& instanceID, const device gInstanceData& gInstanceData_1)
+inline V2F _VS(thread const float3& PosL, thread const uint& instanceID, const device gInstanceData& gInstanceData_1)
 {
     InstanceData instData;
     instData.MATRIX_MVP = transpose(gInstanceData_1._data[instanceID].MATRIX_MVP);

--- a/reference/shaders-msl/asm/vert/invariant.msl21.asm.vert
+++ b/reference/shaders-msl/asm/vert/invariant.msl21.asm.vert
@@ -10,7 +10,7 @@ struct main0_out
     float4 gl_Position [[position, invariant]];
 };
 
-float4 _main()
+inline float4 _main()
 {
     return float4(1.0);
 }

--- a/reference/shaders-msl/asm/vert/uint-vertex-id-instance-id.asm.vert
+++ b/reference/shaders-msl/asm/vert/uint-vertex-id-instance-id.asm.vert
@@ -10,7 +10,7 @@ struct main0_out
     float4 gl_Position [[position]];
 };
 
-float4 _main(thread const uint& vid, thread const uint& iid)
+inline float4 _main(thread const uint& vid, thread const uint& iid)
 {
     return float4(float(vid + iid));
 }

--- a/reference/shaders-msl/comp/access-private-workgroup-in-function.comp
+++ b/reference/shaders-msl/comp/access-private-workgroup-in-function.comp
@@ -5,12 +5,12 @@
 
 using namespace metal;
 
-void set_f(thread int& f)
+inline void set_f(thread int& f)
 {
     f = 40;
 }
 
-void set_shared_u(threadgroup int& u)
+inline void set_shared_u(threadgroup int& u)
 {
     u = 50;
 }

--- a/reference/shaders-msl/comp/array-length.comp
+++ b/reference/shaders-msl/comp/array-length.comp
@@ -16,7 +16,7 @@ struct SSBO1
     float bz[1];
 };
 
-uint get_size(device SSBO& v_14, constant uint& v_14BufferSize, device SSBO1* (&ssbos)[2], constant uint* ssbosBufferSize)
+inline uint get_size(device SSBO& v_14, constant uint& v_14BufferSize, device SSBO1* (&ssbos)[2], constant uint* ssbosBufferSize)
 {
     return uint(int((v_14BufferSize - 16) / 16) + int((ssbosBufferSize[1] - 0) / 4));
 }

--- a/reference/shaders-msl/comp/array-length.msl2.argument.discrete.comp
+++ b/reference/shaders-msl/comp/array-length.msl2.argument.discrete.comp
@@ -39,7 +39,7 @@ struct spvDescriptorSetBuffer1
     constant uint* spvBufferSizeConstants [[id(2)]];
 };
 
-uint get_size(device SSBO& v_16, constant uint& v_16BufferSize, device SSBO1* constant (&ssbos)[2], constant uint* ssbosBufferSize, device SSBO2& v_38, constant uint& v_38BufferSize, device SSBO3* (&ssbos2)[2], constant uint* ssbos2BufferSize)
+inline uint get_size(device SSBO& v_16, constant uint& v_16BufferSize, device SSBO1* constant (&ssbos)[2], constant uint* ssbosBufferSize, device SSBO2& v_38, constant uint& v_38BufferSize, device SSBO3* (&ssbos2)[2], constant uint* ssbos2BufferSize)
 {
     uint len = uint(int((v_16BufferSize - 16) / 16));
     len += uint(int((ssbosBufferSize[1] - 0) / 4));

--- a/reference/shaders-msl/comp/barriers.comp
+++ b/reference/shaders-msl/comp/barriers.comp
@@ -7,57 +7,57 @@ using namespace metal;
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(4u, 1u, 1u);
 
-void barrier_shared()
+inline void barrier_shared()
 {
     threadgroup_barrier(mem_flags::mem_threadgroup);
 }
 
-void full_barrier()
+inline void full_barrier()
 {
     threadgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup | mem_flags::mem_texture);
 }
 
-void image_barrier()
+inline void image_barrier()
 {
     threadgroup_barrier(mem_flags::mem_texture);
 }
 
-void buffer_barrier()
+inline void buffer_barrier()
 {
     threadgroup_barrier(mem_flags::mem_device);
 }
 
-void group_barrier()
+inline void group_barrier()
 {
     threadgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup | mem_flags::mem_texture);
 }
 
-void barrier_shared_exec()
+inline void barrier_shared_exec()
 {
     threadgroup_barrier(mem_flags::mem_threadgroup);
 }
 
-void full_barrier_exec()
+inline void full_barrier_exec()
 {
     threadgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup | mem_flags::mem_texture);
 }
 
-void image_barrier_exec()
+inline void image_barrier_exec()
 {
     threadgroup_barrier(mem_flags::mem_texture);
 }
 
-void buffer_barrier_exec()
+inline void buffer_barrier_exec()
 {
     threadgroup_barrier(mem_flags::mem_device);
 }
 
-void group_barrier_exec()
+inline void group_barrier_exec()
 {
     threadgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup | mem_flags::mem_texture);
 }
 
-void exec_barrier()
+inline void exec_barrier()
 {
     threadgroup_barrier(mem_flags::mem_threadgroup);
 }

--- a/reference/shaders-msl/comp/cfg-preserve-parameter.comp
+++ b/reference/shaders-msl/comp/cfg-preserve-parameter.comp
@@ -5,7 +5,7 @@
 
 using namespace metal;
 
-void out_test_0(thread const int& cond, thread int& i)
+inline void out_test_0(thread const int& cond, thread int& i)
 {
     if (cond == 0)
     {
@@ -17,7 +17,7 @@ void out_test_0(thread const int& cond, thread int& i)
     }
 }
 
-void out_test_1(thread const int& cond, thread int& i)
+inline void out_test_1(thread const int& cond, thread int& i)
 {
     switch (cond)
     {
@@ -34,7 +34,7 @@ void out_test_1(thread const int& cond, thread int& i)
     }
 }
 
-void inout_test_0(thread const int& cond, thread int& i)
+inline void inout_test_0(thread const int& cond, thread int& i)
 {
     if (cond == 0)
     {
@@ -42,7 +42,7 @@ void inout_test_0(thread const int& cond, thread int& i)
     }
 }
 
-void inout_test_1(thread const int& cond, thread int& i)
+inline void inout_test_1(thread const int& cond, thread int& i)
 {
     switch (cond)
     {

--- a/reference/shaders-msl/comp/complex-type-alias.comp
+++ b/reference/shaders-msl/comp/complex-type-alias.comp
@@ -44,7 +44,7 @@ struct SSBO
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(8u, 8u, 1u);
 
-void Zero(thread Foo0& v)
+inline void Zero(thread Foo0& v)
 {
     v.a = 0.0;
 }

--- a/reference/shaders-msl/comp/composite-array-initialization.comp
+++ b/reference/shaders-msl/comp/composite-array-initialization.comp
@@ -30,7 +30,7 @@ constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(2u, 1u, 1u);
 constant Data _25[2] = { Data{ 1.0, 2.0 }, Data{ 3.0, 4.0 } };
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -39,7 +39,7 @@ void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -48,7 +48,7 @@ void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T 
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -57,7 +57,7 @@ void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -66,7 +66,7 @@ void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -75,7 +75,7 @@ void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -83,7 +83,7 @@ void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgr
     }
 }
 
-Data combine(thread const Data& a, thread const Data& b)
+inline Data combine(thread const Data& a, thread const Data& b)
 {
     return Data{ a.a + b.a, a.b + b.b };
 }

--- a/reference/shaders-msl/comp/composite-construct.comp
+++ b/reference/shaders-msl/comp/composite-construct.comp
@@ -24,7 +24,7 @@ struct Composite
 constant float4 _43[2] = { float4(20.0), float4(40.0) };
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -33,7 +33,7 @@ void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -42,7 +42,7 @@ void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T 
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -51,7 +51,7 @@ void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -60,7 +60,7 @@ void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -69,7 +69,7 @@ void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {

--- a/reference/shaders-msl/comp/copy-array-of-arrays.comp
+++ b/reference/shaders-msl/comp/copy-array-of-arrays.comp
@@ -18,7 +18,7 @@ constant float _20[2][2] = { { 1.0, 2.0 }, { 3.0, 4.0 } };
 constant float _21[2][2][2] = { { { 1.0, 2.0 }, { 3.0, 4.0 } }, { { 1.0, 2.0 }, { 3.0, 4.0 } } };
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -27,7 +27,7 @@ void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -36,7 +36,7 @@ void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T 
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -45,7 +45,7 @@ void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -54,7 +54,7 @@ void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -63,7 +63,7 @@ void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -72,7 +72,7 @@ void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgr
 }
 
 template<typename T, uint A, uint B>
-void spvArrayCopyFromConstantToStack2(thread T (&dst)[A][B], constant T (&src)[A][B])
+inline void spvArrayCopyFromConstantToStack2(thread T (&dst)[A][B], constant T (&src)[A][B])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -81,7 +81,7 @@ void spvArrayCopyFromConstantToStack2(thread T (&dst)[A][B], constant T (&src)[A
 }
 
 template<typename T, uint A, uint B>
-void spvArrayCopyFromConstantToThreadGroup2(threadgroup T (&dst)[A][B], constant T (&src)[A][B])
+inline void spvArrayCopyFromConstantToThreadGroup2(threadgroup T (&dst)[A][B], constant T (&src)[A][B])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -90,7 +90,7 @@ void spvArrayCopyFromConstantToThreadGroup2(threadgroup T (&dst)[A][B], constant
 }
 
 template<typename T, uint A, uint B>
-void spvArrayCopyFromStackToStack2(thread T (&dst)[A][B], thread const T (&src)[A][B])
+inline void spvArrayCopyFromStackToStack2(thread T (&dst)[A][B], thread const T (&src)[A][B])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -99,7 +99,7 @@ void spvArrayCopyFromStackToStack2(thread T (&dst)[A][B], thread const T (&src)[
 }
 
 template<typename T, uint A, uint B>
-void spvArrayCopyFromStackToThreadGroup2(threadgroup T (&dst)[A][B], thread const T (&src)[A][B])
+inline void spvArrayCopyFromStackToThreadGroup2(threadgroup T (&dst)[A][B], thread const T (&src)[A][B])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -108,7 +108,7 @@ void spvArrayCopyFromStackToThreadGroup2(threadgroup T (&dst)[A][B], thread cons
 }
 
 template<typename T, uint A, uint B>
-void spvArrayCopyFromThreadGroupToStack2(thread T (&dst)[A][B], threadgroup const T (&src)[A][B])
+inline void spvArrayCopyFromThreadGroupToStack2(thread T (&dst)[A][B], threadgroup const T (&src)[A][B])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -117,7 +117,7 @@ void spvArrayCopyFromThreadGroupToStack2(thread T (&dst)[A][B], threadgroup cons
 }
 
 template<typename T, uint A, uint B>
-void spvArrayCopyFromThreadGroupToThreadGroup2(threadgroup T (&dst)[A][B], threadgroup const T (&src)[A][B])
+inline void spvArrayCopyFromThreadGroupToThreadGroup2(threadgroup T (&dst)[A][B], threadgroup const T (&src)[A][B])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -126,7 +126,7 @@ void spvArrayCopyFromThreadGroupToThreadGroup2(threadgroup T (&dst)[A][B], threa
 }
 
 template<typename T, uint A, uint B, uint C>
-void spvArrayCopyFromConstantToStack3(thread T (&dst)[A][B][C], constant T (&src)[A][B][C])
+inline void spvArrayCopyFromConstantToStack3(thread T (&dst)[A][B][C], constant T (&src)[A][B][C])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -135,7 +135,7 @@ void spvArrayCopyFromConstantToStack3(thread T (&dst)[A][B][C], constant T (&src
 }
 
 template<typename T, uint A, uint B, uint C>
-void spvArrayCopyFromConstantToThreadGroup3(threadgroup T (&dst)[A][B][C], constant T (&src)[A][B][C])
+inline void spvArrayCopyFromConstantToThreadGroup3(threadgroup T (&dst)[A][B][C], constant T (&src)[A][B][C])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -144,7 +144,7 @@ void spvArrayCopyFromConstantToThreadGroup3(threadgroup T (&dst)[A][B][C], const
 }
 
 template<typename T, uint A, uint B, uint C>
-void spvArrayCopyFromStackToStack3(thread T (&dst)[A][B][C], thread const T (&src)[A][B][C])
+inline void spvArrayCopyFromStackToStack3(thread T (&dst)[A][B][C], thread const T (&src)[A][B][C])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -153,7 +153,7 @@ void spvArrayCopyFromStackToStack3(thread T (&dst)[A][B][C], thread const T (&sr
 }
 
 template<typename T, uint A, uint B, uint C>
-void spvArrayCopyFromStackToThreadGroup3(threadgroup T (&dst)[A][B][C], thread const T (&src)[A][B][C])
+inline void spvArrayCopyFromStackToThreadGroup3(threadgroup T (&dst)[A][B][C], thread const T (&src)[A][B][C])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -162,7 +162,7 @@ void spvArrayCopyFromStackToThreadGroup3(threadgroup T (&dst)[A][B][C], thread c
 }
 
 template<typename T, uint A, uint B, uint C>
-void spvArrayCopyFromThreadGroupToStack3(thread T (&dst)[A][B][C], threadgroup const T (&src)[A][B][C])
+inline void spvArrayCopyFromThreadGroupToStack3(thread T (&dst)[A][B][C], threadgroup const T (&src)[A][B][C])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -171,7 +171,7 @@ void spvArrayCopyFromThreadGroupToStack3(thread T (&dst)[A][B][C], threadgroup c
 }
 
 template<typename T, uint A, uint B, uint C>
-void spvArrayCopyFromThreadGroupToThreadGroup3(threadgroup T (&dst)[A][B][C], threadgroup const T (&src)[A][B][C])
+inline void spvArrayCopyFromThreadGroupToThreadGroup3(threadgroup T (&dst)[A][B][C], threadgroup const T (&src)[A][B][C])
 {
     for (uint i = 0; i < A; i++)
     {

--- a/reference/shaders-msl/comp/functions.comp
+++ b/reference/shaders-msl/comp/functions.comp
@@ -5,7 +5,7 @@
 
 using namespace metal;
 
-void myfunc(threadgroup int (&foo)[1337])
+inline void myfunc(threadgroup int (&foo)[1337])
 {
     foo[0] = 13;
 }

--- a/reference/shaders-msl/comp/global-invocation-id-writable-ssbo-in-function.comp
+++ b/reference/shaders-msl/comp/global-invocation-id-writable-ssbo-in-function.comp
@@ -13,12 +13,12 @@ struct myBlock
 
 // Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
-Tx mod(Tx x, Ty y)
+inline Tx mod(Tx x, Ty y)
 {
     return x - y * floor(x / y);
 }
 
-float getB(device myBlock& myStorage, thread uint3& gl_GlobalInvocationID)
+inline float getB(device myBlock& myStorage, thread uint3& gl_GlobalInvocationID)
 {
     return myStorage.b[gl_GlobalInvocationID.x];
 }

--- a/reference/shaders-msl/comp/global-invocation-id.comp
+++ b/reference/shaders-msl/comp/global-invocation-id.comp
@@ -13,7 +13,7 @@ struct myBlock
 
 // Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
-Tx mod(Tx x, Ty y)
+inline Tx mod(Tx x, Ty y)
 {
     return x - y * floor(x / y);
 }

--- a/reference/shaders-msl/comp/inverse.comp
+++ b/reference/shaders-msl/comp/inverse.comp
@@ -33,7 +33,7 @@ inline float spvDet3x3(float a1, float a2, float a3, float b1, float b2, float b
 
 // Returns the inverse of a matrix, by using the algorithm of calculating the classical
 // adjoint and dividing by the determinant. The contents of the matrix are changed.
-float4x4 spvInverse4x4(float4x4 m)
+inline float4x4 spvInverse4x4(float4x4 m)
 {
     float4x4 adj;	// The adjoint matrix (inverse after dividing by determinant)
 
@@ -68,7 +68,7 @@ float4x4 spvInverse4x4(float4x4 m)
 
 // Returns the inverse of a matrix, by using the algorithm of calculating the classical
 // adjoint and dividing by the determinant. The contents of the matrix are changed.
-float3x3 spvInverse3x3(float3x3 m)
+inline float3x3 spvInverse3x3(float3x3 m)
 {
     float3x3 adj;	// The adjoint matrix (inverse after dividing by determinant)
 
@@ -95,7 +95,7 @@ float3x3 spvInverse3x3(float3x3 m)
 
 // Returns the inverse of a matrix, by using the algorithm of calculating the classical
 // adjoint and dividing by the determinant. The contents of the matrix are changed.
-float2x2 spvInverse2x2(float2x2 m)
+inline float2x2 spvInverse2x2(float2x2 m)
 {
     float2x2 adj;	// The adjoint matrix (inverse after dividing by determinant)
 

--- a/reference/shaders-msl/comp/local-invocation-id.comp
+++ b/reference/shaders-msl/comp/local-invocation-id.comp
@@ -13,7 +13,7 @@ struct myBlock
 
 // Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
-Tx mod(Tx x, Ty y)
+inline Tx mod(Tx x, Ty y)
 {
     return x - y * floor(x / y);
 }

--- a/reference/shaders-msl/comp/local-invocation-index.comp
+++ b/reference/shaders-msl/comp/local-invocation-index.comp
@@ -13,7 +13,7 @@ struct myBlock
 
 // Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
-Tx mod(Tx x, Ty y)
+inline Tx mod(Tx x, Ty y)
 {
     return x - y * floor(x / y);
 }

--- a/reference/shaders-msl/comp/mod.comp
+++ b/reference/shaders-msl/comp/mod.comp
@@ -17,7 +17,7 @@ struct SSBO2
 
 // Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
-Tx mod(Tx x, Ty y)
+inline Tx mod(Tx x, Ty y)
 {
     return x - y * floor(x / y);
 }

--- a/reference/shaders-msl/comp/shared-array-of-arrays.comp
+++ b/reference/shaders-msl/comp/shared-array-of-arrays.comp
@@ -12,7 +12,7 @@ struct SSBO
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(4u, 4u, 1u);
 
-void work(threadgroup float (&foo)[4][4], thread uint3& gl_LocalInvocationID, thread uint& gl_LocalInvocationIndex, device SSBO& v_67, thread uint3& gl_GlobalInvocationID)
+inline void work(threadgroup float (&foo)[4][4], thread uint3& gl_LocalInvocationID, thread uint& gl_LocalInvocationIndex, device SSBO& v_67, thread uint3& gl_GlobalInvocationID)
 {
     foo[gl_LocalInvocationID.x][gl_LocalInvocationID.y] = float(gl_LocalInvocationIndex);
     threadgroup_barrier(mem_flags::mem_threadgroup);

--- a/reference/shaders-msl/comp/type-alias.comp
+++ b/reference/shaders-msl/comp/type-alias.comp
@@ -40,12 +40,12 @@ struct SSBO2
     float4 outputs[1];
 };
 
-float4 overload(thread const S0& s0)
+inline float4 overload(thread const S0& s0)
 {
     return s0.a;
 }
 
-float4 overload(thread const S1& s1)
+inline float4 overload(thread const S1& s1)
 {
     return s1.a;
 }

--- a/reference/shaders-msl/comp/writable-ssbo.comp
+++ b/reference/shaders-msl/comp/writable-ssbo.comp
@@ -13,7 +13,7 @@ struct myBlock
 
 // Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
-Tx mod(Tx x, Ty y)
+inline Tx mod(Tx x, Ty y)
 {
     return x - y * floor(x / y);
 }

--- a/reference/shaders-msl/desktop-only/tesc/basic.desktop.sso.tesc
+++ b/reference/shaders-msl/desktop-only/tesc/basic.desktop.sso.tesc
@@ -20,7 +20,7 @@ struct main0_in
     float4 gl_Position [[attribute(0)]];
 };
 
-void set_position(device main0_out* thread & gl_out, thread uint& gl_InvocationID, threadgroup main0_in* thread & gl_in)
+inline void set_position(device main0_out* thread & gl_out, thread uint& gl_InvocationID, threadgroup main0_in* thread & gl_in)
 {
     gl_out[gl_InvocationID].gl_Position = gl_in[0].gl_Position + gl_in[1].gl_Position;
 }

--- a/reference/shaders-msl/frag/argument-buffers.msl2.argument.frag
+++ b/reference/shaders-msl/frag/argument-buffers.msl2.argument.frag
@@ -62,7 +62,7 @@ struct main0_in
     float2 vUV [[user(locn0)]];
 };
 
-float4 sample_in_function2(thread texture2d<float> uTexture, thread const sampler uTextureSmplr, thread float2& vUV, thread const array<texture2d<float>, 4> uTexture2, thread const array<sampler, 2> uSampler, thread const array<texture2d<float>, 2> uTextures, thread const array<sampler, 2> uTexturesSmplr, device SSBO& v_60, const device SSBOs* constant (&ssbos)[2], constant Push& registers)
+inline float4 sample_in_function2(thread texture2d<float> uTexture, thread const sampler uTextureSmplr, thread float2& vUV, thread const array<texture2d<float>, 4> uTexture2, thread const array<sampler, 2> uSampler, thread const array<texture2d<float>, 2> uTextures, thread const array<sampler, 2> uTexturesSmplr, device SSBO& v_60, const device SSBOs* constant (&ssbos)[2], constant Push& registers)
 {
     float4 ret = uTexture.sample(uTextureSmplr, vUV);
     ret += uTexture2[2].sample(uSampler[1], vUV);
@@ -73,7 +73,7 @@ float4 sample_in_function2(thread texture2d<float> uTexture, thread const sample
     return ret;
 }
 
-float4 sample_in_function(thread texture2d<float> uTexture, thread const sampler uTextureSmplr, thread float2& vUV, thread const array<texture2d<float>, 4> uTexture2, thread const array<sampler, 2> uSampler, thread const array<texture2d<float>, 2> uTextures, thread const array<sampler, 2> uTexturesSmplr, device SSBO& v_60, const device SSBOs* constant (&ssbos)[2], constant Push& registers, constant UBO& v_90, constant UBOs* constant (&ubos)[4])
+inline float4 sample_in_function(thread texture2d<float> uTexture, thread const sampler uTextureSmplr, thread float2& vUV, thread const array<texture2d<float>, 4> uTexture2, thread const array<sampler, 2> uSampler, thread const array<texture2d<float>, 2> uTextures, thread const array<sampler, 2> uTexturesSmplr, device SSBO& v_60, const device SSBOs* constant (&ssbos)[2], constant Push& registers, constant UBO& v_90, constant UBOs* constant (&ubos)[4])
 {
     float4 ret = sample_in_function2(uTexture, uTextureSmplr, vUV, uTexture2, uSampler, uTextures, uTexturesSmplr, v_60, ssbos, registers);
     ret += v_90.ubo;

--- a/reference/shaders-msl/frag/array-of-texture-swizzle.msl2.argument.discrete.swizzle.frag
+++ b/reference/shaders-msl/frag/array-of-texture-swizzle.msl2.argument.discrete.swizzle.frag
@@ -142,17 +142,17 @@ inline vec<T, 4> spvGatherCompareSwizzle(sampler s, const thread Tex& t, Ts... p
     return t.gather_compare(s, spvForward<Ts>(params)...);
 }
 
-float4 sample_in_func_1(thread const array<texture2d<float>, 4> uSampler0, thread const array<sampler, 4> uSampler0Smplr, constant uint* uSampler0Swzl, thread float2& vUV)
+inline float4 sample_in_func_1(thread const array<texture2d<float>, 4> uSampler0, thread const array<sampler, 4> uSampler0Smplr, constant uint* uSampler0Swzl, thread float2& vUV)
 {
     return spvTextureSwizzle(uSampler0[2].sample(uSampler0Smplr[2], vUV), uSampler0Swzl[2]);
 }
 
-float4 sample_in_func_2(thread float2& vUV, thread texture2d<float> uSampler1, thread const sampler uSampler1Smplr, constant uint& uSampler1Swzl)
+inline float4 sample_in_func_2(thread float2& vUV, thread texture2d<float> uSampler1, thread const sampler uSampler1Smplr, constant uint& uSampler1Swzl)
 {
     return spvTextureSwizzle(uSampler1.sample(uSampler1Smplr, vUV), uSampler1Swzl);
 }
 
-float4 sample_single_in_func(thread const texture2d<float> s, thread const sampler sSmplr, constant uint& sSwzl, thread float2& vUV)
+inline float4 sample_single_in_func(thread const texture2d<float> s, thread const sampler sSmplr, constant uint& sSwzl, thread float2& vUV)
 {
     return spvTextureSwizzle(s.sample(sSmplr, vUV), sSwzl);
 }

--- a/reference/shaders-msl/frag/array-of-texture-swizzle.msl2.swizzle.frag
+++ b/reference/shaders-msl/frag/array-of-texture-swizzle.msl2.swizzle.frag
@@ -135,12 +135,12 @@ inline vec<T, 4> spvGatherCompareSwizzle(sampler s, const thread Tex& t, Ts... p
     return t.gather_compare(s, spvForward<Ts>(params)...);
 }
 
-float4 sample_in_func(thread const array<texture2d<float>, 4> uSampler, thread const array<sampler, 4> uSamplerSmplr, constant uint* uSamplerSwzl, thread float2& vUV)
+inline float4 sample_in_func(thread const array<texture2d<float>, 4> uSampler, thread const array<sampler, 4> uSamplerSmplr, constant uint* uSamplerSwzl, thread float2& vUV)
 {
     return spvTextureSwizzle(uSampler[2].sample(uSamplerSmplr[2], vUV), uSamplerSwzl[2]);
 }
 
-float4 sample_single_in_func(thread const texture2d<float> s, thread const sampler sSmplr, constant uint& sSwzl, thread float2& vUV)
+inline float4 sample_single_in_func(thread const texture2d<float> s, thread const sampler sSmplr, constant uint& sSwzl, thread float2& vUV)
 {
     return spvTextureSwizzle(s.sample(sSmplr, vUV), sSwzl);
 }

--- a/reference/shaders-msl/frag/buffer-read-write.frag
+++ b/reference/shaders-msl/frag/buffer-read-write.frag
@@ -11,7 +11,7 @@ struct main0_out
 };
 
 // Returns 2D texture coords corresponding to 1D texel buffer coords
-uint2 spvTexelBufferCoord(uint tc)
+inline uint2 spvTexelBufferCoord(uint tc)
 {
     return uint2(tc % 4096, tc / 4096);
 }

--- a/reference/shaders-msl/frag/constant-array.frag
+++ b/reference/shaders-msl/frag/constant-array.frag
@@ -27,7 +27,7 @@ struct main0_in
     int index [[user(locn0)]];
 };
 
-float4 resolve(thread const Foobar& f)
+inline float4 resolve(thread const Foobar& f)
 {
     return float4(f.a + f.b);
 }

--- a/reference/shaders-msl/frag/constant-composites.frag
+++ b/reference/shaders-msl/frag/constant-composites.frag
@@ -25,7 +25,7 @@ struct main0_in
 };
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -34,7 +34,7 @@ void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -43,7 +43,7 @@ void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T 
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -52,7 +52,7 @@ void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -61,7 +61,7 @@ void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -70,7 +70,7 @@ void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {

--- a/reference/shaders-msl/frag/flush_params.frag
+++ b/reference/shaders-msl/frag/flush_params.frag
@@ -15,12 +15,12 @@ struct main0_out
     float4 FragColor [[color(0)]];
 };
 
-void foo2(thread Structy& f)
+inline void foo2(thread Structy& f)
 {
     f.c = float4(10.0);
 }
 
-Structy foo()
+inline Structy foo()
 {
     Structy param;
     foo2(param);

--- a/reference/shaders-msl/frag/fp16.desktop.invalid.frag
+++ b/reference/shaders-msl/frag/fp16.desktop.invalid.frag
@@ -21,36 +21,36 @@ struct main0_in
 
 // Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
-Tx mod(Tx x, Ty y)
+inline Tx mod(Tx x, Ty y)
 {
     return x - y * floor(x / y);
 }
 
 // Implementation of the GLSL radians() function
 template<typename T>
-T radians(T d)
+inline T radians(T d)
 {
     return d * T(0.01745329251);
 }
 
 // Implementation of the GLSL degrees() function
 template<typename T>
-T degrees(T r)
+inline T degrees(T r)
 {
     return r * T(57.2957795131);
 }
 
-half2x2 test_mat2(thread const half2& a, thread const half2& b, thread const half2& c, thread const half2& d)
+inline half2x2 test_mat2(thread const half2& a, thread const half2& b, thread const half2& c, thread const half2& d)
 {
     return half2x2(half2(a), half2(b)) * half2x2(half2(c), half2(d));
 }
 
-half3x3 test_mat3(thread const half3& a, thread const half3& b, thread const half3& c, thread const half3& d, thread const half3& e, thread const half3& f)
+inline half3x3 test_mat3(thread const half3& a, thread const half3& b, thread const half3& c, thread const half3& d, thread const half3& e, thread const half3& f)
 {
     return half3x3(half3(a), half3(b), half3(c)) * half3x3(half3(d), half3(e), half3(f));
 }
 
-void test_constants()
+inline void test_constants()
 {
     half a = half(1.0);
     half b = half(1.5);
@@ -62,12 +62,12 @@ void test_constants()
     half h = half(9.5367431640625e-07);
 }
 
-half test_result()
+inline half test_result()
 {
     return half(1.0);
 }
 
-void test_conversions()
+inline void test_conversions()
 {
     half one = test_result();
     int a = int(one);
@@ -80,7 +80,7 @@ void test_conversions()
     half d2 = half(d);
 }
 
-void test_builtins(thread half4& v4, thread half3& v3, thread half& v1)
+inline void test_builtins(thread half4& v4, thread half3& v3, thread half& v1)
 {
     half4 res = radians(v4);
     res = degrees(v4);

--- a/reference/shaders-msl/frag/fragment-component-padding.pad-fragment.frag
+++ b/reference/shaders-msl/frag/fragment-component-padding.pad-fragment.frag
@@ -18,7 +18,7 @@ struct main0_in
     float3 vColor [[user(locn0)]];
 };
 
-void set_globals(thread float (&FragColors)[2], thread float3& vColor, thread float2& FragColor2, thread float3& FragColor3)
+inline void set_globals(thread float (&FragColors)[2], thread float3& vColor, thread float2& FragColor2, thread float3& FragColor3)
 {
     FragColors[0] = vColor.x;
     FragColors[1] = vColor.y;

--- a/reference/shaders-msl/frag/helper-invocation.msl21.frag
+++ b/reference/shaders-msl/frag/helper-invocation.msl21.frag
@@ -15,7 +15,7 @@ struct main0_in
     float2 vUV [[user(locn0)]];
 };
 
-float4 foo(thread bool& gl_HelperInvocation, thread texture2d<float> uSampler, thread const sampler uSamplerSmplr, thread float2& vUV)
+inline float4 foo(thread bool& gl_HelperInvocation, thread texture2d<float> uSampler, thread const sampler uSamplerSmplr, thread float2& vUV)
 {
     float4 color;
     if (!gl_HelperInvocation)

--- a/reference/shaders-msl/frag/image-query-lod.msl22.frag
+++ b/reference/shaders-msl/frag/image-query-lod.msl22.frag
@@ -15,7 +15,7 @@ struct main0_in
     float3 vUV [[user(locn0)]];
 };
 
-void from_function(thread float2& FragColor, thread texture2d<float> uSampler2D, thread const sampler uSampler2DSmplr, thread float3& vUV, thread texture3d<float> uSampler3D, thread const sampler uSampler3DSmplr, thread texturecube<float> uSamplerCube, thread const sampler uSamplerCubeSmplr, thread texture2d<float> uTexture2D, thread sampler uSampler, thread texture3d<float> uTexture3D, thread texturecube<float> uTextureCube)
+inline void from_function(thread float2& FragColor, thread texture2d<float> uSampler2D, thread const sampler uSampler2DSmplr, thread float3& vUV, thread texture3d<float> uSampler3D, thread const sampler uSampler3DSmplr, thread texturecube<float> uSamplerCube, thread const sampler uSamplerCubeSmplr, thread texture2d<float> uTexture2D, thread sampler uSampler, thread texture3d<float> uTexture3D, thread texturecube<float> uTextureCube)
 {
     float2 _22;
     _22.x = uSampler2D.calculate_clamped_lod(uSampler2DSmplr, vUV.xy);

--- a/reference/shaders-msl/frag/input-attachment-ms.frag
+++ b/reference/shaders-msl/frag/input-attachment-ms.frag
@@ -10,7 +10,7 @@ struct main0_out
     float4 FragColor [[color(0)]];
 };
 
-float4 load_subpasses(thread const texture2d_ms<float> uInput, thread uint& gl_SampleID, thread float4& gl_FragCoord)
+inline float4 load_subpasses(thread const texture2d_ms<float> uInput, thread uint& gl_SampleID, thread float4& gl_FragCoord)
 {
     return uInput.read(uint2(gl_FragCoord.xy), gl_SampleID);
 }

--- a/reference/shaders-msl/frag/input-attachment.frag
+++ b/reference/shaders-msl/frag/input-attachment.frag
@@ -10,7 +10,7 @@ struct main0_out
     float4 FragColor [[color(0)]];
 };
 
-float4 load_subpasses(thread const texture2d<float> uInput, thread float4& gl_FragCoord)
+inline float4 load_subpasses(thread const texture2d<float> uInput, thread float4& gl_FragCoord)
 {
     return uInput.read(uint2(gl_FragCoord.xy), 0);
 }

--- a/reference/shaders-msl/frag/lut-promotion.frag
+++ b/reference/shaders-msl/frag/lut-promotion.frag
@@ -20,7 +20,7 @@ struct main0_in
 };
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -29,7 +29,7 @@ void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -38,7 +38,7 @@ void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T 
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -47,7 +47,7 @@ void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -56,7 +56,7 @@ void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -65,7 +65,7 @@ void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {

--- a/reference/shaders-msl/frag/mrt-array.frag
+++ b/reference/shaders-msl/frag/mrt-array.frag
@@ -21,17 +21,17 @@ struct main0_in
 
 // Implementation of the GLSL mod() function, which is slightly different than Metal fmod()
 template<typename Tx, typename Ty>
-Tx mod(Tx x, Ty y)
+inline Tx mod(Tx x, Ty y)
 {
     return x - y * floor(x / y);
 }
 
-void write_deeper_in_function(thread float4 (&FragColor)[4], thread float4& vA, thread float4& vB)
+inline void write_deeper_in_function(thread float4 (&FragColor)[4], thread float4& vA, thread float4& vB)
 {
     FragColor[3] = vA * vB;
 }
 
-void write_in_function(thread float4 (&FragColor)[4], thread float4& vA, thread float4& vB)
+inline void write_in_function(thread float4 (&FragColor)[4], thread float4& vA, thread float4& vB)
 {
     FragColor[2] = vA - vB;
     write_deeper_in_function(FragColor, vA, vB);

--- a/reference/shaders-msl/frag/packing-test-3.frag
+++ b/reference/shaders-msl/frag/packing-test-3.frag
@@ -32,7 +32,7 @@ struct main0_out
     float4 _entryPointOutput [[color(0)]];
 };
 
-float4 _main(thread const VertexOutput& IN, constant CB0& v_26)
+inline float4 _main(thread const VertexOutput& IN, constant CB0& v_26)
 {
     TestStruct st;
     st.position = float3(v_26.CB0[1].position);

--- a/reference/shaders-msl/frag/private-variable-prototype-declaration.frag
+++ b/reference/shaders-msl/frag/private-variable-prototype-declaration.frag
@@ -15,12 +15,12 @@ struct main0_out
     float3 FragColor [[color(0)]];
 };
 
-void someFunction(thread AStruct& s)
+inline void someFunction(thread AStruct& s)
 {
     s.foobar = float4(1.0);
 }
 
-void otherFunction(thread float3& global_variable)
+inline void otherFunction(thread float3& global_variable)
 {
     global_variable = float3(1.0);
 }

--- a/reference/shaders-msl/frag/readonly-ssbo.frag
+++ b/reference/shaders-msl/frag/readonly-ssbo.frag
@@ -15,7 +15,7 @@ struct main0_out
     float4 FragColor [[color(0)]];
 };
 
-float4 read_from_function(const device SSBO& v_13)
+inline float4 read_from_function(const device SSBO& v_13)
 {
     return v_13.v;
 }

--- a/reference/shaders-msl/frag/sample-depth-separate-image-sampler.frag
+++ b/reference/shaders-msl/frag/sample-depth-separate-image-sampler.frag
@@ -10,12 +10,12 @@ struct main0_out
     float FragColor [[color(0)]];
 };
 
-float sample_depth_from_function(thread const depth2d<float> uT, thread const sampler uS)
+inline float sample_depth_from_function(thread const depth2d<float> uT, thread const sampler uS)
 {
     return uT.sample_compare(uS, float3(0.5).xy, float3(0.5).z);
 }
 
-float sample_color_from_function(thread const texture2d<float> uT, thread const sampler uS)
+inline float sample_color_from_function(thread const texture2d<float> uT, thread const sampler uS)
 {
     return uT.sample(uS, float2(0.5)).x;
 }

--- a/reference/shaders-msl/frag/sample-position-func.frag
+++ b/reference/shaders-msl/frag/sample-position-func.frag
@@ -15,7 +15,7 @@ struct main0_in
     int index [[user(locn0)]];
 };
 
-float4 getColor(thread const int& i, thread float2& gl_SamplePosition)
+inline float4 getColor(thread const int& i, thread float2& gl_SamplePosition)
 {
     return float4(gl_SamplePosition, float(i), 1.0);
 }

--- a/reference/shaders-msl/frag/sampler-image-arrays.msl2.frag
+++ b/reference/shaders-msl/frag/sampler-image-arrays.msl2.frag
@@ -16,17 +16,17 @@ struct main0_in
     int vIndex [[user(locn1)]];
 };
 
-float4 sample_from_global(thread int& vIndex, thread float2& vTex, thread const array<texture2d<float>, 4> uSampler, thread const array<sampler, 4> uSamplerSmplr)
+inline float4 sample_from_global(thread int& vIndex, thread float2& vTex, thread const array<texture2d<float>, 4> uSampler, thread const array<sampler, 4> uSamplerSmplr)
 {
     return uSampler[vIndex].sample(uSamplerSmplr[vIndex], (vTex + float2(0.100000001490116119384765625)));
 }
 
-float4 sample_from_argument(thread const array<texture2d<float>, 4> samplers, thread const array<sampler, 4> samplersSmplr, thread int& vIndex, thread float2& vTex)
+inline float4 sample_from_argument(thread const array<texture2d<float>, 4> samplers, thread const array<sampler, 4> samplersSmplr, thread int& vIndex, thread float2& vTex)
 {
     return samplers[vIndex].sample(samplersSmplr[vIndex], (vTex + float2(0.20000000298023223876953125)));
 }
 
-float4 sample_single_from_argument(thread const texture2d<float> samp, thread const sampler sampSmplr, thread float2& vTex)
+inline float4 sample_single_from_argument(thread const texture2d<float> samp, thread const sampler sampSmplr, thread float2& vTex)
 {
     return samp.sample(sampSmplr, (vTex + float2(0.300000011920928955078125)));
 }

--- a/reference/shaders-msl/frag/sampler.frag
+++ b/reference/shaders-msl/frag/sampler.frag
@@ -16,7 +16,7 @@ struct main0_in
     float2 vTex [[user(locn1)]];
 };
 
-float4 sample_texture(thread const texture2d<float> tex, thread const sampler texSmplr, thread const float2& uv)
+inline float4 sample_texture(thread const texture2d<float> tex, thread const sampler texSmplr, thread const float2& uv)
 {
     return tex.sample(texSmplr, uv);
 }

--- a/reference/shaders-msl/frag/separate-image-sampler-argument.frag
+++ b/reference/shaders-msl/frag/separate-image-sampler-argument.frag
@@ -10,7 +10,7 @@ struct main0_out
     float4 FragColor [[color(0)]];
 };
 
-float4 samp(thread const texture2d<float> t, thread const sampler s)
+inline float4 samp(thread const texture2d<float> t, thread const sampler s)
 {
     return t.sample(s, float2(0.5));
 }

--- a/reference/shaders-msl/frag/shader-arithmetic-8bit.frag
+++ b/reference/shaders-msl/frag/shader-arithmetic-8bit.frag
@@ -34,7 +34,7 @@ struct main0_in
     int4 vColor [[user(locn0)]];
 };
 
-void packing_int8(device SSBO& ssbo)
+inline void packing_int8(device SSBO& ssbo)
 {
     short i16 = 10;
     int i32 = 20;
@@ -48,7 +48,7 @@ void packing_int8(device SSBO& ssbo)
     ssbo.i8[3] = i8_4.w;
 }
 
-void packing_uint8(device SSBO& ssbo)
+inline void packing_uint8(device SSBO& ssbo)
 {
     ushort u16 = 10u;
     uint u32 = 20u;
@@ -62,7 +62,7 @@ void packing_uint8(device SSBO& ssbo)
     ssbo.u8[3] = u8_4.w;
 }
 
-void compute_int8(device SSBO& ssbo, thread int4& vColor, constant Push& registers, constant UBO& ubo, thread int4& FragColorInt)
+inline void compute_int8(device SSBO& ssbo, thread int4& vColor, constant Push& registers, constant UBO& ubo, thread int4& FragColorInt)
 {
     char4 tmp = char4(vColor);
     tmp += char4(registers.i8);
@@ -74,7 +74,7 @@ void compute_int8(device SSBO& ssbo, thread int4& vColor, constant Push& registe
     FragColorInt = int4(tmp);
 }
 
-void compute_uint8(device SSBO& ssbo, thread int4& vColor, constant Push& registers, constant UBO& ubo, thread uint4& FragColorUint)
+inline void compute_uint8(device SSBO& ssbo, thread int4& vColor, constant Push& registers, constant UBO& ubo, thread uint4& FragColorUint)
 {
     uchar4 tmp = uchar4(char4(vColor));
     tmp += uchar4(registers.u8);

--- a/reference/shaders-msl/frag/shadow-compare-global-alias.invalid.frag
+++ b/reference/shaders-msl/frag/shadow-compare-global-alias.invalid.frag
@@ -15,22 +15,22 @@ struct main0_in
     float3 vUV [[user(locn0)]];
 };
 
-float Samp(thread const float3& uv, thread depth2d<float> uTex, thread sampler uSamp)
+inline float Samp(thread const float3& uv, thread depth2d<float> uTex, thread sampler uSamp)
 {
     return uTex.sample_compare(uSamp, uv.xy, uv.z);
 }
 
-float Samp2(thread const float3& uv, thread depth2d<float> uSampler, thread const sampler uSamplerSmplr, thread float3& vUV)
+inline float Samp2(thread const float3& uv, thread depth2d<float> uSampler, thread const sampler uSamplerSmplr, thread float3& vUV)
 {
     return uSampler.sample_compare(uSamplerSmplr, vUV.xy, vUV.z);
 }
 
-float Samp3(thread const depth2d<float> uT, thread const sampler uS, thread const float3& uv, thread float3& vUV)
+inline float Samp3(thread const depth2d<float> uT, thread const sampler uS, thread const float3& uv, thread float3& vUV)
 {
     return uT.sample_compare(uS, vUV.xy, vUV.z);
 }
 
-float Samp4(thread const depth2d<float> uS, thread const sampler uSSmplr, thread const float3& uv, thread float3& vUV)
+inline float Samp4(thread const depth2d<float> uS, thread const sampler uSSmplr, thread const float3& uv, thread float3& vUV)
 {
     return uS.sample_compare(uSSmplr, vUV.xy, vUV.z);
 }

--- a/reference/shaders-msl/frag/stencil-export.msl21.frag
+++ b/reference/shaders-msl/frag/stencil-export.msl21.frag
@@ -12,7 +12,7 @@ struct main0_out
     uint gl_FragStencilRefARB [[stencil]];
 };
 
-void update_stencil(thread uint& gl_FragStencilRefARB)
+inline void update_stencil(thread uint& gl_FragStencilRefARB)
 {
     gl_FragStencilRefARB = uint(int(gl_FragStencilRefARB) + 10);
 }

--- a/reference/shaders-msl/frag/write-depth-in-function.frag
+++ b/reference/shaders-msl/frag/write-depth-in-function.frag
@@ -11,7 +11,7 @@ struct main0_out
     float gl_FragDepth [[depth(any)]];
 };
 
-void set_output_depth(thread float& gl_FragDepth)
+inline void set_output_depth(thread float& gl_FragDepth)
 {
     gl_FragDepth = 0.20000000298023223876953125;
 }

--- a/reference/shaders-msl/tesc/water_tess.tesc
+++ b/reference/shaders-msl/tesc/water_tess.tesc
@@ -26,7 +26,7 @@ struct main0_in
     float2 vPatchPosBase [[attribute(0)]];
 };
 
-bool frustum_cull(thread const float2& p0, constant UBO& v_41)
+inline bool frustum_cull(thread const float2& p0, constant UBO& v_41)
 {
     float2 min_xz = (p0 - float2(10.0)) * v_41.uScale.xy;
     float2 max_xz = ((p0 + v_41.uPatchSize) + float2(10.0)) * v_41.uScale.xy;
@@ -49,7 +49,7 @@ bool frustum_cull(thread const float2& p0, constant UBO& v_41)
     return !_215;
 }
 
-float lod_factor(thread const float2& pos_, constant UBO& v_41)
+inline float lod_factor(thread const float2& pos_, constant UBO& v_41)
 {
     float2 pos = pos_ * v_41.uScale.xy;
     float3 dist_to_cam = v_41.uCamPos - float3(pos.x, 0.0, pos.y);
@@ -57,17 +57,17 @@ float lod_factor(thread const float2& pos_, constant UBO& v_41)
     return fast::clamp(level, 0.0, v_41.uMaxTessLevel.x);
 }
 
-float4 tess_level(thread const float4& lod, constant UBO& v_41)
+inline float4 tess_level(thread const float4& lod, constant UBO& v_41)
 {
     return exp2(-lod) * v_41.uMaxTessLevel.y;
 }
 
-float tess_level(thread const float& lod, constant UBO& v_41)
+inline float tess_level(thread const float& lod, constant UBO& v_41)
 {
     return v_41.uMaxTessLevel.y * exp2(-lod);
 }
 
-void compute_tess_levels(thread const float2& p0, constant UBO& v_41, device float2& vOutPatchPosBase, device float4& vPatchLods, device half (&gl_TessLevelOuter)[4], device half (&gl_TessLevelInner)[2])
+inline void compute_tess_levels(thread const float2& p0, constant UBO& v_41, device float2& vOutPatchPosBase, device float4& vPatchLods, device half (&gl_TessLevelOuter)[4], device half (&gl_TessLevelInner)[2])
 {
     vOutPatchPosBase = p0;
     float2 param = p0 + (float2(-0.5) * v_41.uPatchSize);

--- a/reference/shaders-msl/tese/input-array.tese
+++ b/reference/shaders-msl/tese/input-array.tese
@@ -21,7 +21,7 @@ struct main0_patchIn
     patch_control_point<main0_in> gl_in;
 };
 
-void set_position(thread float4& gl_Position, thread patch_control_point<main0_in>& gl_in, thread float2& gl_TessCoord)
+inline void set_position(thread float4& gl_Position, thread patch_control_point<main0_in>& gl_in, thread float2& gl_TessCoord)
 {
     gl_Position = (gl_in[0].Floats * gl_TessCoord.x) + (gl_in[1].Floats2 * gl_TessCoord.y);
 }

--- a/reference/shaders-msl/tese/input-types.tese
+++ b/reference/shaders-msl/tese/input-types.tese
@@ -47,7 +47,7 @@ struct main0_patchIn
     patch_control_point<main0_in> gl_in;
 };
 
-void set_from_function(thread float4& gl_Position, thread patch_control_point<main0_in>& gl_in, thread PatchBlock& patch_block, thread float4& vColors, thread Foo& vFoo)
+inline void set_from_function(thread float4& gl_Position, thread patch_control_point<main0_in>& gl_in, thread PatchBlock& patch_block, thread float4& vColors, thread Foo& vFoo)
 {
     gl_Position = gl_in[0].Block_a;
     gl_Position += gl_in[0].Block_b;

--- a/reference/shaders-msl/tese/quad.tese
+++ b/reference/shaders-msl/tese/quad.tese
@@ -16,7 +16,7 @@ struct main0_patchIn
     float4 gl_TessLevelOuter [[attribute(1)]];
 };
 
-void set_position(thread float4& gl_Position, thread float2& gl_TessCoord, thread float2& gl_TessLevelInner, thread float4& gl_TessLevelOuter)
+inline void set_position(thread float4& gl_Position, thread float2& gl_TessCoord, thread float2& gl_TessLevelInner, thread float4& gl_TessLevelOuter)
 {
     gl_Position = float4(((gl_TessCoord.x * gl_TessLevelInner.x) * gl_TessLevelOuter.x) + (((1.0 - gl_TessCoord.x) * gl_TessLevelInner.x) * gl_TessLevelOuter.z), ((gl_TessCoord.y * gl_TessLevelInner.y) * gl_TessLevelOuter.y) + (((1.0 - gl_TessCoord.y) * gl_TessLevelInner.y) * gl_TessLevelOuter.w), 0.0, 1.0);
 }

--- a/reference/shaders-msl/tese/set-from-function.tese
+++ b/reference/shaders-msl/tese/set-from-function.tese
@@ -37,7 +37,7 @@ struct main0_patchIn
     patch_control_point<main0_in> gl_in;
 };
 
-void set_from_function(thread float4& gl_Position, thread patch_control_point<main0_in>& gl_in, thread float4& vColors, thread Foo& vFoo)
+inline void set_from_function(thread float4& gl_Position, thread patch_control_point<main0_in>& gl_in, thread float4& vColors, thread Foo& vFoo)
 {
     gl_Position = gl_in[0].Block_a;
     gl_Position += gl_in[0].Block_b;

--- a/reference/shaders-msl/tese/water_tess.tese
+++ b/reference/shaders-msl/tese/water_tess.tese
@@ -28,12 +28,12 @@ struct main0_patchIn
     float4 vPatchLods [[attribute(1)]];
 };
 
-float2 lerp_vertex(thread const float2& tess_coord, thread float2& vOutPatchPosBase, constant UBO& v_31)
+inline float2 lerp_vertex(thread const float2& tess_coord, thread float2& vOutPatchPosBase, constant UBO& v_31)
 {
     return vOutPatchPosBase + (tess_coord * v_31.uPatchSize);
 }
 
-float2 lod_factor(thread const float2& tess_coord, thread float4& vPatchLods)
+inline float2 lod_factor(thread const float2& tess_coord, thread float4& vPatchLods)
 {
     float2 x = mix(vPatchLods.yx, vPatchLods.zw, float2(tess_coord.x));
     float level = mix(x.x, x.y, tess_coord.y);
@@ -42,7 +42,7 @@ float2 lod_factor(thread const float2& tess_coord, thread float4& vPatchLods)
     return float2(floor_level, fract_level);
 }
 
-float3 sample_height_displacement(thread const float2& uv, thread const float2& off, thread const float2& lod, thread texture2d<float> uHeightmapDisplacement, thread const sampler uHeightmapDisplacementSmplr)
+inline float3 sample_height_displacement(thread const float2& uv, thread const float2& off, thread const float2& lod, thread texture2d<float> uHeightmapDisplacement, thread const sampler uHeightmapDisplacementSmplr)
 {
     return mix(uHeightmapDisplacement.sample(uHeightmapDisplacementSmplr, (uv + (off * 0.5)), level(lod.x)).xyz, uHeightmapDisplacement.sample(uHeightmapDisplacementSmplr, (uv + (off * 1.0)), level(lod.x + 1.0)).xyz, float3(lod.y));
 }

--- a/reference/shaders-msl/vert/functions.vert
+++ b/reference/shaders-msl/vert/functions.vert
@@ -31,28 +31,28 @@ struct main0_in
 
 // Implementation of the GLSL radians() function
 template<typename T>
-T radians(T d)
+inline T radians(T d)
 {
     return d * T(0.01745329251);
 }
 
 // Implementation of the GLSL degrees() function
 template<typename T>
-T degrees(T r)
+inline T degrees(T r)
 {
     return r * T(57.2957795131);
 }
 
 // Implementation of the GLSL findLSB() function
 template<typename T>
-T spvFindLSB(T x)
+inline T spvFindLSB(T x)
 {
     return select(ctz(x), T(-1), x == T(0));
 }
 
 // Implementation of the signed GLSL findMSB() function
 template<typename T>
-T spvFindSMSB(T x)
+inline T spvFindSMSB(T x)
 {
     T v = select(x, T(-1) - x, x < T(0));
     return select(clz(T(0)) - (clz(v) + T(1)), T(-1), v == T(0));
@@ -72,7 +72,7 @@ inline float spvDet3x3(float a1, float a2, float a3, float b1, float b2, float b
 
 // Returns the inverse of a matrix, by using the algorithm of calculating the classical
 // adjoint and dividing by the determinant. The contents of the matrix are changed.
-float4x4 spvInverse4x4(float4x4 m)
+inline float4x4 spvInverse4x4(float4x4 m)
 {
     float4x4 adj;	// The adjoint matrix (inverse after dividing by determinant)
 

--- a/reference/shaders-msl/vert/in_out_array_mat.vert
+++ b/reference/shaders-msl/vert/in_out_array_mat.vert
@@ -38,13 +38,13 @@ struct main0_in
     float4 inViewMat_3 [[attribute(8)]];
 };
 
-void write_deeper_in_function(thread float4x4& outTransModel, constant UBO& ubo, thread float4& color, thread float4 (&colors)[3])
+inline void write_deeper_in_function(thread float4x4& outTransModel, constant UBO& ubo, thread float4& color, thread float4 (&colors)[3])
 {
     outTransModel[1].y = ubo.lodBias;
     color = colors[2];
 }
 
-void write_in_function(thread float4x4& outTransModel, constant UBO& ubo, thread float4& color, thread float4 (&colors)[3], thread float3& inNormal)
+inline void write_in_function(thread float4x4& outTransModel, constant UBO& ubo, thread float4& color, thread float4 (&colors)[3], thread float3& inNormal)
 {
     outTransModel[2] = float4(inNormal, 1.0);
     write_deeper_in_function(outTransModel, ubo, color, colors);

--- a/reference/shaders-msl/vert/leaf-function.capture.vert
+++ b/reference/shaders-msl/vert/leaf-function.capture.vert
@@ -22,7 +22,7 @@ struct main0_in
     float3 aNormal [[attribute(1)]];
 };
 
-void set_output(device float4& gl_Position, constant UBO& v_18, thread float4& aVertex, device float3& vNormal, thread float3& aNormal)
+inline void set_output(device float4& gl_Position, constant UBO& v_18, thread float4& aVertex, device float3& vNormal, thread float3& aNormal)
 {
     gl_Position = v_18.uMVP * aVertex;
     vNormal = aNormal;

--- a/reference/shaders-msl/vert/read-from-row-major-array.vert
+++ b/reference/shaders-msl/vert/read-from-row-major-array.vert
@@ -21,12 +21,12 @@ struct main0_in
     float4 a_position [[attribute(0)]];
 };
 
-float compare_float(thread const float& a, thread const float& b)
+inline float compare_float(thread const float& a, thread const float& b)
 {
     return float(abs(a - b) < 0.0500000007450580596923828125);
 }
 
-float compare_vec3(thread const float3& a, thread const float3& b)
+inline float compare_vec3(thread const float3& a, thread const float3& b)
 {
     float param = a.x;
     float param_1 = b.x;
@@ -37,7 +37,7 @@ float compare_vec3(thread const float3& a, thread const float3& b)
     return (compare_float(param, param_1) * compare_float(param_2, param_3)) * compare_float(param_4, param_5);
 }
 
-float compare_mat2x3(thread const float2x3& a, thread const float2x3& b)
+inline float compare_mat2x3(thread const float2x3& a, thread const float2x3& b)
 {
     float3 param = a[0];
     float3 param_1 = b[0];

--- a/reference/shaders-msl/vert/resource-arrays-leaf.ios.vert
+++ b/reference/shaders-msl/vert/resource-arrays-leaf.ios.vert
@@ -22,7 +22,7 @@ struct constant_block
 #endif
 constant int arraySize = SPIRV_CROSS_CONSTANT_ID_0;
 
-void doWork(device storage_block* (&storage)[2], constant constant_block* (&constants)[4], thread const array<texture2d<int>, 3> images)
+inline void doWork(device storage_block* (&storage)[2], constant constant_block* (&constants)[4], thread const array<texture2d<int>, 3> images)
 {
     storage[0]->baz = uint4(constants[3]->foo);
     storage[1]->quux = images[2].read(uint2(int2(constants[1]->bar))).xy;

--- a/reference/shaders-msl/vert/return-array.vert
+++ b/reference/shaders-msl/vert/return-array.vert
@@ -19,7 +19,7 @@ struct main0_in
 };
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -28,7 +28,7 @@ void spvArrayCopyFromConstantToStack1(thread T (&dst)[A], constant T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
+inline void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -37,7 +37,7 @@ void spvArrayCopyFromConstantToThreadGroup1(threadgroup T (&dst)[A], constant T 
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -46,7 +46,7 @@ void spvArrayCopyFromStackToStack1(thread T (&dst)[A], thread const T (&src)[A])
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
+inline void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -55,7 +55,7 @@ void spvArrayCopyFromStackToThreadGroup1(threadgroup T (&dst)[A], thread const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -64,7 +64,7 @@ void spvArrayCopyFromThreadGroupToStack1(thread T (&dst)[A], threadgroup const T
 }
 
 template<typename T, uint A>
-void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
+inline void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgroup const T (&src)[A])
 {
     for (uint i = 0; i < A; i++)
     {
@@ -72,12 +72,12 @@ void spvArrayCopyFromThreadGroupToThreadGroup1(threadgroup T (&dst)[A], threadgr
     }
 }
 
-void test(thread float4 (&SPIRV_Cross_return_value)[2])
+inline void test(thread float4 (&SPIRV_Cross_return_value)[2])
 {
     spvArrayCopyFromConstantToStack1(SPIRV_Cross_return_value, _20);
 }
 
-void test2(thread float4 (&SPIRV_Cross_return_value)[2], thread float4& vInput0, thread float4& vInput1)
+inline void test2(thread float4 (&SPIRV_Cross_return_value)[2], thread float4& vInput0, thread float4& vInput1)
 {
     float4 foobar[2];
     foobar[0] = vInput0;

--- a/reference/shaders-msl/vert/set_builtin_in_func.vert
+++ b/reference/shaders-msl/vert/set_builtin_in_func.vert
@@ -11,7 +11,7 @@ struct main0_out
     float gl_PointSize [[point_size]];
 };
 
-void write_outblock(thread float4& gl_Position, thread float& gl_PointSize)
+inline void write_outblock(thread float4& gl_Position, thread float& gl_PointSize)
 {
     gl_PointSize = 1.0;
     gl_Position = float4(gl_PointSize);

--- a/reference/shaders-msl/vert/sign-int-types.vert
+++ b/reference/shaders-msl/vert/sign-int-types.vert
@@ -38,7 +38,7 @@ struct main0_in
 
 // Implementation of the GLSL sign() function for integer types
 template<typename T, typename E = typename enable_if<is_integral<T>::value>::type>
-T sign(T x)
+inline T sign(T x)
 {
     return select(select(select(x, T(0), x == T(0)), T(1), x > T(0)), T(-1), x < T(0));
 }

--- a/reference/shaders-msl/vert/texture_buffer.vert
+++ b/reference/shaders-msl/vert/texture_buffer.vert
@@ -11,7 +11,7 @@ struct main0_out
 };
 
 // Returns 2D texture coords corresponding to 1D texel buffer coords
-uint2 spvTexelBufferCoord(uint tc)
+inline uint2 spvTexelBufferCoord(uint tc)
 {
     return uint2(tc % 4096, tc / 4096);
 }

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -5368,9 +5368,10 @@ void CompilerMSL::emit_function_prototype(SPIRFunction &func, const Bitset &)
 		add_function_overload(func);
 
 	local_variable_names = resource_names;
-	string decl;
 
 	processing_entry_point = (func.self == ir.default_entry_point);
+    
+    string decl = processing_entry_point ? "" : "inline ";
 
 	auto &type = get<SPIRType>(func.return_type);
 
@@ -5381,7 +5382,7 @@ void CompilerMSL::emit_function_prototype(SPIRFunction &func, const Bitset &)
 	else
 	{
 		// We cannot return arrays in MSL, so "return" through an out variable.
-		decl = "void";
+		decl += "void";
 	}
 
 	decl += " ";

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -3116,7 +3116,7 @@ void CompilerMSL::emit_custom_functions()
 		case SPVFuncImplMod:
 			statement("// Implementation of the GLSL mod() function, which is slightly different than Metal fmod()");
 			statement("template<typename Tx, typename Ty>");
-			statement("Tx mod(Tx x, Ty y)");
+			statement("inline Tx mod(Tx x, Ty y)");
 			begin_scope();
 			statement("return x - y * floor(x / y);");
 			end_scope();
@@ -3126,7 +3126,7 @@ void CompilerMSL::emit_custom_functions()
 		case SPVFuncImplRadians:
 			statement("// Implementation of the GLSL radians() function");
 			statement("template<typename T>");
-			statement("T radians(T d)");
+			statement("inline T radians(T d)");
 			begin_scope();
 			statement("return d * T(0.01745329251);");
 			end_scope();
@@ -3136,7 +3136,7 @@ void CompilerMSL::emit_custom_functions()
 		case SPVFuncImplDegrees:
 			statement("// Implementation of the GLSL degrees() function");
 			statement("template<typename T>");
-			statement("T degrees(T r)");
+			statement("inline T degrees(T r)");
 			begin_scope();
 			statement("return r * T(57.2957795131);");
 			end_scope();
@@ -3146,7 +3146,7 @@ void CompilerMSL::emit_custom_functions()
 		case SPVFuncImplFindILsb:
 			statement("// Implementation of the GLSL findLSB() function");
 			statement("template<typename T>");
-			statement("T spvFindLSB(T x)");
+			statement("inline T spvFindLSB(T x)");
 			begin_scope();
 			statement("return select(ctz(x), T(-1), x == T(0));");
 			end_scope();
@@ -3156,7 +3156,7 @@ void CompilerMSL::emit_custom_functions()
 		case SPVFuncImplFindUMsb:
 			statement("// Implementation of the unsigned GLSL findMSB() function");
 			statement("template<typename T>");
-			statement("T spvFindUMSB(T x)");
+			statement("inline T spvFindUMSB(T x)");
 			begin_scope();
 			statement("return select(clz(T(0)) - (clz(x) + T(1)), T(-1), x == T(0));");
 			end_scope();
@@ -3166,7 +3166,7 @@ void CompilerMSL::emit_custom_functions()
 		case SPVFuncImplFindSMsb:
 			statement("// Implementation of the signed GLSL findMSB() function");
 			statement("template<typename T>");
-			statement("T spvFindSMSB(T x)");
+			statement("inline T spvFindSMSB(T x)");
 			begin_scope();
 			statement("T v = select(x, T(-1) - x, x < T(0));");
 			statement("return select(clz(T(0)) - (clz(v) + T(1)), T(-1), v == T(0));");
@@ -3177,7 +3177,7 @@ void CompilerMSL::emit_custom_functions()
 		case SPVFuncImplSSign:
 			statement("// Implementation of the GLSL sign() function for integer types");
 			statement("template<typename T, typename E = typename enable_if<is_integral<T>::value>::type>");
-			statement("T sign(T x)");
+			statement("inline T sign(T x)");
 			begin_scope();
 			statement("return select(select(select(x, T(0), x == T(0)), T(1), x > T(0)), T(-1), x < T(0));");
 			end_scope();
@@ -3225,7 +3225,7 @@ void CompilerMSL::emit_custom_functions()
 					array_arg += "]";
 				}
 
-				statement("void spvArrayCopy", function_name_tags[variant], dimensions, "(", dst_address_space[variant],
+				statement("inline void spvArrayCopy", function_name_tags[variant], dimensions, "(", dst_address_space[variant],
 				          " T (&dst)", array_arg, ", ", src_address_space[variant], " T (&src)", array_arg, ")");
 
 				begin_scope();
@@ -3248,7 +3248,7 @@ void CompilerMSL::emit_custom_functions()
 		{
 			string tex_width_str = convert_to_string(msl_options.texel_buffer_texture_width);
 			statement("// Returns 2D texture coords corresponding to 1D texel buffer coords");
-			statement("uint2 spvTexelBufferCoord(uint tc)");
+			statement("inline uint2 spvTexelBufferCoord(uint tc)");
 			begin_scope();
 			statement(join("return uint2(tc % ", tex_width_str, ", tc / ", tex_width_str, ");"));
 			end_scope();
@@ -3274,7 +3274,7 @@ void CompilerMSL::emit_custom_functions()
 			statement("");
 			statement("// Returns the inverse of a matrix, by using the algorithm of calculating the classical");
 			statement("// adjoint and dividing by the determinant. The contents of the matrix are changed.");
-			statement("float4x4 spvInverse4x4(float4x4 m)");
+			statement("inline float4x4 spvInverse4x4(float4x4 m)");
 			begin_scope();
 			statement("float4x4 adj;	// The adjoint matrix (inverse after dividing by determinant)");
 			statement_no_indent("");
@@ -3339,7 +3339,7 @@ void CompilerMSL::emit_custom_functions()
 
 			statement("// Returns the inverse of a matrix, by using the algorithm of calculating the classical");
 			statement("// adjoint and dividing by the determinant. The contents of the matrix are changed.");
-			statement("float3x3 spvInverse3x3(float3x3 m)");
+			statement("inline float3x3 spvInverse3x3(float3x3 m)");
 			begin_scope();
 			statement("float3x3 adj;	// The adjoint matrix (inverse after dividing by determinant)");
 			statement_no_indent("");
@@ -3369,7 +3369,7 @@ void CompilerMSL::emit_custom_functions()
 		case SPVFuncImplInverse2x2:
 			statement("// Returns the inverse of a matrix, by using the algorithm of calculating the classical");
 			statement("// adjoint and dividing by the determinant. The contents of the matrix are changed.");
-			statement("float2x2 spvInverse2x2(float2x2 m)");
+			statement("inline float2x2 spvInverse2x2(float2x2 m)");
 			begin_scope();
 			statement("float2x2 adj;	// The adjoint matrix (inverse after dividing by determinant)");
 			statement_no_indent("");

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -3225,8 +3225,9 @@ void CompilerMSL::emit_custom_functions()
 					array_arg += "]";
 				}
 
-				statement("inline void spvArrayCopy", function_name_tags[variant], dimensions, "(", dst_address_space[variant],
-				          " T (&dst)", array_arg, ", ", src_address_space[variant], " T (&src)", array_arg, ")");
+				statement("inline void spvArrayCopy", function_name_tags[variant], dimensions, "(",
+				          dst_address_space[variant], " T (&dst)", array_arg, ", ", src_address_space[variant],
+				          " T (&src)", array_arg, ")");
 
 				begin_scope();
 				statement("for (uint i = 0; i < A; i++)");
@@ -5370,8 +5371,8 @@ void CompilerMSL::emit_function_prototype(SPIRFunction &func, const Bitset &)
 	local_variable_names = resource_names;
 
 	processing_entry_point = (func.self == ir.default_entry_point);
-    
-    string decl = processing_entry_point ? "" : "inline ";
+
+	string decl = processing_entry_point ? "" : "inline ";
 
 	auto &type = get<SPIRType>(func.return_type);
 


### PR DESCRIPTION
This PR ensures that all emitted MSL functions are marked as inline, enabling multiple output files to be bundled together into a metallib without duplicate symbols.

The commits are probably best viewed separately; the last one just updates all the tests, while the first two make the functionality change.