### PR TITLE
Improve compatibility with clang-cl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ if (WIN32)
 	set(CMAKE_DEBUG_POSTFIX "d")
 endif()
 
-if (CMAKE_COMPILER_IS_GNUCXX OR (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang"))
+if (CMAKE_COMPILER_IS_GNUCXX OR ((${CMAKE_CXX_COMPILER_ID} MATCHES "Clang") AND NOT MSVC))
 	set(spirv-compiler-options ${spirv-compiler-options} -Wall -Wextra -Wshadow)
 	if (SPIRV_CROSS_MISC_WARNINGS)
 		if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")

--- a/main.cpp
+++ b/main.cpp
@@ -35,10 +35,6 @@
 #include "gitversion.h"
 #endif
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4996)
-#endif
-
 using namespace spv;
 using namespace SPIRV_CROSS_NAMESPACE;
 using namespace std;
@@ -190,6 +186,14 @@ struct CLIParser
 	bool ended_state = false;
 };
 
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
 static vector<uint32_t> read_spirv_file(const char *path)
 {
 	FILE *file = fopen(path, "rb");
@@ -224,6 +228,12 @@ static bool write_string_to_file(const char *path, const char *string)
 	fclose(file);
 	return true;
 }
+
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 static void print_resources(const Compiler &compiler, const char *tag, const SmallVector<Resource> &resources)
 {

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -209,9 +209,12 @@ inline std::string convert_to_string(const T &t)
 #define SPIRV_CROSS_FLT_FMT "%.32g"
 #endif
 
-#ifdef _MSC_VER
-// sprintf warning.
-// We cannot rely on snprintf existing because, ..., MSVC.
+// Disable sprintf and strcat warnings.
+// We cannot rely on snprintf and family existing because, ..., MSVC.
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable : 4996)
 #endif
@@ -259,7 +262,9 @@ inline std::string convert_to_string(double t, char locale_radix_point)
 	return buf;
 }
 
-#ifdef _MSC_VER
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
 #pragma warning(pop)
 #endif
 


### PR DESCRIPTION
Closes #1315
Just makes sure that clang-cl receives the same settings for warnings as MSVC and disable the same warnings in code. 