### PR TITLE
Disable -Werror by default in CMake, fix -Wshorten-64-to-32 warnings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
   - "./build_glslang_spirv_tools.sh Release"
   - mkdir build
   - cd build
-  - cmake .. -DSPIRV_CROSS_SHARED=ON -DCMAKE_INSTALL_PREFIX=output -DCMAKE_BUILD_TYPE=Release -G "${GENERATOR}" -DPYTHON_EXECUTABLE:FILEPATH="${PYTHON3}" -DSPIRV_CROSS_ENABLE_TESTS=ON
+  - cmake .. -DSPIRV_CROSS_WERROR=ON -DSPIRV_CROSS_MISC_WARNINGS=ON -DSPIRV_CROSS_SHARED=ON -DCMAKE_INSTALL_PREFIX=output -DCMAKE_BUILD_TYPE=Release -G "${GENERATOR}" -DPYTHON_EXECUTABLE:FILEPATH="${PYTHON3}" -DSPIRV_CROSS_ENABLE_TESTS=ON
   - cmake --build . --config Release
   - cmake --build . --config Release --target install
   - ctest --verbose -C Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,9 @@ option(SPIRV_CROSS_FORCE_STL_TYPES "Force use of STL types instead of STL replac
 
 option(SPIRV_CROSS_SKIP_INSTALL "Skips installation targets." OFF)
 
+option(SPIRV_CROSS_WERROR "Fail build on warnings." OFF)
+option(SPIRV_CROSS_MISC_WARNINGS "Misc warnings useful for Travis runs." OFF)
+
 if(${CMAKE_GENERATOR} MATCHES "Makefile")
 	if(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
 		message(FATAL_ERROR "Build out of tree to avoid overwriting Makefile")
@@ -79,7 +82,15 @@ if(SPIRV_CROSS_FORCE_STL_TYPES)
 endif()
 
 if (CMAKE_COMPILER_IS_GNUCXX OR (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang"))
-	set(spirv-compiler-options ${spirv-compiler-options} -Wall -Wextra -Werror -Wshadow)
+	set(spirv-compiler-options ${spirv-compiler-options} -Wall -Wextra -Wshadow)
+	if (SPIRV_CROSS_MISC_WARNINGS)
+		if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+			set(spirv-compiler-options ${spirv-compiler-options} -Wshorten-64-to-32)
+		endif()
+	endif()
+	if (SPIRV_CROSS_WERROR)
+		set(spirv-compiler-options ${spirv-compiler-options} -Werror)
+	endif()
 
 	if (SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS)
 		set(spirv-compiler-options ${spirv-compiler-options} -fno-exceptions)

--- a/spirv_cfg.cpp
+++ b/spirv_cfg.cpp
@@ -163,7 +163,7 @@ bool CFG::post_order_visit(uint32_t block_id)
 		{
 			auto &pred = pred_itr->second;
 			auto succ_itr = succeeding_edges.find(block_id);
-			uint32_t num_succeeding_edges = 0;
+			size_t num_succeeding_edges = 0;
 			if (succ_itr != end(succeeding_edges))
 				num_succeeding_edges = succ_itr->second.size();
 

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -4767,8 +4767,8 @@ string CompilerGLSL::to_combined_image_sampler(VariableID image_id, VariableID s
 		// If any parameter originates from a parameter, we will find it in our argument list.
 		bool global_image = image_itr == end(args);
 		bool global_sampler = sampler_itr == end(args);
-		VariableID iid = global_image ? image_id : VariableID(image_itr - begin(args));
-		VariableID sid = global_sampler ? samp_id : VariableID(sampler_itr - begin(args));
+		VariableID iid = global_image ? image_id : VariableID(uint32_t(image_itr - begin(args)));
+		VariableID sid = global_sampler ? samp_id : VariableID(uint32_t(sampler_itr - begin(args)));
 
 		auto &combined = current_function->combined_parameters;
 		auto itr = find_if(begin(combined), end(combined), [=](const SPIRFunction::CombinedImageSamplerParameter &p) {


### PR DESCRIPTION
Fix #1155.