### PR TITLE
MSL: Only disable output variables in fragment shaders.

### DIFF
--- a/reference/opt/shaders-msl/vert/no-disable-vertex-out.frag-output.vert
+++ b/reference/opt/shaders-msl/vert/no-disable-vertex-out.frag-output.vert
@@ -1,0 +1,28 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct buf
+{
+    float4x4 MVP;
+    float4 position[36];
+    float4 attr[36];
+};
+
+struct main0_out
+{
+    float4 texcoord [[user(locn0)]];
+    float3 frag_pos [[user(locn1)]];
+    float4 gl_Position [[position]];
+};
+
+vertex main0_out main0(constant buf& ubuf [[buffer(0)]], uint gl_VertexIndex [[vertex_id]])
+{
+    main0_out out = {};
+    out.texcoord = ubuf.attr[int(gl_VertexIndex)];
+    out.gl_Position = ubuf.MVP * ubuf.position[int(gl_VertexIndex)];
+    out.frag_pos = out.gl_Position.xyz;
+    return out;
+}
+

--- a/reference/shaders-msl/vert/no-disable-vertex-out.frag-output.vert
+++ b/reference/shaders-msl/vert/no-disable-vertex-out.frag-output.vert
@@ -1,0 +1,28 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct buf
+{
+    float4x4 MVP;
+    float4 position[36];
+    float4 attr[36];
+};
+
+struct main0_out
+{
+    float4 texcoord [[user(locn0)]];
+    float3 frag_pos [[user(locn1)]];
+    float4 gl_Position [[position]];
+};
+
+vertex main0_out main0(constant buf& ubuf [[buffer(0)]], uint gl_VertexIndex [[vertex_id]])
+{
+    main0_out out = {};
+    out.texcoord = ubuf.attr[int(gl_VertexIndex)];
+    out.gl_Position = ubuf.MVP * ubuf.position[int(gl_VertexIndex)];
+    out.frag_pos = out.gl_Position.xyz;
+    return out;
+}
+

--- a/shaders-msl/vert/no-disable-vertex-out.frag-output.vert
+++ b/shaders-msl/vert/no-disable-vertex-out.frag-output.vert
@@ -1,0 +1,16 @@
+#version 400
+#extension GL_ARB_separate_shader_objects : enable
+#extension GL_ARB_shading_language_420pack : enable
+layout(std140, binding = 0) uniform buf {
+	mat4 MVP;
+	vec4 position[12*3];
+	vec4 attr[12*3];
+} ubuf;
+layout (location = 0) out vec4 texcoord;
+layout (location = 1) out vec3 frag_pos;
+void main() 
+{
+	texcoord = ubuf.attr[gl_VertexIndex];
+	gl_Position = ubuf.MVP * ubuf.position[gl_VertexIndex];
+	frag_pos = gl_Position.xyz;
+}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -2481,7 +2481,7 @@ uint32_t CompilerMSL::add_interface_block(StorageClass storage, bool patch)
 		// It's not enough to simply avoid marking fragment outputs if the pipeline won't
 		// accept them. We can't put them in the struct at all, or otherwise the compiler
 		// complains that the outputs weren't explicitly marked.
-		if (storage == StorageClassOutput && !patch &&
+		if (get_execution_model() == ExecutionModelFragment && storage == StorageClassOutput && !patch &&
 			((is_builtin && ((bi_type == BuiltInFragDepth && !msl_options.enable_frag_depth_builtin) ||
 		                    (bi_type == BuiltInFragStencilRefEXT && !msl_options.enable_frag_stencil_ref_builtin))) ||
 		     (!is_builtin && !(msl_options.enable_frag_output_mask & (1 << location)))))


### PR DESCRIPTION
Forgot to do this in #1319.

Fixes #1322.