### PR TITLE
MSL: Support layered input attachments.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,7 +323,7 @@ if (SPIRV_CROSS_STATIC)
 endif()
 
 set(spirv-cross-abi-major 0)
-set(spirv-cross-abi-minor 38)
+set(spirv-cross-abi-minor 39)
 set(spirv-cross-abi-patch 0)
 
 if (SPIRV_CROSS_SHARED)

--- a/main.cpp
+++ b/main.cpp
@@ -562,6 +562,7 @@ struct CLIArguments
 	bool msl_multi_patch_workgroup = false;
 	bool msl_vertex_for_tessellation = false;
 	uint32_t msl_additional_fixed_sample_mask = 0xffffffff;
+	bool msl_arrayed_subpass_input = false;
 	bool glsl_emit_push_constant_as_ubo = false;
 	bool glsl_emit_ubo_as_plain_uniforms = false;
 	bool glsl_force_flattened_io_blocks = false;
@@ -765,7 +766,9 @@ static void print_help_msl()
 	                "\t[--msl-vertex-for-tessellation]:\n\t\tWhen handling a vertex shader, marks it as one that will be used with a new-style tessellation control shader.\n"
 					"\t\tThe vertex shader is output to MSL as a compute kernel which outputs vertices to the buffer in the order they are received, rather than in index order as with --msl-capture-output normally.\n"
 	                "\t[--msl-additional-fixed-sample-mask <mask>]:\n"
-	                "\t\tSet an additional fixed sample mask. If the shader outputs a sample mask, then the final sample mask will be a bitwise AND of the two.\n");
+	                "\t\tSet an additional fixed sample mask. If the shader outputs a sample mask, then the final sample mask will be a bitwise AND of the two.\n"
+	                "\t[--msl-arrayed-subpass-input]:\n\t\tAssume that images of dimension SubpassData have multiple layers. Layered input attachments are accessed relative to BuiltInLayer.\n"
+	                "\t\tThis option has no effect if multiview is also enabled.\n");
 	// clang-format on
 }
 
@@ -1003,6 +1006,7 @@ static string compile_iteration(const CLIArguments &args, std::vector<uint32_t> 
 		msl_opts.multi_patch_workgroup = args.msl_multi_patch_workgroup;
 		msl_opts.vertex_for_tessellation = args.msl_vertex_for_tessellation;
 		msl_opts.additional_fixed_sample_mask = args.msl_additional_fixed_sample_mask;
+		msl_opts.arrayed_subpass_input = args.msl_arrayed_subpass_input;
 		msl_comp->set_msl_options(msl_opts);
 		for (auto &v : args.msl_discrete_descriptor_sets)
 			msl_comp->add_discrete_descriptor_set(v);
@@ -1422,6 +1426,7 @@ static int main_inner(int argc, char *argv[])
 	cbs.add("--msl-vertex-for-tessellation", [&args](CLIParser &) { args.msl_vertex_for_tessellation = true; });
 	cbs.add("--msl-additional-fixed-sample-mask",
 	        [&args](CLIParser &parser) { args.msl_additional_fixed_sample_mask = parser.next_hex_uint(); });
+	cbs.add("--msl-arrayed-subpass-input", [&args](CLIParser &) { args.msl_arrayed_subpass_input = true; });
 	cbs.add("--extension", [&args](CLIParser &parser) { args.extensions.push_back(parser.next_string()); });
 	cbs.add("--rename-entry-point", [&args](CLIParser &parser) {
 		auto old_name = parser.next_string();

--- a/reference/opt/shaders-msl/frag/input-attachment-ms.arrayed-subpass.msl21.frag
+++ b/reference/opt/shaders-msl/frag/input-attachment-ms.arrayed-subpass.msl21.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(texture2d_ms_array<float> uSubpass0 [[texture(0)]], texture2d_ms_array<float> uSubpass1 [[texture(1)]], uint gl_SampleID [[sample_id]], float4 gl_FragCoord [[position]], uint gl_Layer [[render_target_array_index]])
+{
+    main0_out out = {};
+    out.FragColor = (uSubpass0.read(uint2(gl_FragCoord.xy), gl_Layer, 1) + uSubpass1.read(uint2(gl_FragCoord.xy), gl_Layer, 2)) + uSubpass0.read(uint2(gl_FragCoord.xy), gl_Layer, gl_SampleID);
+    return out;
+}
+

--- a/reference/opt/shaders-msl/frag/input-attachment-ms.multiview.msl21.frag
+++ b/reference/opt/shaders-msl/frag/input-attachment-ms.multiview.msl21.frag
@@ -1,0 +1,18 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(constant uint* spvViewMask [[buffer(24)]], texture2d_ms_array<float> uSubpass0 [[texture(0)]], texture2d_ms_array<float> uSubpass1 [[texture(1)]], uint gl_SampleID [[sample_id]], float4 gl_FragCoord [[position]], uint gl_ViewIndex [[render_target_array_index]])
+{
+    main0_out out = {};
+    gl_ViewIndex += spvViewMask[0];
+    out.FragColor = (uSubpass0.read(uint2(gl_FragCoord.xy), gl_ViewIndex, 1) + uSubpass1.read(uint2(gl_FragCoord.xy), gl_ViewIndex, 2)) + uSubpass0.read(uint2(gl_FragCoord.xy), gl_ViewIndex, gl_SampleID);
+    return out;
+}
+

--- a/reference/opt/shaders-msl/frag/input-attachment.arrayed-subpass.frag
+++ b/reference/opt/shaders-msl/frag/input-attachment.arrayed-subpass.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(texture2d_array<float> uSubpass0 [[texture(0)]], texture2d_array<float> uSubpass1 [[texture(1)]], float4 gl_FragCoord [[position]], uint gl_Layer [[render_target_array_index]])
+{
+    main0_out out = {};
+    out.FragColor = uSubpass0.read(uint2(gl_FragCoord.xy), gl_Layer) + uSubpass1.read(uint2(gl_FragCoord.xy), gl_Layer);
+    return out;
+}
+

--- a/reference/opt/shaders-msl/frag/input-attachment.frag
+++ b/reference/opt/shaders-msl/frag/input-attachment.frag
@@ -11,7 +11,7 @@ struct main0_out
 fragment main0_out main0(texture2d<float> uSubpass0 [[texture(0)]], texture2d<float> uSubpass1 [[texture(1)]], float4 gl_FragCoord [[position]])
 {
     main0_out out = {};
-    out.FragColor = uSubpass0.read(uint2(gl_FragCoord.xy), 0) + uSubpass1.read(uint2(gl_FragCoord.xy), 0);
+    out.FragColor = uSubpass0.read(uint2(gl_FragCoord.xy)) + uSubpass1.read(uint2(gl_FragCoord.xy));
     return out;
 }
 

--- a/reference/opt/shaders-msl/frag/input-attachment.multiview.frag
+++ b/reference/opt/shaders-msl/frag/input-attachment.multiview.frag
@@ -1,0 +1,18 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(constant uint* spvViewMask [[buffer(24)]], texture2d_array<float> uSubpass0 [[texture(0)]], texture2d_array<float> uSubpass1 [[texture(1)]], float4 gl_FragCoord [[position]], uint gl_ViewIndex [[render_target_array_index]])
+{
+    main0_out out = {};
+    gl_ViewIndex += spvViewMask[0];
+    out.FragColor = uSubpass0.read(uint2(gl_FragCoord.xy), gl_ViewIndex) + uSubpass1.read(uint2(gl_FragCoord.xy), gl_ViewIndex);
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/asm/frag/input-attachment-unused-frag-coord.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/input-attachment-unused-frag-coord.asm.frag
@@ -13,13 +13,13 @@ struct main0_out
 static inline __attribute__((always_inline))
 float4 load_subpasses(thread const texture2d<float> uInput, thread float4& gl_FragCoord)
 {
-    return uInput.read(uint2(gl_FragCoord.xy), 0);
+    return uInput.read(uint2(gl_FragCoord.xy));
 }
 
 fragment main0_out main0(texture2d<float> uSubpass0 [[texture(0)]], texture2d<float> uSubpass1 [[texture(1)]], float4 gl_FragCoord [[position]])
 {
     main0_out out = {};
-    out.FragColor = uSubpass0.read(uint2(gl_FragCoord.xy), 0) + load_subpasses(uSubpass1, gl_FragCoord);
+    out.FragColor = uSubpass0.read(uint2(gl_FragCoord.xy)) + load_subpasses(uSubpass1, gl_FragCoord);
     return out;
 }
 

--- a/reference/shaders-msl/frag/input-attachment-ms.arrayed-subpass.msl21.frag
+++ b/reference/shaders-msl/frag/input-attachment-ms.arrayed-subpass.msl21.frag
@@ -1,0 +1,26 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+static inline __attribute__((always_inline))
+float4 load_subpasses(thread const texture2d_ms_array<float> uInput, thread uint& gl_SampleID, thread float4& gl_FragCoord, thread uint& gl_Layer)
+{
+    float4 _24 = uInput.read(uint2(gl_FragCoord.xy), gl_Layer, gl_SampleID);
+    return _24;
+}
+
+fragment main0_out main0(texture2d_ms_array<float> uSubpass0 [[texture(0)]], texture2d_ms_array<float> uSubpass1 [[texture(1)]], uint gl_SampleID [[sample_id]], float4 gl_FragCoord [[position]], uint gl_Layer [[render_target_array_index]])
+{
+    main0_out out = {};
+    out.FragColor = (uSubpass0.read(uint2(gl_FragCoord.xy), gl_Layer, 1) + uSubpass1.read(uint2(gl_FragCoord.xy), gl_Layer, 2)) + load_subpasses(uSubpass0, gl_SampleID, gl_FragCoord, gl_Layer);
+    return out;
+}
+

--- a/reference/shaders-msl/frag/input-attachment-ms.multiview.msl21.frag
+++ b/reference/shaders-msl/frag/input-attachment-ms.multiview.msl21.frag
@@ -1,0 +1,27 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+static inline __attribute__((always_inline))
+float4 load_subpasses(thread const texture2d_ms_array<float> uInput, thread uint& gl_SampleID, thread float4& gl_FragCoord, thread uint& gl_ViewIndex)
+{
+    float4 _24 = uInput.read(uint2(gl_FragCoord.xy), gl_ViewIndex, gl_SampleID);
+    return _24;
+}
+
+fragment main0_out main0(constant uint* spvViewMask [[buffer(24)]], texture2d_ms_array<float> uSubpass0 [[texture(0)]], texture2d_ms_array<float> uSubpass1 [[texture(1)]], uint gl_SampleID [[sample_id]], float4 gl_FragCoord [[position]], uint gl_ViewIndex [[render_target_array_index]])
+{
+    main0_out out = {};
+    gl_ViewIndex += spvViewMask[0];
+    out.FragColor = (uSubpass0.read(uint2(gl_FragCoord.xy), gl_ViewIndex, 1) + uSubpass1.read(uint2(gl_FragCoord.xy), gl_ViewIndex, 2)) + load_subpasses(uSubpass0, gl_SampleID, gl_FragCoord, gl_ViewIndex);
+    return out;
+}
+

--- a/reference/shaders-msl/frag/input-attachment.arrayed-subpass.frag
+++ b/reference/shaders-msl/frag/input-attachment.arrayed-subpass.frag
@@ -1,0 +1,25 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+static inline __attribute__((always_inline))
+float4 load_subpasses(thread const texture2d_array<float> uInput, thread float4& gl_FragCoord, thread uint& gl_Layer)
+{
+    return uInput.read(uint2(gl_FragCoord.xy), gl_Layer);
+}
+
+fragment main0_out main0(texture2d_array<float> uSubpass0 [[texture(0)]], texture2d_array<float> uSubpass1 [[texture(1)]], float4 gl_FragCoord [[position]], uint gl_Layer [[render_target_array_index]])
+{
+    main0_out out = {};
+    out.FragColor = uSubpass0.read(uint2(gl_FragCoord.xy), gl_Layer) + load_subpasses(uSubpass1, gl_FragCoord, gl_Layer);
+    return out;
+}
+

--- a/reference/shaders-msl/frag/input-attachment.frag
+++ b/reference/shaders-msl/frag/input-attachment.frag
@@ -13,13 +13,13 @@ struct main0_out
 static inline __attribute__((always_inline))
 float4 load_subpasses(thread const texture2d<float> uInput, thread float4& gl_FragCoord)
 {
-    return uInput.read(uint2(gl_FragCoord.xy), 0);
+    return uInput.read(uint2(gl_FragCoord.xy));
 }
 
 fragment main0_out main0(texture2d<float> uSubpass0 [[texture(0)]], texture2d<float> uSubpass1 [[texture(1)]], float4 gl_FragCoord [[position]])
 {
     main0_out out = {};
-    out.FragColor = uSubpass0.read(uint2(gl_FragCoord.xy), 0) + load_subpasses(uSubpass1, gl_FragCoord);
+    out.FragColor = uSubpass0.read(uint2(gl_FragCoord.xy)) + load_subpasses(uSubpass1, gl_FragCoord);
     return out;
 }
 

--- a/reference/shaders-msl/frag/input-attachment.multiview.frag
+++ b/reference/shaders-msl/frag/input-attachment.multiview.frag
@@ -1,0 +1,26 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+static inline __attribute__((always_inline))
+float4 load_subpasses(thread const texture2d_array<float> uInput, thread float4& gl_FragCoord, thread uint& gl_ViewIndex)
+{
+    return uInput.read(uint2(gl_FragCoord.xy), gl_ViewIndex);
+}
+
+fragment main0_out main0(constant uint* spvViewMask [[buffer(24)]], texture2d_array<float> uSubpass0 [[texture(0)]], texture2d_array<float> uSubpass1 [[texture(1)]], float4 gl_FragCoord [[position]], uint gl_ViewIndex [[render_target_array_index]])
+{
+    main0_out out = {};
+    gl_ViewIndex += spvViewMask[0];
+    out.FragColor = uSubpass0.read(uint2(gl_FragCoord.xy), gl_ViewIndex) + load_subpasses(uSubpass1, gl_FragCoord, gl_ViewIndex);
+    return out;
+}
+

--- a/shaders-msl/frag/input-attachment-ms.arrayed-subpass.msl21.frag
+++ b/shaders-msl/frag/input-attachment-ms.arrayed-subpass.msl21.frag
@@ -1,0 +1,15 @@
+#version 450
+
+layout(input_attachment_index = 0, set = 0, binding = 0) uniform subpassInputMS uSubpass0;
+layout(input_attachment_index = 1, set = 0, binding = 1) uniform subpassInputMS uSubpass1;
+layout(location = 0) out vec4 FragColor;
+
+vec4 load_subpasses(mediump subpassInputMS uInput)
+{
+	return subpassLoad(uInput, gl_SampleID);
+}
+
+void main()
+{
+    FragColor = subpassLoad(uSubpass0, 1) + subpassLoad(uSubpass1, 2) + load_subpasses(uSubpass0);
+}

--- a/shaders-msl/frag/input-attachment-ms.multiview.msl21.frag
+++ b/shaders-msl/frag/input-attachment-ms.multiview.msl21.frag
@@ -1,0 +1,15 @@
+#version 450
+
+layout(input_attachment_index = 0, set = 0, binding = 0) uniform subpassInputMS uSubpass0;
+layout(input_attachment_index = 1, set = 0, binding = 1) uniform subpassInputMS uSubpass1;
+layout(location = 0) out vec4 FragColor;
+
+vec4 load_subpasses(mediump subpassInputMS uInput)
+{
+	return subpassLoad(uInput, gl_SampleID);
+}
+
+void main()
+{
+    FragColor = subpassLoad(uSubpass0, 1) + subpassLoad(uSubpass1, 2) + load_subpasses(uSubpass0);
+}

--- a/shaders-msl/frag/input-attachment.arrayed-subpass.frag
+++ b/shaders-msl/frag/input-attachment.arrayed-subpass.frag
@@ -1,0 +1,16 @@
+#version 310 es
+precision mediump float;
+
+layout(input_attachment_index = 0, set = 0, binding = 0) uniform mediump subpassInput uSubpass0;
+layout(input_attachment_index = 1, set = 0, binding = 1) uniform mediump subpassInput uSubpass1;
+layout(location = 0) out vec4 FragColor;
+
+vec4 load_subpasses(mediump subpassInput uInput)
+{
+	return subpassLoad(uInput);
+}
+
+void main()
+{
+    FragColor = subpassLoad(uSubpass0) + load_subpasses(uSubpass1);
+}

--- a/shaders-msl/frag/input-attachment.multiview.frag
+++ b/shaders-msl/frag/input-attachment.multiview.frag
@@ -1,0 +1,16 @@
+#version 310 es
+precision mediump float;
+
+layout(input_attachment_index = 0, set = 0, binding = 0) uniform mediump subpassInput uSubpass0;
+layout(input_attachment_index = 1, set = 0, binding = 1) uniform mediump subpassInput uSubpass1;
+layout(location = 0) out vec4 FragColor;
+
+vec4 load_subpasses(mediump subpassInput uInput)
+{
+	return subpassLoad(uInput);
+}
+
+void main()
+{
+    FragColor = subpassLoad(uSubpass0) + load_subpasses(uSubpass1);
+}

--- a/spirv_cross_c.cpp
+++ b/spirv_cross_c.cpp
@@ -662,6 +662,10 @@ spvc_result spvc_compiler_options_set_uint(spvc_compiler_options options, spvc_c
 	case SPVC_COMPILER_OPTION_MSL_MULTIVIEW_LAYERED_RENDERING:
 		options->msl.multiview_layered_rendering = value != 0;
 		break;
+
+	case SPVC_COMPILER_OPTION_MSL_ARRAYED_SUBPASS_INPUT:
+		options->msl.arrayed_subpass_input = value != 0;
+		break;
 #endif
 
 	default:

--- a/spirv_cross_c.h
+++ b/spirv_cross_c.h
@@ -33,7 +33,7 @@ extern "C" {
 /* Bumped if ABI or API breaks backwards compatibility. */
 #define SPVC_C_API_VERSION_MAJOR 0
 /* Bumped if APIs or enumerations are added in a backwards compatible way. */
-#define SPVC_C_API_VERSION_MINOR 38
+#define SPVC_C_API_VERSION_MINOR 39
 /* Bumped if internal implementation details change. */
 #define SPVC_C_API_VERSION_PATCH 0
 
@@ -637,6 +637,7 @@ typedef enum spvc_compiler_option
 	SPVC_COMPILER_OPTION_GLSL_FORCE_FLATTENED_IO_BLOCKS = 66 | SPVC_COMPILER_OPTION_GLSL_BIT,
 
 	SPVC_COMPILER_OPTION_MSL_MULTIVIEW_LAYERED_RENDERING = 67 | SPVC_COMPILER_OPTION_MSL_BIT,
+	SPVC_COMPILER_OPTION_MSL_ARRAYED_SUBPASS_INPUT = 68 | SPVC_COMPILER_OPTION_MSL_BIT,
 
 	SPVC_COMPILER_OPTION_INT_MAX = 0x7fffffff
 } spvc_compiler_option;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -348,6 +348,12 @@ public:
 		// to index the output buffer.
 		bool vertex_for_tessellation = false;
 
+		// Assume that SubpassData images have multiple layers. Layered input attachments
+		// are addressed relative to the Layer output from the vertex pipeline. This option
+		// has no effect with multiview, since all input attachments are assumed to be layered
+		// and will be addressed using the current ViewIndex.
+		bool arrayed_subpass_input = false;
+
 		enum class IndexType
 		{
 			None = 0,

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -298,6 +298,8 @@ def cross_compile_msl(shader, spirv, opt, iterations, paths):
     if '.fixed-sample-mask.' in shader:
         msl_args.append('--msl-additional-fixed-sample-mask')
         msl_args.append('0x00000022')
+    if '.arrayed-subpass.' in shader:
+        msl_args.append('--msl-arrayed-subpass-input')
 
     subprocess.check_call(msl_args)
 


### PR DESCRIPTION
These need to use arrayed texture types, or Metal will complain when
binding the resource. The target layer is addressed relative to the
Layer output by the vertex pipeline, or to the ViewIndex if in a
multiview pipeline. Unlike with the s/t coordinates, Vulkan does not
forbid non-zero layer coordinates here, though this cannot be expressed
in Vulkan GLSL. I wonder, then, if non-zero layer coordinates were even
intended to be supported.

Supporting 3D textures will require additional work. Part of the problem
is that Metal does not allow texture views to subset a 3D texture, so we
need some way to pass the base depth to the shader.