### PR TITLE
CFG: Compute actual immediate dominators.

### DIFF
--- a/spirv_cfg.cpp
+++ b/spirv_cfg.cpp
@@ -61,7 +61,7 @@ void CFG::build_immediate_dominators()
 			if (immediate_dominators[block])
 			{
 				assert(immediate_dominators[edge]);
-				immediate_dominators[block] = find_common_dominator(block, edge);
+				immediate_dominators[block] = find_common_dominator(immediate_dominators[block], edge);
 			}
 			else
 				immediate_dominators[block] = edge;


### PR DESCRIPTION
This wasn't really a visible bug, since the DominatorBuilder would resolve this
issue, but it is still a bug.