### PR TITLE
Enabling setting an additional fixed sampleMask in Metal fragment shaders.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -560,6 +560,7 @@ struct CLIArguments
 	bool msl_enable_clip_distance_user_varying = true;
 	bool msl_multi_patch_workgroup = false;
 	bool msl_vertex_for_tessellation = false;
+	uint32_t msl_additional_fixed_sample_mask = 0xffffffff;
 	bool glsl_emit_push_constant_as_ubo = false;
 	bool glsl_emit_ubo_as_plain_uniforms = false;
 	SmallVector<pair<uint32_t, uint32_t>> glsl_ext_framebuffer_fetch;
@@ -757,7 +758,9 @@ static void print_help_msl()
 					"\t\tIn addition, this style also passes input variables in buffers directly instead of using vertex attribute processing.\n"
 					"\t\tIn a future version of SPIRV-Cross, this will become the default.\n"
 	                "\t[--msl-vertex-for-tessellation]:\n\t\tWhen handling a vertex shader, marks it as one that will be used with a new-style tessellation control shader.\n"
-					"\t\tThe vertex shader is output to MSL as a compute kernel which outputs vertices to the buffer in the order they are received, rather than in index order as with --msl-capture-output normally.\n");
+					"\t\tThe vertex shader is output to MSL as a compute kernel which outputs vertices to the buffer in the order they are received, rather than in index order as with --msl-capture-output normally.\n"
+	                "\t[--msl-additional-fixed-sample-mask <mask>]:\n"
+	                "\t\tSet an additional fixed sample mask. If the shader outputs a sample mask, then the final sample mask will be a bitwise AND of the two.\n");
 	// clang-format on
 }
 
@@ -993,6 +996,7 @@ static string compile_iteration(const CLIArguments &args, std::vector<uint32_t> 
 		msl_opts.enable_clip_distance_user_varying = args.msl_enable_clip_distance_user_varying;
 		msl_opts.multi_patch_workgroup = args.msl_multi_patch_workgroup;
 		msl_opts.vertex_for_tessellation = args.msl_vertex_for_tessellation;
+		msl_opts.additional_fixed_sample_mask = args.msl_additional_fixed_sample_mask;
 		msl_comp->set_msl_options(msl_opts);
 		for (auto &v : args.msl_discrete_descriptor_sets)
 			msl_comp->add_discrete_descriptor_set(v);
@@ -1406,6 +1410,8 @@ static int main_inner(int argc, char *argv[])
 	});
 	cbs.add("--msl-multi-patch-workgroup", [&args](CLIParser &) { args.msl_multi_patch_workgroup = true; });
 	cbs.add("--msl-vertex-for-tessellation", [&args](CLIParser &) { args.msl_vertex_for_tessellation = true; });
+	cbs.add("--msl-additional-fixed-sample-mask",
+	        [&args](CLIParser &parser) { args.msl_additional_fixed_sample_mask = parser.next_hex_uint(); });
 	cbs.add("--extension", [&args](CLIParser &parser) { args.extensions.push_back(parser.next_string()); });
 	cbs.add("--rename-entry-point", [&args](CLIParser &parser) {
 		auto old_name = parser.next_string();

--- a/reference/opt/shaders-msl/frag/sample-mask-in-and-out.fixed-sample-mask.frag
+++ b/reference/opt/shaders-msl/frag/sample-mask-in-and-out.fixed-sample-mask.frag
@@ -1,0 +1,20 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+    uint gl_SampleMask [[sample_mask]];
+};
+
+fragment main0_out main0(uint gl_SampleMaskIn [[sample_mask]])
+{
+    main0_out out = {};
+    out.FragColor = float4(1.0);
+    out.gl_SampleMask = gl_SampleMaskIn;
+    out.gl_SampleMask &= 34;
+    return out;
+}
+

--- a/reference/opt/shaders-msl/frag/sample-mask-not-used.fixed-sample-mask.frag
+++ b/reference/opt/shaders-msl/frag/sample-mask-not-used.fixed-sample-mask.frag
@@ -1,0 +1,19 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+    uint gl_SampleMask [[sample_mask]];
+};
+
+fragment main0_out main0()
+{
+    main0_out out = {};
+    out.FragColor = float4(1.0);
+    out.gl_SampleMask = 34;
+    return out;
+}
+

--- a/reference/opt/shaders-msl/frag/sample-mask.fixed-sample-mask.frag
+++ b/reference/opt/shaders-msl/frag/sample-mask.fixed-sample-mask.frag
@@ -1,0 +1,20 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+    uint gl_SampleMask [[sample_mask]];
+};
+
+fragment main0_out main0()
+{
+    main0_out out = {};
+    out.FragColor = float4(1.0);
+    out.gl_SampleMask = 0;
+    out.gl_SampleMask &= 34;
+    return out;
+}
+

--- a/reference/shaders-msl/frag/sample-mask-in-and-out.fixed-sample-mask.frag
+++ b/reference/shaders-msl/frag/sample-mask-in-and-out.fixed-sample-mask.frag
@@ -1,0 +1,20 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+    uint gl_SampleMask [[sample_mask]];
+};
+
+fragment main0_out main0(uint gl_SampleMaskIn [[sample_mask]])
+{
+    main0_out out = {};
+    out.FragColor = float4(1.0);
+    out.gl_SampleMask = gl_SampleMaskIn;
+    out.gl_SampleMask &= 34;
+    return out;
+}
+

--- a/reference/shaders-msl/frag/sample-mask-not-used.fixed-sample-mask.frag
+++ b/reference/shaders-msl/frag/sample-mask-not-used.fixed-sample-mask.frag
@@ -1,0 +1,19 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+    uint gl_SampleMask [[sample_mask]];
+};
+
+fragment main0_out main0()
+{
+    main0_out out = {};
+    out.FragColor = float4(1.0);
+    out.gl_SampleMask = 34;
+    return out;
+}
+

--- a/reference/shaders-msl/frag/sample-mask.fixed-sample-mask.frag
+++ b/reference/shaders-msl/frag/sample-mask.fixed-sample-mask.frag
@@ -1,0 +1,20 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+    uint gl_SampleMask [[sample_mask]];
+};
+
+fragment main0_out main0()
+{
+    main0_out out = {};
+    out.FragColor = float4(1.0);
+    out.gl_SampleMask = 0;
+    out.gl_SampleMask &= 34;
+    return out;
+}
+

--- a/shaders-msl/frag/sample-mask-in-and-out.fixed-sample-mask.frag
+++ b/shaders-msl/frag/sample-mask-in-and-out.fixed-sample-mask.frag
@@ -1,0 +1,10 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = vec4(1.0);
+	gl_SampleMask[0] = gl_SampleMaskIn[0];
+}
+

--- a/shaders-msl/frag/sample-mask-not-used.fixed-sample-mask.frag
+++ b/shaders-msl/frag/sample-mask-not-used.fixed-sample-mask.frag
@@ -1,0 +1,8 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = vec4(1.0);
+}

--- a/shaders-msl/frag/sample-mask.fixed-sample-mask.frag
+++ b/shaders-msl/frag/sample-mask.fixed-sample-mask.frag
@@ -1,0 +1,10 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = vec4(1.0);
+	gl_SampleMask[0] = 0;
+}
+

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -278,6 +278,10 @@ public:
 		uint32_t shader_input_wg_index = 0;
 		uint32_t device_index = 0;
 		uint32_t enable_frag_output_mask = 0xffffffff;
+		// Metal doesn't allow setting a fixed sample mask directly in the pipeline.
+		// We can evade this restriction by ANDing the internal sample_mask output
+		// of the shader with the additional fixed sample mask.
+		uint32_t additional_fixed_sample_mask = 0xffffffff;
 		bool enable_point_size_builtin = true;
 		bool enable_frag_depth_builtin = true;
 		bool enable_frag_stencil_ref_builtin = true;
@@ -809,6 +813,7 @@ protected:
 	void emit_entry_point_declarations() override;
 	uint32_t builtin_frag_coord_id = 0;
 	uint32_t builtin_sample_id_id = 0;
+	uint32_t builtin_sample_mask_id = 0;
 	uint32_t builtin_vertex_idx_id = 0;
 	uint32_t builtin_base_vertex_id = 0;
 	uint32_t builtin_instance_idx_id = 0;
@@ -826,6 +831,8 @@ protected:
 	uint32_t view_mask_buffer_id = 0;
 	uint32_t dynamic_offsets_buffer_id = 0;
 	uint32_t uint_type_id = 0;
+
+	bool does_shader_write_sample_mask = false;
 
 	void bitcast_to_builtin_store(uint32_t target_id, std::string &expr, const SPIRType &expr_type) override;
 	void bitcast_from_builtin_load(uint32_t source_id, std::string &expr, const SPIRType &expr_type) override;

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -293,6 +293,9 @@ def cross_compile_msl(shader, spirv, opt, iterations, paths):
         msl_args.append('2')
     if '.for-tess.' in shader:
         msl_args.append('--msl-vertex-for-tessellation')
+    if '.fixed-sample-mask.' in shader:
+        msl_args.append('--msl-additional-fixed-sample-mask')
+        msl_args.append('0x00000022')
 
     subprocess.check_call(msl_args)
 


### PR DESCRIPTION
In Metal render pipelines don't have an option to set a sampleMask
parameter, the only way to get that functionality is to set the
sample_mask output of the fragment shader to this value directly.
We also need to take care to combine the fixed sample mask with the
one that the shader might possibly output.