### PR TITLE
MSL: Support inline uniform blocks in argument buffers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,7 +315,7 @@ if (SPIRV_CROSS_STATIC)
 endif()
 
 set(spirv-cross-abi-major 0)
-set(spirv-cross-abi-minor 23)
+set(spirv-cross-abi-minor 24)
 set(spirv-cross-abi-patch 0)
 
 if (SPIRV_CROSS_SHARED)

--- a/reference/opt/shaders-msl/comp/basic.inline-block.msl2.comp
+++ b/reference/opt/shaders-msl/comp/basic.inline-block.msl2.comp
@@ -1,0 +1,53 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+typedef packed_float4 packed_float4x4[4];
+
+struct Baz
+{
+    int f;
+    int g;
+};
+
+struct X
+{
+    int x;
+    int y;
+    float z;
+};
+
+struct Foo
+{
+    int a;
+    int b;
+    packed_float4x4 c;
+    X x[2];
+};
+
+struct Bar
+{
+    int d;
+    int e;
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(3u, 3u, 2u);
+
+struct spvDescriptorSetBuffer0
+{
+    Foo m_32 [[id(0)]];
+    constant Bar* m_38 [[id(12)]];
+};
+
+struct spvDescriptorSetBuffer1
+{
+    device Baz* baz [[id(0)]][3];
+};
+
+kernel void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], constant spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+{
+    spvDescriptorSet1.baz[gl_GlobalInvocationID.x]->f = spvDescriptorSet0.m_32.a + (*spvDescriptorSet0.m_38).d;
+    spvDescriptorSet1.baz[gl_GlobalInvocationID.x]->g = spvDescriptorSet0.m_32.b * (*spvDescriptorSet0.m_38).e;
+}
+

--- a/reference/opt/shaders-msl/comp/basic.inline-block.msl2.comp
+++ b/reference/opt/shaders-msl/comp/basic.inline-block.msl2.comp
@@ -36,8 +36,8 @@ constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(3u, 3u, 2u);
 
 struct spvDescriptorSetBuffer0
 {
-    Foo m_32 [[id(0)]];
-    constant Bar* m_38 [[id(12)]];
+    constant Bar* m_38 [[id(0)]];
+    Foo m_32 [[id(1)]];
 };
 
 struct spvDescriptorSetBuffer1

--- a/reference/shaders-msl/comp/basic.inline-block.msl2.comp
+++ b/reference/shaders-msl/comp/basic.inline-block.msl2.comp
@@ -36,8 +36,8 @@ constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(3u, 3u, 2u);
 
 struct spvDescriptorSetBuffer0
 {
-    Foo m_32 [[id(0)]];
-    constant Bar* m_38 [[id(12)]];
+    constant Bar* m_38 [[id(0)]];
+    Foo m_32 [[id(1)]];
 };
 
 struct spvDescriptorSetBuffer1

--- a/reference/shaders-msl/comp/basic.inline-block.msl2.comp
+++ b/reference/shaders-msl/comp/basic.inline-block.msl2.comp
@@ -1,0 +1,54 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+typedef packed_float4 packed_float4x4[4];
+
+struct Baz
+{
+    int f;
+    int g;
+};
+
+struct X
+{
+    int x;
+    int y;
+    float z;
+};
+
+struct Foo
+{
+    int a;
+    int b;
+    packed_float4x4 c;
+    X x[2];
+};
+
+struct Bar
+{
+    int d;
+    int e;
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(3u, 3u, 2u);
+
+struct spvDescriptorSetBuffer0
+{
+    Foo m_32 [[id(0)]];
+    constant Bar* m_38 [[id(12)]];
+};
+
+struct spvDescriptorSetBuffer1
+{
+    device Baz* baz [[id(0)]][3];
+};
+
+kernel void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], constant spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+{
+    uint3 coords = gl_GlobalInvocationID;
+    spvDescriptorSet1.baz[coords.x]->f = spvDescriptorSet0.m_32.a + (*spvDescriptorSet0.m_38).d;
+    spvDescriptorSet1.baz[coords.x]->g = spvDescriptorSet0.m_32.b * (*spvDescriptorSet0.m_38).e;
+}
+

--- a/shaders-msl/comp/basic.inline-block.msl2.comp
+++ b/shaders-msl/comp/basic.inline-block.msl2.comp
@@ -1,0 +1,37 @@
+#version 450
+#extension GL_EXT_scalar_block_layout : require
+layout(local_size_x = 3, local_size_y = 3, local_size_z = 2) in;
+
+struct X
+{
+	int x;
+	int y;
+	float z;
+};
+
+layout(set = 0, binding = 0, scalar) uniform Foo
+{
+	int a;
+	int b;
+	mat4 c;
+	X x[2];
+};
+
+layout(set = 0, binding = 1) uniform Bar
+{
+	int d;
+	int e;
+};
+
+layout(set = 1, binding = 2) buffer Baz
+{
+	int f;
+	int g;
+} baz[3];
+
+void main()
+{
+	uvec3 coords = gl_GlobalInvocationID;
+	baz[coords.x].f = a + d;
+	baz[coords.x].g = b * e;
+}

--- a/spirv_cross_c.cpp
+++ b/spirv_cross_c.cpp
@@ -1029,6 +1029,26 @@ spvc_result spvc_compiler_msl_add_dynamic_buffer(spvc_compiler compiler, unsigne
 #endif
 }
 
+spvc_result spvc_compiler_msl_add_inline_uniform_block(spvc_compiler compiler, unsigned desc_set, unsigned binding)
+{
+#if SPIRV_CROSS_C_API_MSL
+	if (compiler->backend != SPVC_BACKEND_MSL)
+	{
+		compiler->context->report_error("MSL function used on a non-MSL backend.");
+		return SPVC_ERROR_INVALID_ARGUMENT;
+	}
+
+	auto &msl = *static_cast<CompilerMSL *>(compiler->compiler.get());
+	msl.add_inline_uniform_block(desc_set, binding);
+	return SPVC_SUCCESS;
+#else
+	(void)binding;
+	(void)desc_set;
+	compiler->context->report_error("MSL function used on a non-MSL backend.");
+	return SPVC_ERROR_INVALID_ARGUMENT;
+#endif
+}
+
 spvc_result spvc_compiler_msl_add_discrete_descriptor_set(spvc_compiler compiler, unsigned desc_set)
 {
 #if SPIRV_CROSS_C_API_MSL

--- a/spirv_cross_c.h
+++ b/spirv_cross_c.h
@@ -33,7 +33,7 @@ extern "C" {
 /* Bumped if ABI or API breaks backwards compatibility. */
 #define SPVC_C_API_VERSION_MAJOR 0
 /* Bumped if APIs or enumerations are added in a backwards compatible way. */
-#define SPVC_C_API_VERSION_MINOR 23
+#define SPVC_C_API_VERSION_MINOR 24
 /* Bumped if internal implementation details change. */
 #define SPVC_C_API_VERSION_PATCH 0
 
@@ -690,6 +690,8 @@ SPVC_PUBLIC_API unsigned spvc_compiler_msl_get_automatic_resource_binding(spvc_c
 SPVC_PUBLIC_API unsigned spvc_compiler_msl_get_automatic_resource_binding_secondary(spvc_compiler compiler, spvc_variable_id id);
 
 SPVC_PUBLIC_API spvc_result spvc_compiler_msl_add_dynamic_buffer(spvc_compiler compiler, unsigned desc_set, unsigned binding, unsigned index);
+
+SPVC_PUBLIC_API spvc_result spvc_compiler_msl_add_inline_uniform_block(spvc_compiler compiler, unsigned desc_set, unsigned binding);
 
 /*
  * Reflect resources.

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -432,6 +432,13 @@ public:
 	// an offset taken from the dynamic offset buffer.
 	void add_dynamic_buffer(uint32_t desc_set, uint32_t binding, uint32_t index);
 
+	// desc_set and binding are the SPIR-V descriptor set and binding of a buffer resource
+	// in this shader. This function marks that resource as an inline uniform block
+	// (VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT). This function only has any effect if argument buffers
+	// are enabled. If so, the buffer block will be directly embedded into the argument
+	// buffer, instead of being referenced indirectly via pointer.
+	void add_inline_uniform_block(uint32_t desc_set, uint32_t binding);
+
 	// When using MSL argument buffers, we can force "classic" MSL 1.0 binding schemes for certain descriptor sets.
 	// This corresponds to VK_KHR_push_descriptor in Vulkan.
 	void add_discrete_descriptor_set(uint32_t desc_set);
@@ -853,6 +860,9 @@ protected:
 
 	// Must be ordered since array is in a specific order.
 	std::map<SetBindingPair, std::pair<uint32_t, uint32_t>> buffers_requiring_dynamic_offset;
+
+	std::unordered_set<SetBindingPair, InternalHasher> inline_uniform_blocks;
+	uint32_t get_inline_uniform_block_binding_stride(SPIRType &type);
 
 	uint32_t argument_buffer_ids[kMaxArgumentBuffers];
 	uint32_t argument_buffer_discrete_mask = 0;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -862,7 +862,6 @@ protected:
 	std::map<SetBindingPair, std::pair<uint32_t, uint32_t>> buffers_requiring_dynamic_offset;
 
 	std::unordered_set<SetBindingPair, InternalHasher> inline_uniform_blocks;
-	uint32_t get_inline_uniform_block_binding_stride(SPIRType &type);
 
 	uint32_t argument_buffer_ids[kMaxArgumentBuffers];
 	uint32_t argument_buffer_discrete_mask = 0;

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -244,6 +244,11 @@ def cross_compile_msl(shader, spirv, opt, iterations, paths):
         msl_args.append('--msl-dynamic-buffer')
         msl_args.append('1')
         msl_args.append('2')
+    if '.inline-block.' in shader:
+        # Arbitrary for testing purposes.
+        msl_args.append('--msl-inline-uniform-block')
+        msl_args.append('0')
+        msl_args.append('0')
     if '.device-argument-buffer.' in shader:
         msl_args.append('--msl-device-argument-buffer')
         msl_args.append('0')


### PR DESCRIPTION
Here, the inline uniform block is explicit: we instantiate the buffer
block itself in the argument buffer, instead of a pointer to the buffer.
I just hope this will work with the `MTLArgumentDescriptor` API...

Note that Metal recursively assigns individual members of embedded
structs IDs. This means for automatic assignment that we have to
calculate the binding stride for a given buffer block. For MoltenVK,
we'll simply increment the ID by the size of the inline uniform block.
Then the later IDs will never conflict with the inline uniform block. We
can get away with this because Metal doesn't require that IDs be
contiguous, only monotonically increasing.