### PR TITLE
Give names to anonymous structs (VS2013 fix)

### DIFF
--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -664,7 +664,7 @@ struct SPIREntryPoint
 	SmallVector<VariableID> interface_variables;
 
 	Bitset flags;
-	struct
+	struct WorkgroupSize
 	{
 		uint32_t x = 0, y = 0, z = 0;
 		uint32_t constant = 0; // Workgroup size can be expressed as a constant/spec-constant instead.

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -129,7 +129,7 @@ public:
 			Highp
 		};
 
-		struct
+		struct Vertex
 		{
 			// GLSL: In vertex shaders, rewrite [0, w] depth (Vulkan/D3D style) to [-w, w] depth (GL style).
 			// MSL: In vertex shaders, rewrite [-w, w] depth (GL style) to [0, w] depth.
@@ -146,7 +146,7 @@ public:
 			bool support_nonzero_base_instance = true;
 		} vertex;
 
-		struct
+		struct Fragment
 		{
 			// Add precision mediump float in ES targets when emitting GLES source.
 			// Add precision highp int in ES targets when emitting GLES source.


### PR DESCRIPTION
Give names to anonymous structs because VS2013 does not support in-class initializers of sub-structs (it silently ignored them without error or warning!)

```c++
	struct Options
	{
		int version = 450;
		struct
		{
			bool flip_vert_y = false;
		} vertex;
	};
	Options opts;
	printf("version: %d\n", opts.version);
	printf("flip_vert_y: %d\n", opts.vertex.flip_vert_y);
```

The code above prints
```
version: 450
flip_vert_y: 204
```
in VS2013 debug builds, adding a name to the inner struct fixes it.