### PR TITLE
GLSL: Support a workaround for loading row-major matrices

### DIFF
--- a/reference/opt/shaders/asm/frag/loop-body-dominator-continue-access.asm.frag
+++ b/reference/opt/shaders/asm/frag/loop-body-dominator-continue-access.asm.frag
@@ -12,6 +12,8 @@ layout(location = 0) out int _entryPointOutput;
 
 int _231;
 
+mat4 SPIRV_Cross_workaround_load_row_major(mat4 wrap) { return wrap; }
+
 void main()
 {
     int _228;
@@ -35,7 +37,7 @@ void main()
                     _223 = mat4(vec4(1.0, 0.0, 0.0, 0.0), vec4(0.0, 1.0, 0.0, 0.0), vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0));
                     break;
                 } while(false);
-                vec4 _170 = (_223 * _11.lightVP[_222]) * vec4(fragWorld, 1.0);
+                vec4 _170 = (_223 * SPIRV_Cross_workaround_load_row_major(_11.lightVP[_222])) * vec4(fragWorld, 1.0);
                 float _172 = _170.z;
                 float _179 = _170.x;
                 float _181 = _170.y;

--- a/reference/opt/shaders/frag/ubo-load-row-major-workaround.frag
+++ b/reference/opt/shaders/frag/ubo-load-row-major-workaround.frag
@@ -1,0 +1,46 @@
+#version 450
+
+struct RowMajor
+{
+    mat4 B;
+};
+
+struct NestedRowMajor
+{
+    RowMajor rm;
+};
+
+layout(binding = 2, std140) uniform UBO3
+{
+    layout(row_major) NestedRowMajor rm2;
+} _17;
+
+layout(binding = 1, std140) uniform UBO2
+{
+    layout(row_major) RowMajor rm;
+} _35;
+
+layout(binding = 0, std140) uniform UBO
+{
+    layout(row_major) mat4 A;
+    mat4 C;
+} _42;
+
+layout(binding = 3, std140) uniform UBONoWorkaround
+{
+    mat4 D;
+} _56;
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) in vec4 Clip;
+
+NestedRowMajor SPIRV_Cross_workaround_load_row_major(NestedRowMajor wrap) { return wrap; }
+mat4 SPIRV_Cross_workaround_load_row_major(mat4 wrap) { return wrap; }
+
+void main()
+{
+    FragColor = (((SPIRV_Cross_workaround_load_row_major(_17.rm2).rm.B * SPIRV_Cross_workaround_load_row_major(_35.rm.B)) * SPIRV_Cross_workaround_load_row_major(_42.A)) * SPIRV_Cross_workaround_load_row_major(_42.C)) * Clip;
+    FragColor += (_56.D * Clip);
+    FragColor += (_42.A[1] * Clip);
+}
+

--- a/reference/opt/shaders/legacy/vert/transpose.legacy.vert
+++ b/reference/opt/shaders/legacy/vert/transpose.legacy.vert
@@ -11,8 +11,10 @@ uniform Buffer _13;
 
 attribute vec4 Position;
 
+mat4 SPIRV_Cross_workaround_load_row_major(mat4 wrap) { return wrap; }
+
 void main()
 {
-    gl_Position = (((_13.M * (Position * _13.MVPRowMajor)) + (_13.M * (_13.MVPColMajor * Position))) + (_13.M * (_13.MVPRowMajor * Position))) + (_13.M * (Position * _13.MVPColMajor));
+    gl_Position = (((SPIRV_Cross_workaround_load_row_major(_13.M) * (Position * _13.MVPRowMajor)) + (SPIRV_Cross_workaround_load_row_major(_13.M) * (SPIRV_Cross_workaround_load_row_major(_13.MVPColMajor) * Position))) + (SPIRV_Cross_workaround_load_row_major(_13.M) * (_13.MVPRowMajor * Position))) + (SPIRV_Cross_workaround_load_row_major(_13.M) * (Position * SPIRV_Cross_workaround_load_row_major(_13.MVPColMajor)));
 }
 

--- a/reference/opt/shaders/vert/read-from-row-major-array.vert
+++ b/reference/opt/shaders/vert/read-from-row-major-array.vert
@@ -8,9 +8,11 @@ layout(binding = 0, std140) uniform Block
 layout(location = 0) in vec4 a_position;
 layout(location = 0) out mediump float v_vtxResult;
 
+mat2x3 SPIRV_Cross_workaround_load_row_major(mat2x3 wrap) { return wrap; }
+
 void main()
 {
     gl_Position = a_position;
-    v_vtxResult = ((float(abs(_104.var[0][0][0].x - 2.0) < 0.0500000007450580596923828125) * float(abs(_104.var[0][0][0].y - 6.0) < 0.0500000007450580596923828125)) * float(abs(_104.var[0][0][0].z - (-6.0)) < 0.0500000007450580596923828125)) * ((float(abs(_104.var[0][0][1].x) < 0.0500000007450580596923828125) * float(abs(_104.var[0][0][1].y - 5.0) < 0.0500000007450580596923828125)) * float(abs(_104.var[0][0][1].z - 5.0) < 0.0500000007450580596923828125));
+    v_vtxResult = ((float(abs(SPIRV_Cross_workaround_load_row_major(_104.var[0][0])[0].x - 2.0) < 0.0500000007450580596923828125) * float(abs(SPIRV_Cross_workaround_load_row_major(_104.var[0][0])[0].y - 6.0) < 0.0500000007450580596923828125)) * float(abs(SPIRV_Cross_workaround_load_row_major(_104.var[0][0])[0].z - (-6.0)) < 0.0500000007450580596923828125)) * ((float(abs(SPIRV_Cross_workaround_load_row_major(_104.var[0][0])[1].x) < 0.0500000007450580596923828125) * float(abs(SPIRV_Cross_workaround_load_row_major(_104.var[0][0])[1].y - 5.0) < 0.0500000007450580596923828125)) * float(abs(SPIRV_Cross_workaround_load_row_major(_104.var[0][0])[1].z - 5.0) < 0.0500000007450580596923828125));
 }
 

--- a/reference/shaders/asm/frag/loop-body-dominator-continue-access.asm.frag
+++ b/reference/shaders/asm/frag/loop-body-dominator-continue-access.asm.frag
@@ -10,6 +10,8 @@ layout(binding = 0, std140) uniform Foo
 layout(location = 0) in vec3 fragWorld;
 layout(location = 0) out int _entryPointOutput;
 
+mat4 SPIRV_Cross_workaround_load_row_major(mat4 wrap) { return wrap; }
+
 mat4 GetClip2TexMatrix()
 {
     if (_11.test == 0)
@@ -23,7 +25,7 @@ int GetCascade(vec3 fragWorldPosition)
 {
     for (uint cascadeIndex = 0u; cascadeIndex < _11.shadowCascadesNum; cascadeIndex++)
     {
-        mat4 worldToShadowMap = GetClip2TexMatrix() * _11.lightVP[cascadeIndex];
+        mat4 worldToShadowMap = GetClip2TexMatrix() * SPIRV_Cross_workaround_load_row_major(_11.lightVP[cascadeIndex]);
         vec4 fragShadowMapPos = worldToShadowMap * vec4(fragWorldPosition, 1.0);
         if ((((fragShadowMapPos.z >= 0.0) && (fragShadowMapPos.z <= 1.0)) && (max(fragShadowMapPos.x, fragShadowMapPos.y) <= 1.0)) && (min(fragShadowMapPos.x, fragShadowMapPos.y) >= 0.0))
         {

--- a/reference/shaders/frag/ubo-load-row-major-workaround.frag
+++ b/reference/shaders/frag/ubo-load-row-major-workaround.frag
@@ -1,0 +1,48 @@
+#version 450
+
+struct RowMajor
+{
+    mat4 B;
+};
+
+struct NestedRowMajor
+{
+    RowMajor rm;
+};
+
+layout(binding = 2, std140) uniform UBO3
+{
+    layout(row_major) NestedRowMajor rm2;
+} _17;
+
+layout(binding = 1, std140) uniform UBO2
+{
+    layout(row_major) RowMajor rm;
+} _35;
+
+layout(binding = 0, std140) uniform UBO
+{
+    layout(row_major) mat4 A;
+    mat4 C;
+} _42;
+
+layout(binding = 3, std140) uniform UBONoWorkaround
+{
+    mat4 D;
+} _56;
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) in vec4 Clip;
+
+NestedRowMajor SPIRV_Cross_workaround_load_row_major(NestedRowMajor wrap) { return wrap; }
+mat4 SPIRV_Cross_workaround_load_row_major(mat4 wrap) { return wrap; }
+
+void main()
+{
+    NestedRowMajor rm2_loaded;
+    rm2_loaded.rm.B = SPIRV_Cross_workaround_load_row_major(_17.rm2).rm.B;
+    FragColor = (((rm2_loaded.rm.B * SPIRV_Cross_workaround_load_row_major(_35.rm.B)) * SPIRV_Cross_workaround_load_row_major(_42.A)) * SPIRV_Cross_workaround_load_row_major(_42.C)) * Clip;
+    FragColor += (_56.D * Clip);
+    FragColor += (_42.A[1] * Clip);
+}
+

--- a/reference/shaders/legacy/vert/transpose.legacy.vert
+++ b/reference/shaders/legacy/vert/transpose.legacy.vert
@@ -11,12 +11,14 @@ uniform Buffer _13;
 
 attribute vec4 Position;
 
+mat4 SPIRV_Cross_workaround_load_row_major(mat4 wrap) { return wrap; }
+
 void main()
 {
-    vec4 c0 = _13.M * (Position * _13.MVPRowMajor);
-    vec4 c1 = _13.M * (_13.MVPColMajor * Position);
-    vec4 c2 = _13.M * (_13.MVPRowMajor * Position);
-    vec4 c3 = _13.M * (Position * _13.MVPColMajor);
+    vec4 c0 = SPIRV_Cross_workaround_load_row_major(_13.M) * (Position * _13.MVPRowMajor);
+    vec4 c1 = SPIRV_Cross_workaround_load_row_major(_13.M) * (SPIRV_Cross_workaround_load_row_major(_13.MVPColMajor) * Position);
+    vec4 c2 = SPIRV_Cross_workaround_load_row_major(_13.M) * (_13.MVPRowMajor * Position);
+    vec4 c3 = SPIRV_Cross_workaround_load_row_major(_13.M) * (Position * SPIRV_Cross_workaround_load_row_major(_13.MVPColMajor));
     gl_Position = ((c0 + c1) + c2) + c3;
 }
 

--- a/reference/shaders/vert/read-from-row-major-array.vert
+++ b/reference/shaders/vert/read-from-row-major-array.vert
@@ -8,6 +8,8 @@ layout(binding = 0, std140) uniform Block
 layout(location = 0) in vec4 a_position;
 layout(location = 0) out mediump float v_vtxResult;
 
+mat2x3 SPIRV_Cross_workaround_load_row_major(mat2x3 wrap) { return wrap; }
+
 mediump float compare_float(float a, float b)
 {
     return float(abs(a - b) < 0.0500000007450580596923828125);
@@ -37,7 +39,7 @@ void main()
 {
     gl_Position = a_position;
     mediump float result = 1.0;
-    mat2x3 param = _104.var[0][0];
+    mat2x3 param = SPIRV_Cross_workaround_load_row_major(_104.var[0][0]);
     mat2x3 param_1 = mat2x3(vec3(2.0, 6.0, -6.0), vec3(0.0, 5.0, 5.0));
     result *= compare_mat2x3(param, param_1);
     v_vtxResult = result;

--- a/shaders/frag/ubo-load-row-major-workaround.frag
+++ b/shaders/frag/ubo-load-row-major-workaround.frag
@@ -1,0 +1,44 @@
+#version 450
+
+struct RowMajor
+{
+	mat4 B;
+};
+
+struct NestedRowMajor
+{
+	RowMajor rm;
+};
+
+layout(set = 0, binding = 0, row_major) uniform UBO
+{
+	mat4 A;
+	layout(column_major) mat4 C; // This should also be worked around.
+};
+
+
+layout(set = 0, binding = 1, row_major) uniform UBO2
+{
+	RowMajor rm;
+};
+
+layout(set = 0, binding = 2, row_major) uniform UBO3
+{
+	NestedRowMajor rm2;
+};
+
+layout(set = 0, binding = 3) uniform UBONoWorkaround
+{
+	mat4 D;
+};
+
+layout(location = 0) in vec4 Clip;
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	NestedRowMajor rm2_loaded = rm2;
+	FragColor = rm2_loaded.rm.B * rm.B * A * C * Clip;
+	FragColor += D * Clip;
+	FragColor += A[1] * Clip;
+}

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -560,6 +560,7 @@ protected:
 		bool support_small_type_sampling_result = false;
 		bool support_case_fallthrough = true;
 		bool use_array_constructor = false;
+		bool needs_row_major_load_workaround = false;
 	} backend;
 
 	void emit_struct(SPIRType &type);
@@ -783,6 +784,10 @@ protected:
 	// and we need to reuse the IDs across recompilation loops.
 	// Currently used by NMin/Max/Clamp implementations.
 	std::unordered_map<uint32_t, uint32_t> extra_sub_expressions;
+
+	SmallVector<TypeID> workaround_ubo_load_overload_types;
+	void request_workaround_wrapper_overload(TypeID id);
+	void rewrite_load_for_wrapped_row_major(std::string &expr, TypeID loaded_type, ID ptr);
 
 	uint32_t statement_count = 0;
 


### PR DESCRIPTION
Fix needs to be verified to be effective for this PR to be considered for merging.

Fix #1491.