### PR TITLE
MSL: Support SPV_EXT_demote_to_helper_invocation for MSL 2.3.

### DIFF
--- a/reference/opt/shaders-msl/vulkan/frag/demote-to-helper-forwarding.asm.vk.nocompat.msl23.frag
+++ b/reference/opt/shaders-msl/vulkan/frag/demote-to-helper-forwarding.asm.vk.nocompat.msl23.frag
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0()
+{
+    main0_out out = {};
+    bool _15 = simd_is_helper_thread();
+    discard_fragment();
+    if (!_15)
+    {
+        out.FragColor = float4(1.0, 0.0, 0.0, 1.0);
+    }
+    return out;
+}
+

--- a/reference/opt/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl23.frag
+++ b/reference/opt/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl23.frag
@@ -1,0 +1,11 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+fragment void main0()
+{
+    discard_fragment();
+    bool _9 = simd_is_helper_thread();
+}
+

--- a/reference/opt/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl23.ios.frag
+++ b/reference/opt/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl23.ios.frag
@@ -1,0 +1,11 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+fragment void main0()
+{
+    discard_fragment();
+    bool _9 = simd_is_helper_thread();
+}
+

--- a/reference/shaders-msl/vulkan/frag/demote-to-helper-forwarding.asm.vk.nocompat.msl23.frag
+++ b/reference/shaders-msl/vulkan/frag/demote-to-helper-forwarding.asm.vk.nocompat.msl23.frag
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0()
+{
+    main0_out out = {};
+    bool _15 = simd_is_helper_thread();
+    discard_fragment();
+    if (!_15)
+    {
+        out.FragColor = float4(1.0, 0.0, 0.0, 1.0);
+    }
+    return out;
+}
+

--- a/reference/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl23.frag
+++ b/reference/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl23.frag
@@ -1,0 +1,12 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+fragment void main0()
+{
+    discard_fragment();
+    bool _9 = simd_is_helper_thread();
+    bool helper = _9;
+}
+

--- a/reference/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl23.ios.frag
+++ b/reference/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl23.ios.frag
@@ -1,0 +1,12 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+fragment void main0()
+{
+    discard_fragment();
+    bool _9 = simd_is_helper_thread();
+    bool helper = _9;
+}
+

--- a/shaders-msl/vulkan/frag/demote-to-helper-forwarding.asm.vk.nocompat.msl23.frag
+++ b/shaders-msl/vulkan/frag/demote-to-helper-forwarding.asm.vk.nocompat.msl23.frag
@@ -1,0 +1,41 @@
+; SPIR-V
+; Version: 1.3
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 19
+; Schema: 0
+               OpCapability Shader
+               OpCapability DemoteToHelperInvocationEXT
+               OpExtension "SPV_EXT_demote_to_helper_invocation"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_demote_to_helper_invocation"
+               OpName %main "main"
+               OpName %FragColor "FragColor"
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %bool = OpTypeBool
+%_ptr_Function_bool = OpTypePointer Function %bool
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+    %float_1 = OpConstant %float 1
+    %float_0 = OpConstant %float 0
+         %19 = OpConstantComposite %v4float %float_1 %float_0 %float_0 %float_1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %9 = OpIsHelperInvocationEXT %bool
+               OpDemoteToHelperInvocationEXT
+         %10 = OpLogicalNot %bool %9
+               OpSelectionMerge %12 None
+               OpBranchConditional %10 %11 %12
+         %11 = OpLabel
+               OpStore %FragColor %19
+               OpBranch %12
+         %12 = OpLabel
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl23.frag
+++ b/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl23.frag
@@ -1,0 +1,8 @@
+#version 450
+#extension GL_EXT_demote_to_helper_invocation : require
+
+void main()
+{
+	demote;
+	bool helper = helperInvocationEXT();
+}

--- a/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl23.ios.frag
+++ b/shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl23.ios.frag
@@ -1,0 +1,8 @@
+#version 450
+#extension GL_EXT_demote_to_helper_invocation : require
+
+void main()
+{
+	demote;
+	bool helper = helperInvocationEXT();
+}


### PR DESCRIPTION
MSL 2.3 has everything needed to support this extension on all
platforms. The existing `discard_fragment()` function was given demote
semantics, similar to Direct3D, and the `simd_is_helper_thread()`
function was finally added to iOS.

I've left the old test alone. Should I remove it in favor of these?