### PR TITLE
GLSL/HLSL: Be more exhaustive with aliasing struct type declarations.

### DIFF
--- a/reference/opt/shaders-hlsl/asm/comp/block-name-alias-global.asm.comp
+++ b/reference/opt/shaders-hlsl/asm/comp/block-name-alias-global.asm.comp
@@ -4,22 +4,16 @@ struct A
     int b;
 };
 
-struct A_1
-{
-    int a;
-    int b;
-};
-
 RWByteAddressBuffer C1 : register(u1);
 cbuffer C2 : register(b2)
 {
-    A_1 C2_1_Data[1024] : packoffset(c0);
+    A C2_1_Data[1024] : packoffset(c0);
 };
 
 RWByteAddressBuffer C3 : register(u0);
 cbuffer B : register(b3)
 {
-    A_1 C4_Data[1024] : packoffset(c0);
+    A C4_Data[1024] : packoffset(c0);
 };
 
 

--- a/reference/opt/shaders/asm/comp/block-name-alias-global.asm.comp
+++ b/reference/opt/shaders/asm/comp/block-name-alias-global.asm.comp
@@ -7,12 +7,6 @@ struct A
     int b;
 };
 
-struct A_1
-{
-    int a;
-    int b;
-};
-
 layout(binding = 1, std430) buffer C1
 {
     A Data[];
@@ -20,7 +14,7 @@ layout(binding = 1, std430) buffer C1
 
 layout(binding = 2, std140) uniform C2
 {
-    A_1 Data[1024];
+    A Data[1024];
 } C2_1;
 
 layout(binding = 0, std430) buffer B
@@ -30,7 +24,7 @@ layout(binding = 0, std430) buffer B
 
 layout(binding = 3, std140) uniform B
 {
-    A_1 Data[1024];
+    A Data[1024];
 } C4;
 
 void main()

--- a/reference/opt/shaders/comp/struct-packing.comp
+++ b/reference/opt/shaders/comp/struct-packing.comp
@@ -43,48 +43,6 @@ struct Content
     S4 m3s[8];
 };
 
-struct S0_1
-{
-    vec2 a[1];
-    float b;
-};
-
-struct S1_1
-{
-    vec3 a;
-    float b;
-};
-
-struct S2_1
-{
-    vec3 a[1];
-    float b;
-};
-
-struct S3_1
-{
-    vec2 a;
-    float b;
-};
-
-struct S4_1
-{
-    vec2 c;
-};
-
-struct Content_1
-{
-    S0_1 m0s[1];
-    S1_1 m1s[1];
-    S2_1 m2s[1];
-    S0_1 m0;
-    S1_1 m1;
-    S2_1 m2;
-    S3_1 m3;
-    float m4;
-    S4_1 m3s[8];
-};
-
 layout(binding = 1, std430) restrict buffer SSBO1
 {
     Content content;
@@ -103,9 +61,9 @@ layout(binding = 1, std430) restrict buffer SSBO1
 
 layout(binding = 0, std140) restrict buffer SSBO0
 {
-    Content_1 content;
-    Content_1 content1[2];
-    Content_1 content2;
+    Content content;
+    Content content1[2];
+    Content content2;
     mat2 m0;
     mat2 m1;
     mat2x3 m2[4];

--- a/reference/opt/shaders/desktop-only/comp/enhanced-layouts.comp
+++ b/reference/opt/shaders/desktop-only/comp/enhanced-layouts.comp
@@ -8,13 +8,6 @@ struct Foo
     int c;
 };
 
-struct Foo_1
-{
-    int a;
-    int b;
-    int c;
-};
-
 layout(binding = 1, std140) buffer SSBO1
 {
     layout(offset = 4) int a;
@@ -27,7 +20,7 @@ layout(binding = 2, std430) buffer SSBO2
 {
     layout(offset = 4) int a;
     layout(offset = 8) int b;
-    layout(offset = 16) Foo_1 foo;
+    layout(offset = 16) Foo foo;
     layout(offset = 48) int c[8];
 } ssbo2;
 

--- a/reference/opt/shaders/frag/ubo_layout.frag
+++ b/reference/opt/shaders/frag/ubo_layout.frag
@@ -7,11 +7,6 @@ struct Str
     mat4 foo;
 };
 
-struct Str_1
-{
-    mat4 foo;
-};
-
 layout(binding = 0, std140) uniform UBO1
 {
     layout(row_major) Str foo;
@@ -19,7 +14,7 @@ layout(binding = 0, std140) uniform UBO1
 
 layout(binding = 1, std140) uniform UBO2
 {
-    Str_1 foo;
+    Str foo;
 } ubo0;
 
 layout(location = 0) out vec4 FragColor;

--- a/reference/shaders-hlsl-no-opt/asm/comp/aliased-struct-divergent-member-name.asm.comp
+++ b/reference/shaders-hlsl-no-opt/asm/comp/aliased-struct-divergent-member-name.asm.comp
@@ -3,11 +3,6 @@ struct T
     float c;
 };
 
-struct T_1
-{
-    float b;
-};
-
 static const T _18 = { 40.0f };
 
 RWByteAddressBuffer _7 : register(u0);

--- a/reference/shaders-hlsl-no-opt/asm/vert/complex-link-by-name.asm.vert
+++ b/reference/shaders-hlsl-no-opt/asm/vert/complex-link-by-name.asm.vert
@@ -1,0 +1,54 @@
+struct Struct_vec4
+{
+    float4 m0;
+};
+
+cbuffer UBO : register(b0)
+{
+    Struct_vec4 ubo_binding_0_m0 : packoffset(c0);
+    Struct_vec4 ubo_binding_0_m1 : packoffset(c1);
+};
+
+
+static float4 gl_Position;
+static Struct_vec4 output_location_2;
+static Struct_vec4 output_location_3;
+
+struct VertexOut
+{
+    Struct_vec4 m0 : TEXCOORD0;
+    Struct_vec4 m1 : TEXCOORD1;
+};
+
+static VertexOut output_location_0;
+
+struct SPIRV_Cross_Output
+{
+    Struct_vec4 output_location_2 : TEXCOORD2;
+    Struct_vec4 output_location_3 : TEXCOORD3;
+    float4 gl_Position : SV_Position;
+};
+
+void vert_main()
+{
+    Struct_vec4 c;
+    c.m0 = ubo_binding_0_m0.m0;
+    Struct_vec4 b;
+    b.m0 = ubo_binding_0_m1.m0;
+    gl_Position = c.m0 + b.m0;
+    output_location_0.m0 = c;
+    output_location_0.m1 = b;
+    output_location_2 = c;
+    output_location_3 = b;
+}
+
+SPIRV_Cross_Output main(out VertexOut stage_outputoutput_location_0)
+{
+    vert_main();
+    stage_outputoutput_location_0 = output_location_0;
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    stage_output.output_location_2 = output_location_2;
+    stage_output.output_location_3 = output_location_3;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/asm/comp/block-name-alias-global.asm.comp
+++ b/reference/shaders-hlsl/asm/comp/block-name-alias-global.asm.comp
@@ -4,22 +4,16 @@ struct A
     int b;
 };
 
-struct A_1
-{
-    int a;
-    int b;
-};
-
 RWByteAddressBuffer C1 : register(u1);
 cbuffer C2 : register(b2)
 {
-    A_1 C2_1_Data[1024] : packoffset(c0);
+    A C2_1_Data[1024] : packoffset(c0);
 };
 
 RWByteAddressBuffer C3 : register(u0);
 cbuffer B : register(b3)
 {
-    A_1 C4_Data[1024] : packoffset(c0);
+    A C4_Data[1024] : packoffset(c0);
 };
 
 

--- a/reference/shaders-no-opt/asm/comp/aliased-struct-divergent-member-name.asm.comp
+++ b/reference/shaders-no-opt/asm/comp/aliased-struct-divergent-member-name.asm.comp
@@ -6,14 +6,9 @@ struct T
     float c;
 };
 
-struct T_1
-{
-    float b;
-};
-
 layout(binding = 0, std430) buffer SSBO1
 {
-    T_1 foo[];
+    T foo[];
 } _7;
 
 layout(binding = 1, std140) buffer SSBO2
@@ -24,7 +19,7 @@ layout(binding = 1, std140) buffer SSBO2
 void main()
 {
     T v = T(40.0);
-    _7.foo[10].b = v.c;
+    _7.foo[10].c = v.c;
     _10.bar[30].c = v.c;
 }
 

--- a/reference/shaders-no-opt/asm/vert/complex-link-by-name.asm.vert
+++ b/reference/shaders-no-opt/asm/vert/complex-link-by-name.asm.vert
@@ -1,0 +1,35 @@
+#version 450
+
+struct Struct_vec4
+{
+    vec4 m0;
+};
+
+layout(binding = 0, std140) uniform UBO
+{
+    Struct_vec4 m0;
+    Struct_vec4 m1;
+} ubo_binding_0;
+
+layout(location = 0) out VertexOut
+{
+    Struct_vec4 m0;
+    Struct_vec4 m1;
+} output_location_0;
+
+layout(location = 2) out Struct_vec4 output_location_2;
+layout(location = 3) out Struct_vec4 output_location_3;
+
+void main()
+{
+    Struct_vec4 c;
+    c.m0 = ubo_binding_0.m0.m0;
+    Struct_vec4 b;
+    b.m0 = ubo_binding_0.m1.m0;
+    gl_Position = c.m0 + b.m0;
+    output_location_0.m0 = c;
+    output_location_0.m1 = b;
+    output_location_2 = c;
+    output_location_3 = b;
+}
+

--- a/reference/shaders-no-opt/asm/vert/complex-link-by-name.force-flattened-io.legacy.asm.vert
+++ b/reference/shaders-no-opt/asm/vert/complex-link-by-name.force-flattened-io.legacy.asm.vert
@@ -1,0 +1,33 @@
+#version 100
+
+struct Struct_vec4
+{
+    vec4 m0;
+};
+
+struct UBO
+{
+    Struct_vec4 m0;
+    Struct_vec4 m1;
+};
+
+uniform UBO ubo_binding_0;
+
+varying vec4 output_location_0_m0_m0;
+varying vec4 output_location_0_m1_m0;
+varying vec4 output_location_2_m0;
+varying vec4 output_location_3_m0;
+
+void main()
+{
+    Struct_vec4 c;
+    c.m0 = ubo_binding_0.m0.m0;
+    Struct_vec4 b;
+    b.m0 = ubo_binding_0.m1.m0;
+    gl_Position = c.m0 + b.m0;
+    output_location_0_m0_m0 = c.m0;
+    output_location_0_m1_m0 = b.m0;
+    output_location_2_m0 = c.m0;
+    output_location_3_m0 = b.m0;
+}
+

--- a/reference/shaders-no-opt/comp/struct-packing-scalar.nocompat.invalid.vk.comp.vk
+++ b/reference/shaders-no-opt/comp/struct-packing-scalar.nocompat.invalid.vk.comp.vk
@@ -44,48 +44,6 @@ struct Content
     S4 m3s[8];
 };
 
-struct S0_1
-{
-    vec2 a[1];
-    float b;
-};
-
-struct S1_1
-{
-    vec3 a;
-    float b;
-};
-
-struct S2_1
-{
-    vec3 a[1];
-    float b;
-};
-
-struct S3_1
-{
-    vec2 a;
-    float b;
-};
-
-struct S4_1
-{
-    vec2 c;
-};
-
-struct Content_1
-{
-    S0_1 m0s[1];
-    S1_1 m1s[1];
-    S2_1 m2s[1];
-    S0_1 m0;
-    S1_1 m1;
-    S2_1 m2;
-    S3_1 m3;
-    float m4;
-    S4_1 m3s[8];
-};
-
 layout(set = 0, binding = 1, scalar) restrict buffer SSBO1
 {
     Content content;
@@ -104,9 +62,9 @@ layout(set = 0, binding = 1, scalar) restrict buffer SSBO1
 
 layout(set = 0, binding = 0, std140) restrict buffer SSBO0
 {
-    Content_1 content;
-    Content_1 content1[2];
-    Content_1 content2;
+    Content content;
+    Content content1[2];
+    Content content2;
     mat2 m0;
     mat2 m1;
     mat2x3 m2[4];

--- a/reference/shaders/asm/comp/block-name-alias-global.asm.comp
+++ b/reference/shaders/asm/comp/block-name-alias-global.asm.comp
@@ -7,12 +7,6 @@ struct A
     int b;
 };
 
-struct A_1
-{
-    int a;
-    int b;
-};
-
 layout(binding = 1, std430) buffer C1
 {
     A Data[];
@@ -20,7 +14,7 @@ layout(binding = 1, std430) buffer C1
 
 layout(binding = 2, std140) uniform C2
 {
-    A_1 Data[1024];
+    A Data[1024];
 } C2_1;
 
 layout(binding = 0, std430) buffer B
@@ -30,7 +24,7 @@ layout(binding = 0, std430) buffer B
 
 layout(binding = 3, std140) uniform B
 {
-    A_1 Data[1024];
+    A Data[1024];
 } C4;
 
 void main()

--- a/reference/shaders/comp/struct-packing.comp
+++ b/reference/shaders/comp/struct-packing.comp
@@ -43,48 +43,6 @@ struct Content
     S4 m3s[8];
 };
 
-struct S0_1
-{
-    vec2 a[1];
-    float b;
-};
-
-struct S1_1
-{
-    vec3 a;
-    float b;
-};
-
-struct S2_1
-{
-    vec3 a[1];
-    float b;
-};
-
-struct S3_1
-{
-    vec2 a;
-    float b;
-};
-
-struct S4_1
-{
-    vec2 c;
-};
-
-struct Content_1
-{
-    S0_1 m0s[1];
-    S1_1 m1s[1];
-    S2_1 m2s[1];
-    S0_1 m0;
-    S1_1 m1;
-    S2_1 m2;
-    S3_1 m3;
-    float m4;
-    S4_1 m3s[8];
-};
-
 layout(binding = 1, std430) restrict buffer SSBO1
 {
     Content content;
@@ -103,9 +61,9 @@ layout(binding = 1, std430) restrict buffer SSBO1
 
 layout(binding = 0, std140) restrict buffer SSBO0
 {
-    Content_1 content;
-    Content_1 content1[2];
-    Content_1 content2;
+    Content content;
+    Content content1[2];
+    Content content2;
     mat2 m0;
     mat2 m1;
     mat2x3 m2[4];

--- a/reference/shaders/desktop-only/comp/enhanced-layouts.comp
+++ b/reference/shaders/desktop-only/comp/enhanced-layouts.comp
@@ -8,13 +8,6 @@ struct Foo
     int c;
 };
 
-struct Foo_1
-{
-    int a;
-    int b;
-    int c;
-};
-
 layout(binding = 1, std140) buffer SSBO1
 {
     layout(offset = 4) int a;
@@ -27,7 +20,7 @@ layout(binding = 2, std430) buffer SSBO2
 {
     layout(offset = 4) int a;
     layout(offset = 8) int b;
-    layout(offset = 16) Foo_1 foo;
+    layout(offset = 16) Foo foo;
     layout(offset = 48) int c[8];
 } ssbo2;
 

--- a/reference/shaders/frag/struct-type-unrelated-alias.frag
+++ b/reference/shaders/frag/struct-type-unrelated-alias.frag
@@ -5,19 +5,14 @@ struct T
     float a;
 };
 
-struct T_1
-{
-    float b;
-};
-
 layout(location = 0) out float FragColor;
 
 void main()
 {
     T foo;
     foo.a = 10.0;
-    T_1 bar;
-    bar.b = 20.0;
-    FragColor = foo.a + bar.b;
+    T bar;
+    bar.a = 20.0;
+    FragColor = foo.a + bar.a;
 }
 

--- a/reference/shaders/frag/ubo_layout.frag
+++ b/reference/shaders/frag/ubo_layout.frag
@@ -7,11 +7,6 @@ struct Str
     mat4 foo;
 };
 
-struct Str_1
-{
-    mat4 foo;
-};
-
 layout(binding = 0, std140) uniform UBO1
 {
     layout(row_major) Str foo;
@@ -19,7 +14,7 @@ layout(binding = 0, std140) uniform UBO1
 
 layout(binding = 1, std140) uniform UBO2
 {
-    Str_1 foo;
+    Str foo;
 } ubo0;
 
 layout(location = 0) out vec4 FragColor;

--- a/shaders-hlsl-no-opt/asm/vert/complex-link-by-name.asm.vert
+++ b/shaders-hlsl-no-opt/asm/vert/complex-link-by-name.asm.vert
@@ -1,0 +1,119 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 59
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main" %_ %output_location_0 %output_location_2 %output_location_3
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %Foo "Struct_vec4"
+               OpMemberName %Foo 0 "m0"
+               OpName %c "c"
+               OpName %Foo_0 "Struct_vec4"
+               OpMemberName %Foo_0 0 "m0"
+               OpName %Bar "Struct_vec4"
+               OpMemberName %Bar 0 "m0"
+               OpName %UBO "UBO"
+               OpMemberName %UBO 0 "m0"
+               OpMemberName %UBO 1 "m1"
+               OpName %ubo_binding_0 "ubo_binding_0"
+               OpName %Bar_0 "Struct_vec4"
+               OpMemberName %Bar_0 0 "m0"
+               OpName %b "b"
+               OpName %gl_PerVertex "gl_PerVertex"
+               OpMemberName %gl_PerVertex 0 "gl_Position"
+               OpMemberName %gl_PerVertex 1 "gl_PointSize"
+               OpMemberName %gl_PerVertex 2 "gl_ClipDistance"
+               OpMemberName %gl_PerVertex 3 "gl_CullDistance"
+               OpName %_ ""
+               OpName %VertexOut "VertexOut"
+               OpMemberName %VertexOut 0 "m0"
+               OpMemberName %VertexOut 1 "m1"
+               OpName %output_location_0 "output_location_0"
+               OpName %output_location_2 "output_location_2"
+               OpName %output_location_3 "output_location_3"
+               OpMemberDecorate %Foo_0 0 Offset 0
+               OpMemberDecorate %Bar 0 Offset 0
+               OpMemberDecorate %UBO 0 Offset 0
+               OpMemberDecorate %UBO 1 Offset 16
+               OpDecorate %UBO Block
+               OpDecorate %ubo_binding_0 DescriptorSet 0
+               OpDecorate %ubo_binding_0 Binding 0
+               OpMemberDecorate %gl_PerVertex 0 BuiltIn Position
+               OpMemberDecorate %gl_PerVertex 1 BuiltIn PointSize
+               OpMemberDecorate %gl_PerVertex 2 BuiltIn ClipDistance
+               OpMemberDecorate %gl_PerVertex 3 BuiltIn CullDistance
+               OpDecorate %gl_PerVertex Block
+               OpDecorate %VertexOut Block
+               OpDecorate %output_location_0 Location 0
+               OpDecorate %output_location_2 Location 2
+               OpDecorate %output_location_3 Location 3
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+        %Foo = OpTypeStruct %v4float
+%_ptr_Function_Foo = OpTypePointer Function %Foo
+      %Foo_0 = OpTypeStruct %v4float
+        %Bar = OpTypeStruct %v4float
+        %UBO = OpTypeStruct %Foo_0 %Bar
+%_ptr_Uniform_UBO = OpTypePointer Uniform %UBO
+%ubo_binding_0 = OpVariable %_ptr_Uniform_UBO Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_Foo_0 = OpTypePointer Uniform %Foo_0
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+      %Bar_0 = OpTypeStruct %v4float
+%_ptr_Function_Bar_0 = OpTypePointer Function %Bar_0
+      %int_1 = OpConstant %int 1
+%_ptr_Uniform_Bar = OpTypePointer Uniform %Bar
+       %uint = OpTypeInt 32 0
+     %uint_1 = OpConstant %uint 1
+%_arr_float_uint_1 = OpTypeArray %float %uint_1
+%gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
+%_ptr_Output_gl_PerVertex = OpTypePointer Output %gl_PerVertex
+          %_ = OpVariable %_ptr_Output_gl_PerVertex Output
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %VertexOut = OpTypeStruct %Foo %Bar_0
+%_ptr_Output_VertexOut = OpTypePointer Output %VertexOut
+%output_location_0 = OpVariable %_ptr_Output_VertexOut Output
+%_ptr_Output_Foo = OpTypePointer Output %Foo
+%_ptr_Output_Bar_0 = OpTypePointer Output %Bar_0
+%output_location_2 = OpVariable %_ptr_Output_Foo Output
+%output_location_3 = OpVariable %_ptr_Output_Bar_0 Output
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %c = OpVariable %_ptr_Function_Foo Function
+          %b = OpVariable %_ptr_Function_Bar_0 Function
+         %19 = OpAccessChain %_ptr_Uniform_Foo_0 %ubo_binding_0 %int_0
+         %20 = OpLoad %Foo_0 %19
+         %21 = OpCompositeExtract %v4float %20 0
+         %23 = OpAccessChain %_ptr_Function_v4float %c %int_0
+               OpStore %23 %21
+         %29 = OpAccessChain %_ptr_Uniform_Bar %ubo_binding_0 %int_1
+         %30 = OpLoad %Bar %29
+         %31 = OpCompositeExtract %v4float %30 0
+         %32 = OpAccessChain %_ptr_Function_v4float %b %int_0
+               OpStore %32 %31
+         %39 = OpAccessChain %_ptr_Function_v4float %c %int_0
+         %40 = OpLoad %v4float %39
+         %41 = OpAccessChain %_ptr_Function_v4float %b %int_0
+         %42 = OpLoad %v4float %41
+         %43 = OpFAdd %v4float %40 %42
+         %45 = OpAccessChain %_ptr_Output_v4float %_ %int_0
+               OpStore %45 %43
+         %49 = OpLoad %Foo %c
+         %51 = OpAccessChain %_ptr_Output_Foo %output_location_0 %int_0
+               OpStore %51 %49
+         %52 = OpLoad %Bar_0 %b
+         %54 = OpAccessChain %_ptr_Output_Bar_0 %output_location_0 %int_1
+               OpStore %54 %52
+         %56 = OpLoad %Foo %c
+               OpStore %output_location_2 %56
+         %58 = OpLoad %Bar_0 %b
+               OpStore %output_location_3 %58
+               OpReturn
+               OpFunctionEnd

--- a/shaders-no-opt/asm/vert/complex-link-by-name.asm.vert
+++ b/shaders-no-opt/asm/vert/complex-link-by-name.asm.vert
@@ -1,0 +1,119 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 59
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main" %_ %output_location_0 %output_location_2 %output_location_3
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %Foo "Struct_vec4"
+               OpMemberName %Foo 0 "m0"
+               OpName %c "c"
+               OpName %Foo_0 "Struct_vec4"
+               OpMemberName %Foo_0 0 "m0"
+               OpName %Bar "Struct_vec4"
+               OpMemberName %Bar 0 "m0"
+               OpName %UBO "UBO"
+               OpMemberName %UBO 0 "m0"
+               OpMemberName %UBO 1 "m1"
+               OpName %ubo_binding_0 "ubo_binding_0"
+               OpName %Bar_0 "Struct_vec4"
+               OpMemberName %Bar_0 0 "m0"
+               OpName %b "b"
+               OpName %gl_PerVertex "gl_PerVertex"
+               OpMemberName %gl_PerVertex 0 "gl_Position"
+               OpMemberName %gl_PerVertex 1 "gl_PointSize"
+               OpMemberName %gl_PerVertex 2 "gl_ClipDistance"
+               OpMemberName %gl_PerVertex 3 "gl_CullDistance"
+               OpName %_ ""
+               OpName %VertexOut "VertexOut"
+               OpMemberName %VertexOut 0 "m0"
+               OpMemberName %VertexOut 1 "m1"
+               OpName %output_location_0 "output_location_0"
+               OpName %output_location_2 "output_location_2"
+               OpName %output_location_3 "output_location_3"
+               OpMemberDecorate %Foo_0 0 Offset 0
+               OpMemberDecorate %Bar 0 Offset 0
+               OpMemberDecorate %UBO 0 Offset 0
+               OpMemberDecorate %UBO 1 Offset 16
+               OpDecorate %UBO Block
+               OpDecorate %ubo_binding_0 DescriptorSet 0
+               OpDecorate %ubo_binding_0 Binding 0
+               OpMemberDecorate %gl_PerVertex 0 BuiltIn Position
+               OpMemberDecorate %gl_PerVertex 1 BuiltIn PointSize
+               OpMemberDecorate %gl_PerVertex 2 BuiltIn ClipDistance
+               OpMemberDecorate %gl_PerVertex 3 BuiltIn CullDistance
+               OpDecorate %gl_PerVertex Block
+               OpDecorate %VertexOut Block
+               OpDecorate %output_location_0 Location 0
+               OpDecorate %output_location_2 Location 2
+               OpDecorate %output_location_3 Location 3
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+        %Foo = OpTypeStruct %v4float
+%_ptr_Function_Foo = OpTypePointer Function %Foo
+      %Foo_0 = OpTypeStruct %v4float
+        %Bar = OpTypeStruct %v4float
+        %UBO = OpTypeStruct %Foo_0 %Bar
+%_ptr_Uniform_UBO = OpTypePointer Uniform %UBO
+%ubo_binding_0 = OpVariable %_ptr_Uniform_UBO Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_Foo_0 = OpTypePointer Uniform %Foo_0
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+      %Bar_0 = OpTypeStruct %v4float
+%_ptr_Function_Bar_0 = OpTypePointer Function %Bar_0
+      %int_1 = OpConstant %int 1
+%_ptr_Uniform_Bar = OpTypePointer Uniform %Bar
+       %uint = OpTypeInt 32 0
+     %uint_1 = OpConstant %uint 1
+%_arr_float_uint_1 = OpTypeArray %float %uint_1
+%gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
+%_ptr_Output_gl_PerVertex = OpTypePointer Output %gl_PerVertex
+          %_ = OpVariable %_ptr_Output_gl_PerVertex Output
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %VertexOut = OpTypeStruct %Foo %Bar_0
+%_ptr_Output_VertexOut = OpTypePointer Output %VertexOut
+%output_location_0 = OpVariable %_ptr_Output_VertexOut Output
+%_ptr_Output_Foo = OpTypePointer Output %Foo
+%_ptr_Output_Bar_0 = OpTypePointer Output %Bar_0
+%output_location_2 = OpVariable %_ptr_Output_Foo Output
+%output_location_3 = OpVariable %_ptr_Output_Bar_0 Output
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %c = OpVariable %_ptr_Function_Foo Function
+          %b = OpVariable %_ptr_Function_Bar_0 Function
+         %19 = OpAccessChain %_ptr_Uniform_Foo_0 %ubo_binding_0 %int_0
+         %20 = OpLoad %Foo_0 %19
+         %21 = OpCompositeExtract %v4float %20 0
+         %23 = OpAccessChain %_ptr_Function_v4float %c %int_0
+               OpStore %23 %21
+         %29 = OpAccessChain %_ptr_Uniform_Bar %ubo_binding_0 %int_1
+         %30 = OpLoad %Bar %29
+         %31 = OpCompositeExtract %v4float %30 0
+         %32 = OpAccessChain %_ptr_Function_v4float %b %int_0
+               OpStore %32 %31
+         %39 = OpAccessChain %_ptr_Function_v4float %c %int_0
+         %40 = OpLoad %v4float %39
+         %41 = OpAccessChain %_ptr_Function_v4float %b %int_0
+         %42 = OpLoad %v4float %41
+         %43 = OpFAdd %v4float %40 %42
+         %45 = OpAccessChain %_ptr_Output_v4float %_ %int_0
+               OpStore %45 %43
+         %49 = OpLoad %Foo %c
+         %51 = OpAccessChain %_ptr_Output_Foo %output_location_0 %int_0
+               OpStore %51 %49
+         %52 = OpLoad %Bar_0 %b
+         %54 = OpAccessChain %_ptr_Output_Bar_0 %output_location_0 %int_1
+               OpStore %54 %52
+         %56 = OpLoad %Foo %c
+               OpStore %output_location_2 %56
+         %58 = OpLoad %Bar_0 %b
+               OpStore %output_location_3 %58
+               OpReturn
+               OpFunctionEnd

--- a/shaders-no-opt/asm/vert/complex-link-by-name.force-flattened-io.legacy.asm.vert
+++ b/shaders-no-opt/asm/vert/complex-link-by-name.force-flattened-io.legacy.asm.vert
@@ -1,0 +1,119 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 59
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main" %_ %output_location_0 %output_location_2 %output_location_3
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %Foo "Struct_vec4"
+               OpMemberName %Foo 0 "m0"
+               OpName %c "c"
+               OpName %Foo_0 "Struct_vec4"
+               OpMemberName %Foo_0 0 "m0"
+               OpName %Bar "Struct_vec4"
+               OpMemberName %Bar 0 "m0"
+               OpName %UBO "UBO"
+               OpMemberName %UBO 0 "m0"
+               OpMemberName %UBO 1 "m1"
+               OpName %ubo_binding_0 "ubo_binding_0"
+               OpName %Bar_0 "Struct_vec4"
+               OpMemberName %Bar_0 0 "m0"
+               OpName %b "b"
+               OpName %gl_PerVertex "gl_PerVertex"
+               OpMemberName %gl_PerVertex 0 "gl_Position"
+               OpMemberName %gl_PerVertex 1 "gl_PointSize"
+               OpMemberName %gl_PerVertex 2 "gl_ClipDistance"
+               OpMemberName %gl_PerVertex 3 "gl_CullDistance"
+               OpName %_ ""
+               OpName %VertexOut "VertexOut"
+               OpMemberName %VertexOut 0 "m0"
+               OpMemberName %VertexOut 1 "m1"
+               OpName %output_location_0 "output_location_0"
+               OpName %output_location_2 "output_location_2"
+               OpName %output_location_3 "output_location_3"
+               OpMemberDecorate %Foo_0 0 Offset 0
+               OpMemberDecorate %Bar 0 Offset 0
+               OpMemberDecorate %UBO 0 Offset 0
+               OpMemberDecorate %UBO 1 Offset 16
+               OpDecorate %UBO Block
+               OpDecorate %ubo_binding_0 DescriptorSet 0
+               OpDecorate %ubo_binding_0 Binding 0
+               OpMemberDecorate %gl_PerVertex 0 BuiltIn Position
+               OpMemberDecorate %gl_PerVertex 1 BuiltIn PointSize
+               OpMemberDecorate %gl_PerVertex 2 BuiltIn ClipDistance
+               OpMemberDecorate %gl_PerVertex 3 BuiltIn CullDistance
+               OpDecorate %gl_PerVertex Block
+               OpDecorate %VertexOut Block
+               OpDecorate %output_location_0 Location 0
+               OpDecorate %output_location_2 Location 2
+               OpDecorate %output_location_3 Location 3
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+        %Foo = OpTypeStruct %v4float
+%_ptr_Function_Foo = OpTypePointer Function %Foo
+      %Foo_0 = OpTypeStruct %v4float
+        %Bar = OpTypeStruct %v4float
+        %UBO = OpTypeStruct %Foo_0 %Bar
+%_ptr_Uniform_UBO = OpTypePointer Uniform %UBO
+%ubo_binding_0 = OpVariable %_ptr_Uniform_UBO Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_Foo_0 = OpTypePointer Uniform %Foo_0
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+      %Bar_0 = OpTypeStruct %v4float
+%_ptr_Function_Bar_0 = OpTypePointer Function %Bar_0
+      %int_1 = OpConstant %int 1
+%_ptr_Uniform_Bar = OpTypePointer Uniform %Bar
+       %uint = OpTypeInt 32 0
+     %uint_1 = OpConstant %uint 1
+%_arr_float_uint_1 = OpTypeArray %float %uint_1
+%gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
+%_ptr_Output_gl_PerVertex = OpTypePointer Output %gl_PerVertex
+          %_ = OpVariable %_ptr_Output_gl_PerVertex Output
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %VertexOut = OpTypeStruct %Foo %Bar_0
+%_ptr_Output_VertexOut = OpTypePointer Output %VertexOut
+%output_location_0 = OpVariable %_ptr_Output_VertexOut Output
+%_ptr_Output_Foo = OpTypePointer Output %Foo
+%_ptr_Output_Bar_0 = OpTypePointer Output %Bar_0
+%output_location_2 = OpVariable %_ptr_Output_Foo Output
+%output_location_3 = OpVariable %_ptr_Output_Bar_0 Output
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %c = OpVariable %_ptr_Function_Foo Function
+          %b = OpVariable %_ptr_Function_Bar_0 Function
+         %19 = OpAccessChain %_ptr_Uniform_Foo_0 %ubo_binding_0 %int_0
+         %20 = OpLoad %Foo_0 %19
+         %21 = OpCompositeExtract %v4float %20 0
+         %23 = OpAccessChain %_ptr_Function_v4float %c %int_0
+               OpStore %23 %21
+         %29 = OpAccessChain %_ptr_Uniform_Bar %ubo_binding_0 %int_1
+         %30 = OpLoad %Bar %29
+         %31 = OpCompositeExtract %v4float %30 0
+         %32 = OpAccessChain %_ptr_Function_v4float %b %int_0
+               OpStore %32 %31
+         %39 = OpAccessChain %_ptr_Function_v4float %c %int_0
+         %40 = OpLoad %v4float %39
+         %41 = OpAccessChain %_ptr_Function_v4float %b %int_0
+         %42 = OpLoad %v4float %41
+         %43 = OpFAdd %v4float %40 %42
+         %45 = OpAccessChain %_ptr_Output_v4float %_ %int_0
+               OpStore %45 %43
+         %49 = OpLoad %Foo %c
+         %51 = OpAccessChain %_ptr_Output_Foo %output_location_0 %int_0
+               OpStore %51 %49
+         %52 = OpLoad %Bar_0 %b
+         %54 = OpAccessChain %_ptr_Output_Bar_0 %output_location_0 %int_1
+               OpStore %54 %52
+         %56 = OpLoad %Foo %c
+               OpStore %output_location_2 %56
+         %58 = OpLoad %Bar_0 %b
+               OpStore %output_location_3 %58
+               OpReturn
+               OpFunctionEnd

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -14071,15 +14071,15 @@ void CompilerGLSL::fixup_type_alias()
 	// FIXME: Multiple alias types which are both block-like will be awkward, for now, it's best to just drop the type
 	// alias if the slave type is a block type.
 	ir.for_each_typed_id<SPIRType>([&](uint32_t self, SPIRType &type) {
-		if (type.type_alias && type_is_block_like(type))
+		if (type.type_alias && type_is_block_like(type) && type.self == ID(self))
 		{
 			// Become the master.
 			ir.for_each_typed_id<SPIRType>([&](uint32_t other_id, SPIRType &other_type) {
-				if (other_id == type.self)
+				if (other_id == self)
 					return;
 
 				if (other_type.type_alias == type.type_alias)
-					other_type.type_alias = type.self;
+					other_type.type_alias = self;
 			});
 
 			this->get<SPIRType>(type.type_alias).type_alias = self;

--- a/spirv_reflect.cpp
+++ b/spirv_reflect.cpp
@@ -267,7 +267,6 @@ string CompilerReflection::compile()
 	json_stream = std::make_shared<simple_json::Stream>();
 	json_stream->set_current_locale_radix_character(current_locale_radix_character);
 	json_stream->begin_json_object();
-	fixup_type_alias();
 	reorder_type_alias();
 	emit_entry_points();
 	emit_types();
@@ -326,9 +325,6 @@ void CompilerReflection::emit_type(uint32_t type_id, bool &emitted_open_tag)
 {
 	auto &type = get<SPIRType>(type_id);
 	auto name = type_to_glsl(type);
-
-	if (type.type_alias != TypeID(0))
-		return;
 
 	if (!emitted_open_tag)
 	{


### PR DESCRIPTION
Fixes some issues which now allows the same struct type to be declared as just one struct in all cases, not just buffer block / value type aliasing cases. This makes it far easier to link GLSL shaders by name, since type names and member names need to match up exactly.

Fix #1408.