### PR TITLE
MSL: Force storage images on iOS to use discrete descriptors.

### DIFF
--- a/reference/opt/shaders-msl/comp/argument-buffers-image-load-store.ios.msl2.argument.comp
+++ b/reference/opt/shaders-msl/comp/argument-buffers-image-load-store.ios.msl2.argument.comp
@@ -1,0 +1,11 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+kernel void main0(texture2d<float, access::write> uImage [[texture(0)]], texture2d<float> uImageRead [[texture(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+{
+    int2 _17 = int2(gl_GlobalInvocationID.xy);
+    uImage.write(uImageRead.read(uint2(_17)), uint2(_17));
+}
+

--- a/reference/shaders-msl/comp/argument-buffers-image-load-store.ios.msl2.argument.comp
+++ b/reference/shaders-msl/comp/argument-buffers-image-load-store.ios.msl2.argument.comp
@@ -1,0 +1,11 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+kernel void main0(texture2d<float, access::write> uImage [[texture(0)]], texture2d<float> uImageRead [[texture(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+{
+    int2 coord = int2(gl_GlobalInvocationID.xy);
+    uImage.write(uImageRead.read(uint2(coord)), uint2(coord));
+}
+

--- a/shaders-msl/comp/argument-buffers-image-load-store.ios.msl2.argument.comp
+++ b/shaders-msl/comp/argument-buffers-image-load-store.ios.msl2.argument.comp
@@ -1,0 +1,10 @@
+#version 450
+
+layout(set = 0, binding = 1, r32f) writeonly uniform image2D uImage;
+layout(set = 0, binding = 2, r32f) readonly uniform image2D uImageRead;
+
+void main()
+{
+   ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+   imageStore(uImage, coord, imageLoad(uImageRead, coord));
+}

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -54,9 +54,9 @@ struct MSLVertexAttr
 // Matches the binding index of a MSL resource for a binding within a descriptor set.
 // Taken together, the stage, desc_set and binding combine to form a reference to a resource
 // descriptor used in a particular shading stage.
-// If using MSL 2.0 argument buffers, and the descriptor set is not marked as a discrete descriptor set,
-// the binding reference we remap to will become an [[id(N)]] attribute within
-// the "descriptor set" argument buffer structure.
+// If using MSL 2.0 argument buffers, the descriptor set is not marked as a discrete descriptor set,
+// and (for iOS only) the resource is not a storage image (sampled != 2), the binding reference we
+// remap to will become an [[id(N)]] attribute within the "descriptor set" argument buffer structure.
 // For resources which are bound in the "classic" MSL 1.0 way or discrete descriptors, the remap will become a
 // [[buffer(N)]], [[texture(N)]] or [[sampler(N)]] depending on the resource types used.
 struct MSLResourceBinding


### PR DESCRIPTION
Writable textures cannot use argument buffers on iOS. They must be
passed as arguments directly to the shader function. Since we won't know
if a given storage image will have the `NonWritable` decoration at the
time we encode the argument buffer, we must therefore pass all storage
images as discrete arguments. Previously, we were throwing an error if
we encountered an argument buffer with a writable texture in it on iOS.