### PR TITLE
HLSL: Do not emit globallycoherent for SRV ByteAddressBuffer.

### DIFF
--- a/reference/opt/shaders-hlsl/frag/readonly-coherent-ssbo.force-uav.frag
+++ b/reference/opt/shaders-hlsl/frag/readonly-coherent-ssbo.force-uav.frag
@@ -1,0 +1,21 @@
+globallycoherent RWByteAddressBuffer _12 : register(u0);
+
+static float4 FragColor;
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    FragColor = asfloat(_12.Load4(0));
+}
+
+SPIRV_Cross_Output main()
+{
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/opt/shaders-hlsl/frag/readonly-coherent-ssbo.frag
+++ b/reference/opt/shaders-hlsl/frag/readonly-coherent-ssbo.frag
@@ -1,0 +1,21 @@
+ByteAddressBuffer _12 : register(t0);
+
+static float4 FragColor;
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    FragColor = asfloat(_12.Load4(0));
+}
+
+SPIRV_Cross_Output main()
+{
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/frag/readonly-coherent-ssbo.force-uav.frag
+++ b/reference/shaders-hlsl/frag/readonly-coherent-ssbo.force-uav.frag
@@ -1,0 +1,21 @@
+globallycoherent RWByteAddressBuffer _12 : register(u0);
+
+static float4 FragColor;
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    FragColor = asfloat(_12.Load4(0));
+}
+
+SPIRV_Cross_Output main()
+{
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/frag/readonly-coherent-ssbo.frag
+++ b/reference/shaders-hlsl/frag/readonly-coherent-ssbo.frag
@@ -1,0 +1,21 @@
+ByteAddressBuffer _12 : register(t0);
+
+static float4 FragColor;
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    FragColor = asfloat(_12.Load4(0));
+}
+
+SPIRV_Cross_Output main()
+{
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/shaders-hlsl/frag/readonly-coherent-ssbo.force-uav.frag
+++ b/shaders-hlsl/frag/readonly-coherent-ssbo.force-uav.frag
@@ -1,0 +1,12 @@
+#version 450
+
+layout(set = 0, binding = 0) coherent readonly buffer SSBO
+{
+	vec4 a;
+};
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = a;
+}

--- a/shaders-hlsl/frag/readonly-coherent-ssbo.frag
+++ b/shaders-hlsl/frag/readonly-coherent-ssbo.frag
@@ -1,0 +1,12 @@
+#version 450
+
+layout(set = 0, binding = 0) coherent readonly buffer SSBO
+{
+	vec4 a;
+};
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = a;
+}

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1858,7 +1858,7 @@ void CompilerHLSL::emit_buffer_block(const SPIRVariable &var)
 	{
 		Bitset flags = ir.get_buffer_block_flags(var);
 		bool is_readonly = flags.get(DecorationNonWritable) && !hlsl_options.force_storage_buffer_as_uav;
-		bool is_coherent = flags.get(DecorationCoherent);
+		bool is_coherent = flags.get(DecorationCoherent) && !is_readonly;
 		bool is_interlocked = interlocked_resources.count(var.self) > 0;
 		const char *type_name = "ByteAddressBuffer ";
 		if (!is_readonly)


### PR DESCRIPTION
Fix #1289.