### PR TITLE
CMake: Add option to skip installation targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ option(SPIRV_CROSS_SANITIZE_UNDEFINED "Sanitize undefined" OFF)
 option(SPIRV_CROSS_NAMESPACE_OVERRIDE "" "Override the namespace used in the C++ API.")
 option(SPIRV_CROSS_FORCE_STL_TYPES "Force use of STL types instead of STL replacements in certain places. Might reduce performance." OFF)
 
+option(SPIRV_CROSS_SKIP_INSTALL "Skips installation targets." OFF)
+
 if(${CMAKE_GENERATOR} MATCHES "Makefile")
 	if(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
 		message(FATAL_ERROR "Build out of tree to avoid overwriting Makefile")
@@ -142,15 +144,18 @@ macro(spirv_cross_add_library name config_name library_type)
 			target_compile_definitions(${name} PRIVATE SPIRV_CROSS_NAMESPACE_OVERRIDE=${SPIRV_CROSS_NAMESPACE_OVERRIDE})
 		endif()
 	endif()
-	install(TARGETS ${name}
+
+	if (NOT SPIRV_CROSS_SKIP_INSTALL)
+		install(TARGETS ${name}
 			EXPORT ${config_name}Config
 			RUNTIME DESTINATION bin
 			LIBRARY DESTINATION lib
 			ARCHIVE DESTINATION lib
 			PUBLIC_HEADER DESTINATION include/spirv_cross)
-	install(FILES ${hdrs} DESTINATION include/spirv_cross)
-	install(EXPORT ${config_name}Config DESTINATION share/${config_name}/cmake)
-	export(TARGETS ${name} FILE ${config_name}Config.cmake)
+		install(FILES ${hdrs} DESTINATION include/spirv_cross)
+		install(EXPORT ${config_name}Config DESTINATION share/${config_name}/cmake)
+		export(TARGETS ${name} FILE ${config_name}Config.cmake)
+	endif()
 endmacro()
 
 set(spirv-cross-core-sources
@@ -294,10 +299,13 @@ if (SPIRV_CROSS_SHARED)
 	set(SPIRV_CROSS_VERSION ${spirv-cross-abi-major}.${spirv-cross-abi-minor}.${spirv-cross-abi-patch})
 	set(SPIRV_CROSS_INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib)
 	set(SPIRV_CROSS_INSTALL_INC_DIR ${CMAKE_INSTALL_PREFIX}/include/spirv_cross)
-	configure_file(
+
+	if (NOT SPIRV_CROSS_SKIP_INSTALL)
+		configure_file(
 			${CMAKE_CURRENT_SOURCE_DIR}/pkg-config/spirv-cross-c-shared.pc.in
 			${CMAKE_CURRENT_BINARY_DIR}/spirv-cross-c-shared.pc @ONLY)
-	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/spirv-cross-c-shared.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/share/pkgconfig)
+		install(FILES ${CMAKE_CURRENT_BINARY_DIR}/spirv-cross-c-shared.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/share/pkgconfig)
+	endif()
 
 	spirv_cross_add_library(spirv-cross-c-shared spirv_cross_c_shared SHARED
 			${spirv-cross-core-sources}
@@ -395,7 +403,9 @@ if (SPIRV_CROSS_CLI)
 	target_include_directories(spirv-cross PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 	target_compile_definitions(spirv-cross PRIVATE ${spirv-compiler-defines} HAVE_SPIRV_CROSS_GIT_VERSION)
 	set_target_properties(spirv-cross PROPERTIES LINK_FLAGS "${spirv-cross-link-flags}")
-	install(TARGETS spirv-cross RUNTIME DESTINATION bin)
+	if (NOT SPIRV_CROSS_SKIP_INSTALL)
+		install(TARGETS spirv-cross RUNTIME DESTINATION bin)
+	endif()
 	target_link_libraries(spirv-cross PRIVATE
 			spirv-cross-glsl
 			spirv-cross-hlsl


### PR DESCRIPTION
Fix #1153.