### PR TITLE
MSL: Redirect member indices when buffer has been sorted by Offset.

### DIFF
--- a/reference/shaders-hlsl-no-opt/frag/ubo-offset-out-of-order.frag
+++ b/reference/shaders-hlsl-no-opt/frag/ubo-offset-out-of-order.frag
@@ -1,0 +1,33 @@
+cbuffer UBO : register(b0)
+{
+    row_major float4x4 _13_m : packoffset(c1);
+    float4 _13_v : packoffset(c0);
+};
+
+
+static float4 FragColor;
+static float4 vColor;
+
+struct SPIRV_Cross_Input
+{
+    float4 vColor : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    FragColor = mul(vColor, _13_m) + _13_v;
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    vColor = stage_input.vColor;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-msl-no-opt/frag/ubo-offset-out-of-order.frag
+++ b/reference/shaders-msl-no-opt/frag/ubo-offset-out-of-order.frag
@@ -1,0 +1,28 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBO
+{
+    float4 v;
+    float4x4 m;
+};
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vColor [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant UBO& _13 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.FragColor = (_13.m * in.vColor) + _13.v;
+    return out;
+}
+

--- a/reference/shaders-no-opt/vulkan/frag/ubo-offset-out-of-order.vk.nocompat.frag.vk
+++ b/reference/shaders-no-opt/vulkan/frag/ubo-offset-out-of-order.vk.nocompat.frag.vk
@@ -1,0 +1,16 @@
+#version 450
+
+layout(set = 0, binding = 0, std140) uniform UBO
+{
+    layout(offset = 16) mat4 m;
+    layout(offset = 0) vec4 v;
+} _13;
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) in vec4 vColor;
+
+void main()
+{
+    FragColor = (_13.m * vColor) + _13.v;
+}
+

--- a/shaders-hlsl-no-opt/frag/ubo-offset-out-of-order.frag
+++ b/shaders-hlsl-no-opt/frag/ubo-offset-out-of-order.frag
@@ -1,0 +1,16 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+
+layout(set = 0, binding = 0) uniform UBO
+{
+	layout(offset = 16) mat4 m;
+	layout(offset = 0) vec4 v;
+};
+
+layout(location = 0) in vec4 vColor;
+
+void main()
+{
+	FragColor = m * vColor + v;
+}

--- a/shaders-msl-no-opt/frag/ubo-offset-out-of-order.frag
+++ b/shaders-msl-no-opt/frag/ubo-offset-out-of-order.frag
@@ -1,0 +1,16 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+
+layout(set = 0, binding = 0) uniform UBO
+{
+	layout(offset = 16) mat4 m;
+	layout(offset = 0) vec4 v;
+};
+
+layout(location = 0) in vec4 vColor;
+
+void main()
+{
+	FragColor = m * vColor + v;
+}

--- a/shaders-no-opt/vulkan/frag/ubo-offset-out-of-order.vk.nocompat.frag
+++ b/shaders-no-opt/vulkan/frag/ubo-offset-out-of-order.vk.nocompat.frag
@@ -1,0 +1,16 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+
+layout(std140, binding = 0) uniform UBO
+{
+	layout(offset = 16) mat4 m;
+	layout(offset = 0) vec4 v;
+};
+
+layout(location = 0) in vec4 vColor;
+
+void main()
+{
+	FragColor = m * vColor + v;
+}

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -563,6 +563,10 @@ struct SPIRType : IVariant
 
 	SmallVector<TypeID> member_types;
 
+	// If member order has been rewritten to handle certain scenarios with Offset,
+	// allow codegen to rewrite the index.
+	SmallVector<uint32_t> member_type_index_redirection;
+
 	struct ImageType
 	{
 		TypeID type;


### PR DESCRIPTION
If a buffer rewrites its Offsets, all member references to that struct
are invalidated, and must be redirected, do so in to_member_reference,
but there might be other places where this is needed. Fix as required.
SPIR-V code relying on this is somewhat questionable, but seems to be
in-spec.

Fix #1354.