### PR TITLE
HLSL: Improve error reporting for cbuffer layout mismatch

### DIFF
--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -558,7 +558,8 @@ protected:
 	virtual void emit_block_hints(const SPIRBlock &block);
 	virtual std::string to_initializer_expression(const SPIRVariable &var);
 
-	bool buffer_is_packing_standard(const SPIRType &type, BufferPackingStandard packing, uint32_t start_offset = 0,
+	bool buffer_is_packing_standard(const SPIRType &type, BufferPackingStandard packing,
+	                                uint32_t *failed_index = nullptr, uint32_t start_offset = 0,
 	                                uint32_t end_offset = ~(0u));
 	std::string buffer_to_packing_standard(const SPIRType &type, bool support_std430_without_scalar_layout);
 


### PR DESCRIPTION
Report which buffer failed validation as well as which member triggered the error.

Fix #1199.