### PR TITLE
MSL: Fix multiview view index calculation with a non-zero base instance.

### DIFF
--- a/reference/opt/shaders-msl/vulkan/vert/multiview.multiview.nocompat.vk.vert
+++ b/reference/opt/shaders-msl/vulkan/vert/multiview.multiview.nocompat.vk.vert
@@ -19,11 +19,11 @@ struct main0_in
     float4 Position [[attribute(0)]];
 };
 
-vertex main0_out main0(main0_in in [[stage_in]], constant uint* spvViewMask [[buffer(24)]], constant MVPs& _19 [[buffer(0)]], uint gl_InstanceIndex [[instance_id]])
+vertex main0_out main0(main0_in in [[stage_in]], constant uint* spvViewMask [[buffer(24)]], constant MVPs& _19 [[buffer(0)]], uint gl_InstanceIndex [[instance_id]], uint gl_BaseInstance [[base_instance]])
 {
     main0_out out = {};
-    uint gl_ViewIndex = spvViewMask[0] + gl_InstanceIndex % spvViewMask[1];
-    gl_InstanceIndex /= spvViewMask[1];
+    uint gl_ViewIndex = spvViewMask[0] + (gl_InstanceIndex - gl_BaseInstance) % spvViewMask[1];
+    gl_InstanceIndex = (gl_InstanceIndex - gl_BaseInstance) / spvViewMask[1] + gl_BaseInstance;
     out.gl_Position = _19.MVP[int(gl_ViewIndex)] * in.Position;
     out.gl_Layer = gl_ViewIndex - spvViewMask[0];
     return out;

--- a/reference/opt/shaders-msl/vulkan/vert/multiview.nocompat.vk.vert
+++ b/reference/opt/shaders-msl/vulkan/vert/multiview.nocompat.vk.vert
@@ -19,7 +19,7 @@ struct main0_in
     float4 Position [[attribute(0)]];
 };
 
-vertex main0_out main0(main0_in in [[stage_in]], constant MVPs& _19 [[buffer(0)]], uint gl_InstanceIndex [[instance_id]])
+vertex main0_out main0(main0_in in [[stage_in]], constant MVPs& _19 [[buffer(0)]], uint gl_InstanceIndex [[instance_id]], uint gl_BaseInstance [[base_instance]])
 {
     main0_out out = {};
     const uint gl_ViewIndex = 0;

--- a/reference/shaders-msl/vulkan/vert/multiview.multiview.nocompat.vk.vert
+++ b/reference/shaders-msl/vulkan/vert/multiview.multiview.nocompat.vk.vert
@@ -19,11 +19,11 @@ struct main0_in
     float4 Position [[attribute(0)]];
 };
 
-vertex main0_out main0(main0_in in [[stage_in]], constant uint* spvViewMask [[buffer(24)]], constant MVPs& _19 [[buffer(0)]], uint gl_InstanceIndex [[instance_id]])
+vertex main0_out main0(main0_in in [[stage_in]], constant uint* spvViewMask [[buffer(24)]], constant MVPs& _19 [[buffer(0)]], uint gl_InstanceIndex [[instance_id]], uint gl_BaseInstance [[base_instance]])
 {
     main0_out out = {};
-    uint gl_ViewIndex = spvViewMask[0] + gl_InstanceIndex % spvViewMask[1];
-    gl_InstanceIndex /= spvViewMask[1];
+    uint gl_ViewIndex = spvViewMask[0] + (gl_InstanceIndex - gl_BaseInstance) % spvViewMask[1];
+    gl_InstanceIndex = (gl_InstanceIndex - gl_BaseInstance) / spvViewMask[1] + gl_BaseInstance;
     out.gl_Position = _19.MVP[int(gl_ViewIndex)] * in.Position;
     out.gl_Layer = gl_ViewIndex - spvViewMask[0];
     return out;

--- a/reference/shaders-msl/vulkan/vert/multiview.nocompat.vk.vert
+++ b/reference/shaders-msl/vulkan/vert/multiview.nocompat.vk.vert
@@ -19,7 +19,7 @@ struct main0_in
     float4 Position [[attribute(0)]];
 };
 
-vertex main0_out main0(main0_in in [[stage_in]], constant MVPs& _19 [[buffer(0)]], uint gl_InstanceIndex [[instance_id]])
+vertex main0_out main0(main0_in in [[stage_in]], constant MVPs& _19 [[buffer(0)]], uint gl_InstanceIndex [[instance_id]], uint gl_BaseInstance [[base_instance]])
 {
     main0_out out = {};
     const uint gl_ViewIndex = 0;


### PR DESCRIPTION
Account for a non-zero base instance when calculating the view index and
the "real" instance index. Before, it was likely broken with a non-zero
base instance, since the calculated instance index could be less than
the base instance.