### PR TITLE
Merge SPV_EXT_fragment_shader_interlock with fixes

### DIFF
--- a/reference/opt/shaders-hlsl/frag/pixel-interlock-ordered.sm51.fxconly.frag
+++ b/reference/opt/shaders-hlsl/frag/pixel-interlock-ordered.sm51.fxconly.frag
@@ -1,0 +1,24 @@
+RWByteAddressBuffer _9 : register(u6, space0);
+globallycoherent RasterizerOrderedByteAddressBuffer _42 : register(u3, space0);
+RasterizerOrderedByteAddressBuffer _52 : register(u4, space0);
+RWTexture2D<unorm float4> img4 : register(u5, space0);
+RasterizerOrderedTexture2D<unorm float4> img : register(u0, space0);
+RasterizerOrderedTexture2D<unorm float4> img3 : register(u2, space0);
+RasterizerOrderedTexture2D<uint> img2 : register(u1, space0);
+
+void frag_main()
+{
+    _9.Store(0, uint(0));
+    img4[int2(1, 1)] = float4(1.0f, 0.0f, 0.0f, 1.0f);
+    img[int2(0, 0)] = img3[int2(0, 0)];
+    uint _39;
+    InterlockedAdd(img2[int2(0, 0)], 1u, _39);
+    _42.Store(0, uint(int(_42.Load(0)) + 42));
+    uint _55;
+    _42.InterlockedAnd(4, _52.Load(0), _55);
+}
+
+void main()
+{
+    frag_main();
+}

--- a/reference/opt/shaders-msl/frag/pixel-interlock-ordered.msl2.argument.frag
+++ b/reference/opt/shaders-msl/frag/pixel-interlock-ordered.msl2.argument.frag
@@ -1,0 +1,43 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct Buffer3
+{
+    int baz;
+};
+
+struct Buffer
+{
+    int foo;
+    uint bar;
+};
+
+struct Buffer2
+{
+    uint quux;
+};
+
+struct spvDescriptorSetBuffer0
+{
+    device Buffer3* m_9 [[id(0)]];
+    texture2d<float, access::write> img4 [[id(1)]];
+    texture2d<float, access::write> img [[id(2), raster_order_group(0)]];
+    texture2d<float> img3 [[id(3), raster_order_group(0)]];
+    volatile device Buffer* m_34 [[id(4), raster_order_group(0)]];
+    device Buffer2* m_44 [[id(5), raster_order_group(0)]];
+};
+
+fragment void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]])
+{
+    (*spvDescriptorSet0.m_9).baz = 0;
+    spvDescriptorSet0.img4.write(float4(1.0, 0.0, 0.0, 1.0), uint2(int2(1)));
+    spvDescriptorSet0.img.write(spvDescriptorSet0.img3.read(uint2(int2(0))), uint2(int2(0)));
+    (*spvDescriptorSet0.m_34).foo += 42;
+    uint _49 = atomic_fetch_and_explicit((volatile device atomic_uint*)&(*spvDescriptorSet0.m_34).bar, (*spvDescriptorSet0.m_44).quux, memory_order_relaxed);
+}
+

--- a/reference/opt/shaders-msl/frag/pixel-interlock-ordered.msl2.frag
+++ b/reference/opt/shaders-msl/frag/pixel-interlock-ordered.msl2.frag
@@ -1,0 +1,33 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct Buffer3
+{
+    int baz;
+};
+
+struct Buffer
+{
+    int foo;
+    uint bar;
+};
+
+struct Buffer2
+{
+    uint quux;
+};
+
+fragment void main0(device Buffer3& _9 [[buffer(0)]], volatile device Buffer& _34 [[buffer(1), raster_order_group(0)]], device Buffer2& _44 [[buffer(2), raster_order_group(0)]], texture2d<float, access::write> img4 [[texture(0)]], texture2d<float, access::write> img [[texture(1), raster_order_group(0)]], texture2d<float> img3 [[texture(2), raster_order_group(0)]])
+{
+    _9.baz = 0;
+    img4.write(float4(1.0, 0.0, 0.0, 1.0), uint2(int2(1)));
+    img.write(img3.read(uint2(int2(0))), uint2(int2(0)));
+    _34.foo += 42;
+    uint _49 = atomic_fetch_and_explicit((volatile device atomic_uint*)&_34.bar, _44.quux, memory_order_relaxed);
+}
+

--- a/reference/opt/shaders/frag/pixel-interlock-ordered.frag
+++ b/reference/opt/shaders/frag/pixel-interlock-ordered.frag
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(pixel_interlock_ordered) in;
+
+layout(binding = 2, std430) coherent buffer Buffer
+{
+    int foo;
+    uint bar;
+} _30;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+
+void main()
+{
+    beginInvocationInterlockARB();
+    imageStore(img, ivec2(0), vec4(1.0, 0.0, 0.0, 1.0));
+    uint _27 = imageAtomicAdd(img2, ivec2(0), 1u);
+    _30.foo += 42;
+    uint _41 = atomicAnd(_30.bar, 255u);
+    endInvocationInterlockARB();
+}
+

--- a/reference/opt/shaders/frag/pixel-interlock-unordered.frag
+++ b/reference/opt/shaders/frag/pixel-interlock-unordered.frag
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(pixel_interlock_unordered) in;
+
+layout(binding = 2, std430) coherent buffer Buffer
+{
+    int foo;
+    uint bar;
+} _30;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+
+void main()
+{
+    beginInvocationInterlockARB();
+    imageStore(img, ivec2(0), vec4(1.0, 0.0, 0.0, 1.0));
+    uint _27 = imageAtomicAdd(img2, ivec2(0), 1u);
+    _30.foo += 42;
+    uint _41 = atomicAnd(_30.bar, 255u);
+    endInvocationInterlockARB();
+}
+

--- a/reference/opt/shaders/frag/sample-interlock-ordered.frag
+++ b/reference/opt/shaders/frag/sample-interlock-ordered.frag
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(sample_interlock_ordered) in;
+
+layout(binding = 2, std430) coherent buffer Buffer
+{
+    int foo;
+    uint bar;
+} _30;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+
+void main()
+{
+    beginInvocationInterlockARB();
+    imageStore(img, ivec2(0), vec4(1.0, 0.0, 0.0, 1.0));
+    uint _27 = imageAtomicAdd(img2, ivec2(0), 1u);
+    _30.foo += 42;
+    uint _47 = atomicAnd(_30.bar, uint(gl_SampleMaskIn[0]));
+    endInvocationInterlockARB();
+}
+

--- a/reference/opt/shaders/frag/sample-interlock-unordered.frag
+++ b/reference/opt/shaders/frag/sample-interlock-unordered.frag
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(sample_interlock_unordered) in;
+
+layout(binding = 2, std430) coherent buffer Buffer
+{
+    int foo;
+    uint bar;
+} _30;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+
+void main()
+{
+    beginInvocationInterlockARB();
+    imageStore(img, ivec2(0), vec4(1.0, 0.0, 0.0, 1.0));
+    uint _27 = imageAtomicAdd(img2, ivec2(0), 1u);
+    _30.foo += 42;
+    uint _41 = atomicAnd(_30.bar, 255u);
+    endInvocationInterlockARB();
+}
+

--- a/reference/shaders-hlsl-no-opt/asm/frag/pixel-interlock-callstack.sm51.fxconly.asm.frag
+++ b/reference/shaders-hlsl-no-opt/asm/frag/pixel-interlock-callstack.sm51.fxconly.asm.frag
@@ -1,0 +1,32 @@
+RasterizerOrderedByteAddressBuffer _7 : register(u1, space0);
+RWByteAddressBuffer _9 : register(u0, space0);
+
+static float4 gl_FragCoord;
+struct SPIRV_Cross_Input
+{
+    float4 gl_FragCoord : SV_Position;
+};
+
+void callee2()
+{
+    int _31 = int(gl_FragCoord.x);
+    _7.Store(_31 * 4 + 0, _7.Load(_31 * 4 + 0) + 1u);
+}
+
+void callee()
+{
+    int _39 = int(gl_FragCoord.x);
+    _9.Store(_39 * 4 + 0, _9.Load(_39 * 4 + 0) + 1u);
+    callee2();
+}
+
+void frag_main()
+{
+    callee();
+}
+
+void main(SPIRV_Cross_Input stage_input)
+{
+    gl_FragCoord = stage_input.gl_FragCoord;
+    frag_main();
+}

--- a/reference/shaders-hlsl-no-opt/asm/frag/pixel-interlock-control-flow.sm51.fxconly.asm.frag
+++ b/reference/shaders-hlsl-no-opt/asm/frag/pixel-interlock-control-flow.sm51.fxconly.asm.frag
@@ -1,0 +1,42 @@
+RasterizerOrderedByteAddressBuffer _7 : register(u1, space0);
+RWByteAddressBuffer _13 : register(u2, space0);
+RasterizerOrderedByteAddressBuffer _9 : register(u0, space0);
+
+static float4 gl_FragCoord;
+struct SPIRV_Cross_Input
+{
+    float4 gl_FragCoord : SV_Position;
+};
+
+void callee2()
+{
+    int _44 = int(gl_FragCoord.x);
+    _7.Store(_44 * 4 + 0, _7.Load(_44 * 4 + 0) + 1u);
+}
+
+void callee()
+{
+    int _52 = int(gl_FragCoord.x);
+    _9.Store(_52 * 4 + 0, _9.Load(_52 * 4 + 0) + 1u);
+    callee2();
+    if (true)
+    {
+    }
+}
+
+void _35()
+{
+    _13.Store(int(gl_FragCoord.x) * 4 + 0, 4u);
+}
+
+void frag_main()
+{
+    callee();
+    _35();
+}
+
+void main(SPIRV_Cross_Input stage_input)
+{
+    gl_FragCoord = stage_input.gl_FragCoord;
+    frag_main();
+}

--- a/reference/shaders-hlsl-no-opt/asm/frag/pixel-interlock-split-functions.sm51.fxconly.asm.frag
+++ b/reference/shaders-hlsl-no-opt/asm/frag/pixel-interlock-split-functions.sm51.fxconly.asm.frag
@@ -1,0 +1,42 @@
+RasterizerOrderedByteAddressBuffer _7 : register(u1, space0);
+RasterizerOrderedByteAddressBuffer _9 : register(u0, space0);
+
+static float4 gl_FragCoord;
+struct SPIRV_Cross_Input
+{
+    float4 gl_FragCoord : SV_Position;
+};
+
+void callee2()
+{
+    int _37 = int(gl_FragCoord.x);
+    _7.Store(_37 * 4 + 0, _7.Load(_37 * 4 + 0) + 1u);
+}
+
+void callee()
+{
+    int _45 = int(gl_FragCoord.x);
+    _9.Store(_45 * 4 + 0, _9.Load(_45 * 4 + 0) + 1u);
+    callee2();
+}
+
+void _29()
+{
+}
+
+void _31()
+{
+}
+
+void frag_main()
+{
+    callee();
+    _29();
+    _31();
+}
+
+void main(SPIRV_Cross_Input stage_input)
+{
+    gl_FragCoord = stage_input.gl_FragCoord;
+    frag_main();
+}

--- a/reference/shaders-hlsl-no-opt/frag/pixel-interlock-simple-callstack.sm51.fxconly.frag
+++ b/reference/shaders-hlsl-no-opt/frag/pixel-interlock-simple-callstack.sm51.fxconly.frag
@@ -1,0 +1,32 @@
+RasterizerOrderedByteAddressBuffer _14 : register(u1, space0);
+RasterizerOrderedByteAddressBuffer _35 : register(u0, space0);
+
+static float4 gl_FragCoord;
+struct SPIRV_Cross_Input
+{
+    float4 gl_FragCoord : SV_Position;
+};
+
+void callee2()
+{
+    int _25 = int(gl_FragCoord.x);
+    _14.Store(_25 * 4 + 0, _14.Load(_25 * 4 + 0) + 1u);
+}
+
+void callee()
+{
+    int _38 = int(gl_FragCoord.x);
+    _35.Store(_38 * 4 + 0, _35.Load(_38 * 4 + 0) + 1u);
+    callee2();
+}
+
+void frag_main()
+{
+    callee();
+}
+
+void main(SPIRV_Cross_Input stage_input)
+{
+    gl_FragCoord = stage_input.gl_FragCoord;
+    frag_main();
+}

--- a/reference/shaders-hlsl/frag/pixel-interlock-ordered.sm51.fxconly.frag
+++ b/reference/shaders-hlsl/frag/pixel-interlock-ordered.sm51.fxconly.frag
@@ -1,0 +1,24 @@
+RWByteAddressBuffer _9 : register(u6, space0);
+globallycoherent RasterizerOrderedByteAddressBuffer _42 : register(u3, space0);
+RasterizerOrderedByteAddressBuffer _52 : register(u4, space0);
+RWTexture2D<unorm float4> img4 : register(u5, space0);
+RasterizerOrderedTexture2D<unorm float4> img : register(u0, space0);
+RasterizerOrderedTexture2D<unorm float4> img3 : register(u2, space0);
+RasterizerOrderedTexture2D<uint> img2 : register(u1, space0);
+
+void frag_main()
+{
+    _9.Store(0, uint(0));
+    img4[int2(1, 1)] = float4(1.0f, 0.0f, 0.0f, 1.0f);
+    img[int2(0, 0)] = img3[int2(0, 0)];
+    uint _39;
+    InterlockedAdd(img2[int2(0, 0)], 1u, _39);
+    _42.Store(0, uint(int(_42.Load(0)) + 42));
+    uint _55;
+    _42.InterlockedAnd(4, _52.Load(0), _55);
+}
+
+void main()
+{
+    frag_main();
+}

--- a/reference/shaders-msl-no-opt/asm/frag/pixel-interlock-callstack.msl2.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/pixel-interlock-callstack.msl2.asm.frag
@@ -1,0 +1,35 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct SSBO1
+{
+    uint values1[1];
+};
+
+struct SSBO0
+{
+    uint values0[1];
+};
+
+inline void callee2(thread float4& gl_FragCoord, device SSBO1& v_7)
+{
+    int _31 = int(gl_FragCoord.x);
+    v_7.values1[_31]++;
+}
+
+inline void callee(thread float4& gl_FragCoord, device SSBO1& v_7, device SSBO0& v_9)
+{
+    int _39 = int(gl_FragCoord.x);
+    v_9.values0[_39]++;
+    callee2(gl_FragCoord, v_7);
+}
+
+fragment void main0(device SSBO1& v_7 [[buffer(0), raster_order_group(0)]], device SSBO0& v_9 [[buffer(1)]], float4 gl_FragCoord [[position]])
+{
+    callee(gl_FragCoord, v_7, v_9);
+}
+

--- a/reference/shaders-msl-no-opt/asm/frag/pixel-interlock-control-flow.msl2.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/pixel-interlock-control-flow.msl2.asm.frag
@@ -1,0 +1,49 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct SSBO1
+{
+    uint values1[1];
+};
+
+struct _12
+{
+    uint _m0[1];
+};
+
+struct SSBO0
+{
+    uint values0[1];
+};
+
+inline void callee2(thread float4& gl_FragCoord, device SSBO1& v_7)
+{
+    int _44 = int(gl_FragCoord.x);
+    v_7.values1[_44]++;
+}
+
+inline void callee(thread float4& gl_FragCoord, device SSBO1& v_7, device SSBO0& v_9)
+{
+    int _52 = int(gl_FragCoord.x);
+    v_9.values0[_52]++;
+    callee2(gl_FragCoord, v_7);
+    if (true)
+    {
+    }
+}
+
+inline void _35(thread float4& gl_FragCoord, device _12& v_13)
+{
+    v_13._m0[int(gl_FragCoord.x)] = 4u;
+}
+
+fragment void main0(device SSBO1& v_7 [[buffer(0), raster_order_group(0)]], device _12& v_13 [[buffer(1)]], device SSBO0& v_9 [[buffer(2), raster_order_group(0)]], float4 gl_FragCoord [[position]])
+{
+    callee(gl_FragCoord, v_7, v_9);
+    _35(gl_FragCoord, v_13);
+}
+

--- a/reference/shaders-msl-no-opt/asm/frag/pixel-interlock-split-functions.msl2.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/pixel-interlock-split-functions.msl2.asm.frag
@@ -1,0 +1,45 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct SSBO1
+{
+    uint values1[1];
+};
+
+struct SSBO0
+{
+    uint values0[1];
+};
+
+inline void callee2(thread float4& gl_FragCoord, device SSBO1& v_7)
+{
+    int _37 = int(gl_FragCoord.x);
+    v_7.values1[_37]++;
+}
+
+inline void callee(thread float4& gl_FragCoord, device SSBO1& v_7, device SSBO0& v_9)
+{
+    int _45 = int(gl_FragCoord.x);
+    v_9.values0[_45]++;
+    callee2(gl_FragCoord, v_7);
+}
+
+inline void _29()
+{
+}
+
+inline void _31()
+{
+}
+
+fragment void main0(device SSBO1& v_7 [[buffer(0), raster_order_group(0)]], device SSBO0& v_9 [[buffer(1), raster_order_group(0)]], float4 gl_FragCoord [[position]])
+{
+    callee(gl_FragCoord, v_7, v_9);
+    _29();
+    _31();
+}
+

--- a/reference/shaders-msl-no-opt/frag/pixel-interlock-simple-callstack.msl2.frag
+++ b/reference/shaders-msl-no-opt/frag/pixel-interlock-simple-callstack.msl2.frag
@@ -1,0 +1,35 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct SSBO1
+{
+    uint values1[1];
+};
+
+struct SSBO0
+{
+    uint values0[1];
+};
+
+inline void callee2(device SSBO1& v_14, thread float4& gl_FragCoord)
+{
+    int _25 = int(gl_FragCoord.x);
+    v_14.values1[_25]++;
+}
+
+inline void callee(device SSBO1& v_14, thread float4& gl_FragCoord, device SSBO0& v_35)
+{
+    int _38 = int(gl_FragCoord.x);
+    v_35.values0[_38]++;
+    callee2(v_14, gl_FragCoord);
+}
+
+fragment void main0(device SSBO1& v_14 [[buffer(0), raster_order_group(0)]], device SSBO0& v_35 [[buffer(1), raster_order_group(0)]], float4 gl_FragCoord [[position]])
+{
+    callee(v_14, gl_FragCoord, v_35);
+}
+

--- a/reference/shaders-msl/frag/pixel-interlock-ordered.msl2.argument.frag
+++ b/reference/shaders-msl/frag/pixel-interlock-ordered.msl2.argument.frag
@@ -1,0 +1,43 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct Buffer3
+{
+    int baz;
+};
+
+struct Buffer
+{
+    int foo;
+    uint bar;
+};
+
+struct Buffer2
+{
+    uint quux;
+};
+
+struct spvDescriptorSetBuffer0
+{
+    device Buffer3* m_9 [[id(0)]];
+    texture2d<float, access::write> img4 [[id(1)]];
+    texture2d<float, access::write> img [[id(2), raster_order_group(0)]];
+    texture2d<float> img3 [[id(3), raster_order_group(0)]];
+    volatile device Buffer* m_34 [[id(4), raster_order_group(0)]];
+    device Buffer2* m_44 [[id(5), raster_order_group(0)]];
+};
+
+fragment void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]])
+{
+    (*spvDescriptorSet0.m_9).baz = 0;
+    spvDescriptorSet0.img4.write(float4(1.0, 0.0, 0.0, 1.0), uint2(int2(1)));
+    spvDescriptorSet0.img.write(spvDescriptorSet0.img3.read(uint2(int2(0))), uint2(int2(0)));
+    (*spvDescriptorSet0.m_34).foo += 42;
+    uint _49 = atomic_fetch_and_explicit((volatile device atomic_uint*)&(*spvDescriptorSet0.m_34).bar, (*spvDescriptorSet0.m_44).quux, memory_order_relaxed);
+}
+

--- a/reference/shaders-msl/frag/pixel-interlock-ordered.msl2.frag
+++ b/reference/shaders-msl/frag/pixel-interlock-ordered.msl2.frag
@@ -1,0 +1,33 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct Buffer3
+{
+    int baz;
+};
+
+struct Buffer
+{
+    int foo;
+    uint bar;
+};
+
+struct Buffer2
+{
+    uint quux;
+};
+
+fragment void main0(device Buffer3& _9 [[buffer(0)]], volatile device Buffer& _34 [[buffer(1), raster_order_group(0)]], device Buffer2& _44 [[buffer(2), raster_order_group(0)]], texture2d<float, access::write> img4 [[texture(0)]], texture2d<float, access::write> img [[texture(1), raster_order_group(0)]], texture2d<float> img3 [[texture(2), raster_order_group(0)]])
+{
+    _9.baz = 0;
+    img4.write(float4(1.0, 0.0, 0.0, 1.0), uint2(int2(1)));
+    img.write(img3.read(uint2(int2(0))), uint2(int2(0)));
+    _34.foo += 42;
+    uint _49 = atomic_fetch_and_explicit((volatile device atomic_uint*)&_34.bar, _44.quux, memory_order_relaxed);
+}
+

--- a/reference/shaders-no-opt/asm/frag/pixel-interlock-callstack.asm.frag
+++ b/reference/shaders-no-opt/asm/frag/pixel-interlock-callstack.asm.frag
@@ -1,0 +1,39 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(pixel_interlock_ordered) in;
+
+layout(binding = 1, std430) buffer SSBO1
+{
+    uint values1[];
+} _7;
+
+layout(binding = 0, std430) buffer SSBO0
+{
+    uint values0[];
+} _9;
+
+void callee2()
+{
+    int _31 = int(gl_FragCoord.x);
+    _7.values1[_31]++;
+}
+
+void callee()
+{
+    int _39 = int(gl_FragCoord.x);
+    _9.values0[_39]++;
+    callee2();
+}
+
+void spvMainInterlockedBody()
+{
+    callee();
+}
+
+void main()
+{
+    // Interlocks were used in a way not compatible with GLSL, this is very slow.
+    beginInvocationInterlockARB();
+    spvMainInterlockedBody();
+    endInvocationInterlockARB();
+}

--- a/reference/shaders-no-opt/asm/frag/pixel-interlock-control-flow.asm.frag
+++ b/reference/shaders-no-opt/asm/frag/pixel-interlock-control-flow.asm.frag
@@ -1,0 +1,53 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(pixel_interlock_ordered) in;
+
+layout(binding = 1, std430) buffer SSBO1
+{
+    uint values1[];
+} _7;
+
+layout(binding = 2, std430) buffer _12_13
+{
+    uint _m0[];
+} _13;
+
+layout(binding = 0, std430) buffer SSBO0
+{
+    uint values0[];
+} _9;
+
+void callee2()
+{
+    int _44 = int(gl_FragCoord.x);
+    _7.values1[_44]++;
+}
+
+void callee()
+{
+    int _52 = int(gl_FragCoord.x);
+    _9.values0[_52]++;
+    callee2();
+    if (true)
+    {
+    }
+}
+
+void _35()
+{
+    _13._m0[int(gl_FragCoord.x)] = 4u;
+}
+
+void spvMainInterlockedBody()
+{
+    callee();
+    _35();
+}
+
+void main()
+{
+    // Interlocks were used in a way not compatible with GLSL, this is very slow.
+    beginInvocationInterlockARB();
+    spvMainInterlockedBody();
+    endInvocationInterlockARB();
+}

--- a/reference/shaders-no-opt/asm/frag/pixel-interlock-split-functions.asm.frag
+++ b/reference/shaders-no-opt/asm/frag/pixel-interlock-split-functions.asm.frag
@@ -1,0 +1,49 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(pixel_interlock_ordered) in;
+
+layout(binding = 1, std430) buffer SSBO1
+{
+    uint values1[];
+} _7;
+
+layout(binding = 0, std430) buffer SSBO0
+{
+    uint values0[];
+} _9;
+
+void callee2()
+{
+    int _37 = int(gl_FragCoord.x);
+    _7.values1[_37]++;
+}
+
+void callee()
+{
+    int _45 = int(gl_FragCoord.x);
+    _9.values0[_45]++;
+    callee2();
+}
+
+void _29()
+{
+}
+
+void _31()
+{
+}
+
+void spvMainInterlockedBody()
+{
+    callee();
+    _29();
+    _31();
+}
+
+void main()
+{
+    // Interlocks were used in a way not compatible with GLSL, this is very slow.
+    beginInvocationInterlockARB();
+    spvMainInterlockedBody();
+    endInvocationInterlockARB();
+}

--- a/reference/shaders-no-opt/frag/pixel-interlock-simple-callstack.frag
+++ b/reference/shaders-no-opt/frag/pixel-interlock-simple-callstack.frag
@@ -1,0 +1,34 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(pixel_interlock_ordered) in;
+
+layout(binding = 1, std430) buffer SSBO1
+{
+    uint values1[];
+} _14;
+
+layout(binding = 0, std430) buffer SSBO0
+{
+    uint values0[];
+} _35;
+
+void callee2()
+{
+    int _25 = int(gl_FragCoord.x);
+    _14.values1[_25]++;
+}
+
+void callee()
+{
+    int _38 = int(gl_FragCoord.x);
+    _35.values0[_38]++;
+    callee2();
+}
+
+void main()
+{
+    beginInvocationInterlockARB();
+    callee();
+    endInvocationInterlockARB();
+}
+

--- a/reference/shaders/frag/pixel-interlock-ordered.frag
+++ b/reference/shaders/frag/pixel-interlock-ordered.frag
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(pixel_interlock_ordered) in;
+
+layout(binding = 2, std430) coherent buffer Buffer
+{
+    int foo;
+    uint bar;
+} _30;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+
+void main()
+{
+    beginInvocationInterlockARB();
+    imageStore(img, ivec2(0), vec4(1.0, 0.0, 0.0, 1.0));
+    uint _27 = imageAtomicAdd(img2, ivec2(0), 1u);
+    _30.foo += 42;
+    uint _41 = atomicAnd(_30.bar, 255u);
+    endInvocationInterlockARB();
+}
+

--- a/reference/shaders/frag/pixel-interlock-unordered.frag
+++ b/reference/shaders/frag/pixel-interlock-unordered.frag
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(pixel_interlock_unordered) in;
+
+layout(binding = 2, std430) coherent buffer Buffer
+{
+    int foo;
+    uint bar;
+} _30;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+
+void main()
+{
+    beginInvocationInterlockARB();
+    imageStore(img, ivec2(0), vec4(1.0, 0.0, 0.0, 1.0));
+    uint _27 = imageAtomicAdd(img2, ivec2(0), 1u);
+    _30.foo += 42;
+    uint _41 = atomicAnd(_30.bar, 255u);
+    endInvocationInterlockARB();
+}
+

--- a/reference/shaders/frag/sample-interlock-ordered.frag
+++ b/reference/shaders/frag/sample-interlock-ordered.frag
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(sample_interlock_ordered) in;
+
+layout(binding = 2, std430) coherent buffer Buffer
+{
+    int foo;
+    uint bar;
+} _30;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+
+void main()
+{
+    beginInvocationInterlockARB();
+    imageStore(img, ivec2(0), vec4(1.0, 0.0, 0.0, 1.0));
+    uint _27 = imageAtomicAdd(img2, ivec2(0), 1u);
+    _30.foo += 42;
+    uint _47 = atomicAnd(_30.bar, uint(gl_SampleMaskIn[0]));
+    endInvocationInterlockARB();
+}
+

--- a/reference/shaders/frag/sample-interlock-unordered.frag
+++ b/reference/shaders/frag/sample-interlock-unordered.frag
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(sample_interlock_unordered) in;
+
+layout(binding = 2, std430) coherent buffer Buffer
+{
+    int foo;
+    uint bar;
+} _30;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+
+void main()
+{
+    beginInvocationInterlockARB();
+    imageStore(img, ivec2(0), vec4(1.0, 0.0, 0.0, 1.0));
+    uint _27 = imageAtomicAdd(img2, ivec2(0), 1u);
+    _30.foo += 42;
+    uint _41 = atomicAnd(_30.bar, 255u);
+    endInvocationInterlockARB();
+}
+

--- a/shaders-hlsl-no-opt/asm/frag/pixel-interlock-callstack.sm51.fxconly.asm.frag
+++ b/shaders-hlsl-no-opt/asm/frag/pixel-interlock-callstack.sm51.fxconly.asm.frag
@@ -1,0 +1,89 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 45
+; Schema: 0
+               OpCapability Shader
+               OpCapability FragmentShaderPixelInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %gl_FragCoord
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main PixelInterlockOrderedEXT
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_fragment_shader_interlock"
+               OpName %main "main"
+               OpName %callee2_ "callee2("
+               OpName %callee_ "callee("
+               OpName %SSBO1 "SSBO1"
+               OpMemberName %SSBO1 0 "values1"
+               OpName %_ ""
+               OpName %gl_FragCoord "gl_FragCoord"
+               OpName %SSBO0 "SSBO0"
+               OpMemberName %SSBO0 0 "values0"
+               OpName %__0 ""
+               OpDecorate %_runtimearr_uint ArrayStride 4
+               OpMemberDecorate %SSBO1 0 Offset 0
+               OpDecorate %SSBO1 BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %gl_FragCoord BuiltIn FragCoord
+               OpDecorate %_runtimearr_uint_0 ArrayStride 4
+               OpMemberDecorate %SSBO0 0 Offset 0
+               OpDecorate %SSBO0 BufferBlock
+               OpDecorate %__0 DescriptorSet 0
+               OpDecorate %__0 Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%_runtimearr_uint = OpTypeRuntimeArray %uint
+      %SSBO1 = OpTypeStruct %_runtimearr_uint
+%_ptr_Uniform_SSBO1 = OpTypePointer Uniform %SSBO1
+          %_ = OpVariable %_ptr_Uniform_SSBO1 Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%gl_FragCoord = OpVariable %_ptr_Input_v4float Input
+     %uint_0 = OpConstant %uint 0
+%_ptr_Input_float = OpTypePointer Input %float
+     %uint_1 = OpConstant %uint 1
+%_ptr_Uniform_uint = OpTypePointer Uniform %uint
+%_runtimearr_uint_0 = OpTypeRuntimeArray %uint
+      %SSBO0 = OpTypeStruct %_runtimearr_uint_0
+%_ptr_Uniform_SSBO0 = OpTypePointer Uniform %SSBO0
+        %__0 = OpVariable %_ptr_Uniform_SSBO0 Uniform
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %44 = OpFunctionCall %void %callee_
+               OpReturn
+               OpFunctionEnd
+   %callee2_ = OpFunction %void None %3
+          %7 = OpLabel
+         %23 = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %24 = OpLoad %float %23
+         %25 = OpConvertFToS %int %24
+         %28 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %25
+         %29 = OpLoad %uint %28
+         %30 = OpIAdd %uint %29 %uint_1
+         %31 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %25
+               OpStore %31 %30
+               OpReturn
+               OpFunctionEnd
+    %callee_ = OpFunction %void None %3
+          %9 = OpLabel
+         %36 = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %37 = OpLoad %float %36
+         %38 = OpConvertFToS %int %37
+         %39 = OpAccessChain %_ptr_Uniform_uint %__0 %int_0 %38
+         %40 = OpLoad %uint %39
+         %41 = OpIAdd %uint %40 %uint_1
+         %42 = OpAccessChain %_ptr_Uniform_uint %__0 %int_0 %38
+               OpStore %42 %41
+               OpBeginInvocationInterlockEXT
+         %43 = OpFunctionCall %void %callee2_
+               OpEndInvocationInterlockEXT
+               OpReturn
+               OpFunctionEnd

--- a/shaders-hlsl-no-opt/asm/frag/pixel-interlock-control-flow.sm51.fxconly.asm.frag
+++ b/shaders-hlsl-no-opt/asm/frag/pixel-interlock-control-flow.sm51.fxconly.asm.frag
@@ -1,0 +1,121 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 45
+; Schema: 0
+               OpCapability Shader
+               OpCapability FragmentShaderPixelInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %gl_FragCoord
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main PixelInterlockOrderedEXT
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_fragment_shader_interlock"
+               OpName %main "main"
+               OpName %callee2_ "callee2("
+               OpName %callee_ "callee("
+               OpName %SSBO1 "SSBO1"
+               OpMemberName %SSBO1 0 "values1"
+               OpName %_ ""
+               OpName %gl_FragCoord "gl_FragCoord"
+               OpName %SSBO0 "SSBO0"
+               OpMemberName %SSBO0 0 "values0"
+               OpName %__0 ""
+               OpDecorate %_runtimearr_uint ArrayStride 4
+               OpMemberDecorate %SSBO1 0 Offset 0
+               OpDecorate %SSBO1 BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %gl_FragCoord BuiltIn FragCoord
+               OpDecorate %_runtimearr_uint_0 ArrayStride 4
+               OpMemberDecorate %SSBO0 0 Offset 0
+               OpDecorate %SSBO0 BufferBlock
+               OpDecorate %__0 DescriptorSet 0
+               OpDecorate %__0 Binding 0
+
+               OpMemberDecorate %SSBO2 0 Offset 0
+               OpDecorate %SSBO2 BufferBlock
+               OpDecorate %ssbo2 DescriptorSet 0
+               OpDecorate %ssbo2 Binding 2
+
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%_runtimearr_uint = OpTypeRuntimeArray %uint
+      %SSBO1 = OpTypeStruct %_runtimearr_uint
+      %SSBO2 = OpTypeStruct %_runtimearr_uint
+%_ptr_Uniform_SSBO1 = OpTypePointer Uniform %SSBO1
+%_ptr_Uniform_SSBO2 = OpTypePointer Uniform %SSBO2
+          %_ = OpVariable %_ptr_Uniform_SSBO1 Uniform
+          %ssbo2 = OpVariable %_ptr_Uniform_SSBO2 Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+	  %uint_4 = OpConstant %uint 4
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+	%bool = OpTypeBool
+	%true = OpConstantTrue %bool
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%gl_FragCoord = OpVariable %_ptr_Input_v4float Input
+     %uint_0 = OpConstant %uint 0
+%_ptr_Input_float = OpTypePointer Input %float
+     %uint_1 = OpConstant %uint 1
+%_ptr_Uniform_uint = OpTypePointer Uniform %uint
+%_runtimearr_uint_0 = OpTypeRuntimeArray %uint
+      %SSBO0 = OpTypeStruct %_runtimearr_uint_0
+%_ptr_Uniform_SSBO0 = OpTypePointer Uniform %SSBO0
+        %__0 = OpVariable %_ptr_Uniform_SSBO0 Uniform
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %44 = OpFunctionCall %void %callee_
+		 %callee3_res = OpFunctionCall %void %callee3_
+               OpReturn
+               OpFunctionEnd
+
+   %callee3_ = OpFunction %void None %3
+   	%calle3_block = OpLabel
+         %frag_coord_x_ptr = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %frag_coord_x = OpLoad %float %frag_coord_x_ptr
+         %frag_coord_int = OpConvertFToS %int %frag_coord_x
+         %ssbo_ptr = OpAccessChain %_ptr_Uniform_uint %ssbo2 %int_0 %frag_coord_int
+		 OpStore %ssbo_ptr %uint_4
+	OpReturn
+	OpFunctionEnd
+
+   %callee2_ = OpFunction %void None %3
+          %7 = OpLabel
+         %23 = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %24 = OpLoad %float %23
+         %25 = OpConvertFToS %int %24
+         %28 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %25
+         %29 = OpLoad %uint %28
+         %30 = OpIAdd %uint %29 %uint_1
+         %31 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %25
+               OpStore %31 %30
+               OpReturn
+               OpFunctionEnd
+    %callee_ = OpFunction %void None %3
+          %9 = OpLabel
+         %36 = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %37 = OpLoad %float %36
+         %38 = OpConvertFToS %int %37
+         %39 = OpAccessChain %_ptr_Uniform_uint %__0 %int_0 %38
+         %40 = OpLoad %uint %39
+         %41 = OpIAdd %uint %40 %uint_1
+         %42 = OpAccessChain %_ptr_Uniform_uint %__0 %int_0 %38
+               OpStore %42 %41
+         %43 = OpFunctionCall %void %callee2_
+
+		 OpSelectionMerge %merged_block None
+		 OpBranchConditional %true %dummy_block %merged_block
+		 %dummy_block = OpLabel
+		 	OpBeginInvocationInterlockEXT
+		 	OpEndInvocationInterlockEXT
+			OpBranch %merged_block
+
+			%merged_block = OpLabel
+               OpReturn
+
+               OpFunctionEnd

--- a/shaders-hlsl-no-opt/asm/frag/pixel-interlock-split-functions.sm51.fxconly.asm.frag
+++ b/shaders-hlsl-no-opt/asm/frag/pixel-interlock-split-functions.sm51.fxconly.asm.frag
@@ -1,0 +1,102 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 45
+; Schema: 0
+               OpCapability Shader
+               OpCapability FragmentShaderPixelInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %gl_FragCoord
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main PixelInterlockOrderedEXT
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_fragment_shader_interlock"
+               OpName %main "main"
+               OpName %callee2_ "callee2("
+               OpName %callee_ "callee("
+               OpName %SSBO1 "SSBO1"
+               OpMemberName %SSBO1 0 "values1"
+               OpName %_ ""
+               OpName %gl_FragCoord "gl_FragCoord"
+               OpName %SSBO0 "SSBO0"
+               OpMemberName %SSBO0 0 "values0"
+               OpName %__0 ""
+               OpDecorate %_runtimearr_uint ArrayStride 4
+               OpMemberDecorate %SSBO1 0 Offset 0
+               OpDecorate %SSBO1 BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %gl_FragCoord BuiltIn FragCoord
+               OpDecorate %_runtimearr_uint_0 ArrayStride 4
+               OpMemberDecorate %SSBO0 0 Offset 0
+               OpDecorate %SSBO0 BufferBlock
+               OpDecorate %__0 DescriptorSet 0
+               OpDecorate %__0 Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%_runtimearr_uint = OpTypeRuntimeArray %uint
+      %SSBO1 = OpTypeStruct %_runtimearr_uint
+%_ptr_Uniform_SSBO1 = OpTypePointer Uniform %SSBO1
+          %_ = OpVariable %_ptr_Uniform_SSBO1 Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%gl_FragCoord = OpVariable %_ptr_Input_v4float Input
+     %uint_0 = OpConstant %uint 0
+%_ptr_Input_float = OpTypePointer Input %float
+     %uint_1 = OpConstant %uint 1
+%_ptr_Uniform_uint = OpTypePointer Uniform %uint
+%_runtimearr_uint_0 = OpTypeRuntimeArray %uint
+      %SSBO0 = OpTypeStruct %_runtimearr_uint_0
+%_ptr_Uniform_SSBO0 = OpTypePointer Uniform %SSBO0
+        %__0 = OpVariable %_ptr_Uniform_SSBO0 Uniform
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %44 = OpFunctionCall %void %callee_
+		 %call3res = OpFunctionCall %void %callee3_
+		 %call4res = OpFunctionCall %void %callee4_
+               OpReturn
+               OpFunctionEnd
+
+   %callee3_ = OpFunction %void None %3
+   	      %begin3 = OpLabel
+               OpBeginInvocationInterlockEXT
+			   OpReturn
+               OpFunctionEnd
+
+   %callee4_ = OpFunction %void None %3
+   	      %begin4 = OpLabel
+               OpEndInvocationInterlockEXT
+			   OpReturn
+               OpFunctionEnd
+
+   %callee2_ = OpFunction %void None %3
+          %7 = OpLabel
+         %23 = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %24 = OpLoad %float %23
+         %25 = OpConvertFToS %int %24
+         %28 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %25
+         %29 = OpLoad %uint %28
+         %30 = OpIAdd %uint %29 %uint_1
+         %31 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %25
+               OpStore %31 %30
+               OpReturn
+               OpFunctionEnd
+    %callee_ = OpFunction %void None %3
+          %9 = OpLabel
+         %36 = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %37 = OpLoad %float %36
+         %38 = OpConvertFToS %int %37
+         %39 = OpAccessChain %_ptr_Uniform_uint %__0 %int_0 %38
+         %40 = OpLoad %uint %39
+         %41 = OpIAdd %uint %40 %uint_1
+         %42 = OpAccessChain %_ptr_Uniform_uint %__0 %int_0 %38
+               OpStore %42 %41
+         %43 = OpFunctionCall %void %callee2_
+               OpReturn
+               OpFunctionEnd

--- a/shaders-hlsl-no-opt/frag/pixel-interlock-simple-callstack.sm51.fxconly.frag
+++ b/shaders-hlsl-no-opt/frag/pixel-interlock-simple-callstack.sm51.fxconly.frag
@@ -1,0 +1,31 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(pixel_interlock_ordered) in;
+
+layout(set = 0, binding = 0, std430) buffer SSBO0
+{
+	uint values0[];
+};
+
+layout(set = 0, binding = 1, std430) buffer SSBO1
+{
+	uint values1[];
+};
+
+void callee2()
+{
+	values1[int(gl_FragCoord.x)] += 1;
+}
+
+void callee()
+{
+	values0[int(gl_FragCoord.x)] += 1;
+	callee2();
+}
+
+void main()
+{
+	beginInvocationInterlockARB();
+	callee();
+	endInvocationInterlockARB();
+}

--- a/shaders-hlsl/frag/pixel-interlock-ordered.sm51.fxconly.frag
+++ b/shaders-hlsl/frag/pixel-interlock-ordered.sm51.fxconly.frag
@@ -1,0 +1,36 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+
+layout(pixel_interlock_ordered) in;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+layout(binding = 2, rgba8) uniform readonly image2D img3;
+layout(binding = 3) coherent buffer Buffer
+{
+	int foo;
+	uint bar;
+};
+layout(binding = 4) buffer Buffer2
+{
+	uint quux;
+};
+
+layout(binding = 5, rgba8) uniform writeonly image2D img4;
+layout(binding = 6) buffer Buffer3
+{
+	int baz;
+};
+
+void main()
+{
+	// Deliberately outside the critical section to test usage tracking.
+	baz = 0;
+	imageStore(img4, ivec2(1, 1), vec4(1.0, 0.0, 0.0, 1.0));
+	beginInvocationInterlockARB();
+	imageStore(img, ivec2(0, 0), imageLoad(img3, ivec2(0, 0)));
+	imageAtomicAdd(img2, ivec2(0, 0), 1u);
+	foo += 42;
+	atomicAnd(bar, quux);
+	endInvocationInterlockARB();
+}

--- a/shaders-msl-no-opt/asm/frag/pixel-interlock-callstack.msl2.asm.frag
+++ b/shaders-msl-no-opt/asm/frag/pixel-interlock-callstack.msl2.asm.frag
@@ -1,0 +1,89 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 45
+; Schema: 0
+               OpCapability Shader
+               OpCapability FragmentShaderPixelInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %gl_FragCoord
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main PixelInterlockOrderedEXT
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_fragment_shader_interlock"
+               OpName %main "main"
+               OpName %callee2_ "callee2("
+               OpName %callee_ "callee("
+               OpName %SSBO1 "SSBO1"
+               OpMemberName %SSBO1 0 "values1"
+               OpName %_ ""
+               OpName %gl_FragCoord "gl_FragCoord"
+               OpName %SSBO0 "SSBO0"
+               OpMemberName %SSBO0 0 "values0"
+               OpName %__0 ""
+               OpDecorate %_runtimearr_uint ArrayStride 4
+               OpMemberDecorate %SSBO1 0 Offset 0
+               OpDecorate %SSBO1 BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %gl_FragCoord BuiltIn FragCoord
+               OpDecorate %_runtimearr_uint_0 ArrayStride 4
+               OpMemberDecorate %SSBO0 0 Offset 0
+               OpDecorate %SSBO0 BufferBlock
+               OpDecorate %__0 DescriptorSet 0
+               OpDecorate %__0 Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%_runtimearr_uint = OpTypeRuntimeArray %uint
+      %SSBO1 = OpTypeStruct %_runtimearr_uint
+%_ptr_Uniform_SSBO1 = OpTypePointer Uniform %SSBO1
+          %_ = OpVariable %_ptr_Uniform_SSBO1 Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%gl_FragCoord = OpVariable %_ptr_Input_v4float Input
+     %uint_0 = OpConstant %uint 0
+%_ptr_Input_float = OpTypePointer Input %float
+     %uint_1 = OpConstant %uint 1
+%_ptr_Uniform_uint = OpTypePointer Uniform %uint
+%_runtimearr_uint_0 = OpTypeRuntimeArray %uint
+      %SSBO0 = OpTypeStruct %_runtimearr_uint_0
+%_ptr_Uniform_SSBO0 = OpTypePointer Uniform %SSBO0
+        %__0 = OpVariable %_ptr_Uniform_SSBO0 Uniform
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %44 = OpFunctionCall %void %callee_
+               OpReturn
+               OpFunctionEnd
+   %callee2_ = OpFunction %void None %3
+          %7 = OpLabel
+         %23 = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %24 = OpLoad %float %23
+         %25 = OpConvertFToS %int %24
+         %28 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %25
+         %29 = OpLoad %uint %28
+         %30 = OpIAdd %uint %29 %uint_1
+         %31 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %25
+               OpStore %31 %30
+               OpReturn
+               OpFunctionEnd
+    %callee_ = OpFunction %void None %3
+          %9 = OpLabel
+         %36 = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %37 = OpLoad %float %36
+         %38 = OpConvertFToS %int %37
+         %39 = OpAccessChain %_ptr_Uniform_uint %__0 %int_0 %38
+         %40 = OpLoad %uint %39
+         %41 = OpIAdd %uint %40 %uint_1
+         %42 = OpAccessChain %_ptr_Uniform_uint %__0 %int_0 %38
+               OpStore %42 %41
+               OpBeginInvocationInterlockEXT
+         %43 = OpFunctionCall %void %callee2_
+               OpEndInvocationInterlockEXT
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/frag/pixel-interlock-control-flow.msl2.asm.frag
+++ b/shaders-msl-no-opt/asm/frag/pixel-interlock-control-flow.msl2.asm.frag
@@ -1,0 +1,121 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 45
+; Schema: 0
+               OpCapability Shader
+               OpCapability FragmentShaderPixelInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %gl_FragCoord
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main PixelInterlockOrderedEXT
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_fragment_shader_interlock"
+               OpName %main "main"
+               OpName %callee2_ "callee2("
+               OpName %callee_ "callee("
+               OpName %SSBO1 "SSBO1"
+               OpMemberName %SSBO1 0 "values1"
+               OpName %_ ""
+               OpName %gl_FragCoord "gl_FragCoord"
+               OpName %SSBO0 "SSBO0"
+               OpMemberName %SSBO0 0 "values0"
+               OpName %__0 ""
+               OpDecorate %_runtimearr_uint ArrayStride 4
+               OpMemberDecorate %SSBO1 0 Offset 0
+               OpDecorate %SSBO1 BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %gl_FragCoord BuiltIn FragCoord
+               OpDecorate %_runtimearr_uint_0 ArrayStride 4
+               OpMemberDecorate %SSBO0 0 Offset 0
+               OpDecorate %SSBO0 BufferBlock
+               OpDecorate %__0 DescriptorSet 0
+               OpDecorate %__0 Binding 0
+
+               OpMemberDecorate %SSBO2 0 Offset 0
+               OpDecorate %SSBO2 BufferBlock
+               OpDecorate %ssbo2 DescriptorSet 0
+               OpDecorate %ssbo2 Binding 2
+
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%_runtimearr_uint = OpTypeRuntimeArray %uint
+      %SSBO1 = OpTypeStruct %_runtimearr_uint
+      %SSBO2 = OpTypeStruct %_runtimearr_uint
+%_ptr_Uniform_SSBO1 = OpTypePointer Uniform %SSBO1
+%_ptr_Uniform_SSBO2 = OpTypePointer Uniform %SSBO2
+          %_ = OpVariable %_ptr_Uniform_SSBO1 Uniform
+          %ssbo2 = OpVariable %_ptr_Uniform_SSBO2 Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+	  %uint_4 = OpConstant %uint 4
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+	%bool = OpTypeBool
+	%true = OpConstantTrue %bool
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%gl_FragCoord = OpVariable %_ptr_Input_v4float Input
+     %uint_0 = OpConstant %uint 0
+%_ptr_Input_float = OpTypePointer Input %float
+     %uint_1 = OpConstant %uint 1
+%_ptr_Uniform_uint = OpTypePointer Uniform %uint
+%_runtimearr_uint_0 = OpTypeRuntimeArray %uint
+      %SSBO0 = OpTypeStruct %_runtimearr_uint_0
+%_ptr_Uniform_SSBO0 = OpTypePointer Uniform %SSBO0
+        %__0 = OpVariable %_ptr_Uniform_SSBO0 Uniform
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %44 = OpFunctionCall %void %callee_
+		 %callee3_res = OpFunctionCall %void %callee3_
+               OpReturn
+               OpFunctionEnd
+
+   %callee3_ = OpFunction %void None %3
+   	%calle3_block = OpLabel
+         %frag_coord_x_ptr = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %frag_coord_x = OpLoad %float %frag_coord_x_ptr
+         %frag_coord_int = OpConvertFToS %int %frag_coord_x
+         %ssbo_ptr = OpAccessChain %_ptr_Uniform_uint %ssbo2 %int_0 %frag_coord_int
+		 OpStore %ssbo_ptr %uint_4
+	OpReturn
+	OpFunctionEnd
+
+   %callee2_ = OpFunction %void None %3
+          %7 = OpLabel
+         %23 = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %24 = OpLoad %float %23
+         %25 = OpConvertFToS %int %24
+         %28 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %25
+         %29 = OpLoad %uint %28
+         %30 = OpIAdd %uint %29 %uint_1
+         %31 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %25
+               OpStore %31 %30
+               OpReturn
+               OpFunctionEnd
+    %callee_ = OpFunction %void None %3
+          %9 = OpLabel
+         %36 = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %37 = OpLoad %float %36
+         %38 = OpConvertFToS %int %37
+         %39 = OpAccessChain %_ptr_Uniform_uint %__0 %int_0 %38
+         %40 = OpLoad %uint %39
+         %41 = OpIAdd %uint %40 %uint_1
+         %42 = OpAccessChain %_ptr_Uniform_uint %__0 %int_0 %38
+               OpStore %42 %41
+         %43 = OpFunctionCall %void %callee2_
+
+		 OpSelectionMerge %merged_block None
+		 OpBranchConditional %true %dummy_block %merged_block
+		 %dummy_block = OpLabel
+		 	OpBeginInvocationInterlockEXT
+		 	OpEndInvocationInterlockEXT
+			OpBranch %merged_block
+
+			%merged_block = OpLabel
+               OpReturn
+
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/frag/pixel-interlock-split-functions.msl2.asm.frag
+++ b/shaders-msl-no-opt/asm/frag/pixel-interlock-split-functions.msl2.asm.frag
@@ -1,0 +1,102 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 45
+; Schema: 0
+               OpCapability Shader
+               OpCapability FragmentShaderPixelInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %gl_FragCoord
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main PixelInterlockOrderedEXT
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_fragment_shader_interlock"
+               OpName %main "main"
+               OpName %callee2_ "callee2("
+               OpName %callee_ "callee("
+               OpName %SSBO1 "SSBO1"
+               OpMemberName %SSBO1 0 "values1"
+               OpName %_ ""
+               OpName %gl_FragCoord "gl_FragCoord"
+               OpName %SSBO0 "SSBO0"
+               OpMemberName %SSBO0 0 "values0"
+               OpName %__0 ""
+               OpDecorate %_runtimearr_uint ArrayStride 4
+               OpMemberDecorate %SSBO1 0 Offset 0
+               OpDecorate %SSBO1 BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %gl_FragCoord BuiltIn FragCoord
+               OpDecorate %_runtimearr_uint_0 ArrayStride 4
+               OpMemberDecorate %SSBO0 0 Offset 0
+               OpDecorate %SSBO0 BufferBlock
+               OpDecorate %__0 DescriptorSet 0
+               OpDecorate %__0 Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%_runtimearr_uint = OpTypeRuntimeArray %uint
+      %SSBO1 = OpTypeStruct %_runtimearr_uint
+%_ptr_Uniform_SSBO1 = OpTypePointer Uniform %SSBO1
+          %_ = OpVariable %_ptr_Uniform_SSBO1 Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%gl_FragCoord = OpVariable %_ptr_Input_v4float Input
+     %uint_0 = OpConstant %uint 0
+%_ptr_Input_float = OpTypePointer Input %float
+     %uint_1 = OpConstant %uint 1
+%_ptr_Uniform_uint = OpTypePointer Uniform %uint
+%_runtimearr_uint_0 = OpTypeRuntimeArray %uint
+      %SSBO0 = OpTypeStruct %_runtimearr_uint_0
+%_ptr_Uniform_SSBO0 = OpTypePointer Uniform %SSBO0
+        %__0 = OpVariable %_ptr_Uniform_SSBO0 Uniform
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %44 = OpFunctionCall %void %callee_
+		 %call3res = OpFunctionCall %void %callee3_
+		 %call4res = OpFunctionCall %void %callee4_
+               OpReturn
+               OpFunctionEnd
+
+   %callee3_ = OpFunction %void None %3
+   	      %begin3 = OpLabel
+               OpBeginInvocationInterlockEXT
+			   OpReturn
+               OpFunctionEnd
+
+   %callee4_ = OpFunction %void None %3
+   	      %begin4 = OpLabel
+               OpEndInvocationInterlockEXT
+			   OpReturn
+               OpFunctionEnd
+
+   %callee2_ = OpFunction %void None %3
+          %7 = OpLabel
+         %23 = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %24 = OpLoad %float %23
+         %25 = OpConvertFToS %int %24
+         %28 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %25
+         %29 = OpLoad %uint %28
+         %30 = OpIAdd %uint %29 %uint_1
+         %31 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %25
+               OpStore %31 %30
+               OpReturn
+               OpFunctionEnd
+    %callee_ = OpFunction %void None %3
+          %9 = OpLabel
+         %36 = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %37 = OpLoad %float %36
+         %38 = OpConvertFToS %int %37
+         %39 = OpAccessChain %_ptr_Uniform_uint %__0 %int_0 %38
+         %40 = OpLoad %uint %39
+         %41 = OpIAdd %uint %40 %uint_1
+         %42 = OpAccessChain %_ptr_Uniform_uint %__0 %int_0 %38
+               OpStore %42 %41
+         %43 = OpFunctionCall %void %callee2_
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/frag/pixel-interlock-simple-callstack.msl2.frag
+++ b/shaders-msl-no-opt/frag/pixel-interlock-simple-callstack.msl2.frag
@@ -1,0 +1,31 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(pixel_interlock_ordered) in;
+
+layout(set = 0, binding = 0, std430) buffer SSBO0
+{
+	uint values0[];
+};
+
+layout(set = 0, binding = 1, std430) buffer SSBO1
+{
+	uint values1[];
+};
+
+void callee2()
+{
+	values1[int(gl_FragCoord.x)] += 1;
+}
+
+void callee()
+{
+	values0[int(gl_FragCoord.x)] += 1;
+	callee2();
+}
+
+void main()
+{
+	beginInvocationInterlockARB();
+	callee();
+	endInvocationInterlockARB();
+}

--- a/shaders-msl/frag/pixel-interlock-ordered.msl2.argument.frag
+++ b/shaders-msl/frag/pixel-interlock-ordered.msl2.argument.frag
@@ -1,0 +1,36 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+
+layout(pixel_interlock_ordered) in;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+//layout(binding = 1, r32ui) uniform uimage2D img2;
+layout(binding = 2, rgba8) uniform readonly image2D img3;
+layout(binding = 3) coherent buffer Buffer
+{
+	int foo;
+	uint bar;
+};
+layout(binding = 4) buffer Buffer2
+{
+	uint quux;
+};
+
+layout(binding = 5, rgba8) uniform writeonly image2D img4;
+layout(binding = 6) buffer Buffer3
+{
+	int baz;
+};
+
+void main()
+{
+	// Deliberately outside the critical section to test usage tracking.
+	baz = 0;
+	imageStore(img4, ivec2(1, 1), vec4(1.0, 0.0, 0.0, 1.0));
+	beginInvocationInterlockARB();
+	imageStore(img, ivec2(0, 0), imageLoad(img3, ivec2(0, 0)));
+	//imageAtomicAdd(img2, ivec2(0, 0), 1u);
+	foo += 42;
+	atomicAnd(bar, quux);
+	endInvocationInterlockARB();
+}

--- a/shaders-msl/frag/pixel-interlock-ordered.msl2.frag
+++ b/shaders-msl/frag/pixel-interlock-ordered.msl2.frag
@@ -1,0 +1,36 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+
+layout(pixel_interlock_ordered) in;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+//layout(binding = 1, r32ui) uniform uimage2D img2;
+layout(binding = 2, rgba8) uniform readonly image2D img3;
+layout(binding = 3) coherent buffer Buffer
+{
+	int foo;
+	uint bar;
+};
+layout(binding = 4) buffer Buffer2
+{
+	uint quux;
+};
+
+layout(binding = 5, rgba8) uniform writeonly image2D img4;
+layout(binding = 6) buffer Buffer3
+{
+	int baz;
+};
+
+void main()
+{
+	// Deliberately outside the critical section to test usage tracking.
+	baz = 0;
+	imageStore(img4, ivec2(1, 1), vec4(1.0, 0.0, 0.0, 1.0));
+	beginInvocationInterlockARB();
+	imageStore(img, ivec2(0, 0), imageLoad(img3, ivec2(0, 0)));
+	//imageAtomicAdd(img2, ivec2(0, 0), 1u);
+	foo += 42;
+	atomicAnd(bar, quux);
+	endInvocationInterlockARB();
+}

--- a/shaders-no-opt/asm/frag/pixel-interlock-callstack.asm.frag
+++ b/shaders-no-opt/asm/frag/pixel-interlock-callstack.asm.frag
@@ -1,0 +1,89 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 45
+; Schema: 0
+               OpCapability Shader
+               OpCapability FragmentShaderPixelInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %gl_FragCoord
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main PixelInterlockOrderedEXT
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_fragment_shader_interlock"
+               OpName %main "main"
+               OpName %callee2_ "callee2("
+               OpName %callee_ "callee("
+               OpName %SSBO1 "SSBO1"
+               OpMemberName %SSBO1 0 "values1"
+               OpName %_ ""
+               OpName %gl_FragCoord "gl_FragCoord"
+               OpName %SSBO0 "SSBO0"
+               OpMemberName %SSBO0 0 "values0"
+               OpName %__0 ""
+               OpDecorate %_runtimearr_uint ArrayStride 4
+               OpMemberDecorate %SSBO1 0 Offset 0
+               OpDecorate %SSBO1 BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %gl_FragCoord BuiltIn FragCoord
+               OpDecorate %_runtimearr_uint_0 ArrayStride 4
+               OpMemberDecorate %SSBO0 0 Offset 0
+               OpDecorate %SSBO0 BufferBlock
+               OpDecorate %__0 DescriptorSet 0
+               OpDecorate %__0 Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%_runtimearr_uint = OpTypeRuntimeArray %uint
+      %SSBO1 = OpTypeStruct %_runtimearr_uint
+%_ptr_Uniform_SSBO1 = OpTypePointer Uniform %SSBO1
+          %_ = OpVariable %_ptr_Uniform_SSBO1 Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%gl_FragCoord = OpVariable %_ptr_Input_v4float Input
+     %uint_0 = OpConstant %uint 0
+%_ptr_Input_float = OpTypePointer Input %float
+     %uint_1 = OpConstant %uint 1
+%_ptr_Uniform_uint = OpTypePointer Uniform %uint
+%_runtimearr_uint_0 = OpTypeRuntimeArray %uint
+      %SSBO0 = OpTypeStruct %_runtimearr_uint_0
+%_ptr_Uniform_SSBO0 = OpTypePointer Uniform %SSBO0
+        %__0 = OpVariable %_ptr_Uniform_SSBO0 Uniform
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %44 = OpFunctionCall %void %callee_
+               OpReturn
+               OpFunctionEnd
+   %callee2_ = OpFunction %void None %3
+          %7 = OpLabel
+         %23 = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %24 = OpLoad %float %23
+         %25 = OpConvertFToS %int %24
+         %28 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %25
+         %29 = OpLoad %uint %28
+         %30 = OpIAdd %uint %29 %uint_1
+         %31 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %25
+               OpStore %31 %30
+               OpReturn
+               OpFunctionEnd
+    %callee_ = OpFunction %void None %3
+          %9 = OpLabel
+         %36 = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %37 = OpLoad %float %36
+         %38 = OpConvertFToS %int %37
+         %39 = OpAccessChain %_ptr_Uniform_uint %__0 %int_0 %38
+         %40 = OpLoad %uint %39
+         %41 = OpIAdd %uint %40 %uint_1
+         %42 = OpAccessChain %_ptr_Uniform_uint %__0 %int_0 %38
+               OpStore %42 %41
+               OpBeginInvocationInterlockEXT
+         %43 = OpFunctionCall %void %callee2_
+               OpEndInvocationInterlockEXT
+               OpReturn
+               OpFunctionEnd

--- a/shaders-no-opt/asm/frag/pixel-interlock-control-flow.asm.frag
+++ b/shaders-no-opt/asm/frag/pixel-interlock-control-flow.asm.frag
@@ -1,0 +1,121 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 45
+; Schema: 0
+               OpCapability Shader
+               OpCapability FragmentShaderPixelInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %gl_FragCoord
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main PixelInterlockOrderedEXT
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_fragment_shader_interlock"
+               OpName %main "main"
+               OpName %callee2_ "callee2("
+               OpName %callee_ "callee("
+               OpName %SSBO1 "SSBO1"
+               OpMemberName %SSBO1 0 "values1"
+               OpName %_ ""
+               OpName %gl_FragCoord "gl_FragCoord"
+               OpName %SSBO0 "SSBO0"
+               OpMemberName %SSBO0 0 "values0"
+               OpName %__0 ""
+               OpDecorate %_runtimearr_uint ArrayStride 4
+               OpMemberDecorate %SSBO1 0 Offset 0
+               OpDecorate %SSBO1 BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %gl_FragCoord BuiltIn FragCoord
+               OpDecorate %_runtimearr_uint_0 ArrayStride 4
+               OpMemberDecorate %SSBO0 0 Offset 0
+               OpDecorate %SSBO0 BufferBlock
+               OpDecorate %__0 DescriptorSet 0
+               OpDecorate %__0 Binding 0
+
+               OpMemberDecorate %SSBO2 0 Offset 0
+               OpDecorate %SSBO2 BufferBlock
+               OpDecorate %ssbo2 DescriptorSet 0
+               OpDecorate %ssbo2 Binding 2
+
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%_runtimearr_uint = OpTypeRuntimeArray %uint
+      %SSBO1 = OpTypeStruct %_runtimearr_uint
+      %SSBO2 = OpTypeStruct %_runtimearr_uint
+%_ptr_Uniform_SSBO1 = OpTypePointer Uniform %SSBO1
+%_ptr_Uniform_SSBO2 = OpTypePointer Uniform %SSBO2
+          %_ = OpVariable %_ptr_Uniform_SSBO1 Uniform
+          %ssbo2 = OpVariable %_ptr_Uniform_SSBO2 Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+	  %uint_4 = OpConstant %uint 4
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+	%bool = OpTypeBool
+	%true = OpConstantTrue %bool
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%gl_FragCoord = OpVariable %_ptr_Input_v4float Input
+     %uint_0 = OpConstant %uint 0
+%_ptr_Input_float = OpTypePointer Input %float
+     %uint_1 = OpConstant %uint 1
+%_ptr_Uniform_uint = OpTypePointer Uniform %uint
+%_runtimearr_uint_0 = OpTypeRuntimeArray %uint
+      %SSBO0 = OpTypeStruct %_runtimearr_uint_0
+%_ptr_Uniform_SSBO0 = OpTypePointer Uniform %SSBO0
+        %__0 = OpVariable %_ptr_Uniform_SSBO0 Uniform
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %44 = OpFunctionCall %void %callee_
+		 %callee3_res = OpFunctionCall %void %callee3_
+               OpReturn
+               OpFunctionEnd
+
+   %callee3_ = OpFunction %void None %3
+   	%calle3_block = OpLabel
+         %frag_coord_x_ptr = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %frag_coord_x = OpLoad %float %frag_coord_x_ptr
+         %frag_coord_int = OpConvertFToS %int %frag_coord_x
+         %ssbo_ptr = OpAccessChain %_ptr_Uniform_uint %ssbo2 %int_0 %frag_coord_int
+		 OpStore %ssbo_ptr %uint_4
+	OpReturn
+	OpFunctionEnd
+
+   %callee2_ = OpFunction %void None %3
+          %7 = OpLabel
+         %23 = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %24 = OpLoad %float %23
+         %25 = OpConvertFToS %int %24
+         %28 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %25
+         %29 = OpLoad %uint %28
+         %30 = OpIAdd %uint %29 %uint_1
+         %31 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %25
+               OpStore %31 %30
+               OpReturn
+               OpFunctionEnd
+    %callee_ = OpFunction %void None %3
+          %9 = OpLabel
+         %36 = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %37 = OpLoad %float %36
+         %38 = OpConvertFToS %int %37
+         %39 = OpAccessChain %_ptr_Uniform_uint %__0 %int_0 %38
+         %40 = OpLoad %uint %39
+         %41 = OpIAdd %uint %40 %uint_1
+         %42 = OpAccessChain %_ptr_Uniform_uint %__0 %int_0 %38
+               OpStore %42 %41
+         %43 = OpFunctionCall %void %callee2_
+
+		 OpSelectionMerge %merged_block None
+		 OpBranchConditional %true %dummy_block %merged_block
+		 %dummy_block = OpLabel
+		 	OpBeginInvocationInterlockEXT
+		 	OpEndInvocationInterlockEXT
+			OpBranch %merged_block
+
+			%merged_block = OpLabel
+               OpReturn
+
+               OpFunctionEnd

--- a/shaders-no-opt/asm/frag/pixel-interlock-split-functions.asm.frag
+++ b/shaders-no-opt/asm/frag/pixel-interlock-split-functions.asm.frag
@@ -1,0 +1,102 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 45
+; Schema: 0
+               OpCapability Shader
+               OpCapability FragmentShaderPixelInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %gl_FragCoord
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main PixelInterlockOrderedEXT
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_fragment_shader_interlock"
+               OpName %main "main"
+               OpName %callee2_ "callee2("
+               OpName %callee_ "callee("
+               OpName %SSBO1 "SSBO1"
+               OpMemberName %SSBO1 0 "values1"
+               OpName %_ ""
+               OpName %gl_FragCoord "gl_FragCoord"
+               OpName %SSBO0 "SSBO0"
+               OpMemberName %SSBO0 0 "values0"
+               OpName %__0 ""
+               OpDecorate %_runtimearr_uint ArrayStride 4
+               OpMemberDecorate %SSBO1 0 Offset 0
+               OpDecorate %SSBO1 BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %gl_FragCoord BuiltIn FragCoord
+               OpDecorate %_runtimearr_uint_0 ArrayStride 4
+               OpMemberDecorate %SSBO0 0 Offset 0
+               OpDecorate %SSBO0 BufferBlock
+               OpDecorate %__0 DescriptorSet 0
+               OpDecorate %__0 Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%_runtimearr_uint = OpTypeRuntimeArray %uint
+      %SSBO1 = OpTypeStruct %_runtimearr_uint
+%_ptr_Uniform_SSBO1 = OpTypePointer Uniform %SSBO1
+          %_ = OpVariable %_ptr_Uniform_SSBO1 Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%gl_FragCoord = OpVariable %_ptr_Input_v4float Input
+     %uint_0 = OpConstant %uint 0
+%_ptr_Input_float = OpTypePointer Input %float
+     %uint_1 = OpConstant %uint 1
+%_ptr_Uniform_uint = OpTypePointer Uniform %uint
+%_runtimearr_uint_0 = OpTypeRuntimeArray %uint
+      %SSBO0 = OpTypeStruct %_runtimearr_uint_0
+%_ptr_Uniform_SSBO0 = OpTypePointer Uniform %SSBO0
+        %__0 = OpVariable %_ptr_Uniform_SSBO0 Uniform
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %44 = OpFunctionCall %void %callee_
+		 %call3res = OpFunctionCall %void %callee3_
+		 %call4res = OpFunctionCall %void %callee4_
+               OpReturn
+               OpFunctionEnd
+
+   %callee3_ = OpFunction %void None %3
+   	      %begin3 = OpLabel
+               OpBeginInvocationInterlockEXT
+			   OpReturn
+               OpFunctionEnd
+
+   %callee4_ = OpFunction %void None %3
+   	      %begin4 = OpLabel
+               OpEndInvocationInterlockEXT
+			   OpReturn
+               OpFunctionEnd
+
+   %callee2_ = OpFunction %void None %3
+          %7 = OpLabel
+         %23 = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %24 = OpLoad %float %23
+         %25 = OpConvertFToS %int %24
+         %28 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %25
+         %29 = OpLoad %uint %28
+         %30 = OpIAdd %uint %29 %uint_1
+         %31 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %25
+               OpStore %31 %30
+               OpReturn
+               OpFunctionEnd
+    %callee_ = OpFunction %void None %3
+          %9 = OpLabel
+         %36 = OpAccessChain %_ptr_Input_float %gl_FragCoord %uint_0
+         %37 = OpLoad %float %36
+         %38 = OpConvertFToS %int %37
+         %39 = OpAccessChain %_ptr_Uniform_uint %__0 %int_0 %38
+         %40 = OpLoad %uint %39
+         %41 = OpIAdd %uint %40 %uint_1
+         %42 = OpAccessChain %_ptr_Uniform_uint %__0 %int_0 %38
+               OpStore %42 %41
+         %43 = OpFunctionCall %void %callee2_
+               OpReturn
+               OpFunctionEnd

--- a/shaders-no-opt/frag/pixel-interlock-simple-callstack.frag
+++ b/shaders-no-opt/frag/pixel-interlock-simple-callstack.frag
@@ -1,0 +1,31 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+layout(pixel_interlock_ordered) in;
+
+layout(set = 0, binding = 0, std430) buffer SSBO0
+{
+	uint values0[];
+};
+
+layout(set = 0, binding = 1, std430) buffer SSBO1
+{
+	uint values1[];
+};
+
+void callee2()
+{
+	values1[int(gl_FragCoord.x)] += 1;
+}
+
+void callee()
+{
+	values0[int(gl_FragCoord.x)] += 1;
+	callee2();
+}
+
+void main()
+{
+	beginInvocationInterlockARB();
+	callee();
+	endInvocationInterlockARB();
+}

--- a/shaders/frag/pixel-interlock-ordered.frag
+++ b/shaders/frag/pixel-interlock-ordered.frag
@@ -1,0 +1,22 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+
+layout(pixel_interlock_ordered) in;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+layout(binding = 2) coherent buffer Buffer
+{
+	int foo;
+	uint bar;
+};
+
+void main()
+{
+	beginInvocationInterlockARB();
+	imageStore(img, ivec2(0, 0), vec4(1.0, 0.0, 0.0, 1.0));
+	imageAtomicAdd(img2, ivec2(0, 0), 1u);
+	foo += 42;
+	atomicAnd(bar, 0xff);
+	endInvocationInterlockARB();
+}

--- a/shaders/frag/pixel-interlock-unordered.frag
+++ b/shaders/frag/pixel-interlock-unordered.frag
@@ -1,0 +1,22 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+
+layout(pixel_interlock_unordered) in;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+layout(binding = 2) coherent buffer Buffer
+{
+	int foo;
+	uint bar;
+};
+
+void main()
+{
+	beginInvocationInterlockARB();
+	imageStore(img, ivec2(0, 0), vec4(1.0, 0.0, 0.0, 1.0));
+	imageAtomicAdd(img2, ivec2(0, 0), 1u);
+	foo += 42;
+	atomicAnd(bar, 0xff);
+	endInvocationInterlockARB();
+}

--- a/shaders/frag/sample-interlock-ordered.frag
+++ b/shaders/frag/sample-interlock-ordered.frag
@@ -1,0 +1,22 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+
+layout(sample_interlock_ordered) in;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+layout(binding = 2) coherent buffer Buffer
+{
+	int foo;
+	uint bar;
+};
+
+void main()
+{
+	beginInvocationInterlockARB();
+	imageStore(img, ivec2(0, 0), vec4(1.0, 0.0, 0.0, 1.0));
+	imageAtomicAdd(img2, ivec2(0, 0), 1u);
+	foo += 42;
+	atomicAnd(bar, gl_SampleMaskIn[0]);
+	endInvocationInterlockARB();
+}

--- a/shaders/frag/sample-interlock-unordered.frag
+++ b/shaders/frag/sample-interlock-unordered.frag
@@ -1,0 +1,22 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+
+layout(sample_interlock_unordered) in;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+layout(binding = 2) coherent buffer Buffer
+{
+	int foo;
+	uint bar;
+};
+
+void main()
+{
+	beginInvocationInterlockARB();
+	imageStore(img, ivec2(0, 0), vec4(1.0, 0.0, 0.0, 1.0));
+	imageAtomicAdd(img2, ivec2(0, 0), 1u);
+	foo += 42;
+	atomicAnd(bar, 0xff);
+	endInvocationInterlockARB();
+}

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -710,6 +710,13 @@ protected:
 		{
 		}
 
+		// Called after returning from a function or when entering a block,
+		// can be called multiple times per block,
+		// while set_current_block is only called on block entry.
+		virtual void rearm_current_block(const SPIRBlock &)
+		{
+		}
+
 		virtual bool begin_function_scope(const uint32_t *, uint32_t)
 		{
 			return true;
@@ -969,6 +976,7 @@ protected:
 		bool split_function_case = false;
 		bool control_flow_interlock = false;
 		bool use_critical_section = false;
+		bool call_stack_is_interlocked = false;
 		SmallVector<uint32_t> call_stack;
 
 		void access_potential_resource(uint32_t id);
@@ -982,7 +990,7 @@ protected:
 			call_stack.push_back(entry_point_id);
 		}
 
-		void set_current_block(const SPIRBlock &block) override;
+		void rearm_current_block(const SPIRBlock &block) override;
 		bool handle(spv::Op op, const uint32_t *args, uint32_t length) override;
 		bool begin_function_scope(const uint32_t *args, uint32_t length) override;
 		bool end_function_scope(const uint32_t *args, uint32_t length) override;
@@ -998,7 +1006,7 @@ protected:
 	void analyze_interlocked_resource_usage();
 	// The set of all resources written while inside the critical section, if present.
 	std::unordered_set<uint32_t> interlocked_resources;
-	bool interlocked_complex = false;
+	bool interlocked_is_complex = false;
 
 	void make_constant_null(uint32_t id, uint32_t type);
 

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -945,6 +945,27 @@ protected:
 	                              bool single_function);
 	bool may_read_undefined_variable_in_block(const SPIRBlock &block, uint32_t var);
 
+	// Finds all resources that are written to from inside the critical section, if present.
+	// The critical section is delimited by OpBeginInvocationInterlockEXT and
+	// OpEndInvocationInterlockEXT instructions. In MSL and HLSL, any resources written
+	// while inside the critical section must be placed in a raster order group.
+	struct InterlockedResourceAccessHandler : OpcodeHandler
+	{
+		InterlockedResourceAccessHandler(Compiler &compiler_)
+		    : compiler(compiler_)
+		{
+		}
+
+		bool handle(spv::Op op, const uint32_t *args, uint32_t length) override;
+
+		Compiler &compiler;
+		bool in_crit_sec = false;
+	};
+
+	void analyze_interlocked_resource_usage();
+	// The set of all resources written while inside the critical section, if present.
+	std::unordered_set<uint32_t> interlocked_resources;
+
 	void make_constant_null(uint32_t id, uint32_t type);
 
 	std::unordered_map<uint32_t, std::string> declared_block_names;

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -10166,6 +10166,9 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 				statement("beginInvocationInterlockNV();");
 			else
 				statement("beginInvocationInterlockARB();");
+
+			flush_all_active_variables();
+			// Make sure forwarding doesn't propagate outside interlock region.
 		}
 		break;
 
@@ -10177,6 +10180,9 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 				statement("endInvocationInterlockNV();");
 			else
 				statement("endInvocationInterlockARB();");
+
+			flush_all_active_variables();
+			// Make sure forwarding doesn't propagate outside interlock region.
 		}
 		break;
 

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -4867,12 +4867,7 @@ string CompilerHLSL::compile()
 	validate_shader_model();
 	update_active_builtins();
 	analyze_image_and_sampler_usage();
-	if (get_execution_model() == ExecutionModelFragment &&
-	    (get_entry_point().flags.get(ExecutionModePixelInterlockOrderedEXT) ||
-	     get_entry_point().flags.get(ExecutionModePixelInterlockUnorderedEXT) ||
-	     get_entry_point().flags.get(ExecutionModeSampleInterlockOrderedEXT) ||
-	     get_entry_point().flags.get(ExecutionModeSampleInterlockUnorderedEXT)))
-		analyze_interlocked_resource_usage();
+	analyze_interlocked_resource_usage();
 
 	// Subpass input needs SV_Position.
 	if (need_subpass_input)

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -852,12 +852,7 @@ string CompilerMSL::compile()
 	update_active_builtins();
 	analyze_image_and_sampler_usage();
 	analyze_sampled_image_usage();
-	if (get_execution_model() == ExecutionModelFragment &&
-	    (get_entry_point().flags.get(ExecutionModePixelInterlockOrderedEXT) ||
-	     get_entry_point().flags.get(ExecutionModePixelInterlockUnorderedEXT) ||
-	     get_entry_point().flags.get(ExecutionModeSampleInterlockOrderedEXT) ||
-	     get_entry_point().flags.get(ExecutionModeSampleInterlockUnorderedEXT)))
-		analyze_interlocked_resource_usage();
+	analyze_interlocked_resource_usage();
 	preprocess_op_codes();
 	build_implicit_builtins();
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -852,6 +852,12 @@ string CompilerMSL::compile()
 	update_active_builtins();
 	analyze_image_and_sampler_usage();
 	analyze_sampled_image_usage();
+	if (get_execution_model() == ExecutionModelFragment &&
+	    (get_entry_point().flags.get(ExecutionModePixelInterlockOrderedEXT) ||
+	     get_entry_point().flags.get(ExecutionModePixelInterlockUnorderedEXT) ||
+	     get_entry_point().flags.get(ExecutionModeSampleInterlockOrderedEXT) ||
+	     get_entry_point().flags.get(ExecutionModeSampleInterlockUnorderedEXT)))
+		analyze_interlocked_resource_usage();
 	preprocess_op_codes();
 	build_implicit_builtins();
 
@@ -5541,6 +5547,12 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		emit_op(ops[0], ops[1], "simd_is_helper_thread()", false);
 		break;
 
+	case OpBeginInvocationInterlockEXT:
+	case OpEndInvocationInterlockEXT:
+		if (!msl_options.supports_msl_version(2, 0))
+			SPIRV_CROSS_THROW("Raster order groups require MSL 2.0.");
+		break; // Nothing to do in the body
+
 	default:
 		CompilerGLSL::emit_instruction(instruction);
 		break;
@@ -7436,8 +7448,15 @@ string CompilerMSL::member_attribute_qualifier(const SPIRType &type, uint32_t in
 	bool is_builtin = is_member_builtin(type, index, &builtin);
 
 	if (has_extended_member_decoration(type.self, index, SPIRVCrossDecorationResourceIndexPrimary))
-		return join(" [[id(",
-		            get_extended_member_decoration(type.self, index, SPIRVCrossDecorationResourceIndexPrimary), ")]]");
+	{
+		string quals = join(
+		    " [[id(", get_extended_member_decoration(type.self, index, SPIRVCrossDecorationResourceIndexPrimary), ")");
+		if (interlocked_resources.count(
+		        get_extended_member_decoration(type.self, index, SPIRVCrossDecorationInterfaceOrigID)))
+			quals += ", raster_order_group(0)";
+		quals += "]]";
+		return quals;
+	}
 
 	// Vertex function inputs
 	if (execution.model == ExecutionModelVertex && type.storage == StorageClassInput)
@@ -8239,7 +8258,10 @@ void CompilerMSL::entry_point_args_discrete_descriptors(string &ep_args)
 						ep_args += ", ";
 					ep_args += get_argument_address_space(var) + " " + type_to_glsl(type) + "* " + to_restrict(var_id) +
 					           r.name + "_" + convert_to_string(i);
-					ep_args += " [[buffer(" + convert_to_string(r.index + i) + ")]]";
+					ep_args += " [[buffer(" + convert_to_string(r.index + i) + ")";
+					if (interlocked_resources.count(var_id))
+						ep_args += ", raster_order_group(0)";
+					ep_args += "]]";
 				}
 			}
 			else
@@ -8248,7 +8270,10 @@ void CompilerMSL::entry_point_args_discrete_descriptors(string &ep_args)
 					ep_args += ", ";
 				ep_args +=
 				    get_argument_address_space(var) + " " + type_to_glsl(type) + "& " + to_restrict(var_id) + r.name;
-				ep_args += " [[buffer(" + convert_to_string(r.index) + ")]]";
+				ep_args += " [[buffer(" + convert_to_string(r.index) + ")";
+				if (interlocked_resources.count(var_id))
+					ep_args += ", raster_order_group(0)";
+				ep_args += "]]";
 			}
 			break;
 		}
@@ -8264,7 +8289,10 @@ void CompilerMSL::entry_point_args_discrete_descriptors(string &ep_args)
 			ep_args += image_type_glsl(type, var_id) + " " + r.name;
 			if (r.plane > 0)
 				ep_args += join(plane_name_suffix, r.plane);
-			ep_args += " [[texture(" + convert_to_string(r.index) + ")]]";
+			ep_args += " [[texture(" + convert_to_string(r.index) + ")";
+			if (interlocked_resources.count(var_id))
+				ep_args += ", raster_order_group(0)";
+			ep_args += "]]";
 			break;
 		default:
 			if (!ep_args.empty())
@@ -8274,7 +8302,10 @@ void CompilerMSL::entry_point_args_discrete_descriptors(string &ep_args)
 				           type_to_glsl(type, var_id) + "& " + r.name;
 			else
 				ep_args += type_to_glsl(type, var_id) + " " + r.name;
-			ep_args += " [[buffer(" + convert_to_string(r.index) + ")]]";
+			ep_args += " [[buffer(" + convert_to_string(r.index) + ")";
+			if (interlocked_resources.count(var_id))
+				ep_args += ", raster_order_group(0)";
+			ep_args += "]]";
 			break;
 		}
 	}


### PR DESCRIPTION
This merges the work on fragment_shader_interlocks and adds fixes for complex edge cases which SPIR-V allows but not target languages.