### PR TITLE
MSL: extract vector into swizzle for matrix

### DIFF
--- a/reference/shaders-msl/vert/matrix.swizzle.vert
+++ b/reference/shaders-msl/vert/matrix.swizzle.vert
@@ -1,0 +1,27 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct vertexUniformBuffer1
+{
+    float2x4 transform1;
+};
+
+struct vertexUniformBuffer2
+{
+    float2x4 transform2;
+};
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+vertex main0_out main0(constant vertexUniformBuffer1& _20 [[buffer(0)]], constant vertexUniformBuffer2& _26 [[buffer(1)]])
+{
+    main0_out out = {};
+    out.gl_Position = float4(float2x2(float2(_20.transform1[0].xy) + float2(_26.transform2[0].xy), float2(_20.transform1[1].xy) + float2(_26.transform2[1].xy)) * float2(-1.0), 0.0, 1.0);
+    return out;
+}
+

--- a/shaders-msl/vert/matrix.swizzle.vert
+++ b/shaders-msl/vert/matrix.swizzle.vert
@@ -1,0 +1,15 @@
+#version 450
+
+layout (set = 0, binding = 0) uniform vertexUniformBuffer1 {
+    mat2 transform1;
+};
+
+layout (set = 1, binding = 0) uniform vertexUniformBuffer2{
+    mat2 transform2;
+};
+
+void main() {
+    const vec2 pos[3] = vec2[3](vec2(-1.f, -1.f), vec2(1.f, -1.f), vec2(-1.f, 1.f));
+    gl_Position = vec4((transform1 + transform2) * pos[0], 0.f, 1.f);
+}
+

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -6888,6 +6888,17 @@ string CompilerGLSL::access_chain_internal(uint32_t base, const uint32_t *indice
 
 			type_id = type->parent_type;
 			type = &get<SPIRType>(type_id);
+
+			// Extract into swizzle if vecsize is smaller than the vecsize of physical type
+			if (physical_type != 0)
+			{
+				const auto &m_physical_type = &get<SPIRType>(physical_type);
+				if (m_physical_type != nullptr && type->vecsize < m_physical_type->vecsize && index_is_literal &&
+				    !is_packed && !row_major_matrix_needs_conversion)
+				{
+					expr += vector_swizzle(type->vecsize, 0);
+				}
+			}
 		}
 		// Vector -> Scalar
 		else if (type->vecsize > 1)


### PR DESCRIPTION
For mat2 in MSL, it will be stored as float2x4 because the MatrixStride is required to be 16. But we cannot constuct a vec<float,2) from vec<float, 4>, so extract it into swizzle if actual size is smaller than
its pyhiscal size.

Fix #1200