### PR TITLE
Share test shader script

### DIFF
--- a/test_shaders.sh
+++ b/test_shaders.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+OPTS=$@
+
 if [ -z "$SPIRV_CROSS_PATH" ]; then
 	echo "Building spirv-cross"
 	make -j$(nproc)
@@ -11,17 +13,17 @@ echo "Using glslangValidation in: $(which glslangValidator)."
 echo "Using spirv-opt in: $(which spirv-opt)."
 echo "Using SPIRV-Cross in: \"$SPIRV_CROSS_PATH\"."
 
-./test_shaders.py shaders --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders --opt --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-no-opt --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-msl --msl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-msl --msl --opt --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-msl-no-opt --msl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-hlsl --hlsl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-hlsl --hlsl --opt --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-hlsl-no-opt --hlsl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-reflection --reflect --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-ue4 --msl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-ue4 --msl --opt --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-ue4-no-opt --msl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders ${OPTS} --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders ${OPTS} --opt --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-no-opt ${OPTS} --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-msl ${OPTS} --msl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-msl ${OPTS} --msl --opt --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-msl-no-opt ${OPTS} --msl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-hlsl ${OPTS} --hlsl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-hlsl ${OPTS} --hlsl --opt --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-hlsl-no-opt ${OPTS} --hlsl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-reflection ${OPTS} --reflect --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-ue4 ${OPTS} --msl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-ue4 ${OPTS} --msl --opt --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
+./test_shaders.py shaders-ue4-no-opt ${OPTS} --msl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
 

--- a/update_test_shaders.sh
+++ b/update_test_shaders.sh
@@ -1,28 +1,4 @@
 #!/bin/bash
 
-if [ -z "$SPIRV_CROSS_PATH" ]; then
-	echo "Building spirv-cross"
-	make -j$(nproc)
-	SPIRV_CROSS_PATH="./spirv-cross"
-fi
-
-export PATH="./external/glslang-build/output/bin:./external/spirv-tools-build/output/bin:.:$PATH"
-echo "Using glslangValidation in: $(which glslangValidator)."
-echo "Using spirv-opt in: $(which spirv-opt)."
-echo "Using SPIRV-Cross in: \"$SPIRV_CROSS_PATH\"."
-
-./test_shaders.py shaders --update --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders --update --opt --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-no-opt --update --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-msl --update --msl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-msl --update --msl --opt --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-msl-no-opt --update --msl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-hlsl --update --hlsl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-hlsl --update --hlsl --opt --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-hlsl-no-opt --update --hlsl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-reflection --reflect --update --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-ue4 --update --msl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-ue4 --update --msl --opt --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-./test_shaders.py shaders-ue4-no-opt --update --msl --spirv-cross "$SPIRV_CROSS_PATH" || exit 1
-
+./test_shaders.sh --update
 


### PR DESCRIPTION
This CL adds the ability to pass options to test_shader.sh. The
update_test_shaders.sh script is then changed to call test_shaders.sh
with the --update flag.

This removes the duplication of code between test_shaders.sh and
update_test_shaders.sh.