### PR TITLE
Deal with illegal names in types as well.

### DIFF
--- a/reference/shaders-hlsl-no-opt/comp/illegal-struct-name.asm.comp
+++ b/reference/shaders-hlsl-no-opt/comp/illegal-struct-name.asm.comp
@@ -1,0 +1,22 @@
+struct Foo
+{
+    float _abs;
+};
+
+RWByteAddressBuffer _7 : register(u0);
+
+void comp_main()
+{
+    Foo _24;
+    _24._abs = asfloat(_7.Load(0));
+    Foo f;
+    f._abs = _24._abs;
+    int _abs = 10;
+    _7.Store(4, asuint(f._abs));
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    comp_main();
+}

--- a/reference/shaders-msl-no-opt/comp/illegal-struct-name.asm.comp
+++ b/reference/shaders-msl-no-opt/comp/illegal-struct-name.asm.comp
@@ -1,0 +1,29 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Foo
+{
+    float _abs;
+};
+
+struct Foo_1
+{
+    float _abs;
+};
+
+struct SSBO
+{
+    Foo_1 foo;
+    Foo_1 foo2;
+};
+
+kernel void main0(device SSBO& _7 [[buffer(0)]])
+{
+    Foo f;
+    f._abs = _7.foo._abs;
+    int _abs = 10;
+    _7.foo2._abs = f._abs;
+}
+

--- a/reference/shaders-no-opt/comp/illegal-struct-name.asm.comp
+++ b/reference/shaders-no-opt/comp/illegal-struct-name.asm.comp
@@ -1,0 +1,22 @@
+#version 450
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+struct Foo
+{
+    float _abs;
+};
+
+layout(binding = 0, std430) buffer SSBO
+{
+    Foo foo;
+    Foo foo2;
+} _7;
+
+void main()
+{
+    Foo f;
+    f._abs = _7.foo._abs;
+    int _abs = 10;
+    _7.foo2._abs = f._abs;
+}
+

--- a/shaders-hlsl-no-opt/comp/illegal-struct-name.asm.comp
+++ b/shaders-hlsl-no-opt/comp/illegal-struct-name.asm.comp
@@ -1,0 +1,62 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 8
+; Bound: 31
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %Foo "Foo"
+               OpMemberName %Foo 0 "abs"
+               OpName %f "f"
+               OpName %Foo_0 "Foo"
+               OpMemberName %Foo_0 0 "abs"
+               OpName %SSBO "SSBO"
+               OpMemberName %SSBO 0 "foo"
+               OpMemberName %SSBO 1 "foo2"
+               OpName %_ ""
+               OpName %linear "abs"
+               OpMemberDecorate %Foo_0 0 Offset 0
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpMemberDecorate %SSBO 1 Offset 4
+               OpDecorate %SSBO BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+        %Foo = OpTypeStruct %float
+%_ptr_Function_Foo = OpTypePointer Function %Foo
+      %Foo_0 = OpTypeStruct %float
+       %SSBO = OpTypeStruct %Foo_0 %Foo_0
+%_ptr_Uniform_SSBO = OpTypePointer Uniform %SSBO
+          %_ = OpVariable %_ptr_Uniform_SSBO Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_Foo_0 = OpTypePointer Uniform %Foo_0
+%_ptr_Function_float = OpTypePointer Function %float
+%_ptr_Function_int = OpTypePointer Function %int
+     %int_10 = OpConstant %int 10
+      %int_1 = OpConstant %int 1
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %f = OpVariable %_ptr_Function_Foo Function
+     %linear = OpVariable %_ptr_Function_int Function
+         %17 = OpAccessChain %_ptr_Uniform_Foo_0 %_ %int_0
+         %18 = OpLoad %Foo_0 %17
+         %19 = OpCompositeExtract %float %18 0
+         %21 = OpAccessChain %_ptr_Function_float %f %int_0
+               OpStore %21 %19
+               OpStore %linear %int_10
+         %26 = OpLoad %Foo %f
+         %27 = OpAccessChain %_ptr_Uniform_Foo_0 %_ %int_1
+         %28 = OpCompositeExtract %float %26 0
+         %30 = OpAccessChain %_ptr_Uniform_float %27 %int_0
+               OpStore %30 %28
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/comp/illegal-struct-name.asm.comp
+++ b/shaders-msl-no-opt/comp/illegal-struct-name.asm.comp
@@ -1,0 +1,62 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 8
+; Bound: 31
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %Foo "Foo"
+               OpMemberName %Foo 0 "abs"
+               OpName %f "f"
+               OpName %Foo_0 "Foo"
+               OpMemberName %Foo_0 0 "abs"
+               OpName %SSBO "SSBO"
+               OpMemberName %SSBO 0 "foo"
+               OpMemberName %SSBO 1 "foo2"
+               OpName %_ ""
+               OpName %linear "abs"
+               OpMemberDecorate %Foo_0 0 Offset 0
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpMemberDecorate %SSBO 1 Offset 4
+               OpDecorate %SSBO BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+        %Foo = OpTypeStruct %float
+%_ptr_Function_Foo = OpTypePointer Function %Foo
+      %Foo_0 = OpTypeStruct %float
+       %SSBO = OpTypeStruct %Foo_0 %Foo_0
+%_ptr_Uniform_SSBO = OpTypePointer Uniform %SSBO
+          %_ = OpVariable %_ptr_Uniform_SSBO Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_Foo_0 = OpTypePointer Uniform %Foo_0
+%_ptr_Function_float = OpTypePointer Function %float
+%_ptr_Function_int = OpTypePointer Function %int
+     %int_10 = OpConstant %int 10
+      %int_1 = OpConstant %int 1
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %f = OpVariable %_ptr_Function_Foo Function
+     %linear = OpVariable %_ptr_Function_int Function
+         %17 = OpAccessChain %_ptr_Uniform_Foo_0 %_ %int_0
+         %18 = OpLoad %Foo_0 %17
+         %19 = OpCompositeExtract %float %18 0
+         %21 = OpAccessChain %_ptr_Function_float %f %int_0
+               OpStore %21 %19
+               OpStore %linear %int_10
+         %26 = OpLoad %Foo %f
+         %27 = OpAccessChain %_ptr_Uniform_Foo_0 %_ %int_1
+         %28 = OpCompositeExtract %float %26 0
+         %30 = OpAccessChain %_ptr_Uniform_float %27 %int_0
+               OpStore %30 %28
+               OpReturn
+               OpFunctionEnd

--- a/shaders-no-opt/comp/illegal-struct-name.asm.comp
+++ b/shaders-no-opt/comp/illegal-struct-name.asm.comp
@@ -1,0 +1,62 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 8
+; Bound: 31
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %Foo "Foo"
+               OpMemberName %Foo 0 "abs"
+               OpName %f "f"
+               OpName %Foo_0 "Foo"
+               OpMemberName %Foo_0 0 "abs"
+               OpName %SSBO "SSBO"
+               OpMemberName %SSBO 0 "foo"
+               OpMemberName %SSBO 1 "foo2"
+               OpName %_ ""
+               OpName %linear "abs"
+               OpMemberDecorate %Foo_0 0 Offset 0
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpMemberDecorate %SSBO 1 Offset 4
+               OpDecorate %SSBO BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+        %Foo = OpTypeStruct %float
+%_ptr_Function_Foo = OpTypePointer Function %Foo
+      %Foo_0 = OpTypeStruct %float
+       %SSBO = OpTypeStruct %Foo_0 %Foo_0
+%_ptr_Uniform_SSBO = OpTypePointer Uniform %SSBO
+          %_ = OpVariable %_ptr_Uniform_SSBO Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_Foo_0 = OpTypePointer Uniform %Foo_0
+%_ptr_Function_float = OpTypePointer Function %float
+%_ptr_Function_int = OpTypePointer Function %int
+     %int_10 = OpConstant %int 10
+      %int_1 = OpConstant %int 1
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %f = OpVariable %_ptr_Function_Foo Function
+     %linear = OpVariable %_ptr_Function_int Function
+         %17 = OpAccessChain %_ptr_Uniform_Foo_0 %_ %int_0
+         %18 = OpLoad %Foo_0 %17
+         %19 = OpCompositeExtract %float %18 0
+         %21 = OpAccessChain %_ptr_Function_float %f %int_0
+               OpStore %21 %19
+               OpStore %linear %int_10
+         %26 = OpLoad %Foo %f
+         %27 = OpAccessChain %_ptr_Uniform_Foo_0 %_ %int_1
+         %28 = OpCompositeExtract %float %26 0
+         %30 = OpAccessChain %_ptr_Uniform_float %27 %int_0
+               OpStore %30 %28
+               OpReturn
+               OpFunctionEnd

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -590,6 +590,7 @@ protected:
 	bool check_atomic_image(uint32_t id);
 
 	virtual void replace_illegal_names();
+	void replace_illegal_names(const std::unordered_set<std::string> &keywords);
 	virtual void emit_entry_point_declarations();
 
 	void replace_fragment_output(SPIRVariable &var);

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1113,15 +1113,7 @@ void CompilerHLSL::replace_illegal_names()
 		"line", "linear", "matrix", "point", "row_major", "sampler",
 	};
 
-	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, SPIRVariable &var) {
-		if (!is_hidden_variable(var))
-		{
-			auto &m = ir.meta[var.self].decoration;
-			if (keywords.find(m.alias) != end(keywords))
-				m.alias = join("_", m.alias);
-		}
-	});
-
+	CompilerGLSL::replace_illegal_names(keywords);
 	CompilerGLSL::replace_illegal_names();
 }
 


### PR DESCRIPTION
- Fixes issue with clip_distance flattening in MSL where member to
  flatten from would come from to_member_name, where it should have used
  the builtin name directly. This member name was modified by this patch
  and broke clip distance test shaders.

- Some cleanups with ir.meta, use ir.find_meta instead to not create
  unnecessary hashmap nodes.

Fix #1232