### PR TITLE
Do not consider aliased struct types if the master is not a block

### DIFF
--- a/reference/opt/shaders/frag/struct-type-unrelated-alias.frag
+++ b/reference/opt/shaders/frag/struct-type-unrelated-alias.frag
@@ -1,0 +1,9 @@
+#version 450
+
+layout(location = 0) out float FragColor;
+
+void main()
+{
+    FragColor = 30.0;
+}
+

--- a/reference/shaders-hlsl-no-opt/asm/comp/aliased-struct-divergent-member-name.asm.comp
+++ b/reference/shaders-hlsl-no-opt/asm/comp/aliased-struct-divergent-member-name.asm.comp
@@ -1,0 +1,27 @@
+struct T
+{
+    float c;
+};
+
+struct T_1
+{
+    float b;
+};
+
+static const T _18 = { 40.0f };
+
+RWByteAddressBuffer _7 : register(u0);
+RWByteAddressBuffer _10 : register(u1);
+
+void comp_main()
+{
+    T v = _18;
+    _7.Store(40, asuint(v.c));
+    _10.Store(480, asuint(v.c));
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    comp_main();
+}

--- a/reference/shaders-msl-no-opt/asm/comp/aliased-struct-divergent-member-name.asm.comp
+++ b/reference/shaders-msl-no-opt/asm/comp/aliased-struct-divergent-member-name.asm.comp
@@ -1,0 +1,38 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct T
+{
+    float a;
+};
+
+struct T_1
+{
+    float b;
+};
+
+struct SSBO1
+{
+    T_1 foo[1];
+};
+
+struct T_2
+{
+    float c;
+    char _m0_final_padding[12];
+};
+
+struct SSBO2
+{
+    T_2 bar[1];
+};
+
+kernel void main0(device SSBO1& _7 [[buffer(0)]], device SSBO2& _10 [[buffer(1)]])
+{
+    T v = T{ 40.0 };
+    _7.foo[10].b = v.a;
+    _10.bar[30].c = v.a;
+}
+

--- a/reference/shaders-no-opt/asm/comp/aliased-struct-divergent-member-name.asm.comp
+++ b/reference/shaders-no-opt/asm/comp/aliased-struct-divergent-member-name.asm.comp
@@ -1,0 +1,30 @@
+#version 450
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+struct T
+{
+    float c;
+};
+
+struct T_1
+{
+    float b;
+};
+
+layout(binding = 0, std430) buffer SSBO1
+{
+    T_1 foo[];
+} _7;
+
+layout(binding = 1, std140) buffer SSBO2
+{
+    T bar[];
+} _10;
+
+void main()
+{
+    T v = T(40.0);
+    _7.foo[10].b = v.c;
+    _10.bar[30].c = v.c;
+}
+

--- a/reference/shaders/frag/struct-type-unrelated-alias.frag
+++ b/reference/shaders/frag/struct-type-unrelated-alias.frag
@@ -1,0 +1,23 @@
+#version 450
+
+struct T
+{
+    float a;
+};
+
+struct T_1
+{
+    float b;
+};
+
+layout(location = 0) out float FragColor;
+
+void main()
+{
+    T foo;
+    foo.a = 10.0;
+    T_1 bar;
+    bar.b = 20.0;
+    FragColor = foo.a + bar.b;
+}
+

--- a/shaders-hlsl-no-opt/asm/comp/aliased-struct-divergent-member-name.asm.comp
+++ b/shaders-hlsl-no-opt/asm/comp/aliased-struct-divergent-member-name.asm.comp
@@ -1,0 +1,77 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 37
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %T "T"
+               OpMemberName %T 0 "a"
+               OpName %v "v"
+               OpName %T_0 "T"
+               OpMemberName %T_0 0 "b"
+               OpName %SSBO1 "SSBO1"
+               OpMemberName %SSBO1 0 "foo"
+               OpName %_ ""
+               OpName %T_1 "T"
+               OpMemberName %T_1 0 "c"
+               OpName %SSBO2 "SSBO2"
+               OpMemberName %SSBO2 0 "bar"
+               OpName %__0 ""
+               OpMemberDecorate %T_0 0 Offset 0
+               OpDecorate %_runtimearr_T_0 ArrayStride 4
+               OpMemberDecorate %SSBO1 0 Offset 0
+               OpDecorate %SSBO1 BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 0
+               OpMemberDecorate %T_1 0 Offset 0
+               OpDecorate %_runtimearr_T_1 ArrayStride 16
+               OpMemberDecorate %SSBO2 0 Offset 0
+               OpDecorate %SSBO2 BufferBlock
+               OpDecorate %__0 DescriptorSet 0
+               OpDecorate %__0 Binding 1
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+          %T = OpTypeStruct %float
+%_ptr_Function_T = OpTypePointer Function %T
+   %float_40 = OpConstant %float 40
+         %11 = OpConstantComposite %T %float_40
+        %T_0 = OpTypeStruct %float
+%_runtimearr_T_0 = OpTypeRuntimeArray %T_0
+      %SSBO1 = OpTypeStruct %_runtimearr_T_0
+%_ptr_Uniform_SSBO1 = OpTypePointer Uniform %SSBO1
+          %_ = OpVariable %_ptr_Uniform_SSBO1 Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %int_10 = OpConstant %int 10
+%_ptr_Uniform_T_0 = OpTypePointer Uniform %T_0
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+        %T_1 = OpTypeStruct %float
+%_runtimearr_T_1 = OpTypeRuntimeArray %T_1
+      %SSBO2 = OpTypeStruct %_runtimearr_T_1
+%_ptr_Uniform_SSBO2 = OpTypePointer Uniform %SSBO2
+        %__0 = OpVariable %_ptr_Uniform_SSBO2 Uniform
+     %int_30 = OpConstant %int 30
+%_ptr_Uniform_T_1 = OpTypePointer Uniform %T_1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %v = OpVariable %_ptr_Function_T Function
+               OpStore %v %11
+         %20 = OpLoad %T %v
+         %22 = OpAccessChain %_ptr_Uniform_T_0 %_ %int_0 %int_10
+         %23 = OpCompositeExtract %float %20 0
+         %25 = OpAccessChain %_ptr_Uniform_float %22 %int_0
+               OpStore %25 %23
+         %32 = OpLoad %T %v
+         %34 = OpAccessChain %_ptr_Uniform_T_1 %__0 %int_0 %int_30
+         %35 = OpCompositeExtract %float %32 0
+         %36 = OpAccessChain %_ptr_Uniform_float %34 %int_0
+               OpStore %36 %35
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/comp/aliased-struct-divergent-member-name.asm.comp
+++ b/shaders-msl-no-opt/asm/comp/aliased-struct-divergent-member-name.asm.comp
@@ -1,0 +1,77 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 37
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %T "T"
+               OpMemberName %T 0 "a"
+               OpName %v "v"
+               OpName %T_0 "T"
+               OpMemberName %T_0 0 "b"
+               OpName %SSBO1 "SSBO1"
+               OpMemberName %SSBO1 0 "foo"
+               OpName %_ ""
+               OpName %T_1 "T"
+               OpMemberName %T_1 0 "c"
+               OpName %SSBO2 "SSBO2"
+               OpMemberName %SSBO2 0 "bar"
+               OpName %__0 ""
+               OpMemberDecorate %T_0 0 Offset 0
+               OpDecorate %_runtimearr_T_0 ArrayStride 4
+               OpMemberDecorate %SSBO1 0 Offset 0
+               OpDecorate %SSBO1 BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 0
+               OpMemberDecorate %T_1 0 Offset 0
+               OpDecorate %_runtimearr_T_1 ArrayStride 16
+               OpMemberDecorate %SSBO2 0 Offset 0
+               OpDecorate %SSBO2 BufferBlock
+               OpDecorate %__0 DescriptorSet 0
+               OpDecorate %__0 Binding 1
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+          %T = OpTypeStruct %float
+%_ptr_Function_T = OpTypePointer Function %T
+   %float_40 = OpConstant %float 40
+         %11 = OpConstantComposite %T %float_40
+        %T_0 = OpTypeStruct %float
+%_runtimearr_T_0 = OpTypeRuntimeArray %T_0
+      %SSBO1 = OpTypeStruct %_runtimearr_T_0
+%_ptr_Uniform_SSBO1 = OpTypePointer Uniform %SSBO1
+          %_ = OpVariable %_ptr_Uniform_SSBO1 Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %int_10 = OpConstant %int 10
+%_ptr_Uniform_T_0 = OpTypePointer Uniform %T_0
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+        %T_1 = OpTypeStruct %float
+%_runtimearr_T_1 = OpTypeRuntimeArray %T_1
+      %SSBO2 = OpTypeStruct %_runtimearr_T_1
+%_ptr_Uniform_SSBO2 = OpTypePointer Uniform %SSBO2
+        %__0 = OpVariable %_ptr_Uniform_SSBO2 Uniform
+     %int_30 = OpConstant %int 30
+%_ptr_Uniform_T_1 = OpTypePointer Uniform %T_1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %v = OpVariable %_ptr_Function_T Function
+               OpStore %v %11
+         %20 = OpLoad %T %v
+         %22 = OpAccessChain %_ptr_Uniform_T_0 %_ %int_0 %int_10
+         %23 = OpCompositeExtract %float %20 0
+         %25 = OpAccessChain %_ptr_Uniform_float %22 %int_0
+               OpStore %25 %23
+         %32 = OpLoad %T %v
+         %34 = OpAccessChain %_ptr_Uniform_T_1 %__0 %int_0 %int_30
+         %35 = OpCompositeExtract %float %32 0
+         %36 = OpAccessChain %_ptr_Uniform_float %34 %int_0
+               OpStore %36 %35
+               OpReturn
+               OpFunctionEnd

--- a/shaders-no-opt/asm/comp/aliased-struct-divergent-member-name.asm.comp
+++ b/shaders-no-opt/asm/comp/aliased-struct-divergent-member-name.asm.comp
@@ -1,0 +1,77 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 37
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %T "T"
+               OpMemberName %T 0 "a"
+               OpName %v "v"
+               OpName %T_0 "T"
+               OpMemberName %T_0 0 "b"
+               OpName %SSBO1 "SSBO1"
+               OpMemberName %SSBO1 0 "foo"
+               OpName %_ ""
+               OpName %T_1 "T"
+               OpMemberName %T_1 0 "c"
+               OpName %SSBO2 "SSBO2"
+               OpMemberName %SSBO2 0 "bar"
+               OpName %__0 ""
+               OpMemberDecorate %T_0 0 Offset 0
+               OpDecorate %_runtimearr_T_0 ArrayStride 4
+               OpMemberDecorate %SSBO1 0 Offset 0
+               OpDecorate %SSBO1 BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 0
+               OpMemberDecorate %T_1 0 Offset 0
+               OpDecorate %_runtimearr_T_1 ArrayStride 16
+               OpMemberDecorate %SSBO2 0 Offset 0
+               OpDecorate %SSBO2 BufferBlock
+               OpDecorate %__0 DescriptorSet 0
+               OpDecorate %__0 Binding 1
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+          %T = OpTypeStruct %float
+%_ptr_Function_T = OpTypePointer Function %T
+   %float_40 = OpConstant %float 40
+         %11 = OpConstantComposite %T %float_40
+        %T_0 = OpTypeStruct %float
+%_runtimearr_T_0 = OpTypeRuntimeArray %T_0
+      %SSBO1 = OpTypeStruct %_runtimearr_T_0
+%_ptr_Uniform_SSBO1 = OpTypePointer Uniform %SSBO1
+          %_ = OpVariable %_ptr_Uniform_SSBO1 Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %int_10 = OpConstant %int 10
+%_ptr_Uniform_T_0 = OpTypePointer Uniform %T_0
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+        %T_1 = OpTypeStruct %float
+%_runtimearr_T_1 = OpTypeRuntimeArray %T_1
+      %SSBO2 = OpTypeStruct %_runtimearr_T_1
+%_ptr_Uniform_SSBO2 = OpTypePointer Uniform %SSBO2
+        %__0 = OpVariable %_ptr_Uniform_SSBO2 Uniform
+     %int_30 = OpConstant %int 30
+%_ptr_Uniform_T_1 = OpTypePointer Uniform %T_1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %v = OpVariable %_ptr_Function_T Function
+               OpStore %v %11
+         %20 = OpLoad %T %v
+         %22 = OpAccessChain %_ptr_Uniform_T_0 %_ %int_0 %int_10
+         %23 = OpCompositeExtract %float %20 0
+         %25 = OpAccessChain %_ptr_Uniform_float %22 %int_0
+               OpStore %25 %23
+         %32 = OpLoad %T %v
+         %34 = OpAccessChain %_ptr_Uniform_T_1 %__0 %int_0 %int_30
+         %35 = OpCompositeExtract %float %32 0
+         %36 = OpAccessChain %_ptr_Uniform_float %34 %int_0
+               OpStore %36 %35
+               OpReturn
+               OpFunctionEnd

--- a/shaders/frag/struct-type-unrelated-alias.frag
+++ b/shaders/frag/struct-type-unrelated-alias.frag
@@ -1,0 +1,19 @@
+#version 450
+
+layout(location = 0) out float FragColor;
+
+struct T
+{
+	float a;
+};
+
+void main()
+{
+	T foo;
+	struct T { float b; };
+	T bar;
+
+	foo.a = 10.0;
+	bar.b = 20.0;
+	FragColor = foo.a + bar.b;
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -10228,6 +10228,12 @@ void CompilerGLSL::append_global_func_args(const SPIRFunction &func, uint32_t in
 
 string CompilerGLSL::to_member_name(const SPIRType &type, uint32_t index)
 {
+	if (type.type_alias != TypeID(0) &&
+	    !has_extended_decoration(type.type_alias, SPIRVCrossDecorationBufferBlockRepacked))
+	{
+		return to_member_name(get<SPIRType>(type.type_alias), index);
+	}
+
 	auto &memb = ir.meta[type.self].members;
 	if (index < memb.size() && !memb[index].alias.empty())
 		return memb[index].alias;
@@ -12774,6 +12780,14 @@ void CompilerGLSL::fixup_type_alias()
 		if (type.type_alias && type_is_block_like(type))
 		{
 			// This is not allowed, drop the type_alias.
+			type.type_alias = 0;
+		}
+		else if (type.type_alias && !type_is_block_like(get<SPIRType>(type.type_alias)))
+		{
+			// If the alias master is not a block-like type, there is no reason to use type aliasing.
+			// This case can happen if two structs are declared with the same name, but they are unrelated.
+			// Aliases are only used to deal with aliased types for structs which are used in different buffer types
+			// which all create a variant of the same struct with different DecorationOffset values.
 			type.type_alias = 0;
 		}
 	});

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -12782,7 +12782,7 @@ void CompilerGLSL::fixup_type_alias()
 			// This is not allowed, drop the type_alias.
 			type.type_alias = 0;
 		}
-		else if (type.type_alias && !type_is_block_like(get<SPIRType>(type.type_alias)))
+		else if (type.type_alias && !type_is_block_like(this->get<SPIRType>(type.type_alias)))
 		{
 			// If the alias master is not a block-like type, there is no reason to use type aliasing.
 			// This case can happen if two structs are declared with the same name, but they are unrelated.

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -5773,10 +5773,10 @@ void CompilerMSL::emit_array_copy(const string &lhs, uint32_t rhs_id, StorageCla
 	else
 		add_spv_func_and_recompile(SPVFuncImplArrayCopy);
 
-	bool lhs_thread =
-	    lhs_storage == StorageClassOutput || lhs_storage == StorageClassFunction || lhs_storage == StorageClassGeneric || lhs_storage == StorageClassPrivate;
-	bool rhs_thread =
-	    rhs_storage == StorageClassInput || rhs_storage == StorageClassFunction || rhs_storage == StorageClassGeneric || rhs_storage == StorageClassPrivate;
+	bool lhs_thread = lhs_storage == StorageClassOutput || lhs_storage == StorageClassFunction ||
+	                  lhs_storage == StorageClassGeneric || lhs_storage == StorageClassPrivate;
+	bool rhs_thread = rhs_storage == StorageClassInput || rhs_storage == StorageClassFunction ||
+	                  rhs_storage == StorageClassGeneric || rhs_storage == StorageClassPrivate;
 
 	const char *tag = nullptr;
 	if (lhs_thread && is_constant)

--- a/spirv_reflect.cpp
+++ b/spirv_reflect.cpp
@@ -443,9 +443,12 @@ void CompilerReflection::emit_entry_points()
 				get_work_group_size_specialization_constants(spec_x, spec_y, spec_z);
 
 				json_stream->emit_json_key_array("workgroup_size");
-				json_stream->emit_json_array_value(spec_x.id != ID(0) ? spec_x.constant_id : spv_entry.workgroup_size.x);
-				json_stream->emit_json_array_value(spec_y.id != ID(0) ? spec_y.constant_id : spv_entry.workgroup_size.y);
-				json_stream->emit_json_array_value(spec_z.id != ID(0) ? spec_z.constant_id : spv_entry.workgroup_size.z);
+				json_stream->emit_json_array_value(spec_x.id != ID(0) ? spec_x.constant_id :
+				                                                        spv_entry.workgroup_size.x);
+				json_stream->emit_json_array_value(spec_y.id != ID(0) ? spec_y.constant_id :
+				                                                        spv_entry.workgroup_size.y);
+				json_stream->emit_json_array_value(spec_z.id != ID(0) ? spec_z.constant_id :
+				                                                        spv_entry.workgroup_size.z);
 				json_stream->end_json_array();
 
 				json_stream->emit_json_key_array("workgroup_size_is_spec_constant_id");


### PR DESCRIPTION
It is possible for a shader to declare two plain struct types which simply share the same OpName without there being an implicit value/buffer alias relationship.
    
For to_member_name(), make sure to use the type alias master when resolving member names. The member name may be different in a type alias master if the SPIR-V is being intentionally difficult.

Fix #1167.
