### PR TITLE
Introduce stronger types for the SPIR-V ID in C++ API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,10 @@ if (SPIRV_CROSS_CLI)
 				target_link_libraries(spirv-cross-msl-ycbcr-conversion-test spirv-cross-c)
 				set_target_properties(spirv-cross-msl-ycbcr-conversion-test PROPERTIES LINK_FLAGS "${spirv-cross-link-flags}")
 
+				add_executable(spirv-cross-typed-id-test tests-other/typed_id_test.cpp)
+				target_link_libraries(spirv-cross-typed-id-test spirv-cross-core)
+				set_target_properties(spirv-cross-typed-id-test PROPERTIES LINK_FLAGS "${spirv-cross-link-flags}")
+
 				if (CMAKE_COMPILER_IS_GNUCXX OR (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang"))
 					target_compile_options(spirv-cross-c-api-test PRIVATE -std=c89 -Wall -Wextra)
 				endif()
@@ -483,6 +487,8 @@ if (SPIRV_CROSS_CLI)
 						COMMAND $<TARGET_FILE:spirv-cross-msl-ycbcr-conversion-test> ${CMAKE_CURRENT_SOURCE_DIR}/tests-other/msl_ycbcr_conversion_test.spv)
 				add_test(NAME spirv-cross-msl-ycbcr-conversion-test-2
 						COMMAND $<TARGET_FILE:spirv-cross-msl-ycbcr-conversion-test> ${CMAKE_CURRENT_SOURCE_DIR}/tests-other/msl_ycbcr_conversion_test_2.spv)
+				add_test(NAME spirv-cross-typed-id-test
+						COMMAND $<TARGET_FILE:spirv-cross-typed-id-test>)
 				add_test(NAME spirv-cross-test
 						COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py --parallel
 						${spirv-cross-externals}

--- a/main.cpp
+++ b/main.cpp
@@ -246,7 +246,7 @@ static void print_resources(const Compiler &compiler, const char *tag, const Sma
 		                compiler.get_decoration_bitset(type.self).get(DecorationBufferBlock);
 		bool is_sized_block = is_block && (compiler.get_storage_class(res.id) == StorageClassUniform ||
 		                                   compiler.get_storage_class(res.id) == StorageClassUniformConstant);
-		uint32_t fallback_id = !is_push_constant && is_block ? res.base_type_id : res.id;
+		ID fallback_id = !is_push_constant && is_block ? ID(res.base_type_id) : ID(res.id);
 
 		uint32_t block_size = 0;
 		uint32_t runtime_array_stride = 0;
@@ -268,7 +268,7 @@ static void print_resources(const Compiler &compiler, const char *tag, const Sma
 		for (auto arr : type.array)
 			array = join("[", arr ? convert_to_string(arr) : "", "]") + array;
 
-		fprintf(stderr, " ID %03u : %s%s", res.id,
+		fprintf(stderr, " ID %03u : %s%s", uint32_t(res.id),
 		        !res.name.empty() ? res.name.c_str() : compiler.get_fallback_name(fallback_id).c_str(), array.c_str());
 
 		if (mask.get(DecorationLocation))
@@ -442,7 +442,7 @@ static void print_spec_constants(const Compiler &compiler)
 	fprintf(stderr, "Specialization constants\n");
 	fprintf(stderr, "==================\n\n");
 	for (auto &c : spec_constants)
-		fprintf(stderr, "ID: %u, Spec ID: %u\n", c.id, c.constant_id);
+		fprintf(stderr, "ID: %u, Spec ID: %u\n", uint32_t(c.id), c.constant_id);
 	fprintf(stderr, "==================\n\n");
 }
 

--- a/spirv_cfg.cpp
+++ b/spirv_cfg.cpp
@@ -237,13 +237,13 @@ uint32_t CFG::find_loop_dominator(uint32_t block_id) const
 		for (auto &pred : itr->second)
 		{
 			auto &pred_block = compiler.get<SPIRBlock>(pred);
-			if (pred_block.merge == SPIRBlock::MergeLoop && pred_block.merge_block == block_id)
+			if (pred_block.merge == SPIRBlock::MergeLoop && pred_block.merge_block == ID(block_id))
 			{
 				pred_block_id = pred;
 				ignore_loop_header = true;
 				break;
 			}
-			else if (pred_block.merge == SPIRBlock::MergeSelection && pred_block.next_block == block_id)
+			else if (pred_block.merge == SPIRBlock::MergeSelection && pred_block.next_block == ID(block_id))
 			{
 				pred_block_id = pred;
 				break;
@@ -268,14 +268,14 @@ uint32_t CFG::find_loop_dominator(uint32_t block_id) const
 	return block_id;
 }
 
-bool CFG::node_terminates_control_flow_in_sub_graph(uint32_t from, uint32_t to) const
+bool CFG::node_terminates_control_flow_in_sub_graph(BlockID from, BlockID to) const
 {
 	// Walk backwards, starting from "to" block.
 	// Only follow pred edges if they have a 1:1 relationship, or a merge relationship.
 	// If we cannot find a path to "from", we must assume that to is inside control flow in some way.
 
 	auto &from_block = compiler.get<SPIRBlock>(from);
-	uint32_t ignore_block_id = 0;
+	BlockID ignore_block_id = 0;
 	if (from_block.merge == SPIRBlock::MergeLoop)
 		ignore_block_id = from_block.merge_block;
 

--- a/spirv_cfg.hpp
+++ b/spirv_cfg.hpp
@@ -97,7 +97,7 @@ public:
 
 	uint32_t find_loop_dominator(uint32_t block) const;
 
-	bool node_terminates_control_flow_in_sub_graph(uint32_t from, uint32_t to) const;
+	bool node_terminates_control_flow_in_sub_graph(BlockID from, BlockID to) const;
 
 private:
 	struct VisitOrder

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -20,6 +20,7 @@
 #include "spirv.hpp"
 #include "spirv_cross_containers.hpp"
 #include "spirv_cross_error_handling.hpp"
+#include <functional>
 
 // A bit crude, but allows projects which embed SPIRV-Cross statically to
 // effectively hide all the symbols from other projects.
@@ -270,20 +271,6 @@ struct Instruction
 	uint32_t length = 0;
 };
 
-// Helper for Variant interface.
-struct IVariant
-{
-	virtual ~IVariant() = default;
-	virtual IVariant *clone(ObjectPoolBase *pool) = 0;
-	uint32_t self = 0;
-};
-
-#define SPIRV_CROSS_DECLARE_CLONE(T)                                \
-	IVariant *clone(ObjectPoolBase *pool) override                  \
-	{                                                               \
-		return static_cast<ObjectPool<T> *>(pool)->allocate(*this); \
-	}
-
 enum Types
 {
 	TypeNone,
@@ -303,6 +290,136 @@ enum Types
 	TypeCount
 };
 
+template <Types type>
+class TypedID;
+
+template <>
+class TypedID<TypeNone>
+{
+public:
+	TypedID() = default;
+	TypedID(uint32_t id_)
+	    : id(id_)
+	{
+	}
+
+	template <Types U>
+	TypedID(const TypedID<U> &other)
+	{
+		*this = other;
+	}
+
+	template <Types U>
+	TypedID &operator=(const TypedID<U> &other)
+	{
+		id = uint32_t(other);
+		return *this;
+	}
+
+	// Implicit conversion to u32 is desired here.
+	// As long as we block implicit conversion between TypedID<A> and TypedID<B> we're good.
+	operator uint32_t() const
+	{
+		return id;
+	}
+
+	template <Types U>
+	operator TypedID<U>() const
+	{
+		return TypedID<U>(*this);
+	}
+
+	bool operator==(const TypedID &other) const
+	{
+		return id == other.id;
+	}
+
+	bool operator!=(const TypedID &other) const
+	{
+		return id != other.id;
+	}
+
+	template <Types type>
+	bool operator==(const TypedID<type> &other) const
+	{
+		return id == uint32_t(other);
+	}
+
+	template <Types type>
+	bool operator!=(const TypedID<type> &other) const
+	{
+		return id != uint32_t(other);
+	}
+
+private:
+	uint32_t id = 0;
+};
+
+template <Types type>
+class TypedID
+{
+public:
+	TypedID() = default;
+	TypedID(uint32_t id_)
+	    : id(id_)
+	{
+	}
+
+	explicit TypedID(const TypedID<TypeNone> &other)
+	    : id(uint32_t(other))
+	{
+	}
+
+	operator uint32_t() const
+	{
+		return id;
+	}
+
+	bool operator==(const TypedID &other) const
+	{
+		return id == other.id;
+	}
+
+	bool operator!=(const TypedID &other) const
+	{
+		return id != other.id;
+	}
+
+	bool operator==(const TypedID<TypeNone> &other) const
+	{
+		return id == uint32_t(other);
+	}
+
+	bool operator!=(const TypedID<TypeNone> &other) const
+	{
+		return id != uint32_t(other);
+	}
+
+private:
+	uint32_t id = 0;
+};
+
+using VariableID = TypedID<TypeVariable>;
+using TypeID = TypedID<TypeType>;
+using ConstantID = TypedID<TypeConstant>;
+using FunctionID = TypedID<TypeFunction>;
+using BlockID = TypedID<TypeBlock>;
+using ID = TypedID<TypeNone>;
+
+// Helper for Variant interface.
+struct IVariant
+{
+	virtual ~IVariant() = default;
+	virtual IVariant *clone(ObjectPoolBase *pool) = 0;
+	ID self = 0;
+};
+
+#define SPIRV_CROSS_DECLARE_CLONE(T)                                \
+	IVariant *clone(ObjectPoolBase *pool) override                  \
+	{                                                               \
+		return static_cast<ObjectPool<T> *>(pool)->allocate(*this); \
+	}
+
 struct SPIRUndef : IVariant
 {
 	enum
@@ -310,11 +427,11 @@ struct SPIRUndef : IVariant
 		type = TypeUndef
 	};
 
-	explicit SPIRUndef(uint32_t basetype_)
+	explicit SPIRUndef(TypeID basetype_)
 	    : basetype(basetype_)
 	{
 	}
-	uint32_t basetype;
+	TypeID basetype;
 
 	SPIRV_CROSS_DECLARE_CLONE(SPIRUndef)
 };
@@ -344,15 +461,15 @@ struct SPIRCombinedImageSampler : IVariant
 	{
 		type = TypeCombinedImageSampler
 	};
-	SPIRCombinedImageSampler(uint32_t type_, uint32_t image_, uint32_t sampler_)
+	SPIRCombinedImageSampler(TypeID type_, VariableID image_, VariableID sampler_)
 	    : combined_type(type_)
 	    , image(image_)
 	    , sampler(sampler_)
 	{
 	}
-	uint32_t combined_type;
-	uint32_t image;
-	uint32_t sampler;
+	TypeID combined_type;
+	VariableID image;
+	VariableID sampler;
 
 	SPIRV_CROSS_DECLARE_CLONE(SPIRCombinedImageSampler)
 };
@@ -364,16 +481,18 @@ struct SPIRConstantOp : IVariant
 		type = TypeConstantOp
 	};
 
-	SPIRConstantOp(uint32_t result_type, spv::Op op, const uint32_t *args, uint32_t length)
+	SPIRConstantOp(TypeID result_type, spv::Op op, const uint32_t *args, uint32_t length)
 	    : opcode(op)
-	    , arguments(args, args + length)
 	    , basetype(result_type)
 	{
+		arguments.reserve(length);
+		for (uint32_t i = 0; i < length; i++)
+			arguments.push_back(args[i]);
 	}
 
 	spv::Op opcode;
 	SmallVector<uint32_t> arguments;
-	uint32_t basetype;
+	TypeID basetype;
 
 	SPIRV_CROSS_DECLARE_CLONE(SPIRConstantOp)
 };
@@ -436,11 +555,11 @@ struct SPIRType : IVariant
 
 	spv::StorageClass storage = spv::StorageClassGeneric;
 
-	SmallVector<uint32_t> member_types;
+	SmallVector<TypeID> member_types;
 
 	struct ImageType
 	{
-		uint32_t type;
+		TypeID type;
 		spv::Dim dim;
 		bool depth;
 		bool arrayed;
@@ -453,11 +572,11 @@ struct SPIRType : IVariant
 	// Structs can be declared multiple times if they are used as part of interface blocks.
 	// We want to detect this so that we only emit the struct definition once.
 	// Since we cannot rely on OpName to be equal, we need to figure out aliases.
-	uint32_t type_alias = 0;
+	TypeID type_alias = 0;
 
 	// Denotes the type which this type is based on.
 	// Allows the backend to traverse how a complex type is built up during access chains.
-	uint32_t parent_type = 0;
+	TypeID parent_type = 0;
 
 	// Used in backends to avoid emitting members with conflicting names.
 	std::unordered_set<std::string> member_name_cache;
@@ -496,7 +615,7 @@ struct SPIRExtension : IVariant
 // so in order to avoid conflicts, we can't stick them in the ids array.
 struct SPIREntryPoint
 {
-	SPIREntryPoint(uint32_t self_, spv::ExecutionModel execution_model, const std::string &entry_name)
+	SPIREntryPoint(FunctionID self_, spv::ExecutionModel execution_model, const std::string &entry_name)
 	    : self(self_)
 	    , name(entry_name)
 	    , orig_name(entry_name)
@@ -505,10 +624,10 @@ struct SPIREntryPoint
 	}
 	SPIREntryPoint() = default;
 
-	uint32_t self = 0;
+	FunctionID self = 0;
 	std::string name;
 	std::string orig_name;
-	SmallVector<uint32_t> interface_variables;
+	SmallVector<VariableID> interface_variables;
 
 	Bitset flags;
 	struct
@@ -529,7 +648,7 @@ struct SPIRExpression : IVariant
 	};
 
 	// Only created by the backend target to avoid creating tons of temporaries.
-	SPIRExpression(std::string expr, uint32_t expression_type_, bool immutable_)
+	SPIRExpression(std::string expr, TypeID expression_type_, bool immutable_)
 	    : expression(move(expr))
 	    , expression_type(expression_type_)
 	    , immutable(immutable_)
@@ -539,14 +658,14 @@ struct SPIRExpression : IVariant
 	// If non-zero, prepend expression with to_expression(base_expression).
 	// Used in amortizing multiple calls to to_expression()
 	// where in certain cases that would quickly force a temporary when not needed.
-	uint32_t base_expression = 0;
+	ID base_expression = 0;
 
 	std::string expression;
-	uint32_t expression_type = 0;
+	TypeID expression_type = 0;
 
 	// If this expression is a forwarded load,
 	// allow us to reference the original variable.
-	uint32_t loaded_from = 0;
+	ID loaded_from = 0;
 
 	// If this expression will never change, we can avoid lots of temporaries
 	// in high level source.
@@ -562,11 +681,11 @@ struct SPIRExpression : IVariant
 	bool access_chain = false;
 
 	// A list of expressions which this expression depends on.
-	SmallVector<uint32_t> expression_dependencies;
+	SmallVector<ID> expression_dependencies;
 
 	// By reading this expression, we implicitly read these expressions as well.
 	// Used by access chain Store and Load since we read multiple expressions in this case.
-	SmallVector<uint32_t> implied_read_expressions;
+	SmallVector<ID> implied_read_expressions;
 
 	SPIRV_CROSS_DECLARE_CLONE(SPIRExpression)
 };
@@ -578,12 +697,12 @@ struct SPIRFunctionPrototype : IVariant
 		type = TypeFunctionPrototype
 	};
 
-	explicit SPIRFunctionPrototype(uint32_t return_type_)
+	explicit SPIRFunctionPrototype(TypeID return_type_)
 	    : return_type(return_type_)
 	{
 	}
 
-	uint32_t return_type;
+	TypeID return_type;
 	SmallVector<uint32_t> parameter_types;
 
 	SPIRV_CROSS_DECLARE_CLONE(SPIRFunctionPrototype)
@@ -658,23 +777,23 @@ struct SPIRBlock : IVariant
 	Terminator terminator = Unknown;
 	Merge merge = MergeNone;
 	Hints hint = HintNone;
-	uint32_t next_block = 0;
-	uint32_t merge_block = 0;
-	uint32_t continue_block = 0;
+	BlockID next_block = 0;
+	BlockID merge_block = 0;
+	BlockID continue_block = 0;
 
-	uint32_t return_value = 0; // If 0, return nothing (void).
-	uint32_t condition = 0;
-	uint32_t true_block = 0;
-	uint32_t false_block = 0;
-	uint32_t default_block = 0;
+	ID return_value = 0; // If 0, return nothing (void).
+	ID condition = 0;
+	BlockID true_block = 0;
+	BlockID false_block = 0;
+	BlockID default_block = 0;
 
 	SmallVector<Instruction> ops;
 
 	struct Phi
 	{
-		uint32_t local_variable; // flush local variable ...
-		uint32_t parent; // If we're in from_block and want to branch into this block ...
-		uint32_t function_variable; // to this function-global "phi" variable first.
+		ID local_variable; // flush local variable ...
+		BlockID parent; // If we're in from_block and want to branch into this block ...
+		VariableID function_variable; // to this function-global "phi" variable first.
 	};
 
 	// Before entering this block flush out local variables to magical "phi" variables.
@@ -682,16 +801,16 @@ struct SPIRBlock : IVariant
 
 	// Declare these temporaries before beginning the block.
 	// Used for handling complex continue blocks which have side effects.
-	SmallVector<std::pair<uint32_t, uint32_t>> declare_temporary;
+	SmallVector<std::pair<TypeID, ID>> declare_temporary;
 
 	// Declare these temporaries, but only conditionally if this block turns out to be
 	// a complex loop header.
-	SmallVector<std::pair<uint32_t, uint32_t>> potential_declare_temporary;
+	SmallVector<std::pair<TypeID, ID>> potential_declare_temporary;
 
 	struct Case
 	{
 		uint32_t value;
-		uint32_t block;
+		BlockID block;
 	};
 	SmallVector<Case> cases;
 
@@ -707,25 +826,25 @@ struct SPIRBlock : IVariant
 
 	// If marked, we have explicitly handled Phi from this block, so skip any flushes related to that on a branch.
 	// Used to handle an edge case with switch and case-label fallthrough where fall-through writes to Phi.
-	uint32_t ignore_phi_from_block = 0;
+	BlockID ignore_phi_from_block = 0;
 
 	// The dominating block which this block might be within.
 	// Used in continue; blocks to determine if we really need to write continue.
-	uint32_t loop_dominator = 0;
+	BlockID loop_dominator = 0;
 
 	// All access to these variables are dominated by this block,
 	// so before branching anywhere we need to make sure that we declare these variables.
-	SmallVector<uint32_t> dominated_variables;
+	SmallVector<VariableID> dominated_variables;
 
 	// These are variables which should be declared in a for loop header, if we
 	// fail to use a classic for-loop,
 	// we remove these variables, and fall back to regular variables outside the loop.
-	SmallVector<uint32_t> loop_variables;
+	SmallVector<VariableID> loop_variables;
 
 	// Some expressions are control-flow dependent, i.e. any instruction which relies on derivatives or
 	// sub-group-like operations.
 	// Make sure that we only use these expressions in the original block.
-	SmallVector<uint32_t> invalidate_expressions;
+	SmallVector<ID> invalidate_expressions;
 
 	SPIRV_CROSS_DECLARE_CLONE(SPIRBlock)
 };
@@ -737,7 +856,7 @@ struct SPIRFunction : IVariant
 		type = TypeFunction
 	};
 
-	SPIRFunction(uint32_t return_type_, uint32_t function_type_)
+	SPIRFunction(TypeID return_type_, TypeID function_type_)
 	    : return_type(return_type_)
 	    , function_type(function_type_)
 	{
@@ -745,8 +864,8 @@ struct SPIRFunction : IVariant
 
 	struct Parameter
 	{
-		uint32_t type;
-		uint32_t id;
+		TypeID type;
+		ID id;
 		uint32_t read_count;
 		uint32_t write_count;
 
@@ -768,25 +887,25 @@ struct SPIRFunction : IVariant
 	// or a global ID.
 	struct CombinedImageSamplerParameter
 	{
-		uint32_t id;
-		uint32_t image_id;
-		uint32_t sampler_id;
+		VariableID id;
+		VariableID image_id;
+		VariableID sampler_id;
 		bool global_image;
 		bool global_sampler;
 		bool depth;
 	};
 
-	uint32_t return_type;
-	uint32_t function_type;
+	TypeID return_type;
+	TypeID function_type;
 	SmallVector<Parameter> arguments;
 
 	// Can be used by backends to add magic arguments.
 	// Currently used by combined image/sampler implementation.
 
 	SmallVector<Parameter> shadow_arguments;
-	SmallVector<uint32_t> local_variables;
-	uint32_t entry_block = 0;
-	SmallVector<uint32_t> blocks;
+	SmallVector<VariableID> local_variables;
+	BlockID entry_block = 0;
+	SmallVector<BlockID> blocks;
 	SmallVector<CombinedImageSamplerParameter> combined_parameters;
 
 	struct EntryLine
@@ -796,12 +915,12 @@ struct SPIRFunction : IVariant
 	};
 	EntryLine entry_line;
 
-	void add_local_variable(uint32_t id)
+	void add_local_variable(VariableID id)
 	{
 		local_variables.push_back(id);
 	}
 
-	void add_parameter(uint32_t parameter_type, uint32_t id, bool alias_global_variable = false)
+	void add_parameter(TypeID parameter_type, ID id, bool alias_global_variable = false)
 	{
 		// Arguments are read-only until proven otherwise.
 		arguments.push_back({ parameter_type, id, 0u, 0u, alias_global_variable });
@@ -822,7 +941,7 @@ struct SPIRFunction : IVariant
 	// On function entry, make sure to copy a constant array into thread addr space to work around
 	// the case where we are passing a constant array by value to a function on backends which do not
 	// consider arrays value types.
-	SmallVector<uint32_t> constant_arrays_needed_on_stack;
+	SmallVector<ID> constant_arrays_needed_on_stack;
 
 	bool active = false;
 	bool flush_undeclared = true;
@@ -838,7 +957,7 @@ struct SPIRAccessChain : IVariant
 		type = TypeAccessChain
 	};
 
-	SPIRAccessChain(uint32_t basetype_, spv::StorageClass storage_, std::string base_, std::string dynamic_index_,
+	SPIRAccessChain(TypeID basetype_, spv::StorageClass storage_, std::string base_, std::string dynamic_index_,
 	                int32_t static_index_)
 	    : basetype(basetype_)
 	    , storage(storage_)
@@ -853,20 +972,20 @@ struct SPIRAccessChain : IVariant
 	// which has no usable buffer type ala GLSL SSBOs.
 	// StructuredBuffer is too limited, so our only option is to deal with ByteAddressBuffer which works with raw addresses.
 
-	uint32_t basetype;
+	TypeID basetype;
 	spv::StorageClass storage;
 	std::string base;
 	std::string dynamic_index;
 	int32_t static_index;
 
-	uint32_t loaded_from = 0;
+	VariableID loaded_from = 0;
 	uint32_t matrix_stride = 0;
 	bool row_major_matrix = false;
 	bool immutable = false;
 
 	// By reading this expression, we implicitly read these expressions as well.
 	// Used by access chain Store and Load since we read multiple expressions in this case.
-	SmallVector<uint32_t> implied_read_expressions;
+	SmallVector<ID> implied_read_expressions;
 
 	SPIRV_CROSS_DECLARE_CLONE(SPIRAccessChain)
 };
@@ -879,7 +998,7 @@ struct SPIRVariable : IVariant
 	};
 
 	SPIRVariable() = default;
-	SPIRVariable(uint32_t basetype_, spv::StorageClass storage_, uint32_t initializer_ = 0, uint32_t basevariable_ = 0)
+	SPIRVariable(TypeID basetype_, spv::StorageClass storage_, ID initializer_ = 0, VariableID basevariable_ = 0)
 	    : basetype(basetype_)
 	    , storage(storage_)
 	    , initializer(initializer_)
@@ -887,11 +1006,11 @@ struct SPIRVariable : IVariant
 	{
 	}
 
-	uint32_t basetype = 0;
+	TypeID basetype = 0;
 	spv::StorageClass storage = spv::StorageClassGeneric;
 	uint32_t decoration = 0;
-	uint32_t initializer = 0;
-	uint32_t basevariable = 0;
+	ID initializer = 0;
+	VariableID basevariable = 0;
 
 	SmallVector<uint32_t> dereference_chain;
 	bool compat_builtin = false;
@@ -901,10 +1020,10 @@ struct SPIRVariable : IVariant
 	// When we read the variable as an expression, just forward
 	// shadowed_id as the expression.
 	bool statically_assigned = false;
-	uint32_t static_expression = 0;
+	ID static_expression = 0;
 
 	// Temporaries which can remain forwarded as long as this variable is not modified.
-	SmallVector<uint32_t> dependees;
+	SmallVector<ID> dependees;
 	bool forwardable = true;
 
 	bool deferred_declaration = false;
@@ -917,7 +1036,7 @@ struct SPIRVariable : IVariant
 	uint32_t remapped_components = 0;
 
 	// The block which dominates all access to this variable.
-	uint32_t dominator = 0;
+	BlockID dominator = 0;
 	// If true, this variable is a loop variable, when accessing the variable
 	// outside a loop,
 	// we should statically forward it.
@@ -952,15 +1071,12 @@ struct SPIRConstant : IVariant
 	{
 		Constant r[4];
 		// If != 0, this element is a specialization constant, and we should keep track of it as such.
-		uint32_t id[4];
+		ID id[4];
 		uint32_t vecsize = 1;
 
-		// Workaround for MSVC 2013, initializing an array breaks.
 		ConstantVector()
 		{
 			memset(r, 0, sizeof(r));
-			for (unsigned i = 0; i < 4; i++)
-				id[i] = 0;
 		}
 	};
 
@@ -968,15 +1084,8 @@ struct SPIRConstant : IVariant
 	{
 		ConstantVector c[4];
 		// If != 0, this column is a specialization constant, and we should keep track of it as such.
-		uint32_t id[4];
+		ID id[4];
 		uint32_t columns = 1;
-
-		// Workaround for MSVC 2013, initializing an array breaks.
-		ConstantMatrix()
-		{
-			for (unsigned i = 0; i < 4; i++)
-				id[i] = 0;
-		}
 	};
 
 	static inline float f16_to_f32(uint16_t u16_value)
@@ -1141,16 +1250,18 @@ struct SPIRConstant : IVariant
 
 	SPIRConstant() = default;
 
-	SPIRConstant(uint32_t constant_type_, const uint32_t *elements, uint32_t num_elements, bool specialized)
+	SPIRConstant(TypeID constant_type_, const uint32_t *elements, uint32_t num_elements, bool specialized)
 	    : constant_type(constant_type_)
 	    , specialization(specialized)
 	{
-		subconstants.insert(std::end(subconstants), elements, elements + num_elements);
+		subconstants.reserve(num_elements);
+		for (uint32_t i = 0; i < num_elements; i++)
+			subconstants.push_back(elements[i]);
 		specialization = specialized;
 	}
 
 	// Construct scalar (32-bit).
-	SPIRConstant(uint32_t constant_type_, uint32_t v0, bool specialized)
+	SPIRConstant(TypeID constant_type_, uint32_t v0, bool specialized)
 	    : constant_type(constant_type_)
 	    , specialization(specialized)
 	{
@@ -1160,7 +1271,7 @@ struct SPIRConstant : IVariant
 	}
 
 	// Construct scalar (64-bit).
-	SPIRConstant(uint32_t constant_type_, uint64_t v0, bool specialized)
+	SPIRConstant(TypeID constant_type_, uint64_t v0, bool specialized)
 	    : constant_type(constant_type_)
 	    , specialization(specialized)
 	{
@@ -1170,7 +1281,7 @@ struct SPIRConstant : IVariant
 	}
 
 	// Construct vectors and matrices.
-	SPIRConstant(uint32_t constant_type_, const SPIRConstant *const *vector_elements, uint32_t num_elements,
+	SPIRConstant(TypeID constant_type_, const SPIRConstant *const *vector_elements, uint32_t num_elements,
 	             bool specialized)
 	    : constant_type(constant_type_)
 	    , specialization(specialized)
@@ -1202,7 +1313,7 @@ struct SPIRConstant : IVariant
 		}
 	}
 
-	uint32_t constant_type = 0;
+	TypeID constant_type = 0;
 	ConstantMatrix m;
 
 	// If this constant is a specialization constant (i.e. created with OpSpecConstant*).
@@ -1214,7 +1325,7 @@ struct SPIRConstant : IVariant
 	bool is_used_as_lut = false;
 
 	// For composites which are constant arrays, etc.
-	SmallVector<uint32_t> subconstants;
+	SmallVector<ConstantID> subconstants;
 
 	// Non-Vulkan GLSL, HLSL and sometimes MSL emits defines for each specialization constant,
 	// and uses them to initialize the constant. This allows the user
@@ -1349,9 +1460,9 @@ public:
 		return type;
 	}
 
-	uint32_t get_id() const
+	ID get_id() const
 	{
-		return holder ? holder->self : 0;
+		return holder ? holder->self : ID(0);
 	}
 
 	bool empty() const
@@ -1590,5 +1701,17 @@ static inline bool opcode_is_sign_invariant(spv::Op opcode)
 	}
 }
 } // namespace SPIRV_CROSS_NAMESPACE
+
+namespace std
+{
+template <SPIRV_CROSS_NAMESPACE::Types type>
+struct hash<SPIRV_CROSS_NAMESPACE::TypedID<type>>
+{
+	size_t operator()(const SPIRV_CROSS_NAMESPACE::TypedID<type> &value) const
+	{
+		return std::hash<uint32_t>()(value);
+	}
+};
+} // namespace std
 
 #endif

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -27,18 +27,18 @@ struct Resource
 {
 	// Resources are identified with their SPIR-V ID.
 	// This is the ID of the OpVariable.
-	uint32_t id;
+	ID id;
 
 	// The type ID of the variable which includes arrays and all type modifications.
 	// This type ID is not suitable for parsing OpMemberDecoration of a struct and other decorations in general
 	// since these modifications typically happen on the base_type_id.
-	uint32_t type_id;
+	TypeID type_id;
 
 	// The base type of the declared resource.
 	// This type is the base type which ignores pointers and arrays of the type_id.
 	// This is mostly useful to parse decorations of the underlying type.
 	// base_type_id can also be obtained with get_type(get_type(type_id).self).
-	uint32_t base_type_id;
+	TypeID base_type_id;
 
 	// The declared name (OpName) of the resource.
 	// For Buffer blocks, the name actually reflects the externally
@@ -77,17 +77,17 @@ struct ShaderResources
 struct CombinedImageSampler
 {
 	// The ID of the sampler2D variable.
-	uint32_t combined_id;
+	VariableID combined_id;
 	// The ID of the texture2D variable.
-	uint32_t image_id;
+	VariableID image_id;
 	// The ID of the sampler variable.
-	uint32_t sampler_id;
+	VariableID sampler_id;
 };
 
 struct SpecializationConstant
 {
 	// The ID of the specialization constant.
-	uint32_t id;
+	ConstantID id;
 	// The constant ID of the constant, used in Vulkan during pipeline creation.
 	uint32_t constant_id;
 };
@@ -142,81 +142,81 @@ public:
 	virtual std::string compile();
 
 	// Gets the identifier (OpName) of an ID. If not defined, an empty string will be returned.
-	const std::string &get_name(uint32_t id) const;
+	const std::string &get_name(ID id) const;
 
 	// Applies a decoration to an ID. Effectively injects OpDecorate.
-	void set_decoration(uint32_t id, spv::Decoration decoration, uint32_t argument = 0);
-	void set_decoration_string(uint32_t id, spv::Decoration decoration, const std::string &argument);
+	void set_decoration(ID id, spv::Decoration decoration, uint32_t argument = 0);
+	void set_decoration_string(ID id, spv::Decoration decoration, const std::string &argument);
 
 	// Overrides the identifier OpName of an ID.
 	// Identifiers beginning with underscores or identifiers which contain double underscores
 	// are reserved by the implementation.
-	void set_name(uint32_t id, const std::string &name);
+	void set_name(ID id, const std::string &name);
 
 	// Gets a bitmask for the decorations which are applied to ID.
 	// I.e. (1ull << spv::DecorationFoo) | (1ull << spv::DecorationBar)
-	const Bitset &get_decoration_bitset(uint32_t id) const;
+	const Bitset &get_decoration_bitset(ID id) const;
 
 	// Returns whether the decoration has been applied to the ID.
-	bool has_decoration(uint32_t id, spv::Decoration decoration) const;
+	bool has_decoration(ID id, spv::Decoration decoration) const;
 
 	// Gets the value for decorations which take arguments.
 	// If the decoration is a boolean (i.e. spv::DecorationNonWritable),
 	// 1 will be returned.
 	// If decoration doesn't exist or decoration is not recognized,
 	// 0 will be returned.
-	uint32_t get_decoration(uint32_t id, spv::Decoration decoration) const;
-	const std::string &get_decoration_string(uint32_t id, spv::Decoration decoration) const;
+	uint32_t get_decoration(ID id, spv::Decoration decoration) const;
+	const std::string &get_decoration_string(ID id, spv::Decoration decoration) const;
 
 	// Removes the decoration for an ID.
-	void unset_decoration(uint32_t id, spv::Decoration decoration);
+	void unset_decoration(ID id, spv::Decoration decoration);
 
 	// Gets the SPIR-V type associated with ID.
 	// Mostly used with Resource::type_id and Resource::base_type_id to parse the underlying type of a resource.
-	const SPIRType &get_type(uint32_t id) const;
+	const SPIRType &get_type(TypeID id) const;
 
 	// Gets the SPIR-V type of a variable.
-	const SPIRType &get_type_from_variable(uint32_t id) const;
+	const SPIRType &get_type_from_variable(VariableID id) const;
 
 	// Gets the underlying storage class for an OpVariable.
-	spv::StorageClass get_storage_class(uint32_t id) const;
+	spv::StorageClass get_storage_class(VariableID id) const;
 
 	// If get_name() is an empty string, get the fallback name which will be used
 	// instead in the disassembled source.
-	virtual const std::string get_fallback_name(uint32_t id) const;
+	virtual const std::string get_fallback_name(ID id) const;
 
 	// If get_name() of a Block struct is an empty string, get the fallback name.
 	// This needs to be per-variable as multiple variables can use the same block type.
-	virtual const std::string get_block_fallback_name(uint32_t id) const;
+	virtual const std::string get_block_fallback_name(VariableID id) const;
 
 	// Given an OpTypeStruct in ID, obtain the identifier for member number "index".
 	// This may be an empty string.
-	const std::string &get_member_name(uint32_t id, uint32_t index) const;
+	const std::string &get_member_name(TypeID id, uint32_t index) const;
 
 	// Given an OpTypeStruct in ID, obtain the OpMemberDecoration for member number "index".
-	uint32_t get_member_decoration(uint32_t id, uint32_t index, spv::Decoration decoration) const;
-	const std::string &get_member_decoration_string(uint32_t id, uint32_t index, spv::Decoration decoration) const;
+	uint32_t get_member_decoration(TypeID id, uint32_t index, spv::Decoration decoration) const;
+	const std::string &get_member_decoration_string(TypeID id, uint32_t index, spv::Decoration decoration) const;
 
 	// Sets the member identifier for OpTypeStruct ID, member number "index".
-	void set_member_name(uint32_t id, uint32_t index, const std::string &name);
+	void set_member_name(TypeID id, uint32_t index, const std::string &name);
 
 	// Returns the qualified member identifier for OpTypeStruct ID, member number "index",
 	// or an empty string if no qualified alias exists
-	const std::string &get_member_qualified_name(uint32_t type_id, uint32_t index) const;
+	const std::string &get_member_qualified_name(TypeID type_id, uint32_t index) const;
 
 	// Gets the decoration mask for a member of a struct, similar to get_decoration_mask.
-	const Bitset &get_member_decoration_bitset(uint32_t id, uint32_t index) const;
+	const Bitset &get_member_decoration_bitset(TypeID id, uint32_t index) const;
 
 	// Returns whether the decoration has been applied to a member of a struct.
-	bool has_member_decoration(uint32_t id, uint32_t index, spv::Decoration decoration) const;
+	bool has_member_decoration(TypeID id, uint32_t index, spv::Decoration decoration) const;
 
 	// Similar to set_decoration, but for struct members.
-	void set_member_decoration(uint32_t id, uint32_t index, spv::Decoration decoration, uint32_t argument = 0);
-	void set_member_decoration_string(uint32_t id, uint32_t index, spv::Decoration decoration,
+	void set_member_decoration(TypeID id, uint32_t index, spv::Decoration decoration, uint32_t argument = 0);
+	void set_member_decoration_string(TypeID id, uint32_t index, spv::Decoration decoration,
 	                                  const std::string &argument);
 
 	// Unsets a member decoration, similar to unset_decoration.
-	void unset_member_decoration(uint32_t id, uint32_t index, spv::Decoration decoration);
+	void unset_member_decoration(TypeID id, uint32_t index, spv::Decoration decoration);
 
 	// Gets the fallback name for a member, similar to get_fallback_name.
 	virtual const std::string get_fallback_member_name(uint32_t index) const
@@ -228,7 +228,7 @@ public:
 	// SPIR-V shader. The granularity of this analysis is per-member of a struct.
 	// This can be used for Buffer (UBO), BufferBlock/StorageBuffer (SSBO) and PushConstant blocks.
 	// ID is the Resource::id obtained from get_shader_resources().
-	SmallVector<BufferRange> get_active_buffer_ranges(uint32_t id) const;
+	SmallVector<BufferRange> get_active_buffer_ranges(VariableID id) const;
 
 	// Returns the effective size of a buffer block.
 	size_t get_declared_struct_size(const SPIRType &struct_type) const;
@@ -256,12 +256,12 @@ public:
 	//
 	// To use the returned set as the filter for which variables are used during compilation,
 	// this set can be moved to set_enabled_interface_variables().
-	std::unordered_set<uint32_t> get_active_interface_variables() const;
+	std::unordered_set<VariableID> get_active_interface_variables() const;
 
 	// Sets the interface variables which are used during compilation.
 	// By default, all variables are used.
 	// Once set, compile() will only consider the set in active_variables.
-	void set_enabled_interface_variables(std::unordered_set<uint32_t> active_variables);
+	void set_enabled_interface_variables(std::unordered_set<VariableID> active_variables);
 
 	// Query shader resources, use ids with reflection interface to modify or query binding points, etc.
 	ShaderResources get_shader_resources() const;
@@ -269,19 +269,19 @@ public:
 	// Query shader resources, but only return the variables which are part of active_variables.
 	// E.g.: get_shader_resources(get_active_variables()) to only return the variables which are statically
 	// accessed.
-	ShaderResources get_shader_resources(const std::unordered_set<uint32_t> &active_variables) const;
+	ShaderResources get_shader_resources(const std::unordered_set<VariableID> &active_variables) const;
 
 	// Remapped variables are considered built-in variables and a backend will
 	// not emit a declaration for this variable.
 	// This is mostly useful for making use of builtins which are dependent on extensions.
-	void set_remapped_variable_state(uint32_t id, bool remap_enable);
-	bool get_remapped_variable_state(uint32_t id) const;
+	void set_remapped_variable_state(VariableID id, bool remap_enable);
+	bool get_remapped_variable_state(VariableID id) const;
 
 	// For subpassInput variables which are remapped to plain variables,
 	// the number of components in the remapped
 	// variable must be specified as the backing type of subpass inputs are opaque.
-	void set_subpass_input_remapped_components(uint32_t id, uint32_t components);
-	uint32_t get_subpass_input_remapped_components(uint32_t id) const;
+	void set_subpass_input_remapped_components(VariableID id, uint32_t components);
+	uint32_t get_subpass_input_remapped_components(VariableID id) const;
 
 	// All operations work on the current entry point.
 	// Entry points can be swapped out with set_entry_point().
@@ -362,7 +362,7 @@ public:
 	// If the returned ID is non-zero, it can be decorated with set/bindings as desired before calling compile().
 	// Calling this function also invalidates get_active_interface_variables(), so this should be called
 	// before that function.
-	uint32_t build_dummy_sampler_for_combined_images();
+	VariableID build_dummy_sampler_for_combined_images();
 
 	// Analyzes all separate image and samplers used from the currently selected entry point,
 	// and re-routes them all to a combined image sampler instead.
@@ -411,8 +411,8 @@ public:
 	// constant_type is the SPIRType for the specialization constant,
 	// which can be queried to determine which fields in the unions should be poked at.
 	SmallVector<SpecializationConstant> get_specialization_constants() const;
-	SPIRConstant &get_constant(uint32_t id);
-	const SPIRConstant &get_constant(uint32_t id) const;
+	SPIRConstant &get_constant(ConstantID id);
+	const SPIRConstant &get_constant(ConstantID id) const;
 
 	uint32_t get_current_id_bound() const
 	{
@@ -435,7 +435,7 @@ public:
 	// If the decoration was declared, sets the word_offset to an offset into the provided SPIR-V binary buffer and returns true,
 	// otherwise, returns false.
 	// If the decoration does not have any value attached to it (e.g. DecorationRelaxedPrecision), this function will also return false.
-	bool get_binary_offset_for_decoration(uint32_t id, spv::Decoration decoration, uint32_t &word_offset) const;
+	bool get_binary_offset_for_decoration(VariableID id, spv::Decoration decoration, uint32_t &word_offset) const;
 
 	// HLSL counter buffer reflection interface.
 	// Append/Consume/Increment/Decrement in HLSL is implemented as two "neighbor" buffer objects where
@@ -450,7 +450,7 @@ public:
 	// only return true if OpSource was reported HLSL.
 	// To rely on this functionality, ensure that the SPIR-V module is not stripped.
 
-	bool buffer_is_hlsl_counter_buffer(uint32_t id) const;
+	bool buffer_is_hlsl_counter_buffer(VariableID id) const;
 
 	// Queries if a buffer object has a neighbor "counter" buffer.
 	// If so, the ID of that counter buffer will be returned in counter_id.
@@ -458,7 +458,7 @@ public:
 	// Otherwise, this query is purely based on OpName identifiers as found in the SPIR-V module, and will
 	// only return true if OpSource was reported HLSL.
 	// To rely on this functionality, ensure that the SPIR-V module is not stripped.
-	bool buffer_get_hlsl_counter_buffer(uint32_t id, uint32_t &counter_id) const;
+	bool buffer_get_hlsl_counter_buffer(VariableID id, uint32_t &counter_id) const;
 
 	// Gets the list of all SPIR-V Capabilities which were declared in the SPIR-V module.
 	const SmallVector<spv::Capability> &get_declared_capabilities() const;
@@ -479,13 +479,13 @@ public:
 	// ID is the name of a variable as returned by Resource::id, and must be a variable with a Block-like type.
 	//
 	// This also applies to HLSL cbuffers.
-	std::string get_remapped_declared_block_name(uint32_t id) const;
+	std::string get_remapped_declared_block_name(VariableID id) const;
 
 	// For buffer block variables, get the decorations for that variable.
 	// Sometimes, decorations for buffer blocks are found in member decorations instead
 	// of direct decorations on the variable itself.
 	// The most common use here is to check if a buffer is readonly or writeonly.
-	Bitset get_buffer_block_flags(uint32_t id) const;
+	Bitset get_buffer_block_flags(VariableID id) const;
 
 protected:
 	const uint32_t *stream(const Instruction &instr) const
@@ -509,7 +509,7 @@ protected:
 
 	SPIRFunction *current_function = nullptr;
 	SPIRBlock *current_block = nullptr;
-	std::unordered_set<uint32_t> active_interface_variables;
+	std::unordered_set<VariableID> active_interface_variables;
 	bool check_active_interface_variables = false;
 
 	// If our IDs are out of range here as part of opcodes, throw instead of
@@ -549,7 +549,9 @@ protected:
 	template <typename T>
 	const T *maybe_get(uint32_t id) const
 	{
-		if (ir.ids[id].get_type() == static_cast<Types>(T::type))
+		if (id >= ir.ids.size())
+			return nullptr;
+		else if (ir.ids[id].get_type() == static_cast<Types>(T::type))
 			return &get<T>(id);
 		else
 			return nullptr;
@@ -618,7 +620,7 @@ protected:
 	inline bool is_single_block_loop(uint32_t next) const
 	{
 		auto &block = get<SPIRBlock>(next);
-		return block.merge == SPIRBlock::MergeLoop && block.continue_block == next;
+		return block.merge == SPIRBlock::MergeLoop && block.continue_block == ID(next);
 	}
 
 	inline bool is_break(uint32_t next) const
@@ -748,7 +750,7 @@ protected:
 
 	struct InterfaceVariableAccessHandler : OpcodeHandler
 	{
-		InterfaceVariableAccessHandler(const Compiler &compiler_, std::unordered_set<uint32_t> &variables_)
+		InterfaceVariableAccessHandler(const Compiler &compiler_, std::unordered_set<VariableID> &variables_)
 		    : compiler(compiler_)
 		    , variables(variables_)
 		{
@@ -757,7 +759,7 @@ protected:
 		bool handle(spv::Op opcode, const uint32_t *args, uint32_t length) override;
 
 		const Compiler &compiler;
-		std::unordered_set<uint32_t> &variables;
+		std::unordered_set<VariableID> &variables;
 	};
 
 	struct CombinedImageSamplerHandler : OpcodeHandler
@@ -779,8 +781,8 @@ protected:
 		uint32_t remap_parameter(uint32_t id);
 		void push_remap_parameters(const SPIRFunction &func, const uint32_t *args, uint32_t length);
 		void pop_remap_parameters();
-		void register_combined_image_sampler(SPIRFunction &caller, uint32_t combined_id, uint32_t texture_id,
-		                                     uint32_t sampler_id, bool depth);
+		void register_combined_image_sampler(SPIRFunction &caller, VariableID combined_id, VariableID texture_id,
+		                                     VariableID sampler_id, bool depth);
 	};
 
 	struct DummySamplerForCombinedImageHandler : OpcodeHandler
@@ -813,7 +815,7 @@ protected:
 	// This must be an ordered data structure so we always pick the same type aliases.
 	SmallVector<uint32_t> global_struct_cache;
 
-	ShaderResources get_shader_resources(const std::unordered_set<uint32_t> *active_variables) const;
+	ShaderResources get_shader_resources(const std::unordered_set<VariableID> *active_variables) const;
 
 	VariableTypeRemapCallback variable_remap_callback;
 
@@ -985,7 +987,7 @@ protected:
 	struct InterlockedResourceAccessPrepassHandler : OpcodeHandler
 	{
 		InterlockedResourceAccessPrepassHandler(Compiler &compiler_, uint32_t entry_point_id)
-			: compiler(compiler_)
+		    : compiler(compiler_)
 		{
 			call_stack.push_back(entry_point_id);
 		}
@@ -1038,7 +1040,7 @@ protected:
 	bool reflection_ssbo_instance_name_is_significant() const;
 	std::string get_remapped_declared_block_name(uint32_t id, bool fallback_prefer_instance_name) const;
 
-	bool flush_phi_required(uint32_t from, uint32_t to) const;
+	bool flush_phi_required(BlockID from, BlockID to) const;
 
 private:
 	// Used only to implement the old deprecated get_entry_point() interface.

--- a/spirv_cross_c.cpp
+++ b/spirv_cross_c.cpp
@@ -162,7 +162,7 @@ struct spvc_compiler_options_s : ScratchMemoryAllocation
 
 struct spvc_set_s : ScratchMemoryAllocation
 {
-	std::unordered_set<uint32_t> set;
+	std::unordered_set<VariableID> set;
 };
 
 // Dummy-inherit to we can keep our opaque type handle type safe in C-land as well,

--- a/spirv_cross_parsed_ir.cpp
+++ b/spirv_cross_parsed_ir.cpp
@@ -162,7 +162,7 @@ static string ensure_valid_identifier(const string &name, bool member)
 	return str;
 }
 
-const string &ParsedIR::get_name(uint32_t id) const
+const string &ParsedIR::get_name(ID id) const
 {
 	auto *m = find_meta(id);
 	if (m)
@@ -171,7 +171,7 @@ const string &ParsedIR::get_name(uint32_t id) const
 		return empty_string;
 }
 
-const string &ParsedIR::get_member_name(uint32_t id, uint32_t index) const
+const string &ParsedIR::get_member_name(TypeID id, uint32_t index) const
 {
 	auto *m = find_meta(id);
 	if (m)
@@ -184,7 +184,7 @@ const string &ParsedIR::get_member_name(uint32_t id, uint32_t index) const
 		return empty_string;
 }
 
-void ParsedIR::set_name(uint32_t id, const string &name)
+void ParsedIR::set_name(ID id, const string &name)
 {
 	auto &str = meta[id].decoration.alias;
 	str.clear();
@@ -199,7 +199,7 @@ void ParsedIR::set_name(uint32_t id, const string &name)
 	str = ensure_valid_identifier(name, false);
 }
 
-void ParsedIR::set_member_name(uint32_t id, uint32_t index, const string &name)
+void ParsedIR::set_member_name(TypeID id, uint32_t index, const string &name)
 {
 	meta[id].members.resize(max(meta[id].members.size(), size_t(index) + 1));
 
@@ -215,7 +215,7 @@ void ParsedIR::set_member_name(uint32_t id, uint32_t index, const string &name)
 	str = ensure_valid_identifier(name, true);
 }
 
-void ParsedIR::set_decoration_string(uint32_t id, Decoration decoration, const string &argument)
+void ParsedIR::set_decoration_string(ID id, Decoration decoration, const string &argument)
 {
 	auto &dec = meta[id].decoration;
 	dec.decoration_flags.set(decoration);
@@ -231,7 +231,7 @@ void ParsedIR::set_decoration_string(uint32_t id, Decoration decoration, const s
 	}
 }
 
-void ParsedIR::set_decoration(uint32_t id, Decoration decoration, uint32_t argument)
+void ParsedIR::set_decoration(ID id, Decoration decoration, uint32_t argument)
 {
 	auto &dec = meta[id].decoration;
 	dec.decoration_flags.set(decoration);
@@ -297,7 +297,7 @@ void ParsedIR::set_decoration(uint32_t id, Decoration decoration, uint32_t argum
 	}
 }
 
-void ParsedIR::set_member_decoration(uint32_t id, uint32_t index, Decoration decoration, uint32_t argument)
+void ParsedIR::set_member_decoration(TypeID id, uint32_t index, Decoration decoration, uint32_t argument)
 {
 	meta[id].members.resize(max(meta[id].members.size(), size_t(index) + 1));
 	auto &dec = meta[id].members[index];
@@ -345,7 +345,7 @@ void ParsedIR::set_member_decoration(uint32_t id, uint32_t index, Decoration dec
 
 // Recursively marks any constants referenced by the specified constant instruction as being used
 // as an array length. The id must be a constant instruction (SPIRConstant or SPIRConstantOp).
-void ParsedIR::mark_used_as_array_length(uint32_t id)
+void ParsedIR::mark_used_as_array_length(ID id)
 {
 	switch (ids[id].get_type())
 	{
@@ -401,7 +401,7 @@ Bitset ParsedIR::get_buffer_block_flags(const SPIRVariable &var) const
 	return base_flags;
 }
 
-const Bitset &ParsedIR::get_member_decoration_bitset(uint32_t id, uint32_t index) const
+const Bitset &ParsedIR::get_member_decoration_bitset(TypeID id, uint32_t index) const
 {
 	auto *m = find_meta(id);
 	if (m)
@@ -414,12 +414,12 @@ const Bitset &ParsedIR::get_member_decoration_bitset(uint32_t id, uint32_t index
 		return cleared_bitset;
 }
 
-bool ParsedIR::has_decoration(uint32_t id, Decoration decoration) const
+bool ParsedIR::has_decoration(ID id, Decoration decoration) const
 {
 	return get_decoration_bitset(id).get(decoration);
 }
 
-uint32_t ParsedIR::get_decoration(uint32_t id, Decoration decoration) const
+uint32_t ParsedIR::get_decoration(ID id, Decoration decoration) const
 {
 	auto *m = find_meta(id);
 	if (!m)
@@ -460,7 +460,7 @@ uint32_t ParsedIR::get_decoration(uint32_t id, Decoration decoration) const
 	}
 }
 
-const string &ParsedIR::get_decoration_string(uint32_t id, Decoration decoration) const
+const string &ParsedIR::get_decoration_string(ID id, Decoration decoration) const
 {
 	auto *m = find_meta(id);
 	if (!m)
@@ -481,7 +481,7 @@ const string &ParsedIR::get_decoration_string(uint32_t id, Decoration decoration
 	}
 }
 
-void ParsedIR::unset_decoration(uint32_t id, Decoration decoration)
+void ParsedIR::unset_decoration(ID id, Decoration decoration)
 {
 	auto &dec = meta[id].decoration;
 	dec.decoration_flags.clear(decoration);
@@ -543,12 +543,12 @@ void ParsedIR::unset_decoration(uint32_t id, Decoration decoration)
 	}
 }
 
-bool ParsedIR::has_member_decoration(uint32_t id, uint32_t index, Decoration decoration) const
+bool ParsedIR::has_member_decoration(TypeID id, uint32_t index, Decoration decoration) const
 {
 	return get_member_decoration_bitset(id, index).get(decoration);
 }
 
-uint32_t ParsedIR::get_member_decoration(uint32_t id, uint32_t index, Decoration decoration) const
+uint32_t ParsedIR::get_member_decoration(TypeID id, uint32_t index, Decoration decoration) const
 {
 	auto *m = find_meta(id);
 	if (!m)
@@ -582,7 +582,7 @@ uint32_t ParsedIR::get_member_decoration(uint32_t id, uint32_t index, Decoration
 	}
 }
 
-const Bitset &ParsedIR::get_decoration_bitset(uint32_t id) const
+const Bitset &ParsedIR::get_decoration_bitset(ID id) const
 {
 	auto *m = find_meta(id);
 	if (m)
@@ -594,7 +594,7 @@ const Bitset &ParsedIR::get_decoration_bitset(uint32_t id) const
 		return cleared_bitset;
 }
 
-void ParsedIR::set_member_decoration_string(uint32_t id, uint32_t index, Decoration decoration, const string &argument)
+void ParsedIR::set_member_decoration_string(TypeID id, uint32_t index, Decoration decoration, const string &argument)
 {
 	meta[id].members.resize(max(meta[id].members.size(), size_t(index) + 1));
 	auto &dec = meta[id].members[index];
@@ -611,7 +611,7 @@ void ParsedIR::set_member_decoration_string(uint32_t id, uint32_t index, Decorat
 	}
 }
 
-const string &ParsedIR::get_member_decoration_string(uint32_t id, uint32_t index, Decoration decoration) const
+const string &ParsedIR::get_member_decoration_string(TypeID id, uint32_t index, Decoration decoration) const
 {
 	auto *m = find_meta(id);
 	if (m)
@@ -634,7 +634,7 @@ const string &ParsedIR::get_member_decoration_string(uint32_t id, uint32_t index
 		return empty_string;
 }
 
-void ParsedIR::unset_member_decoration(uint32_t id, uint32_t index, Decoration decoration)
+void ParsedIR::unset_member_decoration(TypeID id, uint32_t index, Decoration decoration)
 {
 	auto &m = meta[id];
 	if (index >= m.members.size())
@@ -687,7 +687,7 @@ uint32_t ParsedIR::increase_bound_by(uint32_t incr_amount)
 	return uint32_t(curr_bound);
 }
 
-void ParsedIR::remove_typed_id(Types type, uint32_t id)
+void ParsedIR::remove_typed_id(Types type, ID id)
 {
 	auto &type_ids = ids_for_type[type];
 	type_ids.erase(remove(begin(type_ids), end(type_ids), id), end(type_ids));
@@ -702,7 +702,7 @@ void ParsedIR::reset_all_of_type(Types type)
 	ids_for_type[type].clear();
 }
 
-void ParsedIR::add_typed_id(Types type, uint32_t id)
+void ParsedIR::add_typed_id(Types type, ID id)
 {
 	if (loop_iteration_depth_hard != 0)
 		SPIRV_CROSS_THROW("Cannot add typed ID while looping over it.");
@@ -748,7 +748,7 @@ void ParsedIR::add_typed_id(Types type, uint32_t id)
 	}
 }
 
-const Meta *ParsedIR::find_meta(uint32_t id) const
+const Meta *ParsedIR::find_meta(ID id) const
 {
 	auto itr = meta.find(id);
 	if (itr != end(meta))
@@ -757,7 +757,7 @@ const Meta *ParsedIR::find_meta(uint32_t id) const
 		return nullptr;
 }
 
-Meta *ParsedIR::find_meta(uint32_t id)
+Meta *ParsedIR::find_meta(ID id)
 {
 	auto itr = meta.find(id);
 	if (itr != end(meta))

--- a/spirv_cross_parsed_ir.hpp
+++ b/spirv_cross_parsed_ir.hpp
@@ -57,19 +57,19 @@ public:
 	SmallVector<Variant> ids;
 
 	// Various meta data for IDs, decorations, names, etc.
-	std::unordered_map<uint32_t, Meta> meta;
+	std::unordered_map<ID, Meta> meta;
 
 	// Holds all IDs which have a certain type.
 	// This is needed so we can iterate through a specific kind of resource quickly,
 	// and in-order of module declaration.
-	SmallVector<uint32_t> ids_for_type[TypeCount];
+	SmallVector<ID> ids_for_type[TypeCount];
 
 	// Special purpose lists which contain a union of types.
 	// This is needed so we can declare specialization constants and structs in an interleaved fashion,
 	// among other things.
 	// Constants can be of struct type, and struct array sizes can use specialization constants.
-	SmallVector<uint32_t> ids_for_constant_or_type;
-	SmallVector<uint32_t> ids_for_constant_or_variable;
+	SmallVector<ID> ids_for_constant_or_type;
+	SmallVector<ID> ids_for_constant_or_variable;
 
 	// Declared capabilities and extensions in the SPIR-V module.
 	// Not really used except for reflection at the moment.
@@ -88,12 +88,12 @@ public:
 	};
 	using BlockMetaFlags = uint8_t;
 	SmallVector<BlockMetaFlags> block_meta;
-	std::unordered_map<uint32_t, uint32_t> continue_block_to_loop_header;
+	std::unordered_map<BlockID, BlockID> continue_block_to_loop_header;
 
 	// Normally, we'd stick SPIREntryPoint in ids array, but it conflicts with SPIRFunction.
 	// Entry points can therefore be seen as some sort of meta structure.
-	std::unordered_map<uint32_t, SPIREntryPoint> entry_points;
-	uint32_t default_entry_point = 0;
+	std::unordered_map<FunctionID, SPIREntryPoint> entry_points;
+	FunctionID default_entry_point = 0;
 
 	struct Source
 	{
@@ -114,34 +114,34 @@ public:
 	// Can be useful for simple "raw" reflection.
 	// However, most members are here because the Parser needs most of these,
 	// and might as well just have the whole suite of decoration/name handling in one place.
-	void set_name(uint32_t id, const std::string &name);
-	const std::string &get_name(uint32_t id) const;
-	void set_decoration(uint32_t id, spv::Decoration decoration, uint32_t argument = 0);
-	void set_decoration_string(uint32_t id, spv::Decoration decoration, const std::string &argument);
-	bool has_decoration(uint32_t id, spv::Decoration decoration) const;
-	uint32_t get_decoration(uint32_t id, spv::Decoration decoration) const;
-	const std::string &get_decoration_string(uint32_t id, spv::Decoration decoration) const;
-	const Bitset &get_decoration_bitset(uint32_t id) const;
-	void unset_decoration(uint32_t id, spv::Decoration decoration);
+	void set_name(ID id, const std::string &name);
+	const std::string &get_name(ID id) const;
+	void set_decoration(ID id, spv::Decoration decoration, uint32_t argument = 0);
+	void set_decoration_string(ID id, spv::Decoration decoration, const std::string &argument);
+	bool has_decoration(ID id, spv::Decoration decoration) const;
+	uint32_t get_decoration(ID id, spv::Decoration decoration) const;
+	const std::string &get_decoration_string(ID id, spv::Decoration decoration) const;
+	const Bitset &get_decoration_bitset(ID id) const;
+	void unset_decoration(ID id, spv::Decoration decoration);
 
 	// Decoration handling methods (for members of a struct).
-	void set_member_name(uint32_t id, uint32_t index, const std::string &name);
-	const std::string &get_member_name(uint32_t id, uint32_t index) const;
-	void set_member_decoration(uint32_t id, uint32_t index, spv::Decoration decoration, uint32_t argument = 0);
-	void set_member_decoration_string(uint32_t id, uint32_t index, spv::Decoration decoration,
+	void set_member_name(TypeID id, uint32_t index, const std::string &name);
+	const std::string &get_member_name(TypeID id, uint32_t index) const;
+	void set_member_decoration(TypeID id, uint32_t index, spv::Decoration decoration, uint32_t argument = 0);
+	void set_member_decoration_string(TypeID id, uint32_t index, spv::Decoration decoration,
 	                                  const std::string &argument);
-	uint32_t get_member_decoration(uint32_t id, uint32_t index, spv::Decoration decoration) const;
-	const std::string &get_member_decoration_string(uint32_t id, uint32_t index, spv::Decoration decoration) const;
-	bool has_member_decoration(uint32_t id, uint32_t index, spv::Decoration decoration) const;
-	const Bitset &get_member_decoration_bitset(uint32_t id, uint32_t index) const;
-	void unset_member_decoration(uint32_t id, uint32_t index, spv::Decoration decoration);
+	uint32_t get_member_decoration(TypeID id, uint32_t index, spv::Decoration decoration) const;
+	const std::string &get_member_decoration_string(TypeID id, uint32_t index, spv::Decoration decoration) const;
+	bool has_member_decoration(TypeID id, uint32_t index, spv::Decoration decoration) const;
+	const Bitset &get_member_decoration_bitset(TypeID id, uint32_t index) const;
+	void unset_member_decoration(TypeID id, uint32_t index, spv::Decoration decoration);
 
-	void mark_used_as_array_length(uint32_t id);
+	void mark_used_as_array_length(ID id);
 	uint32_t increase_bound_by(uint32_t count);
 	Bitset get_buffer_block_flags(const SPIRVariable &var) const;
 
-	void add_typed_id(Types type, uint32_t id);
-	void remove_typed_id(Types type, uint32_t id);
+	void add_typed_id(Types type, ID id);
+	void remove_typed_id(Types type, ID id);
 
 	class LoopLock
 	{
@@ -198,8 +198,8 @@ public:
 
 	void reset_all_of_type(Types type);
 
-	Meta *find_meta(uint32_t id);
-	const Meta *find_meta(uint32_t id) const;
+	Meta *find_meta(ID id);
+	const Meta *find_meta(ID id) const;
 
 	const std::string &get_empty_string() const
 	{

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -209,7 +209,7 @@ public:
 	// For this to work, all types in the block must be the same basic type, e.g. mixing vec2 and vec4 is fine, but
 	// mixing int and float is not.
 	// The name of the uniform array will be the same as the interface block name.
-	void flatten_buffer_block(uint32_t id);
+	void flatten_buffer_block(VariableID id);
 
 protected:
 	void reset();
@@ -259,10 +259,10 @@ protected:
 	virtual void emit_fixup();
 	virtual std::string variable_decl(const SPIRType &type, const std::string &name, uint32_t id = 0);
 	virtual std::string to_func_call_arg(const SPIRFunction::Parameter &arg, uint32_t id);
-	virtual std::string to_function_name(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather,
+	virtual std::string to_function_name(VariableID img, const SPIRType &imgtype, bool is_fetch, bool is_gather,
 	                                     bool is_proj, bool has_array_offsets, bool has_offset, bool has_grad,
 	                                     bool has_dref, uint32_t lod, uint32_t minlod);
-	virtual std::string to_function_args(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather,
+	virtual std::string to_function_args(VariableID img, const SPIRType &imgtype, bool is_fetch, bool is_gather,
 	                                     bool is_proj, uint32_t coord, uint32_t coord_components, uint32_t dref,
 	                                     uint32_t grad_x, uint32_t grad_y, uint32_t lod, uint32_t coffset,
 	                                     uint32_t offset, uint32_t bias, uint32_t comp, uint32_t sample,
@@ -428,17 +428,17 @@ protected:
 	void emit_interface_block(const SPIRVariable &type);
 	void emit_flattened_io_block(const SPIRVariable &var, const char *qual);
 	void emit_block_chain(SPIRBlock &block);
-	void emit_hoisted_temporaries(SmallVector<std::pair<uint32_t, uint32_t>> &temporaries);
+	void emit_hoisted_temporaries(SmallVector<std::pair<TypeID, ID>> &temporaries);
 	std::string constant_value_macro_name(uint32_t id);
 	void emit_constant(const SPIRConstant &constant);
 	void emit_specialization_constant_op(const SPIRConstantOp &constant);
 	std::string emit_continue_block(uint32_t continue_block, bool follow_true_block, bool follow_false_block);
 	bool attempt_emit_loop_header(SPIRBlock &block, SPIRBlock::Method method);
 
-	void branch(uint32_t from, uint32_t to);
-	void branch_to_continue(uint32_t from, uint32_t to);
-	void branch(uint32_t from, uint32_t cond, uint32_t true_block, uint32_t false_block);
-	void flush_phi(uint32_t from, uint32_t to);
+	void branch(BlockID from, BlockID to);
+	void branch_to_continue(BlockID from, BlockID to);
+	void branch(BlockID from, uint32_t cond, BlockID true_block, BlockID false_block);
+	void flush_phi(BlockID from, BlockID to);
 	void flush_variable_declaration(uint32_t id);
 	void flush_undeclared_variables(SPIRBlock &block);
 	void emit_variable_temporary_copies(const SPIRVariable &var);
@@ -543,7 +543,7 @@ protected:
 	virtual std::string layout_for_member(const SPIRType &type, uint32_t index);
 	virtual std::string to_interpolation_qualifiers(const Bitset &flags);
 	std::string layout_for_variable(const SPIRVariable &variable);
-	std::string to_combined_image_sampler(uint32_t image_id, uint32_t samp_id);
+	std::string to_combined_image_sampler(VariableID image_id, VariableID samp_id);
 	virtual bool skip_argument(uint32_t id) const;
 	virtual void emit_array_copy(const std::string &lhs, uint32_t rhs_id, spv::StorageClass lhs_storage,
 	                             spv::StorageClass rhs_storage);

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1045,7 +1045,7 @@ void CompilerHLSL::emit_specialization_constants_and_structs()
 {
 	bool emitted = false;
 	SpecializationConstant wg_x, wg_y, wg_z;
-	uint32_t workgroup_size_id = get_work_group_size_specialization_constants(wg_x, wg_y, wg_z);
+	ID workgroup_size_id = get_work_group_size_specialization_constants(wg_x, wg_y, wg_z);
 
 	auto loop_lock = ir.create_loop_hard_lock();
 	for (auto &id_ : ir.ids_for_constant_or_type)
@@ -2489,7 +2489,7 @@ void CompilerHLSL::emit_texture_op(const Instruction &i)
 
 	uint32_t result_type = ops[0];
 	uint32_t id = ops[1];
-	uint32_t img = ops[2];
+	VariableID img = ops[2];
 	uint32_t coord = ops[3];
 	uint32_t dref = 0;
 	uint32_t comp = 0;
@@ -3724,7 +3724,7 @@ void CompilerHLSL::emit_access_chain(const Instruction &instruction)
 		e.row_major_matrix = row_major_matrix;
 		e.matrix_stride = matrix_stride;
 		e.immutable = should_forward(ops[2]);
-		e.loaded_from = backing_variable ? backing_variable->self : 0;
+		e.loaded_from = backing_variable ? backing_variable->self : ID(0);
 
 		if (chain)
 		{
@@ -4494,7 +4494,7 @@ void CompilerHLSL::emit_instruction(const Instruction &instruction)
 
 		// When using the pointer, we need to know which variable it is actually loaded from.
 		auto *var = maybe_get_backing_variable(ops[2]);
-		e.loaded_from = var ? var->self : 0;
+		e.loaded_from = var ? var->self : ID(0);
 		break;
 	}
 
@@ -4764,7 +4764,7 @@ void CompilerHLSL::add_vertex_attribute_remap(const HLSLVertexAttributeRemap &ve
 	remap_vertex_attributes.push_back(vertex_attributes);
 }
 
-uint32_t CompilerHLSL::remap_num_workgroups_builtin()
+VariableID CompilerHLSL::remap_num_workgroups_builtin()
 {
 	update_active_builtins();
 

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -114,7 +114,7 @@ public:
 	// If non-zero, this returns the variable ID of a cbuffer which corresponds to
 	// the cbuffer declared above. By default, no binding or descriptor set decoration is set,
 	// so the calling application should declare explicit bindings on this ID before calling compile().
-	uint32_t remap_num_workgroups_builtin();
+	VariableID remap_num_workgroups_builtin();
 
 private:
 	std::string type_to_glsl(const SPIRType &type, uint32_t id = 0) override;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -363,21 +363,21 @@ public:
 	// buffer if the shader needs it.
 	bool needs_output_buffer() const
 	{
-		return capture_output_to_buffer && stage_out_var_id != 0;
+		return capture_output_to_buffer && stage_out_var_id != ID(0);
 	}
 
 	// Provide feedback to calling API to allow it to pass a patch output
 	// buffer if the shader needs it.
 	bool needs_patch_output_buffer() const
 	{
-		return capture_output_to_buffer && patch_stage_out_var_id != 0;
+		return capture_output_to_buffer && patch_stage_out_var_id != ID(0);
 	}
 
 	// Provide feedback to calling API to allow it to pass an input threadgroup
 	// buffer if the shader needs it.
 	bool needs_input_threadgroup_mem() const
 	{
-		return capture_output_to_buffer && stage_in_var_id != 0;
+		return capture_output_to_buffer && stage_in_var_id != ID(0);
 	}
 
 	explicit CompilerMSL(std::vector<uint32_t> spirv);
@@ -450,7 +450,7 @@ public:
 	// This can be used on both combined image/samplers (sampler2D) or standalone samplers.
 	// The remapped sampler must not be an array of samplers.
 	// Prefer remap_constexpr_sampler_by_binding unless you're also doing reflection anyways.
-	void remap_constexpr_sampler(uint32_t id, const MSLConstexprSampler &sampler);
+	void remap_constexpr_sampler(VariableID id, const MSLConstexprSampler &sampler);
 
 	// Same as remap_constexpr_sampler, except you provide set/binding, rather than variable ID.
 	// Remaps based on ID take priority over set/binding remaps.
@@ -551,10 +551,10 @@ protected:
 	std::string builtin_to_glsl(spv::BuiltIn builtin, spv::StorageClass storage) override;
 	std::string to_func_call_arg(const SPIRFunction::Parameter &arg, uint32_t id) override;
 	std::string to_name(uint32_t id, bool allow_alias = true) const override;
-	std::string to_function_name(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather, bool is_proj,
+	std::string to_function_name(VariableID img, const SPIRType &imgtype, bool is_fetch, bool is_gather, bool is_proj,
 	                             bool has_array_offsets, bool has_offset, bool has_grad, bool has_dref, uint32_t lod,
 	                             uint32_t minlod) override;
-	std::string to_function_args(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather, bool is_proj,
+	std::string to_function_args(VariableID img, const SPIRType &imgtype, bool is_fetch, bool is_gather, bool is_proj,
 	                             uint32_t coord, uint32_t coord_components, uint32_t dref, uint32_t grad_x,
 	                             uint32_t grad_y, uint32_t lod, uint32_t coffset, uint32_t offset, uint32_t bias,
 	                             uint32_t comp, uint32_t sample, uint32_t minlod, bool *p_forward) override;
@@ -752,12 +752,12 @@ protected:
 	// Intentionally uninitialized, works around MSVC 2013 bug.
 	uint32_t next_metal_resource_ids[kMaxArgumentBuffers];
 
-	uint32_t stage_in_var_id = 0;
-	uint32_t stage_out_var_id = 0;
-	uint32_t patch_stage_in_var_id = 0;
-	uint32_t patch_stage_out_var_id = 0;
-	uint32_t stage_in_ptr_var_id = 0;
-	uint32_t stage_out_ptr_var_id = 0;
+	VariableID stage_in_var_id = 0;
+	VariableID stage_out_var_id = 0;
+	VariableID patch_stage_in_var_id = 0;
+	VariableID patch_stage_out_var_id = 0;
+	VariableID stage_in_ptr_var_id = 0;
+	VariableID stage_out_ptr_var_id = 0;
 	bool has_sampled_images = false;
 	bool needs_vertex_idx_arg = false;
 	bool needs_instance_idx_arg = false;

--- a/spirv_parser.cpp
+++ b/spirv_parser.cpp
@@ -278,7 +278,9 @@ void Parser::parse(const Instruction &instruction)
 
 		// Strings need nul-terminator and consume the whole word.
 		uint32_t strlen_words = uint32_t((e.name.size() + 1 + 3) >> 2);
-		e.interface_variables.insert(end(e.interface_variables), ops + strlen_words + 2, ops + instruction.length);
+
+		for (uint32_t i = strlen_words + 2; i < instruction.length; i++)
+			e.interface_variables.push_back(ops[i]);
 
 		// Set the name of the entry point in case OpName is not provided later.
 		ir.set_name(ops[1], e.name);
@@ -658,7 +660,7 @@ void Parser::parse(const Instruction &instruction)
 				}
 			}
 
-			if (type.type_alias == 0)
+			if (type.type_alias == TypeID(0))
 				global_struct_cache.push_back(id);
 		}
 		break;
@@ -1008,12 +1010,12 @@ void Parser::parse(const Instruction &instruction)
 		ir.block_meta[current_block->self] |= ParsedIR::BLOCK_META_LOOP_HEADER_BIT;
 		ir.block_meta[current_block->merge_block] |= ParsedIR::BLOCK_META_LOOP_MERGE_BIT;
 
-		ir.continue_block_to_loop_header[current_block->continue_block] = current_block->self;
+		ir.continue_block_to_loop_header[current_block->continue_block] = BlockID(current_block->self);
 
 		// Don't add loop headers to continue blocks,
 		// which would make it impossible branch into the loop header since
 		// they are treated as continues.
-		if (current_block->continue_block != current_block->self)
+		if (current_block->continue_block != BlockID(current_block->self))
 			ir.block_meta[current_block->continue_block] |= ParsedIR::BLOCK_META_CONTINUE_BIT;
 
 		if (length >= 3)

--- a/spirv_reflect.cpp
+++ b/spirv_reflect.cpp
@@ -285,7 +285,7 @@ void CompilerReflection::emit_type(const SPIRType &type, bool &emitted_open_tag)
 {
 	auto name = type_to_glsl(type);
 
-	if (type.type_alias != 0)
+	if (type.type_alias != TypeID(0))
 		return;
 
 	if (!emitted_open_tag)
@@ -468,7 +468,7 @@ void CompilerReflection::emit_resources(const char *tag, const SmallVector<Resou
 		bool is_block = get_decoration_bitset(type.self).get(DecorationBlock) ||
 		                get_decoration_bitset(type.self).get(DecorationBufferBlock);
 
-		uint32_t fallback_id = !is_push_constant && is_block ? res.base_type_id : res.id;
+		ID fallback_id = !is_push_constant && is_block ? ID(res.base_type_id) : ID(res.id);
 
 		json_stream->begin_json_object();
 

--- a/tests-other/typed_id_test.cpp
+++ b/tests-other/typed_id_test.cpp
@@ -1,0 +1,49 @@
+#include "spirv_common.hpp"
+
+using namespace SPIRV_CROSS_NAMESPACE;
+
+int main()
+{
+	// Construct from uint32_t.
+	VariableID var_id = 10;
+	TypeID type_id = 20;
+	ConstantID constant_id = 30;
+
+	// Assign from uint32_t.
+	var_id = 100;
+	type_id = 40;
+	constant_id = 60;
+
+	// Construct generic ID.
+	ID generic_var_id = var_id;
+	ID generic_type_id = type_id;
+	ID generic_constant_id = constant_id;
+
+	// Assign generic id.
+	generic_var_id = var_id;
+	generic_type_id = type_id;
+	generic_constant_id = constant_id;
+
+	// Assign generic ID to typed ID
+	var_id = generic_var_id;
+	type_id = generic_type_id;
+	constant_id = generic_constant_id;
+
+	// Implicit conversion to uint32_t.
+	uint32_t a;
+	a = var_id;
+	a = type_id;
+	a = constant_id;
+	a = generic_var_id;
+	a = generic_type_id;
+	a = generic_constant_id;
+
+	// Copy assignment.
+	var_id = VariableID(10);
+	type_id = TypeID(10);
+	constant_id = ConstantID(10);
+
+	// These operations are blocked, assign or construction from mismatched types.
+	//var_id = type_id;
+	//var_id = TypeID(100);
+}


### PR DESCRIPTION
The C++ interface has been completely un-typed in its ID-based interfaces. This attempts to introduce some level of type safety into the API by adding a `TypedID<Types>` wrapper class. These types can freely convert to and from uint32_t and a special `ID` type, but not between each other, so a `TypeID` cannot be confused with a `VariableID` for example. Full type safety is not practical as SPIR-V will often allow any kind of ID, especially with decorations.

Free conversion to and from uint32_t is important not to break too many clients. This type safety can mostly be ignored for API users who don't really care about it.

Fix #1093.
Fix #441.