### PR TITLE
MSL: Support edge case with DX layout in scalar block layout.

### DIFF
--- a/reference/opt/shaders-msl/comp/struct-packing.comp
+++ b/reference/opt/shaders-msl/comp/struct-packing.comp
@@ -66,7 +66,8 @@ struct SSBO1
 
 struct S0_1
 {
-    float4 a[1];
+    packed_float2 a[1];
+    char _m1_pad[8];
     float b;
     char _m0_final_padding[12];
 };
@@ -123,13 +124,13 @@ constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 kernel void main0(device SSBO1& ssbo_430 [[buffer(0)]], device SSBO0& ssbo_140 [[buffer(1)]])
 {
     Content_1 _60 = ssbo_140.content;
-    ssbo_430.content.m0s[0].a[0] = _60.m0s[0].a[0].xy;
+    ssbo_430.content.m0s[0].a[0] = float2(_60.m0s[0].a[0]);
     ssbo_430.content.m0s[0].b = _60.m0s[0].b;
     ssbo_430.content.m1s[0].a = float3(_60.m1s[0].a);
     ssbo_430.content.m1s[0].b = _60.m1s[0].b;
     ssbo_430.content.m2s[0].a[0] = _60.m2s[0].a[0];
     ssbo_430.content.m2s[0].b = _60.m2s[0].b;
-    ssbo_430.content.m0.a[0] = _60.m0.a[0].xy;
+    ssbo_430.content.m0.a[0] = float2(_60.m0.a[0]);
     ssbo_430.content.m0.b = _60.m0.b;
     ssbo_430.content.m1.a = float3(_60.m1.a);
     ssbo_430.content.m1.b = _60.m1.b;

--- a/reference/shaders-msl-no-opt/asm/packing/scalar-array-float2.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/packing/scalar-array-float2.asm.frag
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct type_Foo
+{
+    float4 a[1];
+    char _m1_pad[8];
+    float b;
+};
+
+struct main0_out
+{
+    float2 out_var_SV_Target [[color(0)]];
+};
+
+fragment main0_out main0(constant type_Foo& Foo [[buffer(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = (Foo.a[0].xy + Foo.a[1].xy) + float2(Foo.b);
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/asm/packing/scalar-array-float3-one-element.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/packing/scalar-array-float3-one-element.asm.frag
@@ -1,0 +1,23 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct type_Foo
+{
+    packed_float3 a[1];
+    float b;
+};
+
+struct main0_out
+{
+    float3 out_var_SV_Target [[color(0)]];
+};
+
+fragment main0_out main0(constant type_Foo& Foo [[buffer(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = float3(Foo.a[0]) + float3(Foo.b);
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/asm/packing/scalar-array-float3.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/packing/scalar-array-float3.asm.frag
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct type_Foo
+{
+    float4 a[1];
+    char _m1_pad[12];
+    float b;
+};
+
+struct main0_out
+{
+    float3 out_var_SV_Target [[color(0)]];
+};
+
+fragment main0_out main0(constant type_Foo& Foo [[buffer(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = (Foo.a[0].xyz + Foo.a[1].xyz) + float3(Foo.b);
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/asm/packing/scalar-float2x2-col-major.invalid.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/packing/scalar-float2x2-col-major.invalid.asm.frag
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct type_Foo
+{
+    float4 a[1];
+    char _m1_pad[8];
+    float b;
+};
+
+struct main0_out
+{
+    float2 out_var_SV_Target [[color(0)]];
+};
+
+fragment main0_out main0(constant type_Foo& Foo [[buffer(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = (Foo.a[0u].xy + Foo.a[1u].xy) + float2(Foo.b);
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/asm/packing/scalar-float2x2-row-major.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/packing/scalar-float2x2-row-major.asm.frag
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct type_Foo
+{
+    float4 a[1];
+    char _m1_pad[8];
+    float b;
+};
+
+struct main0_out
+{
+    float2 out_var_SV_Target [[color(0)]];
+};
+
+fragment main0_out main0(constant type_Foo& Foo [[buffer(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = (float2(Foo.a[0][0u], Foo.a[1][0u]) + float2(Foo.a[0][1u], Foo.a[1][1u])) + float2(Foo.b);
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/asm/packing/scalar-float2x3-col-major.invalid.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/packing/scalar-float2x3-col-major.invalid.asm.frag
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct type_Foo
+{
+    float4 a[1];
+    char _m1_pad[12];
+    float b;
+};
+
+struct main0_out
+{
+    float3 out_var_SV_Target [[color(0)]];
+};
+
+fragment main0_out main0(constant type_Foo& Foo [[buffer(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = (Foo.a[0u].xyz + Foo.a[1u].xyz) + float3(Foo.b);
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/asm/packing/scalar-float2x3-row-major.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/packing/scalar-float2x3-row-major.asm.frag
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct type_Foo
+{
+    float2x4 a;
+    char _m1_pad[8];
+    float b;
+};
+
+struct main0_out
+{
+    float3 out_var_SV_Target [[color(0)]];
+};
+
+fragment main0_out main0(constant type_Foo& Foo [[buffer(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = (float3(Foo.a[0][0u], Foo.a[1][0u], Foo.a[2][0u]) + float3(Foo.a[0][1u], Foo.a[1][1u], Foo.a[2][1u])) + float3(Foo.b);
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/asm/packing/scalar-float3x2-col-major.invalid.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/packing/scalar-float3x2-col-major.invalid.asm.frag
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct type_Foo
+{
+    float2x4 a;
+    char _m1_pad[8];
+    float b;
+};
+
+struct main0_out
+{
+    float2 out_var_SV_Target [[color(0)]];
+};
+
+fragment main0_out main0(constant type_Foo& Foo [[buffer(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = (Foo.a[0u].xy + Foo.a[1u].xy) + float2(Foo.b);
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/asm/packing/scalar-float3x2-row-major.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/packing/scalar-float3x2-row-major.asm.frag
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct type_Foo
+{
+    float4 a[1];
+    char _m1_pad[12];
+    float b;
+};
+
+struct main0_out
+{
+    float2 out_var_SV_Target [[color(0)]];
+};
+
+fragment main0_out main0(constant type_Foo& Foo [[buffer(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = (float2(Foo.a[0][0u], Foo.a[1][0u]) + float2(Foo.a[0][1u], Foo.a[1][1u])) + float2(Foo.b);
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/asm/packing/scalar-float3x3-col-major.invalid.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/packing/scalar-float3x3-col-major.invalid.asm.frag
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct type_Foo
+{
+    float2x4 a;
+    char _m1_pad[12];
+    float b;
+};
+
+struct main0_out
+{
+    float3 out_var_SV_Target [[color(0)]];
+};
+
+fragment main0_out main0(constant type_Foo& Foo [[buffer(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = (Foo.a[0u].xyz + Foo.a[1u].xyz) + float3(Foo.b);
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/asm/packing/scalar-float3x3-row-major.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/packing/scalar-float3x3-row-major.asm.frag
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct type_Foo
+{
+    float2x4 a;
+    char _m1_pad[12];
+    float b;
+};
+
+struct main0_out
+{
+    float3 out_var_SV_Target [[color(0)]];
+};
+
+fragment main0_out main0(constant type_Foo& Foo [[buffer(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = (float3(Foo.a[0][0u], Foo.a[1][0u], Foo.a[2][0u]) + float3(Foo.a[0][1u], Foo.a[1][1u], Foo.a[2][1u])) + float3(Foo.b);
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/comp/struct-packing-scalar.nocompat.invalid.vk.comp
+++ b/reference/shaders-msl-no-opt/comp/struct-packing-scalar.nocompat.invalid.vk.comp
@@ -61,7 +61,8 @@ struct SSBO1
 
 struct S0_1
 {
-    float4 a[1];
+    packed_float2 a[1];
+    char _m1_pad[8];
     float b;
     char _m0_final_padding[12];
 };
@@ -125,13 +126,13 @@ constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 kernel void main0(device SSBO1& ssbo_scalar [[buffer(0)]], device SSBO0& ssbo_140 [[buffer(1)]], device SSBO2& ssbo_scalar2 [[buffer(2)]])
 {
-    ssbo_scalar.content.m0s[0].a[0] = ssbo_140.content.m0s[0].a[0].xy;
+    ssbo_scalar.content.m0s[0].a[0] = float2(ssbo_140.content.m0s[0].a[0]);
     ssbo_scalar.content.m0s[0].b = ssbo_140.content.m0s[0].b;
     ssbo_scalar.content.m1s[0].a = float3(ssbo_140.content.m1s[0].a);
     ssbo_scalar.content.m1s[0].b = ssbo_140.content.m1s[0].b;
     ssbo_scalar.content.m2s[0].a[0] = ssbo_140.content.m2s[0].a[0];
     ssbo_scalar.content.m2s[0].b = ssbo_140.content.m2s[0].b;
-    ssbo_scalar.content.m0.a[0] = ssbo_140.content.m0.a[0].xy;
+    ssbo_scalar.content.m0.a[0] = float2(ssbo_140.content.m0.a[0]);
     ssbo_scalar.content.m0.b = ssbo_140.content.m0.b;
     ssbo_scalar.content.m1.a = float3(ssbo_140.content.m1.a);
     ssbo_scalar.content.m1.b = ssbo_140.content.m1.b;

--- a/reference/shaders-msl/comp/struct-packing.comp
+++ b/reference/shaders-msl/comp/struct-packing.comp
@@ -66,7 +66,8 @@ struct SSBO1
 
 struct S0_1
 {
-    float4 a[1];
+    packed_float2 a[1];
+    char _m1_pad[8];
     float b;
     char _m0_final_padding[12];
 };
@@ -123,13 +124,13 @@ constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 kernel void main0(device SSBO1& ssbo_430 [[buffer(0)]], device SSBO0& ssbo_140 [[buffer(1)]])
 {
     Content_1 _60 = ssbo_140.content;
-    ssbo_430.content.m0s[0].a[0] = _60.m0s[0].a[0].xy;
+    ssbo_430.content.m0s[0].a[0] = float2(_60.m0s[0].a[0]);
     ssbo_430.content.m0s[0].b = _60.m0s[0].b;
     ssbo_430.content.m1s[0].a = float3(_60.m1s[0].a);
     ssbo_430.content.m1s[0].b = _60.m1s[0].b;
     ssbo_430.content.m2s[0].a[0] = _60.m2s[0].a[0];
     ssbo_430.content.m2s[0].b = _60.m2s[0].b;
-    ssbo_430.content.m0.a[0] = _60.m0.a[0].xy;
+    ssbo_430.content.m0.a[0] = float2(_60.m0.a[0]);
     ssbo_430.content.m0.b = _60.m0.b;
     ssbo_430.content.m1.a = float3(_60.m1.a);
     ssbo_430.content.m1.b = _60.m1.b;

--- a/shaders-msl-no-opt/asm/packing/scalar-array-float2.asm.frag
+++ b/shaders-msl-no-opt/asm/packing/scalar-array-float2.asm.frag
@@ -1,0 +1,54 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google spiregg; 0
+; Bound: 29
+; Schema: 0
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %out_var_SV_Target
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 600
+               OpName %type_Foo "type.Foo"
+               OpMemberName %type_Foo 0 "a"
+               OpMemberName %type_Foo 1 "b"
+               OpName %Foo "Foo"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpName %main "main"
+               OpDecorate %out_var_SV_Target Location 0
+               OpDecorate %Foo DescriptorSet 0
+               OpDecorate %Foo Binding 0
+               OpDecorate %_arr_v2float_uint_2 ArrayStride 16
+               OpMemberDecorate %type_Foo 0 Offset 0
+               OpMemberDecorate %type_Foo 1 Offset 24
+               OpDecorate %type_Foo Block
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+       %uint = OpTypeInt 32 0
+     %uint_2 = OpConstant %uint 2
+      %float = OpTypeFloat 32
+    %v2float = OpTypeVector %float 2
+%_arr_v2float_uint_2 = OpTypeArray %v2float %uint_2
+   %type_Foo = OpTypeStruct %_arr_v2float_uint_2 %float
+%_ptr_Uniform_type_Foo = OpTypePointer Uniform %type_Foo
+%_ptr_Output_v2float = OpTypePointer Output %v2float
+       %void = OpTypeVoid
+         %16 = OpTypeFunction %void
+%_ptr_Uniform_v2float = OpTypePointer Uniform %v2float
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+        %Foo = OpVariable %_ptr_Uniform_type_Foo Uniform
+%out_var_SV_Target = OpVariable %_ptr_Output_v2float Output
+       %main = OpFunction %void None %16
+         %19 = OpLabel
+         %20 = OpAccessChain %_ptr_Uniform_v2float %Foo %int_0 %int_0
+         %21 = OpLoad %v2float %20
+         %22 = OpAccessChain %_ptr_Uniform_v2float %Foo %int_0 %int_1
+         %23 = OpLoad %v2float %22
+         %24 = OpFAdd %v2float %21 %23
+         %25 = OpAccessChain %_ptr_Uniform_float %Foo %int_1
+         %26 = OpLoad %float %25
+         %27 = OpCompositeConstruct %v2float %26 %26
+         %28 = OpFAdd %v2float %24 %27
+               OpStore %out_var_SV_Target %28
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/packing/scalar-array-float3-one-element.asm.frag
+++ b/shaders-msl-no-opt/asm/packing/scalar-array-float3-one-element.asm.frag
@@ -1,0 +1,51 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google spiregg; 0
+; Bound: 26
+; Schema: 0
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %out_var_SV_Target
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 600
+               OpName %type_Foo "type.Foo"
+               OpMemberName %type_Foo 0 "a"
+               OpMemberName %type_Foo 1 "b"
+               OpName %Foo "Foo"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpName %main "main"
+               OpDecorate %out_var_SV_Target Location 0
+               OpDecorate %Foo DescriptorSet 0
+               OpDecorate %Foo Binding 0
+               OpDecorate %_arr_v3float_uint_1 ArrayStride 16
+               OpMemberDecorate %type_Foo 0 Offset 0
+               OpMemberDecorate %type_Foo 1 Offset 12
+               OpDecorate %type_Foo Block
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+       %uint = OpTypeInt 32 0
+     %uint_1 = OpConstant %uint 1
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%_arr_v3float_uint_1 = OpTypeArray %v3float %uint_1
+   %type_Foo = OpTypeStruct %_arr_v3float_uint_1 %float
+%_ptr_Uniform_type_Foo = OpTypePointer Uniform %type_Foo
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+       %void = OpTypeVoid
+         %16 = OpTypeFunction %void
+%_ptr_Uniform_v3float = OpTypePointer Uniform %v3float
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+        %Foo = OpVariable %_ptr_Uniform_type_Foo Uniform
+%out_var_SV_Target = OpVariable %_ptr_Output_v3float Output
+       %main = OpFunction %void None %16
+         %19 = OpLabel
+         %20 = OpAccessChain %_ptr_Uniform_v3float %Foo %int_0 %int_0
+         %21 = OpLoad %v3float %20
+         %22 = OpAccessChain %_ptr_Uniform_float %Foo %int_1
+         %23 = OpLoad %float %22
+         %24 = OpCompositeConstruct %v3float %23 %23 %23
+         %25 = OpFAdd %v3float %21 %24
+               OpStore %out_var_SV_Target %25
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/packing/scalar-array-float3.asm.frag
+++ b/shaders-msl-no-opt/asm/packing/scalar-array-float3.asm.frag
@@ -1,0 +1,54 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google spiregg; 0
+; Bound: 29
+; Schema: 0
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %out_var_SV_Target
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 600
+               OpName %type_Foo "type.Foo"
+               OpMemberName %type_Foo 0 "a"
+               OpMemberName %type_Foo 1 "b"
+               OpName %Foo "Foo"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpName %main "main"
+               OpDecorate %out_var_SV_Target Location 0
+               OpDecorate %Foo DescriptorSet 0
+               OpDecorate %Foo Binding 0
+               OpDecorate %_arr_v3float_uint_2 ArrayStride 16
+               OpMemberDecorate %type_Foo 0 Offset 0
+               OpMemberDecorate %type_Foo 1 Offset 28
+               OpDecorate %type_Foo Block
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+       %uint = OpTypeInt 32 0
+     %uint_2 = OpConstant %uint 2
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%_arr_v3float_uint_2 = OpTypeArray %v3float %uint_2
+   %type_Foo = OpTypeStruct %_arr_v3float_uint_2 %float
+%_ptr_Uniform_type_Foo = OpTypePointer Uniform %type_Foo
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+       %void = OpTypeVoid
+         %16 = OpTypeFunction %void
+%_ptr_Uniform_v3float = OpTypePointer Uniform %v3float
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+        %Foo = OpVariable %_ptr_Uniform_type_Foo Uniform
+%out_var_SV_Target = OpVariable %_ptr_Output_v3float Output
+       %main = OpFunction %void None %16
+         %19 = OpLabel
+         %20 = OpAccessChain %_ptr_Uniform_v3float %Foo %int_0 %int_0
+         %21 = OpLoad %v3float %20
+         %22 = OpAccessChain %_ptr_Uniform_v3float %Foo %int_0 %int_1
+         %23 = OpLoad %v3float %22
+         %24 = OpFAdd %v3float %21 %23
+         %25 = OpAccessChain %_ptr_Uniform_float %Foo %int_1
+         %26 = OpLoad %float %25
+         %27 = OpCompositeConstruct %v3float %26 %26 %26
+         %28 = OpFAdd %v3float %24 %27
+               OpStore %out_var_SV_Target %28
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/packing/scalar-float2x2-col-major.invalid.asm.frag
+++ b/shaders-msl-no-opt/asm/packing/scalar-float2x2-col-major.invalid.asm.frag
@@ -1,0 +1,56 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google spiregg; 0
+; Bound: 30
+; Schema: 0
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %out_var_SV_Target
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 600
+               OpName %type_Foo "type.Foo"
+               OpMemberName %type_Foo 0 "a"
+               OpMemberName %type_Foo 1 "b"
+               OpName %Foo "Foo"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpName %main "main"
+               OpDecorate %out_var_SV_Target Location 0
+               OpDecorate %Foo DescriptorSet 0
+               OpDecorate %Foo Binding 0
+               OpMemberDecorate %type_Foo 0 Offset 0
+               OpMemberDecorate %type_Foo 0 MatrixStride 16
+               OpMemberDecorate %type_Foo 0 ColMajor
+               OpMemberDecorate %type_Foo 1 Offset 24
+               OpDecorate %type_Foo Block
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %uint_1 = OpConstant %uint 1
+      %int_1 = OpConstant %int 1
+      %float = OpTypeFloat 32
+    %v2float = OpTypeVector %float 2
+%mat2v2float = OpTypeMatrix %v2float 2
+   %type_Foo = OpTypeStruct %mat2v2float %float
+%_ptr_Uniform_type_Foo = OpTypePointer Uniform %type_Foo
+%_ptr_Output_v2float = OpTypePointer Output %v2float
+       %void = OpTypeVoid
+         %17 = OpTypeFunction %void
+%_ptr_Uniform_v2float = OpTypePointer Uniform %v2float
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+        %Foo = OpVariable %_ptr_Uniform_type_Foo Uniform
+%out_var_SV_Target = OpVariable %_ptr_Output_v2float Output
+       %main = OpFunction %void None %17
+         %20 = OpLabel
+         %21 = OpAccessChain %_ptr_Uniform_v2float %Foo %int_0 %uint_0
+         %22 = OpLoad %v2float %21
+         %23 = OpAccessChain %_ptr_Uniform_v2float %Foo %int_0 %uint_1
+         %24 = OpLoad %v2float %23
+         %25 = OpFAdd %v2float %22 %24
+         %26 = OpAccessChain %_ptr_Uniform_float %Foo %int_1
+         %27 = OpLoad %float %26
+         %28 = OpCompositeConstruct %v2float %27 %27
+         %29 = OpFAdd %v2float %25 %28
+               OpStore %out_var_SV_Target %29
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/packing/scalar-float2x2-row-major.asm.frag
+++ b/shaders-msl-no-opt/asm/packing/scalar-float2x2-row-major.asm.frag
@@ -1,0 +1,56 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google spiregg; 0
+; Bound: 30
+; Schema: 0
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %out_var_SV_Target
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 600
+               OpName %type_Foo "type.Foo"
+               OpMemberName %type_Foo 0 "a"
+               OpMemberName %type_Foo 1 "b"
+               OpName %Foo "Foo"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpName %main "main"
+               OpDecorate %out_var_SV_Target Location 0
+               OpDecorate %Foo DescriptorSet 0
+               OpDecorate %Foo Binding 0
+               OpMemberDecorate %type_Foo 0 Offset 0
+               OpMemberDecorate %type_Foo 0 MatrixStride 16
+               OpMemberDecorate %type_Foo 0 RowMajor
+               OpMemberDecorate %type_Foo 1 Offset 24
+               OpDecorate %type_Foo Block
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %uint_1 = OpConstant %uint 1
+      %int_1 = OpConstant %int 1
+      %float = OpTypeFloat 32
+    %v2float = OpTypeVector %float 2
+%mat2v2float = OpTypeMatrix %v2float 2
+   %type_Foo = OpTypeStruct %mat2v2float %float
+%_ptr_Uniform_type_Foo = OpTypePointer Uniform %type_Foo
+%_ptr_Output_v2float = OpTypePointer Output %v2float
+       %void = OpTypeVoid
+         %17 = OpTypeFunction %void
+%_ptr_Uniform_v2float = OpTypePointer Uniform %v2float
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+        %Foo = OpVariable %_ptr_Uniform_type_Foo Uniform
+%out_var_SV_Target = OpVariable %_ptr_Output_v2float Output
+       %main = OpFunction %void None %17
+         %20 = OpLabel
+         %21 = OpAccessChain %_ptr_Uniform_v2float %Foo %int_0 %uint_0
+         %22 = OpLoad %v2float %21
+         %23 = OpAccessChain %_ptr_Uniform_v2float %Foo %int_0 %uint_1
+         %24 = OpLoad %v2float %23
+         %25 = OpFAdd %v2float %22 %24
+         %26 = OpAccessChain %_ptr_Uniform_float %Foo %int_1
+         %27 = OpLoad %float %26
+         %28 = OpCompositeConstruct %v2float %27 %27
+         %29 = OpFAdd %v2float %25 %28
+               OpStore %out_var_SV_Target %29
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/packing/scalar-float2x3-col-major.invalid.asm.frag
+++ b/shaders-msl-no-opt/asm/packing/scalar-float2x3-col-major.invalid.asm.frag
@@ -1,0 +1,56 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google spiregg; 0
+; Bound: 30
+; Schema: 0
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %out_var_SV_Target
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 600
+               OpName %type_Foo "type.Foo"
+               OpMemberName %type_Foo 0 "a"
+               OpMemberName %type_Foo 1 "b"
+               OpName %Foo "Foo"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpName %main "main"
+               OpDecorate %out_var_SV_Target Location 0
+               OpDecorate %Foo DescriptorSet 0
+               OpDecorate %Foo Binding 0
+               OpMemberDecorate %type_Foo 0 Offset 0
+               OpMemberDecorate %type_Foo 0 MatrixStride 16
+               OpMemberDecorate %type_Foo 0 ColMajor
+               OpMemberDecorate %type_Foo 1 Offset 28
+               OpDecorate %type_Foo Block
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %uint_1 = OpConstant %uint 1
+      %int_1 = OpConstant %int 1
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%mat2v3float = OpTypeMatrix %v3float 2
+   %type_Foo = OpTypeStruct %mat2v3float %float
+%_ptr_Uniform_type_Foo = OpTypePointer Uniform %type_Foo
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+       %void = OpTypeVoid
+         %17 = OpTypeFunction %void
+%_ptr_Uniform_v3float = OpTypePointer Uniform %v3float
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+        %Foo = OpVariable %_ptr_Uniform_type_Foo Uniform
+%out_var_SV_Target = OpVariable %_ptr_Output_v3float Output
+       %main = OpFunction %void None %17
+         %20 = OpLabel
+         %21 = OpAccessChain %_ptr_Uniform_v3float %Foo %int_0 %uint_0
+         %22 = OpLoad %v3float %21
+         %23 = OpAccessChain %_ptr_Uniform_v3float %Foo %int_0 %uint_1
+         %24 = OpLoad %v3float %23
+         %25 = OpFAdd %v3float %22 %24
+         %26 = OpAccessChain %_ptr_Uniform_float %Foo %int_1
+         %27 = OpLoad %float %26
+         %28 = OpCompositeConstruct %v3float %27 %27 %27
+         %29 = OpFAdd %v3float %25 %28
+               OpStore %out_var_SV_Target %29
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/packing/scalar-float2x3-row-major.asm.frag
+++ b/shaders-msl-no-opt/asm/packing/scalar-float2x3-row-major.asm.frag
@@ -1,0 +1,56 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google spiregg; 0
+; Bound: 30
+; Schema: 0
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %out_var_SV_Target
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 600
+               OpName %type_Foo "type.Foo"
+               OpMemberName %type_Foo 0 "a"
+               OpMemberName %type_Foo 1 "b"
+               OpName %Foo "Foo"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpName %main "main"
+               OpDecorate %out_var_SV_Target Location 0
+               OpDecorate %Foo DescriptorSet 0
+               OpDecorate %Foo Binding 0
+               OpMemberDecorate %type_Foo 0 Offset 0
+               OpMemberDecorate %type_Foo 0 MatrixStride 16
+               OpMemberDecorate %type_Foo 0 RowMajor
+               OpMemberDecorate %type_Foo 1 Offset 40
+               OpDecorate %type_Foo Block
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %uint_1 = OpConstant %uint 1
+      %int_1 = OpConstant %int 1
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%mat2v3float = OpTypeMatrix %v3float 2
+   %type_Foo = OpTypeStruct %mat2v3float %float
+%_ptr_Uniform_type_Foo = OpTypePointer Uniform %type_Foo
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+       %void = OpTypeVoid
+         %17 = OpTypeFunction %void
+%_ptr_Uniform_v3float = OpTypePointer Uniform %v3float
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+        %Foo = OpVariable %_ptr_Uniform_type_Foo Uniform
+%out_var_SV_Target = OpVariable %_ptr_Output_v3float Output
+       %main = OpFunction %void None %17
+         %20 = OpLabel
+         %21 = OpAccessChain %_ptr_Uniform_v3float %Foo %int_0 %uint_0
+         %22 = OpLoad %v3float %21
+         %23 = OpAccessChain %_ptr_Uniform_v3float %Foo %int_0 %uint_1
+         %24 = OpLoad %v3float %23
+         %25 = OpFAdd %v3float %22 %24
+         %26 = OpAccessChain %_ptr_Uniform_float %Foo %int_1
+         %27 = OpLoad %float %26
+         %28 = OpCompositeConstruct %v3float %27 %27 %27
+         %29 = OpFAdd %v3float %25 %28
+               OpStore %out_var_SV_Target %29
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/packing/scalar-float3x2-col-major.invalid.asm.frag
+++ b/shaders-msl-no-opt/asm/packing/scalar-float3x2-col-major.invalid.asm.frag
@@ -1,0 +1,56 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google spiregg; 0
+; Bound: 30
+; Schema: 0
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %out_var_SV_Target
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 600
+               OpName %type_Foo "type.Foo"
+               OpMemberName %type_Foo 0 "a"
+               OpMemberName %type_Foo 1 "b"
+               OpName %Foo "Foo"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpName %main "main"
+               OpDecorate %out_var_SV_Target Location 0
+               OpDecorate %Foo DescriptorSet 0
+               OpDecorate %Foo Binding 0
+               OpMemberDecorate %type_Foo 0 Offset 0
+               OpMemberDecorate %type_Foo 0 MatrixStride 16
+               OpMemberDecorate %type_Foo 0 ColMajor
+               OpMemberDecorate %type_Foo 1 Offset 40
+               OpDecorate %type_Foo Block
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %uint_1 = OpConstant %uint 1
+      %int_1 = OpConstant %int 1
+      %float = OpTypeFloat 32
+    %v2float = OpTypeVector %float 2
+%mat3v2float = OpTypeMatrix %v2float 3
+   %type_Foo = OpTypeStruct %mat3v2float %float
+%_ptr_Uniform_type_Foo = OpTypePointer Uniform %type_Foo
+%_ptr_Output_v2float = OpTypePointer Output %v2float
+       %void = OpTypeVoid
+         %17 = OpTypeFunction %void
+%_ptr_Uniform_v2float = OpTypePointer Uniform %v2float
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+        %Foo = OpVariable %_ptr_Uniform_type_Foo Uniform
+%out_var_SV_Target = OpVariable %_ptr_Output_v2float Output
+       %main = OpFunction %void None %17
+         %20 = OpLabel
+         %21 = OpAccessChain %_ptr_Uniform_v2float %Foo %int_0 %uint_0
+         %22 = OpLoad %v2float %21
+         %23 = OpAccessChain %_ptr_Uniform_v2float %Foo %int_0 %uint_1
+         %24 = OpLoad %v2float %23
+         %25 = OpFAdd %v2float %22 %24
+         %26 = OpAccessChain %_ptr_Uniform_float %Foo %int_1
+         %27 = OpLoad %float %26
+         %28 = OpCompositeConstruct %v2float %27 %27
+         %29 = OpFAdd %v2float %25 %28
+               OpStore %out_var_SV_Target %29
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/packing/scalar-float3x2-row-major.asm.frag
+++ b/shaders-msl-no-opt/asm/packing/scalar-float3x2-row-major.asm.frag
@@ -1,0 +1,56 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google spiregg; 0
+; Bound: 30
+; Schema: 0
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %out_var_SV_Target
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 600
+               OpName %type_Foo "type.Foo"
+               OpMemberName %type_Foo 0 "a"
+               OpMemberName %type_Foo 1 "b"
+               OpName %Foo "Foo"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpName %main "main"
+               OpDecorate %out_var_SV_Target Location 0
+               OpDecorate %Foo DescriptorSet 0
+               OpDecorate %Foo Binding 0
+               OpMemberDecorate %type_Foo 0 Offset 0
+               OpMemberDecorate %type_Foo 0 MatrixStride 16
+               OpMemberDecorate %type_Foo 0 RowMajor
+               OpMemberDecorate %type_Foo 1 Offset 28
+               OpDecorate %type_Foo Block
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %uint_1 = OpConstant %uint 1
+      %int_1 = OpConstant %int 1
+      %float = OpTypeFloat 32
+    %v2float = OpTypeVector %float 2
+%mat3v2float = OpTypeMatrix %v2float 3
+   %type_Foo = OpTypeStruct %mat3v2float %float
+%_ptr_Uniform_type_Foo = OpTypePointer Uniform %type_Foo
+%_ptr_Output_v2float = OpTypePointer Output %v2float
+       %void = OpTypeVoid
+         %17 = OpTypeFunction %void
+%_ptr_Uniform_v2float = OpTypePointer Uniform %v2float
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+        %Foo = OpVariable %_ptr_Uniform_type_Foo Uniform
+%out_var_SV_Target = OpVariable %_ptr_Output_v2float Output
+       %main = OpFunction %void None %17
+         %20 = OpLabel
+         %21 = OpAccessChain %_ptr_Uniform_v2float %Foo %int_0 %uint_0
+         %22 = OpLoad %v2float %21
+         %23 = OpAccessChain %_ptr_Uniform_v2float %Foo %int_0 %uint_1
+         %24 = OpLoad %v2float %23
+         %25 = OpFAdd %v2float %22 %24
+         %26 = OpAccessChain %_ptr_Uniform_float %Foo %int_1
+         %27 = OpLoad %float %26
+         %28 = OpCompositeConstruct %v2float %27 %27
+         %29 = OpFAdd %v2float %25 %28
+               OpStore %out_var_SV_Target %29
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/packing/scalar-float3x3-col-major.invalid.asm.frag
+++ b/shaders-msl-no-opt/asm/packing/scalar-float3x3-col-major.invalid.asm.frag
@@ -1,0 +1,56 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google spiregg; 0
+; Bound: 30
+; Schema: 0
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %out_var_SV_Target
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 600
+               OpName %type_Foo "type.Foo"
+               OpMemberName %type_Foo 0 "a"
+               OpMemberName %type_Foo 1 "b"
+               OpName %Foo "Foo"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpName %main "main"
+               OpDecorate %out_var_SV_Target Location 0
+               OpDecorate %Foo DescriptorSet 0
+               OpDecorate %Foo Binding 0
+               OpMemberDecorate %type_Foo 0 Offset 0
+               OpMemberDecorate %type_Foo 0 MatrixStride 16
+               OpMemberDecorate %type_Foo 0 ColMajor
+               OpMemberDecorate %type_Foo 1 Offset 44
+               OpDecorate %type_Foo Block
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %uint_1 = OpConstant %uint 1
+      %int_1 = OpConstant %int 1
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%mat3v3float = OpTypeMatrix %v3float 3
+   %type_Foo = OpTypeStruct %mat3v3float %float
+%_ptr_Uniform_type_Foo = OpTypePointer Uniform %type_Foo
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+       %void = OpTypeVoid
+         %17 = OpTypeFunction %void
+%_ptr_Uniform_v3float = OpTypePointer Uniform %v3float
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+        %Foo = OpVariable %_ptr_Uniform_type_Foo Uniform
+%out_var_SV_Target = OpVariable %_ptr_Output_v3float Output
+       %main = OpFunction %void None %17
+         %20 = OpLabel
+         %21 = OpAccessChain %_ptr_Uniform_v3float %Foo %int_0 %uint_0
+         %22 = OpLoad %v3float %21
+         %23 = OpAccessChain %_ptr_Uniform_v3float %Foo %int_0 %uint_1
+         %24 = OpLoad %v3float %23
+         %25 = OpFAdd %v3float %22 %24
+         %26 = OpAccessChain %_ptr_Uniform_float %Foo %int_1
+         %27 = OpLoad %float %26
+         %28 = OpCompositeConstruct %v3float %27 %27 %27
+         %29 = OpFAdd %v3float %25 %28
+               OpStore %out_var_SV_Target %29
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/packing/scalar-float3x3-row-major.asm.frag
+++ b/shaders-msl-no-opt/asm/packing/scalar-float3x3-row-major.asm.frag
@@ -1,0 +1,56 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google spiregg; 0
+; Bound: 30
+; Schema: 0
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %out_var_SV_Target
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 600
+               OpName %type_Foo "type.Foo"
+               OpMemberName %type_Foo 0 "a"
+               OpMemberName %type_Foo 1 "b"
+               OpName %Foo "Foo"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpName %main "main"
+               OpDecorate %out_var_SV_Target Location 0
+               OpDecorate %Foo DescriptorSet 0
+               OpDecorate %Foo Binding 0
+               OpMemberDecorate %type_Foo 0 Offset 0
+               OpMemberDecorate %type_Foo 0 MatrixStride 16
+               OpMemberDecorate %type_Foo 0 RowMajor
+               OpMemberDecorate %type_Foo 1 Offset 44
+               OpDecorate %type_Foo Block
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %uint_1 = OpConstant %uint 1
+      %int_1 = OpConstant %int 1
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%mat3v3float = OpTypeMatrix %v3float 3
+   %type_Foo = OpTypeStruct %mat3v3float %float
+%_ptr_Uniform_type_Foo = OpTypePointer Uniform %type_Foo
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+       %void = OpTypeVoid
+         %17 = OpTypeFunction %void
+%_ptr_Uniform_v3float = OpTypePointer Uniform %v3float
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+        %Foo = OpVariable %_ptr_Uniform_type_Foo Uniform
+%out_var_SV_Target = OpVariable %_ptr_Output_v3float Output
+       %main = OpFunction %void None %17
+         %20 = OpLabel
+         %21 = OpAccessChain %_ptr_Uniform_v3float %Foo %int_0 %uint_0
+         %22 = OpLoad %v3float %21
+         %23 = OpAccessChain %_ptr_Uniform_v3float %Foo %int_0 %uint_1
+         %24 = OpLoad %v3float %23
+         %25 = OpFAdd %v3float %22 %24
+         %26 = OpAccessChain %_ptr_Uniform_float %Foo %int_1
+         %27 = OpLoad %float %26
+         %28 = OpCompositeConstruct %v3float %27 %27 %27
+         %29 = OpFAdd %v3float %25 %28
+               OpStore %out_var_SV_Target %29
+               OpReturn
+               OpFunctionEnd


### PR DESCRIPTION
DX may emit ArrayStride and MatrixStride of 16, but the size of the
object does not align with that and expect to pack other members inside
its last member.

The workaround is to emit array size/col/row one less than we expect and
rely on padding to carve out a "dead zone" for the last member.

Fix #1321.