### PR TITLE
Fix broken access tracking for OpFunctionCall results.

### DIFF
--- a/reference/shaders-no-opt/asm/comp/access-tracking-function-call-result.asm.comp
+++ b/reference/shaders-no-opt/asm/comp/access-tracking-function-call-result.asm.comp
@@ -1,0 +1,24 @@
+#version 460
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0, std430) buffer Output
+{
+    int myout;
+} _5;
+
+int foo()
+{
+    return 12;
+}
+
+void main()
+{
+    int _17 = foo();
+    while (true)
+    {
+        _5.myout = _17;
+        return;
+    }
+    _5.myout = _17;
+}
+

--- a/shaders-no-opt/asm/comp/access-tracking-function-call-result.asm.comp
+++ b/shaders-no-opt/asm/comp/access-tracking-function-call-result.asm.comp
@@ -1,0 +1,54 @@
+; SPIR-V
+; Version: 1.5
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 25
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 460
+               OpName %main "main"
+               OpName %foo_ "foo("
+               OpName %Output "Output"
+               OpMemberName %Output 0 "myout"
+               OpName %_ ""
+               OpMemberDecorate %Output 0 Offset 0
+               OpDecorate %Output BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 0
+       %void = OpTypeVoid
+          %7 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+          %9 = OpTypeFunction %int
+     %int_12 = OpConstant %int 12
+       %bool = OpTypeBool
+       %true = OpConstantTrue %bool
+     %Output = OpTypeStruct %int
+%_ptr_Uniform_Output = OpTypePointer Uniform %Output
+          %_ = OpVariable %_ptr_Uniform_Output Uniform
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_int = OpTypePointer Uniform %int
+       %main = OpFunction %void None %7
+         %16 = OpLabel
+         %17 = OpFunctionCall %int %foo_
+               OpBranch %18
+         %18 = OpLabel
+               OpLoopMerge %19 %20 None
+               OpBranchConditional %true %21 %19
+         %21 = OpLabel
+         %22 = OpAccessChain %_ptr_Uniform_int %_ %int_0
+               OpStore %22 %17
+               OpReturn
+         %20 = OpLabel
+               OpBranch %18
+         %19 = OpLabel
+         %23 = OpAccessChain %_ptr_Uniform_int %_ %int_0
+               OpStore %23 %17
+               OpReturn
+               OpFunctionEnd
+       %foo_ = OpFunction %int None %9
+         %24 = OpLabel
+               OpReturnValue %int_12
+               OpFunctionEnd

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -2902,6 +2902,10 @@ bool Compiler::AnalyzeVariableScopeAccessHandler::handle(spv::Op op, const uint3
 		if (length < 3)
 			return false;
 
+		// Return value may be a temporary.
+		if (compiler.get_type(args[0]).basetype != SPIRType::Void)
+			notify_variable_access(args[1], current_block->self);
+
 		length -= 3;
 		args += 3;
 
@@ -2922,9 +2926,6 @@ bool Compiler::AnalyzeVariableScopeAccessHandler::handle(spv::Op op, const uint3
 			// Might try to copy a Phi variable here.
 			notify_variable_access(args[i], current_block->self);
 		}
-
-		// Return value may be a temporary.
-		notify_variable_access(args[1], current_block->self);
 		break;
 	}
 


### PR DESCRIPTION
We were looking at args[1] after incrementing args array, not before,
which means we tracked garbage.
This is also an out-of-bounds hazard.

Fix #1186.