### PR TITLE
Add GNUInstallDirs + fixes for the pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,14 +322,12 @@ set(spirv-cross-abi-patch 0)
 
 if (SPIRV_CROSS_SHARED)
 	set(SPIRV_CROSS_VERSION ${spirv-cross-abi-major}.${spirv-cross-abi-minor}.${spirv-cross-abi-patch})
-	set(SPIRV_CROSS_INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib)
-	set(SPIRV_CROSS_INSTALL_INC_DIR ${CMAKE_INSTALL_PREFIX}/include/spirv_cross)
 
 	if (NOT SPIRV_CROSS_SKIP_INSTALL)
 		configure_file(
 			${CMAKE_CURRENT_SOURCE_DIR}/pkg-config/spirv-cross-c-shared.pc.in
 			${CMAKE_CURRENT_BINARY_DIR}/spirv-cross-c-shared.pc @ONLY)
-		install(FILES ${CMAKE_CURRENT_BINARY_DIR}/spirv-cross-c-shared.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/share/pkgconfig)
+		install(FILES ${CMAKE_CURRENT_BINARY_DIR}/spirv-cross-c-shared.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 	endif()
 
 	spirv_cross_add_library(spirv-cross-c-shared spirv_cross_c_shared SHARED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ set(CMAKE_CXX_STANDARD 11)
 project(SPIRV-Cross LANGUAGES CXX C)
 enable_testing()
 
+include(GNUInstallDirs)
+
 option(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS "Instead of throwing exceptions assert" OFF)
 option(SPIRV_CROSS_SHARED "Build the C API as a single shared library." OFF)
 option(SPIRV_CROSS_STATIC "Build the C and C++ API as static libraries." ON)
@@ -171,12 +173,12 @@ macro(spirv_cross_add_library name config_name library_type)
 	if (NOT SPIRV_CROSS_SKIP_INSTALL)
 		install(TARGETS ${name}
 			EXPORT ${config_name}Config
-			RUNTIME DESTINATION bin
-			LIBRARY DESTINATION lib
-			ARCHIVE DESTINATION lib
-			PUBLIC_HEADER DESTINATION include/spirv_cross)
-		install(FILES ${hdrs} DESTINATION include/spirv_cross)
-		install(EXPORT ${config_name}Config DESTINATION share/${config_name}/cmake)
+			RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+			LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+			ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+			PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spirv_cross)
+		install(FILES ${hdrs} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spirv_cross)
+		install(EXPORT ${config_name}Config DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${config_name}/cmake)
 		export(TARGETS ${name} FILE ${config_name}Config.cmake)
 	endif()
 endmacro()
@@ -427,7 +429,7 @@ if (SPIRV_CROSS_CLI)
 	target_compile_definitions(spirv-cross PRIVATE ${spirv-compiler-defines} HAVE_SPIRV_CROSS_GIT_VERSION)
 	set_target_properties(spirv-cross PROPERTIES LINK_FLAGS "${spirv-cross-link-flags}")
 	if (NOT SPIRV_CROSS_SKIP_INSTALL)
-		install(TARGETS spirv-cross RUNTIME DESTINATION bin)
+		install(TARGETS spirv-cross RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 	endif()
 	target_link_libraries(spirv-cross PRIVATE
 			spirv-cross-glsl

--- a/pkg-config/spirv-cross-c-shared.pc.in
+++ b/pkg-config/spirv-cross-c-shared.pc.in
@@ -1,8 +1,8 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@SPIRV_CROSS_INSTALL_LIB_DIR@
-sharedlibdir=@SPIRV_CROSS_INSTALL_LIB_DIR@
-includedir=@SPIRV_CROSS_INSTALL_INC_DIR@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+sharedlibdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/spirv_cross
 
 Name: spirv-cross-c-shared
 Description: C API for SPIRV-Cross


### PR DESCRIPTION
This PR has two semi-related commits.

The first one implements `GNUInstallDirs` like other projects in the KhronosGroup (i.e. `Vulkan-ValidationLayers`).

Reference: https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html

The second commit removes the hardcoded variables in the pkg-config file and installs it the correct directory. Since it is not an architecture independent pkg-config file it does not belong in `/usr/share/`, but rather the appropriate `CMAKE_INSTALL_LIBDIR` which is added in the previous commit. On Slackware this is `/usr/lib64/` and `/usr/lib/` on 64-bit and 32-bit installs respectively.

I took the liberty of removing `SPIRV_CROSS_INSTALL_LIB_DIR` and `SPIRV_CROSS_INSTALL_INC_DIR` since they are not used or needed after this PR.

Example pkg-config.in file: https://github.com/pkgconf/pkgconf/blob/c862e030cf83447f679e4f49876f5298f0fc9691/libpkgconf.pc.in