### PR TITLE
MSL: Fix regression with OpCompositeConstruct from std140 float[].

### DIFF
--- a/reference/shaders-msl-no-opt/comp/std140-array-load-composite-construct.comp
+++ b/reference/shaders-msl-no-opt/comp/std140-array-load-composite-construct.comp
@@ -1,0 +1,18 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct SSBO
+{
+    float4 a[16];
+    float4 b[16];
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
+
+kernel void main0(device SSBO& _14 [[buffer(0)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+{
+    _14.b[gl_GlobalInvocationID.x] = float4(_14.a[gl_GlobalInvocationID.x].x);
+}
+

--- a/shaders-msl-no-opt/comp/std140-array-load-composite-construct.comp
+++ b/shaders-msl-no-opt/comp/std140-array-load-composite-construct.comp
@@ -1,0 +1,13 @@
+#version 450
+layout(local_size_x = 1) in;
+
+layout(std140, binding = 0) buffer SSBO
+{
+	float a[16];
+	vec4 b[16];
+};
+
+void main()
+{
+	b[gl_GlobalInvocationID.x] = vec4(a[gl_GlobalInvocationID.x]);
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -3032,7 +3032,7 @@ string CompilerGLSL::to_composite_constructor_expression(uint32_t id)
 		return to_rerolled_array_expression(to_enclosed_expression(id), type);
 	}
 	else
-		return to_expression(id);
+		return to_unpacked_expression(id);
 }
 
 string CompilerGLSL::to_expression(uint32_t id, bool register_expression_read)
@@ -8265,14 +8265,14 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 			if (type_is_empty(out_type) && !backend.supports_empty_struct)
 				constructor_op += "0";
 			else if (splat)
-				constructor_op += to_expression(elems[0]);
+				constructor_op += to_unpacked_expression(elems[0]);
 			else
 				constructor_op += build_composite_combiner(result_type, elems, length);
 			constructor_op += " }";
 		}
 		else if (swizzle_splat && !composite)
 		{
-			constructor_op = remap_swizzle(get<SPIRType>(result_type), 1, to_expression(elems[0]));
+			constructor_op = remap_swizzle(get<SPIRType>(result_type), 1, to_unpacked_expression(elems[0]));
 		}
 		else
 		{
@@ -8280,7 +8280,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 			if (type_is_empty(out_type) && !backend.supports_empty_struct)
 				constructor_op += "0";
 			else if (splat)
-				constructor_op += to_expression(elems[0]);
+				constructor_op += to_unpacked_expression(elems[0]);
 			else
 				constructor_op += build_composite_combiner(result_type, elems, length);
 			constructor_op += ")";


### PR DESCRIPTION
Simple fix, just need to use to_unpacked_expression rather than to_expression here to
deal with this.

Fix #1172.