### PR TITLE
GLSL: Require GL_ARB_draw_instanced for gl_InstanceID in GLSL < 1.40

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -6973,6 +6973,10 @@ string CompilerGLSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 					"Cannot implement gl_InstanceID in Vulkan GLSL. This shader was created with GL semantics.");
 			}
 		}
+		if (!options.es && options.version < 140)
+		{
+			require_extension_internal("GL_ARB_draw_instanced");
+		}
 		return "gl_InstanceID";
 	case BuiltInVertexIndex:
 		if (options.vulkan_semantics)
@@ -6982,7 +6986,13 @@ string CompilerGLSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 	case BuiltInInstanceIndex:
 		if (options.vulkan_semantics)
 			return "gl_InstanceIndex";
-		else if (options.vertex.support_nonzero_base_instance)
+
+		if (!options.es && options.version < 140)
+		{
+			require_extension_internal("GL_ARB_draw_instanced");
+		}
+
+		if (options.vertex.support_nonzero_base_instance)
 		{
 			if (!options.vulkan_semantics)
 			{


### PR DESCRIPTION
gl_InstanceID was introduced in GLSL 1.40, so when generating for older version, it requires an explicit extension.

GL_ARB_draw_instanced provides both gl_InstanceID and gl_InstanceIDARB, so no rename is necessary.

Note that GL_EXT_gpu_shader4 also offers gl_InstanceID, but that extension is not nearly as widely supported as GL_ARB_draw_instanced, according to several OpenGL extension databases I queried.

Thanks for your consideration!