### PR TITLE
HLSL: Fix FragCoord.w.

### DIFF
--- a/reference/opt/shaders-hlsl/asm/frag/single-function-private-lut.asm.frag
+++ b/reference/opt/shaders-hlsl/asm/frag/single-function-private-lut.asm.frag
@@ -55,6 +55,7 @@ void frag_main()
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     frag_main();
     SPIRV_Cross_Output stage_output;
     stage_output.o_color = o_color;

--- a/reference/opt/shaders-hlsl/asm/frag/texel-fetch-no-lod.asm.frag
+++ b/reference/opt/shaders-hlsl/asm/frag/texel-fetch-no-lod.asm.frag
@@ -22,6 +22,7 @@ void frag_main()
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     frag_main();
     SPIRV_Cross_Output stage_output;
     stage_output.FragColor = FragColor;

--- a/reference/opt/shaders-hlsl/frag/builtins.frag
+++ b/reference/opt/shaders-hlsl/frag/builtins.frag
@@ -24,6 +24,7 @@ void frag_main()
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     vColor = stage_input.vColor;
     frag_main();
     SPIRV_Cross_Output stage_output;

--- a/reference/opt/shaders-hlsl/frag/complex-expression-in-access-chain.frag
+++ b/reference/opt/shaders-hlsl/frag/complex-expression-in-access-chain.frag
@@ -28,6 +28,7 @@ void frag_main()
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     vIn = stage_input.vIn;
     vIn2 = stage_input.vIn2;
     frag_main();

--- a/reference/opt/shaders-hlsl/frag/input-attachment-ms.frag
+++ b/reference/opt/shaders-hlsl/frag/input-attachment-ms.frag
@@ -24,6 +24,7 @@ void frag_main()
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     gl_SampleID = stage_input.gl_SampleID;
     frag_main();
     SPIRV_Cross_Output stage_output;

--- a/reference/opt/shaders-hlsl/frag/sampler-array.frag
+++ b/reference/opt/shaders-hlsl/frag/sampler-array.frag
@@ -24,6 +24,7 @@ void frag_main()
 void main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     vTex = stage_input.vTex;
     vIndex = stage_input.vIndex;
     frag_main();

--- a/reference/opt/shaders-hlsl/frag/tex-sampling-ms.frag
+++ b/reference/opt/shaders-hlsl/frag/tex-sampling-ms.frag
@@ -26,6 +26,7 @@ void frag_main()
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     frag_main();
     SPIRV_Cross_Output stage_output;
     stage_output.FragColor = FragColor;

--- a/reference/opt/shaders-hlsl/frag/texel-fetch-offset.frag
+++ b/reference/opt/shaders-hlsl/frag/texel-fetch-offset.frag
@@ -24,6 +24,7 @@ void frag_main()
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     frag_main();
     SPIRV_Cross_Output stage_output;
     stage_output.FragColor = FragColor;

--- a/reference/shaders-hlsl-no-opt/asm/frag/pixel-interlock-callstack.sm51.fxconly.asm.frag
+++ b/reference/shaders-hlsl-no-opt/asm/frag/pixel-interlock-callstack.sm51.fxconly.asm.frag
@@ -28,5 +28,6 @@ void frag_main()
 void main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     frag_main();
 }

--- a/reference/shaders-hlsl-no-opt/asm/frag/pixel-interlock-control-flow.sm51.fxconly.asm.frag
+++ b/reference/shaders-hlsl-no-opt/asm/frag/pixel-interlock-control-flow.sm51.fxconly.asm.frag
@@ -38,5 +38,6 @@ void frag_main()
 void main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     frag_main();
 }

--- a/reference/shaders-hlsl-no-opt/asm/frag/pixel-interlock-split-functions.sm51.fxconly.asm.frag
+++ b/reference/shaders-hlsl-no-opt/asm/frag/pixel-interlock-split-functions.sm51.fxconly.asm.frag
@@ -38,5 +38,6 @@ void frag_main()
 void main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     frag_main();
 }

--- a/reference/shaders-hlsl-no-opt/frag/frag-coord.frag
+++ b/reference/shaders-hlsl-no-opt/frag/frag-coord.frag
@@ -1,8 +1,5 @@
-Texture2D<float4> uSubpass0 : register(t0);
-Texture2D<float4> uSubpass1 : register(t1);
-
 static float4 gl_FragCoord;
-static float4 FragColor;
+static float3 FragColor;
 
 struct SPIRV_Cross_Input
 {
@@ -11,12 +8,12 @@ struct SPIRV_Cross_Input
 
 struct SPIRV_Cross_Output
 {
-    float4 FragColor : SV_Target0;
+    float3 FragColor : SV_Target0;
 };
 
 void frag_main()
 {
-    FragColor = uSubpass0.Load(int3(int2(gl_FragCoord.xy), 0)) + uSubpass1.Load(int3(int2(gl_FragCoord.xy), 0));
+    FragColor = gl_FragCoord.xyz / gl_FragCoord.w.xxx;
 }
 
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)

--- a/reference/shaders-hlsl-no-opt/frag/native-16bit-types.fxconly.nofxc.sm62.native-16bit.frag
+++ b/reference/shaders-hlsl-no-opt/frag/native-16bit-types.fxconly.nofxc.sm62.native-16bit.frag
@@ -66,6 +66,7 @@ void frag_main()
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     Input = stage_input.Input;
     InputI = stage_input.InputI;
     InputU = stage_input.InputU;

--- a/reference/shaders-hlsl-no-opt/frag/pixel-interlock-simple-callstack.sm51.fxconly.frag
+++ b/reference/shaders-hlsl-no-opt/frag/pixel-interlock-simple-callstack.sm51.fxconly.frag
@@ -28,5 +28,6 @@ void frag_main()
 void main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     frag_main();
 }

--- a/reference/shaders-hlsl/asm/frag/single-function-private-lut.asm.frag
+++ b/reference/shaders-hlsl/asm/frag/single-function-private-lut.asm.frag
@@ -58,6 +58,7 @@ void frag_main()
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     frag_main();
     SPIRV_Cross_Output stage_output;
     stage_output.o_color = o_color;

--- a/reference/shaders-hlsl/asm/frag/texel-fetch-no-lod.asm.frag
+++ b/reference/shaders-hlsl/asm/frag/texel-fetch-no-lod.asm.frag
@@ -22,6 +22,7 @@ void frag_main()
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     frag_main();
     SPIRV_Cross_Output stage_output;
     stage_output.FragColor = FragColor;

--- a/reference/shaders-hlsl/frag/builtins.frag
+++ b/reference/shaders-hlsl/frag/builtins.frag
@@ -24,6 +24,7 @@ void frag_main()
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     vColor = stage_input.vColor;
     frag_main();
     SPIRV_Cross_Output stage_output;

--- a/reference/shaders-hlsl/frag/complex-expression-in-access-chain.frag
+++ b/reference/shaders-hlsl/frag/complex-expression-in-access-chain.frag
@@ -31,6 +31,7 @@ void frag_main()
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     vIn = stage_input.vIn;
     vIn2 = stage_input.vIn2;
     frag_main();

--- a/reference/shaders-hlsl/frag/input-attachment-ms.frag
+++ b/reference/shaders-hlsl/frag/input-attachment-ms.frag
@@ -30,6 +30,7 @@ void frag_main()
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     gl_SampleID = stage_input.gl_SampleID;
     frag_main();
     SPIRV_Cross_Output stage_output;

--- a/reference/shaders-hlsl/frag/input-attachment.frag
+++ b/reference/shaders-hlsl/frag/input-attachment.frag
@@ -27,6 +27,7 @@ void frag_main()
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     frag_main();
     SPIRV_Cross_Output stage_output;
     stage_output.FragColor = FragColor;

--- a/reference/shaders-hlsl/frag/sampler-array.frag
+++ b/reference/shaders-hlsl/frag/sampler-array.frag
@@ -38,6 +38,7 @@ void frag_main()
 void main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     vTex = stage_input.vTex;
     vIndex = stage_input.vIndex;
     frag_main();

--- a/reference/shaders-hlsl/frag/tex-sampling-ms.frag
+++ b/reference/shaders-hlsl/frag/tex-sampling-ms.frag
@@ -25,6 +25,7 @@ void frag_main()
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     frag_main();
     SPIRV_Cross_Output stage_output;
     stage_output.FragColor = FragColor;

--- a/reference/shaders-hlsl/frag/texel-fetch-offset.frag
+++ b/reference/shaders-hlsl/frag/texel-fetch-offset.frag
@@ -23,6 +23,7 @@ void frag_main()
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
     gl_FragCoord = stage_input.gl_FragCoord;
+    gl_FragCoord.w = 1.0 / gl_FragCoord.w;
     frag_main();
     SPIRV_Cross_Output stage_output;
     stage_output.FragColor = FragColor;

--- a/shaders-hlsl-no-opt/frag/frag-coord.frag
+++ b/shaders-hlsl-no-opt/frag/frag-coord.frag
@@ -1,0 +1,8 @@
+#version 450
+
+layout(location = 0) out vec3 FragColor;
+
+void main()
+{
+	FragColor = gl_FragCoord.xyz / gl_FragCoord.w;
+}

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -2396,7 +2396,11 @@ void CompilerHLSL::emit_hlsl_entry_point()
 			if (legacy)
 				statement(builtin, " = stage_input.", builtin, " + float4(0.5f, 0.5f, 0.0f, 0.0f);");
 			else
+			{
 				statement(builtin, " = stage_input.", builtin, ";");
+				// ZW are undefined in D3D9, only do this fixup here.
+				statement(builtin, ".w = 1.0 / ", builtin, ".w;");
+			}
 			break;
 
 		case BuiltInVertexId:


### PR DESCRIPTION
Need to invert it, SM 4.0+ uses W, not 1/W (like Vulkan/GL).

Fix #1443.