### PR TITLE
Fix placement of SPIRV_CROSS_DEPRECATED.

### DIFF
--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -43,7 +43,7 @@ enum MSLShaderInputFormat
 
 	MSL_SHADER_INPUT_FORMAT_INT_MAX = 0x7fffffff
 };
-typedef SPIRV_CROSS_DEPRECATED("Use MSLShaderInputFormat.") MSLShaderInputFormat MSLVertexFormat;
+SPIRV_CROSS_DEPRECATED("Use MSLShaderInputFormat.") typedef MSLShaderInputFormat MSLVertexFormat;
 
 // Defines MSL characteristics of a vertex attribute at a particular location.
 // After compilation, it is possible to query whether or not this location was used.


### PR DESCRIPTION
The [[deprecated]] attribute is supposed to be in front of a typedef,
not after the typedef keyword.

PTAL @HansKristian-Work 