### PR TITLE
GLSL: Fix array of input patch variables.

### DIFF
--- a/reference/opt/shaders/desktop-only/tesc/basic.desktop.sso.tesc
+++ b/reference/opt/shaders/desktop-only/tesc/basic.desktop.sso.tesc
@@ -4,7 +4,7 @@ layout(vertices = 1) out;
 in gl_PerVertex
 {
     vec4 gl_Position;
-} gl_in[gl_MaxPatchVertices];
+} gl_in[];
 
 out gl_PerVertex
 {

--- a/reference/opt/shaders/desktop-only/tese/triangle.desktop.sso.tese
+++ b/reference/opt/shaders/desktop-only/tese/triangle.desktop.sso.tese
@@ -4,7 +4,7 @@ layout(triangles, cw, fractional_even_spacing) in;
 in gl_PerVertex
 {
     vec4 gl_Position;
-} gl_in[gl_MaxPatchVertices];
+} gl_in[];
 
 out gl_PerVertex
 {

--- a/reference/opt/shaders/tese/patch-input-array.tese
+++ b/reference/opt/shaders/tese/patch-input-array.tese
@@ -1,0 +1,10 @@
+#version 450
+layout(quads, ccw, equal_spacing) in;
+
+layout(location = 0) patch in float P[4];
+
+void main()
+{
+    gl_Position = vec4(P[0], P[1], P[2], P[3]);
+}
+

--- a/reference/shaders/desktop-only/tesc/basic.desktop.sso.tesc
+++ b/reference/shaders/desktop-only/tesc/basic.desktop.sso.tesc
@@ -4,7 +4,7 @@ layout(vertices = 1) out;
 in gl_PerVertex
 {
     vec4 gl_Position;
-} gl_in[gl_MaxPatchVertices];
+} gl_in[];
 
 out gl_PerVertex
 {

--- a/reference/shaders/desktop-only/tese/triangle.desktop.sso.tese
+++ b/reference/shaders/desktop-only/tese/triangle.desktop.sso.tese
@@ -4,7 +4,7 @@ layout(triangles, cw, fractional_even_spacing) in;
 in gl_PerVertex
 {
     vec4 gl_Position;
-} gl_in[gl_MaxPatchVertices];
+} gl_in[];
 
 out gl_PerVertex
 {

--- a/reference/shaders/tese/patch-input-array.tese
+++ b/reference/shaders/tese/patch-input-array.tese
@@ -1,0 +1,10 @@
+#version 450
+layout(quads, ccw, equal_spacing) in;
+
+layout(location = 0) patch in float P[4];
+
+void main()
+{
+    gl_Position = vec4(P[0], P[1], P[2], P[3]);
+}
+

--- a/shaders/tese/patch-input-array.tese
+++ b/shaders/tese/patch-input-array.tese
@@ -1,0 +1,9 @@
+#version 450
+
+layout(quads) in;
+layout(location = 0) patch in float P[4];
+
+void main()
+{
+	gl_Position = vec4(P[0], P[1], P[2], P[3]);
+}


### PR DESCRIPTION
Hoist out the hack to make array sizes unsized to a place where we can
differentiate patch variables from control point variables.