### PR TITLE
MSL: Remove the old VertexAttr API.

### DIFF
--- a/spirv_cross_c.cpp
+++ b/spirv_cross_c.cpp
@@ -1019,11 +1019,11 @@ spvc_result spvc_compiler_msl_add_vertex_attribute(spvc_compiler compiler, const
 	}
 
 	auto &msl = *static_cast<CompilerMSL *>(compiler->compiler.get());
-	MSLVertexAttr attr;
+	MSLShaderInput attr;
 	attr.location = va->location;
-	attr.format = static_cast<MSLVertexFormat>(va->format);
+	attr.format = static_cast<MSLShaderInputFormat>(va->format);
 	attr.builtin = static_cast<spv::BuiltIn>(va->builtin);
-	msl.add_msl_vertex_attribute(attr);
+	msl.add_msl_shader_input(attr);
 	return SPVC_SUCCESS;
 #else
 	(void)va;
@@ -1163,7 +1163,7 @@ spvc_result spvc_compiler_msl_set_argument_buffer_device_address_space(spvc_comp
 #endif
 }
 
-spvc_bool spvc_compiler_msl_is_vertex_attribute_used(spvc_compiler compiler, unsigned location)
+spvc_bool spvc_compiler_msl_is_shader_input_used(spvc_compiler compiler, unsigned location)
 {
 #if SPIRV_CROSS_C_API_MSL
 	if (compiler->backend != SPVC_BACKEND_MSL)
@@ -1173,12 +1173,17 @@ spvc_bool spvc_compiler_msl_is_vertex_attribute_used(spvc_compiler compiler, uns
 	}
 
 	auto &msl = *static_cast<CompilerMSL *>(compiler->compiler.get());
-	return msl.is_msl_vertex_attribute_used(location) ? SPVC_TRUE : SPVC_FALSE;
+	return msl.is_msl_shader_input_used(location) ? SPVC_TRUE : SPVC_FALSE;
 #else
 	(void)location;
 	compiler->context->report_error("MSL function used on a non-MSL backend.");
 	return SPVC_FALSE;
 #endif
+}
+
+spvc_bool spvc_compiler_msl_is_vertex_attribute_used(spvc_compiler compiler, unsigned location)
+{
+	return spvc_compiler_msl_is_shader_input_used(compiler, location);
 }
 
 spvc_bool spvc_compiler_msl_is_resource_used(spvc_compiler compiler, SpvExecutionModel model, unsigned set,
@@ -2282,7 +2287,7 @@ void spvc_msl_vertex_attribute_init(spvc_msl_vertex_attribute *attr)
 {
 #if SPIRV_CROSS_C_API_MSL
 	// Crude, but works.
-	MSLVertexAttr attr_default;
+	MSLShaderInput attr_default;
 	attr->location = attr_default.location;
 	attr->format = static_cast<spvc_msl_vertex_format>(attr_default.format);
 	attr->builtin = static_cast<SpvBuiltIn>(attr_default.builtin);

--- a/spirv_cross_c.h
+++ b/spirv_cross_c.h
@@ -268,7 +268,9 @@ typedef enum spvc_msl_shader_input_format
 	/* Deprecated names. */
 	SPVC_MSL_VERTEX_FORMAT_OTHER = SPVC_MSL_SHADER_INPUT_FORMAT_OTHER,
 	SPVC_MSL_VERTEX_FORMAT_UINT8 = SPVC_MSL_SHADER_INPUT_FORMAT_UINT8,
-	SPVC_MSL_VERTEX_FORMAT_UINT16 = SPVC_MSL_SHADER_INPUT_FORMAT_UINT16
+	SPVC_MSL_VERTEX_FORMAT_UINT16 = SPVC_MSL_SHADER_INPUT_FORMAT_UINT16,
+
+	SPVC_MSL_SHADER_INPUT_FORMAT_INT_MAX = 0x7fffffff
 } spvc_msl_shader_input_format, spvc_msl_vertex_format;
 
 /* Maps to C++ API. Deprecated; use spvc_msl_shader_input. */
@@ -721,7 +723,11 @@ SPVC_PUBLIC_API spvc_result spvc_compiler_msl_add_shader_input(spvc_compiler com
                                                                const spvc_msl_shader_input *input);
 SPVC_PUBLIC_API spvc_result spvc_compiler_msl_add_discrete_descriptor_set(spvc_compiler compiler, unsigned desc_set);
 SPVC_PUBLIC_API spvc_result spvc_compiler_msl_set_argument_buffer_device_address_space(spvc_compiler compiler, unsigned desc_set, spvc_bool device_address);
+
+/* Obsolete, use is_shader_input_used. */
 SPVC_PUBLIC_API spvc_bool spvc_compiler_msl_is_vertex_attribute_used(spvc_compiler compiler, unsigned location);
+SPVC_PUBLIC_API spvc_bool spvc_compiler_msl_is_shader_input_used(spvc_compiler compiler, unsigned location);
+
 SPVC_PUBLIC_API spvc_bool spvc_compiler_msl_is_resource_used(spvc_compiler compiler,
                                                              SpvExecutionModel model,
                                                              unsigned set,

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -56,15 +56,6 @@ void CompilerMSL::add_msl_shader_input(const MSLShaderInput &si)
 		inputs_by_builtin[si.builtin] = si;
 }
 
-void CompilerMSL::add_msl_vertex_attribute(const MSLVertexAttr &va)
-{
-	MSLShaderInput si;
-	si.location = va.location;
-	si.format = va.format;
-	si.builtin = va.builtin;
-	add_msl_shader_input(si);
-}
-
 void CompilerMSL::add_msl_resource_binding(const MSLResourceBinding &binding)
 {
 	StageSetBinding tuple = { binding.stage, binding.desc_set, binding.binding };
@@ -98,11 +89,6 @@ void CompilerMSL::set_argument_buffer_device_address_space(uint32_t desc_set, bo
 		else
 			argument_buffer_device_storage_mask &= ~(1u << desc_set);
 	}
-}
-
-bool CompilerMSL::is_msl_vertex_attribute_used(uint32_t location)
-{
-	return is_msl_shader_input_used(location);
 }
 
 bool CompilerMSL::is_msl_shader_input_used(uint32_t location)

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -43,16 +43,6 @@ enum MSLShaderInputFormat
 
 	MSL_SHADER_INPUT_FORMAT_INT_MAX = 0x7fffffff
 };
-SPIRV_CROSS_DEPRECATED("Use MSLShaderInputFormat.") typedef MSLShaderInputFormat MSLVertexFormat;
-
-// Defines MSL characteristics of a vertex attribute at a particular location.
-// After compilation, it is possible to query whether or not this location was used.
-struct SPIRV_CROSS_DEPRECATED("Use MSLShaderInput.") MSLVertexAttr
-{
-	uint32_t location = 0;
-	MSLShaderInputFormat format = MSL_SHADER_INPUT_FORMAT_OTHER;
-	spv::BuiltIn builtin = spv::BuiltInMax;
-};
 
 // Defines MSL characteristics of an input variable at a particular location.
 // After compilation, it is possible to query whether or not this location was used.
@@ -438,13 +428,6 @@ public:
 	explicit CompilerMSL(const ParsedIR &ir);
 	explicit CompilerMSL(ParsedIR &&ir);
 
-	// attr is a vertex attribute binding used to match
-	// vertex content locations to MSL attributes. If vertex attributes are provided,
-	// is_msl_vertex_attribute_used() will return true after calling ::compile() if
-	// the location was used by the MSL code.
-	SPIRV_CROSS_DEPRECATED("Use add_msl_shader_input().")
-	void add_msl_vertex_attribute(const MSLVertexAttr &attr);
-
 	// input is a shader input description used to fix up shader input variables.
 	// If shader inputs are provided, is_msl_shader_input_used() will return true after
 	// calling ::compile() if the location was used by the MSL code.
@@ -479,10 +462,6 @@ public:
 	// If an argument buffer is large enough, it may need to be in the device storage space rather than
 	// constant. Opt-in to this behavior here on a per set basis.
 	void set_argument_buffer_device_address_space(uint32_t desc_set, bool device_storage);
-
-	// Query after compilation is done. This allows you to check if a location or set/binding combination was used by the shader.
-	SPIRV_CROSS_DEPRECATED("Use is_msl_shader_input_used().")
-	bool is_msl_vertex_attribute_used(uint32_t location);
 
 	// Query after compilation is done. This allows you to check if an input location was used by the shader.
 	bool is_msl_shader_input_used(uint32_t location);


### PR DESCRIPTION
Too many issues with deprecated declarations on various compilers, just
get rid of it.

Fix #1399.