### PR TITLE
Consider discard and demote as impure statements.

### DIFF
--- a/reference/shaders-no-opt/asm/frag/demote-impure-function-call.vk.nocompat.asm.frag.vk
+++ b/reference/shaders-no-opt/asm/frag/demote-impure-function-call.vk.nocompat.asm.frag.vk
@@ -1,0 +1,22 @@
+#version 450
+#extension GL_EXT_demote_to_helper_invocation : require
+
+layout(location = 0) flat in int vA;
+layout(location = 0) out vec4 FragColor;
+
+vec4 foobar(int a)
+{
+    if (a < 0)
+    {
+        demote;
+    }
+    return vec4(10.0);
+}
+
+void main()
+{
+    int param = vA;
+    vec4 _25 = foobar(param);
+    FragColor = vec4(10.0);
+}
+

--- a/reference/shaders-no-opt/asm/frag/discard-impure-function-call.asm.frag
+++ b/reference/shaders-no-opt/asm/frag/discard-impure-function-call.asm.frag
@@ -1,0 +1,21 @@
+#version 450
+
+layout(location = 0) flat in int vA;
+layout(location = 0) out vec4 FragColor;
+
+vec4 foobar(int a)
+{
+    if (a < 0)
+    {
+        discard;
+    }
+    return vec4(10.0);
+}
+
+void main()
+{
+    int param = vA;
+    vec4 _25 = foobar(param);
+    FragColor = vec4(10.0);
+}
+

--- a/shaders-no-opt/asm/frag/demote-impure-function-call.vk.nocompat.asm.frag
+++ b/shaders-no-opt/asm/frag/demote-impure-function-call.vk.nocompat.asm.frag
@@ -1,0 +1,63 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 33
+; Schema: 0
+               OpCapability Shader
+               OpCapability DemoteToHelperInvocationEXT
+               OpExtension "SPV_EXT_demote_to_helper_invocation"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %vA %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_demote_to_helper_invocation"
+               OpName %main "main"
+               OpName %foobar_i1_ "foobar(i1;"
+               OpName %a "a"
+               OpName %a_0 "a"
+               OpName %vA "vA"
+               OpName %param "param"
+               OpName %FragColor "FragColor"
+               OpDecorate %vA Flat
+               OpDecorate %vA Location 0
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+         %10 = OpTypeFunction %v4float %_ptr_Function_int
+      %int_0 = OpConstant %int 0
+       %bool = OpTypeBool
+   %float_10 = OpConstant %float 10
+         %21 = OpConstantComposite %v4float %float_10 %float_10 %float_10 %float_10
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+%_ptr_Input_int = OpTypePointer Input %int
+         %vA = OpVariable %_ptr_Input_int Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+        %a_0 = OpVariable %_ptr_Function_v4float Function
+      %param = OpVariable %_ptr_Function_int Function
+         %29 = OpLoad %int %vA
+               OpStore %param %29
+         %30 = OpFunctionCall %v4float %foobar_i1_ %param
+               OpStore %FragColor %21
+               OpReturn
+               OpFunctionEnd
+ %foobar_i1_ = OpFunction %v4float None %10
+          %a = OpFunctionParameter %_ptr_Function_int
+         %13 = OpLabel
+         %14 = OpLoad %int %a
+         %17 = OpSLessThan %bool %14 %int_0
+               OpSelectionMerge %19 None
+               OpBranchConditional %17 %18 %19
+         %18 = OpLabel
+               OpDemoteToHelperInvocationEXT
+               OpBranch %19
+         %19 = OpLabel
+               OpReturnValue %21
+               OpFunctionEnd

--- a/shaders-no-opt/asm/frag/discard-impure-function-call.asm.frag
+++ b/shaders-no-opt/asm/frag/discard-impure-function-call.asm.frag
@@ -1,0 +1,59 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 34
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %vA %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %foobar_i1_ "foobar(i1;"
+               OpName %a "a"
+               OpName %a_0 "a"
+               OpName %vA "vA"
+               OpName %param "param"
+               OpName %FragColor "FragColor"
+               OpDecorate %vA Flat
+               OpDecorate %vA Location 0
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+         %10 = OpTypeFunction %v4float %_ptr_Function_int
+      %int_0 = OpConstant %int 0
+       %bool = OpTypeBool
+   %float_10 = OpConstant %float 10
+         %22 = OpConstantComposite %v4float %float_10 %float_10 %float_10 %float_10
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+%_ptr_Input_int = OpTypePointer Input %int
+         %vA = OpVariable %_ptr_Input_int Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+        %a_0 = OpVariable %_ptr_Function_v4float Function
+      %param = OpVariable %_ptr_Function_int Function
+         %30 = OpLoad %int %vA
+               OpStore %param %30
+         %31 = OpFunctionCall %v4float %foobar_i1_ %param
+               OpStore %FragColor %22
+               OpReturn
+               OpFunctionEnd
+ %foobar_i1_ = OpFunction %v4float None %10
+          %a = OpFunctionParameter %_ptr_Function_int
+         %13 = OpLabel
+         %14 = OpLoad %int %a
+         %17 = OpSLessThan %bool %14 %int_0
+               OpSelectionMerge %19 None
+               OpBranchConditional %17 %18 %19
+         %18 = OpLabel
+               OpKill
+         %19 = OpLabel
+               OpReturnValue %22
+               OpFunctionEnd

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -88,6 +88,10 @@ bool Compiler::variable_storage_is_aliased(const SPIRVariable &v)
 
 bool Compiler::block_is_pure(const SPIRBlock &block)
 {
+	// This is a global side effect of the function.
+	if (block.terminator == SPIRBlock::Kill)
+		return false;
+
 	for (auto &i : block.ops)
 	{
 		auto ops = stream(i);
@@ -155,6 +159,10 @@ bool Compiler::block_is_pure(const SPIRBlock &block)
 			return false;
 
 			// OpExtInst is potentially impure depending on extension, but GLSL builtins are at least pure.
+
+		case OpDemoteToHelperInvocationEXT:
+			// This is a global side effect of the function.
+			return false;
 
 		default:
 			break;


### PR DESCRIPTION
Fixes cases where discard and demote are called in pure functions and
the function result is not consumed.

Fix #1151.