### PR TITLE
HLSL: Declare undef variables as static.

### DIFF
--- a/reference/opt/shaders-hlsl/frag/bvec-operations.frag
+++ b/reference/opt/shaders-hlsl/frag/bvec-operations.frag
@@ -11,7 +11,7 @@ struct SPIRV_Cross_Output
     float4 FragColor : SV_Target0;
 };
 
-bool _47;
+static bool _47;
 
 void frag_main()
 {

--- a/reference/shaders-hlsl-no-opt/asm/comp/constant-composite-undef.asm.comp
+++ b/reference/shaders-hlsl-no-opt/asm/comp/constant-composite-undef.asm.comp
@@ -1,6 +1,6 @@
 RWByteAddressBuffer block : register(u0);
 
-float _15;
+static float _15;
 
 void comp_main()
 {

--- a/reference/shaders-hlsl-no-opt/asm/frag/vector-shuffle-undef-index.asm.frag
+++ b/reference/shaders-hlsl-no-opt/asm/frag/vector-shuffle-undef-index.asm.frag
@@ -11,7 +11,7 @@ struct SPIRV_Cross_Output
     float4 FragColor : SV_Target0;
 };
 
-float4 undef;
+static float4 undef;
 
 void frag_main()
 {

--- a/reference/shaders-hlsl/asm/frag/unreachable.asm.frag
+++ b/reference/shaders-hlsl/asm/frag/unreachable.asm.frag
@@ -11,7 +11,7 @@ struct SPIRV_Cross_Output
     float4 FragColor : SV_Target0;
 };
 
-float4 _21;
+static float4 _21;
 
 void frag_main()
 {

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1117,6 +1117,18 @@ void CompilerHLSL::replace_illegal_names()
 	CompilerGLSL::replace_illegal_names();
 }
 
+void CompilerHLSL::declare_undefined_values()
+{
+	bool emitted = false;
+	ir.for_each_typed_id<SPIRUndef>([&](uint32_t, const SPIRUndef &undef) {
+		statement("static ", variable_decl(this->get<SPIRType>(undef.basetype), to_name(undef.self), undef.self), ";");
+		emitted = true;
+	});
+
+	if (emitted)
+		statement("");
+}
+
 void CompilerHLSL::emit_resources()
 {
 	auto &execution = get_entry_point();

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -186,6 +186,7 @@ private:
 	void emit_hlsl_entry_point();
 	void emit_header() override;
 	void emit_resources();
+	void declare_undefined_values() override;
 	void emit_interface_block_globally(const SPIRVariable &type);
 	void emit_interface_block_in_struct(const SPIRVariable &type, std::unordered_set<uint32_t> &active_locations);
 	void emit_builtin_inputs_in_struct();


### PR DESCRIPTION
Undef variables would somehow become cbuffer variables without any
warning ...

Fix #1276.