### PR TITLE
MSL: Do not use base expression with PhysicalTypeID OpCompositeExtract.

### DIFF
--- a/reference/shaders-msl-no-opt/asm/vert/composite-extract-physical-type-id.asm.vert
+++ b/reference/shaders-msl-no-opt/asm/vert/composite-extract-physical-type-id.asm.vert
@@ -1,0 +1,31 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct type_Float2Array
+{
+    float4 arr[3];
+};
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+static inline __attribute__((always_inline))
+float4 src_VSMain(thread const uint& i, constant type_Float2Array& Float2Array)
+{
+    return float4(Float2Array.arr[i].x, Float2Array.arr[i].y, 0.0, 1.0);
+}
+
+vertex main0_out main0(constant type_Float2Array& Float2Array [[buffer(0)]], uint gl_VertexIndex [[vertex_id]])
+{
+    main0_out out = {};
+    uint param_var_i = gl_VertexIndex;
+    out.gl_Position = src_VSMain(param_var_i, Float2Array);
+    return out;
+}
+

--- a/shaders-msl-no-opt/asm/vert/composite-extract-physical-type-id.asm.vert
+++ b/shaders-msl-no-opt/asm/vert/composite-extract-physical-type-id.asm.vert
@@ -1,0 +1,63 @@
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %VSMain "main" %gl_VertexIndex %gl_Position
+               OpSource HLSL 600
+               OpName %type_Float2Array "type.Float2Array"
+               OpMemberName %type_Float2Array 0 "arr"
+               OpName %Float2Array "Float2Array"
+               OpName %VSMain "VSMain"
+               OpName %param_var_i "param.var.i"
+               OpName %src_VSMain "src.VSMain"
+               OpName %i "i"
+               OpName %bb_entry "bb.entry"
+               OpDecorate %gl_VertexIndex BuiltIn VertexIndex
+               OpDecorate %gl_Position BuiltIn Position
+               OpDecorate %Float2Array DescriptorSet 0
+               OpDecorate %Float2Array Binding 0
+               OpDecorate %_arr_v2float_uint_3 ArrayStride 16
+               OpMemberDecorate %type_Float2Array 0 Offset 0
+               OpDecorate %type_Float2Array Block
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+    %float_1 = OpConstant %float 1
+       %uint = OpTypeInt 32 0
+     %uint_3 = OpConstant %uint 3
+    %v2float = OpTypeVector %float 2
+%_arr_v2float_uint_3 = OpTypeArray %v2float %uint_3
+%type_Float2Array = OpTypeStruct %_arr_v2float_uint_3
+%_ptr_Uniform_type_Float2Array = OpTypePointer Uniform %type_Float2Array
+%_ptr_Input_uint = OpTypePointer Input %uint
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+       %void = OpTypeVoid
+         %20 = OpTypeFunction %void
+%_ptr_Function_uint = OpTypePointer Function %uint
+         %27 = OpTypeFunction %v4float %_ptr_Function_uint
+%_ptr_Uniform__arr_v2float_uint_3 = OpTypePointer Uniform %_arr_v2float_uint_3
+%_ptr_Uniform_v2float = OpTypePointer Uniform %v2float
+%Float2Array = OpVariable %_ptr_Uniform_type_Float2Array Uniform
+%gl_VertexIndex = OpVariable %_ptr_Input_uint Input
+%gl_Position = OpVariable %_ptr_Output_v4float Output
+     %VSMain = OpFunction %void None %20
+         %21 = OpLabel
+%param_var_i = OpVariable %_ptr_Function_uint Function
+         %24 = OpLoad %uint %gl_VertexIndex
+               OpStore %param_var_i %24
+         %25 = OpFunctionCall %v4float %src_VSMain %param_var_i
+               OpStore %gl_Position %25
+               OpReturn
+               OpFunctionEnd
+ %src_VSMain = OpFunction %v4float None %27
+          %i = OpFunctionParameter %_ptr_Function_uint
+   %bb_entry = OpLabel
+         %30 = OpLoad %uint %i
+         %32 = OpAccessChain %_ptr_Uniform__arr_v2float_uint_3 %Float2Array %int_0
+         %34 = OpAccessChain %_ptr_Uniform_v2float %32 %30
+         %35 = OpLoad %v2float %34
+         %36 = OpCompositeExtract %float %35 0
+         %37 = OpCompositeExtract %float %35 1
+         %38 = OpCompositeConstruct %v4float %36 %37 %float_0 %float_1
+               OpReturnValue %38
+               OpFunctionEnd

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -8849,8 +8849,9 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		if (composite_type.basetype == SPIRType::Struct || !composite_type.array.empty())
 			allow_base_expression = false;
 
-		// Packed expressions cannot be split up.
-		if (has_extended_decoration(ops[2], SPIRVCrossDecorationPhysicalTypePacked))
+		// Packed expressions or physical ID mapped expressions cannot be split up.
+		if (has_extended_decoration(ops[2], SPIRVCrossDecorationPhysicalTypePacked) ||
+		    has_extended_decoration(ops[2], SPIRVCrossDecorationPhysicalTypeID))
 			allow_base_expression = false;
 
 		// Cannot use base expression for row-major matrix row-extraction since we need to interleave access pattern


### PR DESCRIPTION
Similar reasoning as packed expressions.
Fix #1313.