### PR TITLE
GLSL: Fix issue with array-of-array inputs in tess.

### DIFF
--- a/reference/opt/shaders/tese/load-array-of-array.tese
+++ b/reference/opt/shaders/tese/load-array-of-array.tese
@@ -1,0 +1,10 @@
+#version 450
+layout(quads, ccw, equal_spacing) in;
+
+layout(location = 0) in vec4 vTexCoord[][1];
+
+void main()
+{
+    gl_Position = (vTexCoord[0u][0] + vTexCoord[2u][0]) + vTexCoord[3u][0];
+}
+

--- a/reference/shaders/tese/load-array-of-array.tese
+++ b/reference/shaders/tese/load-array-of-array.tese
@@ -1,0 +1,16 @@
+#version 450
+layout(quads, ccw, equal_spacing) in;
+
+layout(location = 0) in vec4 vTexCoord[][1];
+
+void main()
+{
+    vec4 _17_unrolled[32][1];
+    for (int i = 0; i < int(32); i++)
+    {
+        _17_unrolled[i] = vTexCoord[i];
+    }
+    vec4 tmp[32][1] = _17_unrolled;
+    gl_Position = (tmp[0][0] + tmp[2][0]) + tmp[3][0];
+}
+

--- a/shaders/tese/load-array-of-array.tese
+++ b/shaders/tese/load-array-of-array.tese
@@ -1,0 +1,10 @@
+#version 450
+layout(ccw, quads) in;
+
+layout(location = 0) in vec4 vTexCoord[][1];
+
+void main()
+{
+	vec4 tmp[gl_MaxPatchVertices][1] = vTexCoord;
+	gl_Position = tmp[0][0] + tmp[2][0] + tmp[3][0];
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -10762,8 +10762,10 @@ string CompilerGLSL::to_array_size(const SPIRType &type, uint32_t index)
 
 	// Tessellation control and evaluation shaders must have either gl_MaxPatchVertices or unsized arrays for input arrays.
 	// Opt for unsized as it's the more "correct" variant to use.
-	if (type.storage == StorageClassInput && (get_entry_point().model == ExecutionModelTessellationControl ||
-	                                          get_entry_point().model == ExecutionModelTessellationEvaluation))
+	if (type.storage == StorageClassInput &&
+	    (get_entry_point().model == ExecutionModelTessellationControl ||
+	     get_entry_point().model == ExecutionModelTessellationEvaluation) &&
+	    index == uint32_t(type.array.size() - 1))
 		return "";
 
 	auto &size = type.array[index];
@@ -12765,14 +12767,14 @@ void CompilerGLSL::unroll_array_from_complex_load(uint32_t target_id, uint32_t s
 		auto new_expr = join("_", target_id, "_unrolled");
 		statement(variable_decl(type, new_expr, target_id), ";");
 		string array_expr;
-		if (type.array_size_literal.front())
+		if (type.array_size_literal.back())
 		{
-			array_expr = convert_to_string(type.array.front());
-			if (type.array.front() == 0)
+			array_expr = convert_to_string(type.array.back());
+			if (type.array.back() == 0)
 				SPIRV_CROSS_THROW("Cannot unroll an array copy from unsized array.");
 		}
 		else
-			array_expr = to_expression(type.array.front());
+			array_expr = to_expression(type.array.back());
 
 		// The array size might be a specialization constant, so use a for-loop instead.
 		statement("for (int i = 0; i < int(", array_expr, "); i++)");


### PR DESCRIPTION
Only one dimension can be unsized and wrong dimension was used for
unrolling purposes.

Fix #1182.