### PR TITLE
MSL Argument Buffers: preserve all resources

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1003,6 +1003,31 @@ string CompilerMSL::compile()
 	fixup_image_load_store_access();
 
 	set_enabled_interface_variables(get_active_interface_variables());
+	
+	if (msl_options.argument_buffers)
+ 	{
+ 		// If we're using argument buffers, we need to emit all bindings that 
+		// could be contained within an argument buffer.
+ 		const ShaderResources resources = get_shader_resources();
+ 		for (auto &resource : resources.uniform_buffers)
+ 			active_interface_variables.insert(resource.id);
+
+  		for (auto &resource : resources.storage_buffers)
+ 			active_interface_variables.insert(resource.id);
+
+  		for (auto &resource : resources.storage_images)
+ 			active_interface_variables.insert(resource.id);
+
+  		for (auto &resource : resources.sampled_images)
+ 			active_interface_variables.insert(resource.id);
+
+  		for (auto &resource : resources.separate_images)
+ 			active_interface_variables.insert(resource.id);
+
+  		for (auto &resource : resources.separate_samplers)
+ 			active_interface_variables.insert(resource.id);
+ 	}
+	
 	if (swizzle_buffer_id)
 		active_interface_variables.insert(swizzle_buffer_id);
 	if (buffer_size_buffer_id)


### PR DESCRIPTION
In MSL, the unused contents of an argument buffer are important if that argument buffer is to be used across multiple entry points; unused members still contribute to the layout of the argument buffer. To accomodate use cases where an argument buffer is reused across multiple entry points (e.g. bound to the vertex and fragment stages at the same time, with not all resources used in each stage), don't strip unused resources when argument buffers are enabled.

This is a tentative change for review. If the basic idea looks good then I can go through and update the tests. Otherwise, if this needs to be behind a flag, let me know and I will alter the patch accordingly.