### PR TITLE
HLSL: Workaround FXC bugs with degenerate switch blocks.

### DIFF
--- a/reference/opt/shaders-msl/frag/for-loop-init.frag
+++ b/reference/opt/shaders-msl/frag/for-loop-init.frag
@@ -11,64 +11,61 @@ struct main0_out
 fragment main0_out main0()
 {
     main0_out out = {};
-    switch (0u)
+    do
     {
-        default:
+        out.FragColor = 16;
+        for (int _143 = 0; _143 < 25; )
         {
-            out.FragColor = 16;
-            for (int _143 = 0; _143 < 25; )
+            out.FragColor += 10;
+            _143++;
+            continue;
+        }
+        for (int _144 = 1; _144 < 30; )
+        {
+            out.FragColor += 11;
+            _144++;
+            continue;
+        }
+        int _145;
+        _145 = 0;
+        for (; _145 < 20; )
+        {
+            out.FragColor += 12;
+            _145++;
+            continue;
+        }
+        int _62 = _145 + 3;
+        out.FragColor += _62;
+        if (_62 == 40)
+        {
+            for (int _149 = 0; _149 < 40; )
             {
-                out.FragColor += 10;
-                _143++;
+                out.FragColor += 13;
+                _149++;
                 continue;
             }
-            for (int _144 = 1; _144 < 30; )
-            {
-                out.FragColor += 11;
-                _144++;
-                continue;
-            }
-            int _145;
-            _145 = 0;
-            for (; _145 < 20; )
-            {
-                out.FragColor += 12;
-                _145++;
-                continue;
-            }
-            int _62 = _145 + 3;
-            out.FragColor += _62;
-            if (_62 == 40)
-            {
-                for (int _149 = 0; _149 < 40; )
-                {
-                    out.FragColor += 13;
-                    _149++;
-                    continue;
-                }
-                break;
-            }
-            out.FragColor += _62;
-            int2 _146;
-            _146 = int2(0);
-            for (; _146.x < 10; )
-            {
-                out.FragColor += _146.y;
-                int2 _142 = _146;
-                _142.x = _146.x + 4;
-                _146 = _142;
-                continue;
-            }
-            for (int _148 = _62; _148 < 40; )
-            {
-                out.FragColor += _148;
-                _148++;
-                continue;
-            }
-            out.FragColor += _62;
             break;
         }
-    }
+        out.FragColor += _62;
+        int2 _146;
+        _146 = int2(0);
+        for (; _146.x < 10; )
+        {
+            out.FragColor += _146.y;
+            int2 _142 = _146;
+            _142.x = _146.x + 4;
+            _146 = _142;
+            continue;
+        }
+        for (int _148 = _62; _148 < 40; )
+        {
+            out.FragColor += _148;
+            _148++;
+            continue;
+        }
+        out.FragColor += _62;
+        break;
+    } while(false);
     return out;
 }
 

--- a/reference/opt/shaders/asm/frag/loop-body-dominator-continue-access.asm.frag
+++ b/reference/opt/shaders/asm/frag/loop-body-dominator-continue-access.asm.frag
@@ -15,55 +15,49 @@ int _231;
 void main()
 {
     int _228;
-    switch (0u)
+    do
     {
-        default:
+        bool _225;
+        int _229;
+        uint _222 = 0u;
+        for (;;)
         {
-            bool _225;
-            int _229;
-            uint _222 = 0u;
-            for (;;)
+            if (_222 < _11.shadowCascadesNum)
             {
-                if (_222 < _11.shadowCascadesNum)
+                mat4 _223;
+                do
                 {
-                    mat4 _223;
-                    switch (0u)
+                    if (_11.test == 0)
                     {
-                        default:
-                        {
-                            if (_11.test == 0)
-                            {
-                                _223 = mat4(vec4(0.5, 0.0, 0.0, 0.0), vec4(0.0, 0.5, 0.0, 0.0), vec4(0.0, 0.0, 0.5, 0.0), vec4(0.0, 0.0, 0.0, 1.0));
-                                break;
-                            }
-                            _223 = mat4(vec4(1.0, 0.0, 0.0, 0.0), vec4(0.0, 1.0, 0.0, 0.0), vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0));
-                            break;
-                        }
-                    }
-                    vec4 _170 = (_223 * _11.lightVP[_222]) * vec4(fragWorld, 1.0);
-                    float _172 = _170.z;
-                    float _179 = _170.x;
-                    float _181 = _170.y;
-                    if ((((_172 >= 0.0) && (_172 <= 1.0)) && (max(_179, _181) <= 1.0)) && (min(_179, _181) >= 0.0))
-                    {
-                        _229 = int(_222);
-                        _225 = true;
+                        _223 = mat4(vec4(0.5, 0.0, 0.0, 0.0), vec4(0.0, 0.5, 0.0, 0.0), vec4(0.0, 0.0, 0.5, 0.0), vec4(0.0, 0.0, 0.0, 1.0));
                         break;
                     }
-                    _222++;
-                    continue;
-                }
-                else
+                    _223 = mat4(vec4(1.0, 0.0, 0.0, 0.0), vec4(0.0, 1.0, 0.0, 0.0), vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0));
+                    break;
+                } while(false);
+                vec4 _170 = (_223 * _11.lightVP[_222]) * vec4(fragWorld, 1.0);
+                float _172 = _170.z;
+                float _179 = _170.x;
+                float _181 = _170.y;
+                if ((((_172 >= 0.0) && (_172 <= 1.0)) && (max(_179, _181) <= 1.0)) && (min(_179, _181) >= 0.0))
                 {
-                    _229 = _231;
-                    _225 = false;
+                    _229 = int(_222);
+                    _225 = true;
                     break;
                 }
+                _222++;
+                continue;
             }
-            _228 = -1;
-            break;
+            else
+            {
+                _229 = _231;
+                _225 = false;
+                break;
+            }
         }
-    }
+        _228 = -1;
+        break;
+    } while(false);
     _entryPointOutput = _228;
 }
 

--- a/reference/opt/shaders/frag/for-loop-init.frag
+++ b/reference/opt/shaders/frag/for-loop-init.frag
@@ -6,63 +6,60 @@ layout(location = 0) out mediump int FragColor;
 
 void main()
 {
-    switch (0u)
+    do
     {
-        default:
+        FragColor = 16;
+        for (mediump int _143 = 0; _143 < 25; )
         {
-            FragColor = 16;
-            for (mediump int _143 = 0; _143 < 25; )
+            FragColor += 10;
+            _143++;
+            continue;
+        }
+        for (mediump int _144 = 1; _144 < 30; )
+        {
+            FragColor += 11;
+            _144++;
+            continue;
+        }
+        mediump int _145;
+        _145 = 0;
+        for (; _145 < 20; )
+        {
+            FragColor += 12;
+            _145++;
+            continue;
+        }
+        mediump int _62 = _145 + 3;
+        FragColor += _62;
+        if (_62 == 40)
+        {
+            for (mediump int _149 = 0; _149 < 40; )
             {
-                FragColor += 10;
-                _143++;
+                FragColor += 13;
+                _149++;
                 continue;
             }
-            for (mediump int _144 = 1; _144 < 30; )
-            {
-                FragColor += 11;
-                _144++;
-                continue;
-            }
-            mediump int _145;
-            _145 = 0;
-            for (; _145 < 20; )
-            {
-                FragColor += 12;
-                _145++;
-                continue;
-            }
-            mediump int _62 = _145 + 3;
-            FragColor += _62;
-            if (_62 == 40)
-            {
-                for (mediump int _149 = 0; _149 < 40; )
-                {
-                    FragColor += 13;
-                    _149++;
-                    continue;
-                }
-                break;
-            }
-            FragColor += _62;
-            mediump ivec2 _146;
-            _146 = ivec2(0);
-            for (; _146.x < 10; )
-            {
-                FragColor += _146.y;
-                mediump ivec2 _142 = _146;
-                _142.x = _146.x + 4;
-                _146 = _142;
-                continue;
-            }
-            for (mediump int _148 = _62; _148 < 40; )
-            {
-                FragColor += _148;
-                _148++;
-                continue;
-            }
-            FragColor += _62;
             break;
         }
-    }
+        FragColor += _62;
+        mediump ivec2 _146;
+        _146 = ivec2(0);
+        for (; _146.x < 10; )
+        {
+            FragColor += _146.y;
+            mediump ivec2 _142 = _146;
+            _142.x = _146.x + 4;
+            _146 = _142;
+            continue;
+        }
+        for (mediump int _148 = _62; _148 < 40; )
+        {
+            FragColor += _148;
+            _148++;
+            continue;
+        }
+        FragColor += _62;
+        break;
+    } while(false);
 }
 

--- a/reference/opt/shaders/frag/selection-block-dominator.frag
+++ b/reference/opt/shaders/frag/selection-block-dominator.frag
@@ -5,18 +5,15 @@ layout(location = 0) out vec4 FragColor;
 
 void main()
 {
-    switch (0u)
+    do
     {
-        default:
+        if (vIndex != 1)
         {
-            if (vIndex != 1)
-            {
-                FragColor = vec4(1.0);
-                break;
-            }
-            FragColor = vec4(10.0);
+            FragColor = vec4(1.0);
             break;
         }
-    }
+        FragColor = vec4(10.0);
+        break;
+    } while(false);
 }
 

--- a/reference/shaders-no-opt/asm/frag/switch-single-case-multiple-exit-cfg.asm.frag
+++ b/reference/shaders-no-opt/asm/frag/switch-single-case-multiple-exit-cfg.asm.frag
@@ -9,21 +9,18 @@ vec2 _19;
 void main()
 {
     highp vec2 _30;
-    switch (0)
+    do
     {
-        default:
+        if (gl_FragCoord.x != gl_FragCoord.x)
         {
-            if (gl_FragCoord.x != gl_FragCoord.x)
-            {
-                _30 = _19;
-                break;
-            }
-            highp vec2 _29 = _19;
-            _29.y = _19.y;
-            _30 = _29;
+            _30 = _19;
             break;
         }
-    }
+        highp vec2 _29 = _19;
+        _29.y = _19.y;
+        _30 = _29;
+        break;
+    } while(false);
     _GLF_color = vec4(_30, 1.0, 1.0);
 }
 


### PR DESCRIPTION
When we see a switch block which only contains one default block, emit a
do {} while(false) statement instead, which is far more idiomatic and
readable anyways.

Fix #1402.