### PR TITLE
MSVC 2013: Fix silently broken builds.

### DIFF
--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -664,7 +664,7 @@ struct SPIREntryPoint
 	SmallVector<VariableID> interface_variables;
 
 	Bitset flags;
-	struct
+	struct WorkgroupSize
 	{
 		uint32_t x = 0, y = 0, z = 0;
 		uint32_t constant = 0; // Workgroup size can be expressed as a constant/spec-constant instead.

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -129,7 +129,7 @@ public:
 			Highp
 		};
 
-		struct
+		struct VertexOptions
 		{
 			// GLSL: In vertex shaders, rewrite [0, w] depth (Vulkan/D3D style) to [-w, w] depth (GL style).
 			// MSL: In vertex shaders, rewrite [-w, w] depth (GL style) to [0, w] depth.
@@ -146,7 +146,7 @@ public:
 			bool support_nonzero_base_instance = true;
 		} vertex;
 
-		struct
+		struct FragmentOptions
 		{
 			// Add precision mediump float in ES targets when emitting GLES source.
 			// Add precision highp int in ES targets when emitting GLES source.


### PR DESCRIPTION
Anonymous structs with initializers apparently fail to compile in MSVC
2013, so just name the structs.