### PR TITLE
MSL: Don't use a bitcast for tessellation levels in tesc shaders.

### DIFF
--- a/reference/opt/shaders-msl/tesc/reload-tess-level.multi-patch.tesc
+++ b/reference/opt/shaders-msl/tesc/reload-tess-level.multi-patch.tesc
@@ -1,0 +1,35 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position;
+};
+
+struct main0_in
+{
+    uint3 m_82;
+    ushort2 m_86;
+    float4 gl_Position;
+};
+
+kernel void main0(uint3 gl_GlobalInvocationID [[thread_position_in_grid]], device main0_out* spvOut [[buffer(28)]], constant uint* spvIndirectParams [[buffer(29)]], device MTLQuadTessellationFactorsHalf* spvTessLevel [[buffer(26)]], device main0_in* spvIn [[buffer(22)]])
+{
+    device main0_out* gl_out = &spvOut[gl_GlobalInvocationID.x - gl_GlobalInvocationID.x % 4];
+    device main0_in* gl_in = &spvIn[min(gl_GlobalInvocationID.x / 4, spvIndirectParams[1] - 1) * spvIndirectParams[0]];
+    uint gl_InvocationID = gl_GlobalInvocationID.x % 4;
+    uint gl_PrimitiveID = min(gl_GlobalInvocationID.x / 4, spvIndirectParams[1]);
+    if (gl_InvocationID == 0)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(2.0);
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(3.0);
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(4.0);
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(5.0);
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(mix(float(spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0]), float(spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3]), 0.5));
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(mix(float(spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2]), float(spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1]), 0.5));
+    }
+    gl_out[gl_InvocationID].gl_Position = gl_in[gl_InvocationID].gl_Position;
+}
+

--- a/reference/opt/shaders-msl/tesc/reload-tess-level.tesc
+++ b/reference/opt/shaders-msl/tesc/reload-tess-level.tesc
@@ -1,0 +1,35 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position;
+};
+
+struct main0_in
+{
+    float4 gl_Position [[attribute(0)]];
+};
+
+kernel void main0(main0_in in [[stage_in]], uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], device main0_out* spvOut [[buffer(28)]], constant uint* spvIndirectParams [[buffer(29)]], device MTLQuadTessellationFactorsHalf* spvTessLevel [[buffer(26)]], threadgroup main0_in* gl_in [[threadgroup(0)]])
+{
+    device main0_out* gl_out = &spvOut[gl_PrimitiveID * 4];
+    if (gl_InvocationID < spvIndirectParams[0])
+        gl_in[gl_InvocationID] = in;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (gl_InvocationID >= 4)
+        return;
+    if (gl_InvocationID == 0)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(2.0);
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(3.0);
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(4.0);
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(5.0);
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(mix(float(spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0]), float(spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3]), 0.5));
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(mix(float(spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2]), float(spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1]), 0.5));
+    }
+    gl_out[gl_InvocationID].gl_Position = gl_in[gl_InvocationID].gl_Position;
+}
+

--- a/reference/shaders-msl/tesc/reload-tess-level.multi-patch.tesc
+++ b/reference/shaders-msl/tesc/reload-tess-level.multi-patch.tesc
@@ -1,0 +1,35 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position;
+};
+
+struct main0_in
+{
+    uint3 m_82;
+    ushort2 m_86;
+    float4 gl_Position;
+};
+
+kernel void main0(uint3 gl_GlobalInvocationID [[thread_position_in_grid]], device main0_out* spvOut [[buffer(28)]], constant uint* spvIndirectParams [[buffer(29)]], device MTLQuadTessellationFactorsHalf* spvTessLevel [[buffer(26)]], device main0_in* spvIn [[buffer(22)]])
+{
+    device main0_out* gl_out = &spvOut[gl_GlobalInvocationID.x - gl_GlobalInvocationID.x % 4];
+    device main0_in* gl_in = &spvIn[min(gl_GlobalInvocationID.x / 4, spvIndirectParams[1] - 1) * spvIndirectParams[0]];
+    uint gl_InvocationID = gl_GlobalInvocationID.x % 4;
+    uint gl_PrimitiveID = min(gl_GlobalInvocationID.x / 4, spvIndirectParams[1]);
+    if (gl_InvocationID == 0)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(2.0);
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(3.0);
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(4.0);
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(5.0);
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(mix(float(spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0]), float(spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3]), 0.5));
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(mix(float(spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2]), float(spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1]), 0.5));
+    }
+    gl_out[gl_InvocationID].gl_Position = gl_in[gl_InvocationID].gl_Position;
+}
+

--- a/reference/shaders-msl/tesc/reload-tess-level.tesc
+++ b/reference/shaders-msl/tesc/reload-tess-level.tesc
@@ -1,0 +1,35 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position;
+};
+
+struct main0_in
+{
+    float4 gl_Position [[attribute(0)]];
+};
+
+kernel void main0(main0_in in [[stage_in]], uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], device main0_out* spvOut [[buffer(28)]], constant uint* spvIndirectParams [[buffer(29)]], device MTLQuadTessellationFactorsHalf* spvTessLevel [[buffer(26)]], threadgroup main0_in* gl_in [[threadgroup(0)]])
+{
+    device main0_out* gl_out = &spvOut[gl_PrimitiveID * 4];
+    if (gl_InvocationID < spvIndirectParams[0])
+        gl_in[gl_InvocationID] = in;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (gl_InvocationID >= 4)
+        return;
+    if (gl_InvocationID == 0)
+    {
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(2.0);
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(3.0);
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2] = half(4.0);
+        spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3] = half(5.0);
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[0] = half(mix(float(spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0]), float(spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[3]), 0.5));
+        spvTessLevel[gl_PrimitiveID].insideTessellationFactor[1] = half(mix(float(spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[2]), float(spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1]), 0.5));
+    }
+    gl_out[gl_InvocationID].gl_Position = gl_in[gl_InvocationID].gl_Position;
+}
+

--- a/shaders-msl/tesc/reload-tess-level.multi-patch.tesc
+++ b/shaders-msl/tesc/reload-tess-level.multi-patch.tesc
@@ -1,0 +1,17 @@
+#version 450
+layout(vertices = 4) out;
+
+void main()
+{
+	if (gl_InvocationID == 0)
+	{
+		gl_TessLevelOuter[0] = 2.0;
+		gl_TessLevelOuter[1] = 3.0;
+		gl_TessLevelOuter[2] = 4.0;
+		gl_TessLevelOuter[3] = 5.0;
+		gl_TessLevelInner[0] = mix(gl_TessLevelOuter[0], gl_TessLevelOuter[3], 0.5);
+		gl_TessLevelInner[1] = mix(gl_TessLevelOuter[2], gl_TessLevelOuter[1], 0.5);
+	}
+
+	gl_out[gl_InvocationID].gl_Position =  gl_in[gl_InvocationID].gl_Position;
+}

--- a/shaders-msl/tesc/reload-tess-level.tesc
+++ b/shaders-msl/tesc/reload-tess-level.tesc
@@ -1,0 +1,17 @@
+#version 450
+layout(vertices = 4) out;
+
+void main()
+{
+	if (gl_InvocationID == 0)
+	{
+		gl_TessLevelOuter[0] = 2.0;
+		gl_TessLevelOuter[1] = 3.0;
+		gl_TessLevelOuter[2] = 4.0;
+		gl_TessLevelOuter[3] = 5.0;
+		gl_TessLevelInner[0] = mix(gl_TessLevelOuter[0], gl_TessLevelOuter[3], 0.5);
+		gl_TessLevelInner[1] = mix(gl_TessLevelOuter[2], gl_TessLevelOuter[1], 0.5);
+	}
+
+	gl_out[gl_InvocationID].gl_Position =  gl_in[gl_InvocationID].gl_Position;
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -9313,8 +9313,8 @@ void CompilerGLSL::emit_store_statement(uint32_t lhs_expression, uint32_t rhs_ex
 
 		auto lhs = to_dereferenced_expression(lhs_expression);
 
-		// We might need to bitcast in order to store to a builtin.
-		bitcast_to_builtin_store(lhs_expression, rhs, expression_type(rhs_expression));
+		// We might need to cast in order to store to a builtin.
+		cast_to_builtin_store(lhs_expression, rhs, expression_type(rhs_expression));
 
 		// Tries to optimize assignments like "<lhs> = <lhs> op expr".
 		// While this is purely cosmetic, this is important for legacy ESSL where loop
@@ -9477,8 +9477,8 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		if (expr_type.vecsize > type.vecsize)
 			expr = enclose_expression(expr + vector_swizzle(type.vecsize, 0));
 
-		// We might need to bitcast in order to load from a builtin.
-		bitcast_from_builtin_load(ptr, expr, type);
+		// We might need to cast in order to load from a builtin.
+		cast_from_builtin_load(ptr, expr, type);
 
 		// We might be trying to load a gl_Position[N], where we should be
 		// doing float4[](gl_in[i].gl_Position, ...) instead.
@@ -14484,7 +14484,7 @@ void CompilerGLSL::unroll_array_from_complex_load(uint32_t target_id, uint32_t s
 	}
 }
 
-void CompilerGLSL::bitcast_from_builtin_load(uint32_t source_id, std::string &expr, const SPIRType &expr_type)
+void CompilerGLSL::cast_from_builtin_load(uint32_t source_id, std::string &expr, const SPIRType &expr_type)
 {
 	auto *var = maybe_get_backing_variable(source_id);
 	if (var)
@@ -14536,7 +14536,7 @@ void CompilerGLSL::bitcast_from_builtin_load(uint32_t source_id, std::string &ex
 		expr = bitcast_expression(expr_type, expected_type, expr);
 }
 
-void CompilerGLSL::bitcast_to_builtin_store(uint32_t target_id, std::string &expr, const SPIRType &expr_type)
+void CompilerGLSL::cast_to_builtin_store(uint32_t target_id, std::string &expr, const SPIRType &expr_type)
 {
 	// Only interested in standalone builtin variables.
 	if (!has_decoration(target_id, DecorationBuiltIn))

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -854,9 +854,9 @@ protected:
 
 	// Builtins in GLSL are always specific signedness, but the SPIR-V can declare them
 	// as either unsigned or signed.
-	// Sometimes we will need to automatically perform bitcasts on load and store to make this work.
-	virtual void bitcast_to_builtin_store(uint32_t target_id, std::string &expr, const SPIRType &expr_type);
-	virtual void bitcast_from_builtin_load(uint32_t source_id, std::string &expr, const SPIRType &expr_type);
+	// Sometimes we will need to automatically perform casts on load and store to make this work.
+	virtual void cast_to_builtin_store(uint32_t target_id, std::string &expr, const SPIRType &expr_type);
+	virtual void cast_from_builtin_load(uint32_t source_id, std::string &expr, const SPIRType &expr_type);
 	void unroll_array_from_complex_load(uint32_t target_id, uint32_t source_id, std::string &expr);
 	void convert_non_uniform_expression(const SPIRType &type, std::string &expr);
 

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -844,8 +844,8 @@ protected:
 
 	bool does_shader_write_sample_mask = false;
 
-	void bitcast_to_builtin_store(uint32_t target_id, std::string &expr, const SPIRType &expr_type) override;
-	void bitcast_from_builtin_load(uint32_t source_id, std::string &expr, const SPIRType &expr_type) override;
+	void cast_to_builtin_store(uint32_t target_id, std::string &expr, const SPIRType &expr_type) override;
+	void cast_from_builtin_load(uint32_t source_id, std::string &expr, const SPIRType &expr_type) override;
 	void emit_store_statement(uint32_t lhs_expression, uint32_t rhs_expression) override;
 
 	void analyze_sampled_image_usage();


### PR DESCRIPTION
`half` cannot be bitcasted to `float`, because the two types are not the
same size. Use an expanding cast instead.