### PR TITLE
Fix -Wmicrosoft-enum-value

### DIFF
--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -775,7 +775,7 @@ struct SPIRBlock : IVariant
 		ComplexLoop
 	};
 
-	enum
+	enum : uint32_t
 	{
 		NoDominator = 0xffffffffu
 	};


### PR DESCRIPTION
This is triggered when building projects that depend on SPIRV-Cross with
clang-cl on Windows with `-pedantic`

../../third_party/spirv-cross/spirv_common.hpp(781,3): error: enumerator
value is not representable in the underlying type 'int'
[-Werror,-Wmicrosoft-enum-value]
                NoDominator = 0xffffffffu