### PR TITLE
MSL: Fix mismatching input attachment indices

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -9660,8 +9660,9 @@ void CompilerMSL::entry_point_args_discrete_descriptors(string &ep_args)
 			}
 			else
 			{
+                		uint32_t index = get_decoration(var.self, DecorationInputAttachmentIndex);
 				ep_args += image_type_glsl(type, var_id) + " " + r.name;
-				ep_args += " [[color(" + convert_to_string(r.index) + ")]]";
+				ep_args += " [[color(" + convert_to_string(index) + ")]]";
 			}
 
 			// Emulate texture2D atomic operations


### PR DESCRIPTION
When using e.g. input attachment index 1 without also using input attachment index 0 the incorrect `color(n)` value would be emitted for the input (i.e. `color(0)` instead of `color(1)`). Fix this by using the `InputAttachmentIndex` decoration to determine `n`.