### PR TITLE
Fix OpVectorExtractDynamic with spec constant op index.

### DIFF
--- a/reference/shaders-no-opt/asm/frag/vector-extract-dynamic-spec-constant.asm.frag
+++ b/reference/shaders-no-opt/asm/frag/vector-extract-dynamic-spec-constant.asm.frag
@@ -1,0 +1,27 @@
+#version 450
+
+#ifndef SPIRV_CROSS_CONSTANT_ID_0
+#define SPIRV_CROSS_CONSTANT_ID_0 0
+#endif
+const int omap_r = SPIRV_CROSS_CONSTANT_ID_0;
+#ifndef SPIRV_CROSS_CONSTANT_ID_1
+#define SPIRV_CROSS_CONSTANT_ID_1 1
+#endif
+const int omap_g = SPIRV_CROSS_CONSTANT_ID_1;
+#ifndef SPIRV_CROSS_CONSTANT_ID_2
+#define SPIRV_CROSS_CONSTANT_ID_2 2
+#endif
+const int omap_b = SPIRV_CROSS_CONSTANT_ID_2;
+#ifndef SPIRV_CROSS_CONSTANT_ID_3
+#define SPIRV_CROSS_CONSTANT_ID_3 3
+#endif
+const int omap_a = SPIRV_CROSS_CONSTANT_ID_3;
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) in vec4 vColor;
+
+void main()
+{
+    FragColor = vec4(vColor[omap_r], vColor[omap_g], vColor[omap_b], vColor[omap_a]);
+}
+

--- a/shaders-no-opt/asm/frag/vector-extract-dynamic-spec-constant.asm.frag
+++ b/shaders-no-opt/asm/frag/vector-extract-dynamic-spec-constant.asm.frag
@@ -1,0 +1,49 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 27
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor %vColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %FragColor "FragColor"
+               OpName %vColor "vColor"
+               OpName %omap_r "omap_r"
+               OpName %omap_g "omap_g"
+               OpName %omap_b "omap_b"
+               OpName %omap_a "omap_a"
+               OpDecorate %FragColor Location 0
+               OpDecorate %vColor Location 0
+               OpDecorate %omap_r SpecId 0
+               OpDecorate %omap_g SpecId 1
+               OpDecorate %omap_b SpecId 2
+               OpDecorate %omap_a SpecId 3
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+     %vColor = OpVariable %_ptr_Input_v4float Input
+        %int = OpTypeInt 32 1
+     %omap_r = OpSpecConstant %int 0
+%_ptr_Input_float = OpTypePointer Input %float
+     %omap_g = OpSpecConstant %int 1
+     %omap_b = OpSpecConstant %int 2
+     %omap_a = OpSpecConstant %int 3
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+		  %loaded = OpLoad %v4float %vColor
+         %r = OpVectorExtractDynamic %float %loaded %omap_r
+         %g = OpVectorExtractDynamic %float %loaded %omap_g
+         %b = OpVectorExtractDynamic %float %loaded %omap_b
+         %a = OpVectorExtractDynamic %float %loaded %omap_a
+         %rgba = OpCompositeConstruct %v4float %r %g %b %a
+               OpStore %FragColor %rgba
+               OpReturn
+               OpFunctionEnd

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -6873,8 +6873,16 @@ string CompilerGLSL::access_chain_internal(uint32_t base, const uint32_t *indice
 			else if (ir.ids[index].get_type() == TypeConstant && !is_packed && !row_major_matrix_needs_conversion)
 			{
 				auto &c = get<SPIRConstant>(index);
-				expr += ".";
-				expr += index_to_swizzle(c.scalar());
+				if (c.specialization)
+				{
+					// If the index is a spec constant, we cannot turn extract into a swizzle.
+					expr += join("[", to_expression(index), "]");
+				}
+				else
+				{
+					expr += ".";
+					expr += index_to_swizzle(c.scalar());
+				}
 			}
 			else if (index_is_literal)
 			{


### PR DESCRIPTION
We cannot lower this to a swizzle, keep it dynamically indexed.

Fix #1178.