### PR TITLE
MSL: mark BuiltInFragCoord as implicitly used for subpass reads

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -174,6 +174,7 @@ void CompilerMSL::build_implicit_builtins()
 			if (need_subpass_input && (!msl_options.is_ios() || !msl_options.ios_use_framebuffer_fetch_subpasses) &&
 			    builtin == BuiltInFragCoord)
 			{
+				mark_implicit_builtin(StorageClassInput, BuiltInFragCoord, var.self);
 				builtin_frag_coord_id = var.self;
 				has_frag_coord = true;
 			}


### PR DESCRIPTION
Without this patch, `gl_FragCoord` is not output for subpass reads in certain cases where `gl_FragCoord` is not used elsewhere in the shader.

I'm not sure why this isn't caught by existing tests (e.g. [input-attachment.frag](shaders-msl/frag/input-attachment.frag)), but I encountered this issue in code generated by DXC and passed through spire-opt.