### PR TITLE
Don't emit memoryBarrierShared() in workgroup control barriers.

### DIFF
--- a/reference/opt/shaders/comp/barriers.comp
+++ b/reference/opt/shaders/comp/barriers.comp
@@ -8,21 +8,15 @@ void main()
     memoryBarrierImage();
     memoryBarrierBuffer();
     groupMemoryBarrier();
-    memoryBarrierShared();
     barrier();
     memoryBarrier();
-    memoryBarrierShared();
     barrier();
     memoryBarrierImage();
-    memoryBarrierShared();
     barrier();
     memoryBarrierBuffer();
-    memoryBarrierShared();
     barrier();
     groupMemoryBarrier();
-    memoryBarrierShared();
     barrier();
-    memoryBarrierShared();
     barrier();
 }
 

--- a/reference/opt/shaders/comp/shared.comp
+++ b/reference/opt/shaders/comp/shared.comp
@@ -16,7 +16,6 @@ shared float sShared[4];
 void main()
 {
     sShared[gl_LocalInvocationIndex] = _22.in_data[gl_GlobalInvocationID.x];
-    memoryBarrierShared();
     barrier();
     _44.out_data[gl_GlobalInvocationID.x] = sShared[3u - gl_LocalInvocationIndex];
 }

--- a/reference/shaders/comp/barriers.comp
+++ b/reference/shaders/comp/barriers.comp
@@ -28,41 +28,35 @@ void group_barrier()
 
 void barrier_shared_exec()
 {
-    memoryBarrierShared();
     barrier();
 }
 
 void full_barrier_exec()
 {
     memoryBarrier();
-    memoryBarrierShared();
     barrier();
 }
 
 void image_barrier_exec()
 {
     memoryBarrierImage();
-    memoryBarrierShared();
     barrier();
 }
 
 void buffer_barrier_exec()
 {
     memoryBarrierBuffer();
-    memoryBarrierShared();
     barrier();
 }
 
 void group_barrier_exec()
 {
     groupMemoryBarrier();
-    memoryBarrierShared();
     barrier();
 }
 
 void exec_barrier()
 {
-    memoryBarrierShared();
     barrier();
 }
 

--- a/reference/shaders/comp/shared.comp
+++ b/reference/shaders/comp/shared.comp
@@ -18,7 +18,6 @@ void main()
     uint ident = gl_GlobalInvocationID.x;
     float idata = _22.in_data[ident];
     sShared[gl_LocalInvocationIndex] = idata;
-    memoryBarrierShared();
     barrier();
     _44.out_data[ident] = sShared[(4u - gl_LocalInvocationIndex) - 1u];
 }

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -9892,7 +9892,12 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		if (memory == ScopeWorkgroup) // Only need to consider memory within a group
 		{
 			if (semantics == MemorySemanticsWorkgroupMemoryMask)
-				statement("memoryBarrierShared();");
+			{
+				// OpControlBarrier implies a memory barrier for shared memory as well.
+				bool implies_shared_barrier = opcode == OpControlBarrier && execution_scope == ScopeWorkgroup;
+				if (!implies_shared_barrier)
+					statement("memoryBarrierShared();");
+			}
 			else if (semantics != 0)
 				statement("groupMemoryBarrier();");
 		}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -9931,7 +9931,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		else
 		{
 			const uint32_t all_barriers = MemorySemanticsWorkgroupMemoryMask | MemorySemanticsUniformMemoryMask |
-			                              MemorySemanticsImageMemoryMask | MemorySemanticsAtomicCounterMemoryMask;
+			                              MemorySemanticsImageMemoryMask;
 
 			if (semantics & (MemorySemanticsCrossWorkgroupMemoryMask | MemorySemanticsSubgroupMemoryMask))
 			{
@@ -9953,8 +9953,6 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 					statement("memoryBarrierBuffer();");
 				if (semantics & MemorySemanticsImageMemoryMask)
 					statement("memoryBarrierImage();");
-				if (semantics & MemorySemanticsAtomicCounterMemoryMask)
-					statement("memoryBarrierAtomicCounter();");
 			}
 		}
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -6513,8 +6513,7 @@ void CompilerMSL::emit_barrier(uint32_t id_exe_scope, uint32_t id_mem_scope, uin
 
 		// Fix tessellation patch function processing
 		if (get_execution_model() == ExecutionModelTessellationControl ||
-		    (mem_sem & (MemorySemanticsSubgroupMemoryMask | MemorySemanticsWorkgroupMemoryMask |
-		                MemorySemanticsAtomicCounterMemoryMask)))
+		    (mem_sem & (MemorySemanticsSubgroupMemoryMask | MemorySemanticsWorkgroupMemoryMask)))
 		{
 			if (!mem_flags.empty())
 				mem_flags += " | ";
@@ -6535,13 +6534,11 @@ void CompilerMSL::emit_barrier(uint32_t id_exe_scope, uint32_t id_mem_scope, uin
 	else
 	{
 		if ((mem_sem & (MemorySemanticsUniformMemoryMask | MemorySemanticsCrossWorkgroupMemoryMask)) &&
-		    (mem_sem & (MemorySemanticsSubgroupMemoryMask | MemorySemanticsWorkgroupMemoryMask |
-		                MemorySemanticsAtomicCounterMemoryMask)))
+		    (mem_sem & (MemorySemanticsSubgroupMemoryMask | MemorySemanticsWorkgroupMemoryMask)))
 			bar_stmt += "mem_flags::mem_device_and_threadgroup";
 		else if (mem_sem & (MemorySemanticsUniformMemoryMask | MemorySemanticsCrossWorkgroupMemoryMask))
 			bar_stmt += "mem_flags::mem_device";
-		else if (mem_sem & (MemorySemanticsSubgroupMemoryMask | MemorySemanticsWorkgroupMemoryMask |
-		                    MemorySemanticsAtomicCounterMemoryMask))
+		else if (mem_sem & (MemorySemanticsSubgroupMemoryMask | MemorySemanticsWorkgroupMemoryMask))
 			bar_stmt += "mem_flags::mem_threadgroup";
 		else if (mem_sem & MemorySemanticsImageMemoryMask)
 			bar_stmt += "mem_flags::mem_texture";


### PR DESCRIPTION
This is implied in both GL and GLES. Emitting memoryBarrierShared() was
based on earlier confusion in the spec which has since been fixed and
clarified.