### PR TITLE
MSL: Ensure OpStore source operands are marked for inclusion in function arguments

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1278,6 +1278,11 @@ void CompilerMSL::extract_global_variables_from_function(uint32_t func_id, std::
 				uint32_t base_id = ops[0];
 				if (global_var_ids.find(base_id) != global_var_ids.end())
 					added_arg_ids.insert(base_id);
+				
+                		uint32_t rvalue_id = ops[1];
+                		if (global_var_ids.find(rvalue_id) != global_var_ids.end())
+                    			added_arg_ids.insert(rvalue_id);
+				
 				break;
 			}
 


### PR DESCRIPTION
This ensures that globals are correctly passed through to functions when their only other use is as the r-value of an assignment expression.

Example HLSL:

```
float2 ReadElement(StructuredBuffer<float2> buf, uint index) {
    return buf[index];
}

[[vk::binding(0, 0)]] StructuredBuffer<float2> testBuffer; // In artwork space

float2 ReadFromBuffer(uint index) {
    return ReadElement(testBuffer, index);
}

[shader("pixel")]
float4 SPIRVRValue_Test(float4 input) : SV_TARGET0 {
    return float4(ReadFromBuffer(0));
}
```

Generated SPIR-V via DXC:

```
; SPIR-V
; Version: 1.3
; Generator: Google spiregg; 0
; Bound: 54
; Schema: 0
               OpCapability Shader
               OpExtension "SPV_GOOGLE_hlsl_functionality1"
               OpExtension "SPV_GOOGLE_user_type"
               OpMemoryModel Logical GLSL450
               OpEntryPoint Fragment %SPIRVRValue_Test "SPIRVRValue_Test" %gl_FragCoord %out_var_SV_TARGET0
               OpExecutionMode %SPIRVRValue_Test OriginUpperLeft
               OpSource HLSL 620
               OpName %type_StructuredBuffer_v2float "type.StructuredBuffer.v2float"
               OpName %testBuffer "testBuffer"
               OpName %out_var_SV_TARGET0 "out.var.SV_TARGET0"
               OpName %SPIRVRValue_Test "SPIRVRValue_Test"
               OpName %param_var_input "param.var.input"
               OpName %src_SPIRVRValue_Test "src.SPIRVRValue_Test"
               OpName %input "input"
               OpName %bb_entry "bb.entry"
               OpName %param_var_index "param.var.index"
               OpName %ReadFromBuffer "ReadFromBuffer"
               OpName %index "index"
               OpName %bb_entry_0 "bb.entry"
               OpName %param_var_buf "param.var.buf"
               OpName %param_var_index_0 "param.var.index"
               OpName %ReadElement "ReadElement"
               OpName %buf "buf"
               OpName %index_0 "index"
               OpName %bb_entry_1 "bb.entry"
               OpDecorate %gl_FragCoord BuiltIn FragCoord
               OpDecorateString %gl_FragCoord UserSemantic "SV_Position"
               OpDecorateString %out_var_SV_TARGET0 UserSemantic "SV_TARGET0"
               OpDecorate %out_var_SV_TARGET0 Location 0
               OpDecorate %testBuffer DescriptorSet 0
               OpDecorate %testBuffer Binding 0
               OpDecorate %_runtimearr_v2float ArrayStride 8
               OpMemberDecorate %type_StructuredBuffer_v2float 0 Offset 0
               OpMemberDecorate %type_StructuredBuffer_v2float 0 NonWritable
               OpDecorate %type_StructuredBuffer_v2float BufferBlock
               OpDecorateString %testBuffer UserTypeGOOGLE "structuredbuffer"
       %uint = OpTypeInt 32 0
     %uint_0 = OpConstant %uint 0
      %float = OpTypeFloat 32
    %float_1 = OpConstant %float 1
        %int = OpTypeInt 32 1
      %int_0 = OpConstant %int 0
    %v2float = OpTypeVector %float 2
%_runtimearr_v2float = OpTypeRuntimeArray %v2float
%type_StructuredBuffer_v2float = OpTypeStruct %_runtimearr_v2float
%_ptr_Uniform_type_StructuredBuffer_v2float = OpTypePointer Uniform %type_StructuredBuffer_v2float
    %v4float = OpTypeVector %float 4
%_ptr_Input_v4float = OpTypePointer Input %v4float
%_ptr_Output_v4float = OpTypePointer Output %v4float
       %void = OpTypeVoid
         %19 = OpTypeFunction %void
%_ptr_Function_v4float = OpTypePointer Function %v4float
         %26 = OpTypeFunction %v4float %_ptr_Function_v4float
%_ptr_Function_uint = OpTypePointer Function %uint
         %36 = OpTypeFunction %v2float %_ptr_Function_uint
%_ptr_Function__ptr_Uniform_type_StructuredBuffer_v2float = OpTypePointer Function %_ptr_Uniform_type_StructuredBuffer_v2float
         %45 = OpTypeFunction %v2float %_ptr_Function__ptr_Uniform_type_StructuredBuffer_v2float %_ptr_Function_uint
%_ptr_Uniform_v2float = OpTypePointer Uniform %v2float
 %testBuffer = OpVariable %_ptr_Uniform_type_StructuredBuffer_v2float Uniform
%gl_FragCoord = OpVariable %_ptr_Input_v4float Input
%out_var_SV_TARGET0 = OpVariable %_ptr_Output_v4float Output
%SPIRVRValue_Test = OpFunction %void None %19
         %20 = OpLabel
%param_var_input = OpVariable %_ptr_Function_v4float Function
         %23 = OpLoad %v4float %gl_FragCoord
         %24 = OpFunctionCall %v4float %src_SPIRVRValue_Test %param_var_input
               OpStore %out_var_SV_TARGET0 %24
               OpReturn
               OpFunctionEnd
%src_SPIRVRValue_Test = OpFunction %v4float None %26
      %input = OpFunctionParameter %_ptr_Function_v4float
   %bb_entry = OpLabel
%param_var_index = OpVariable %_ptr_Function_uint Function
               OpStore %param_var_index %uint_0
         %31 = OpFunctionCall %v2float %ReadFromBuffer %param_var_index
         %33 = OpCompositeExtract %float %31 0
         %34 = OpCompositeExtract %float %31 1
         %35 = OpCompositeConstruct %v4float %33 %34 %float_1 %float_1
               OpReturnValue %35
               OpFunctionEnd
%ReadFromBuffer = OpFunction %v2float None %36
      %index = OpFunctionParameter %_ptr_Function_uint
 %bb_entry_0 = OpLabel
%param_var_buf = OpVariable %_ptr_Function__ptr_Uniform_type_StructuredBuffer_v2float Function
%param_var_index_0 = OpVariable %_ptr_Function_uint Function
               OpStore %param_var_buf %testBuffer
         %42 = OpLoad %uint %index
               OpStore %param_var_index_0 %42
         %43 = OpFunctionCall %v2float %ReadElement %param_var_buf %param_var_index_0
               OpReturnValue %43
               OpFunctionEnd
%ReadElement = OpFunction %v2float None %45
        %buf = OpFunctionParameter %_ptr_Function__ptr_Uniform_type_StructuredBuffer_v2float
    %index_0 = OpFunctionParameter %_ptr_Function_uint
 %bb_entry_1 = OpLabel
         %49 = OpLoad %uint %index_0
         %50 = OpLoad %_ptr_Uniform_type_StructuredBuffer_v2float %buf
         %52 = OpAccessChain %_ptr_Uniform_v2float %50 %int_0 %49
         %53 = OpLoad %v2float %52
               OpReturnValue %53
               OpFunctionEnd
```

Previously generated MSL:

```
#pragma clang diagnostic ignored "-Wmissing-prototypes"

#include <metal_stdlib>
#include <simd/simd.h>

using namespace metal;

struct type_StructuredBuffer_v2float
{
    float2 _m0[1];
};

struct spvDescriptorSetBuffer0
{
    const device type_StructuredBuffer_v2float* testBuffer [[id(0)]];
};

struct SPIRVRValue_Test_out
{
    float4 out_var_SV_TARGET0 [[color(0)]];
};

static inline __attribute__((always_inline))
float2 ReadElement(const const device type_StructuredBuffer_v2float* thread & buf, thread const uint& index)
{
    return buf->_m0[index];
}

static inline __attribute__((always_inline))
float2 ReadFromBuffer(thread const uint& index)
{
    const device type_StructuredBuffer_v2float* param_var_buf = &testBuffer;
    uint param_var_index = index;
    return ReadElement(param_var_buf, param_var_index);
}

static inline __attribute__((always_inline))
float4 src_SPIRVRValue_Test(thread const float4& _input)
{
    uint param_var_index = 0u;
    return float4(ReadFromBuffer(param_var_index), 1.0, 1.0);
}

fragment SPIRVRValue_Test_out SPIRVRValue_Test(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(1)]], float4 gl_FragCoord [[position]])
{
    SPIRVRValue_Test_out out = {};
    float4 param_var_input;
    out.out_var_SV_TARGET0 = src_SPIRVRValue_Test(param_var_input);
    return out;
}
```

Note that testBuffer is used but not passed to `ReadFromBuffer`.

Relevant parts of MSL with fix:

```
static inline __attribute__((always_inline))
float2 ReadFromBuffer(thread const uint& index, const device type_StructuredBuffer_v2float& testBuffer)
{
    const device type_StructuredBuffer_v2float* param_var_buf = &testBuffer;
    uint param_var_index = index;
    return ReadElement(param_var_buf, param_var_index);
}

static inline __attribute__((always_inline))
float4 src_SPIRVRValue_Test(thread const float4& _input, const device type_StructuredBuffer_v2float& testBuffer)
{
    uint param_var_index = 0u;
    return float4(ReadFromBuffer(param_var_index, testBuffer), 1.0, 1.0);
}

fragment SPIRVRValue_Test_out SPIRVRValue_Test(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(1)]], float4 gl_FragCoord [[position]])
{
    SPIRVRValue_Test_out out = {};
    float4 param_var_input;
    out.out_var_SV_TARGET0 = src_SPIRVRValue_Test(param_var_input, (*spvDescriptorSet0.testBuffer));
    return out;
}
```