### PR TITLE
MSL: Allow post-depth coverage on Mac in MSL 2.3.

### DIFF
--- a/reference/opt/shaders-msl/frag/post-depth-coverage.msl23.frag
+++ b/reference/opt/shaders-msl/frag/post-depth-coverage.msl23.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+[[ early_fragment_tests ]] fragment main0_out main0(uint gl_SampleMaskIn [[sample_mask, post_depth_coverage]])
+{
+    main0_out out = {};
+    out.FragColor = float4(float(gl_SampleMaskIn));
+    return out;
+}
+

--- a/reference/shaders-msl/frag/post-depth-coverage.msl23.frag
+++ b/reference/shaders-msl/frag/post-depth-coverage.msl23.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+[[ early_fragment_tests ]] fragment main0_out main0(uint gl_SampleMaskIn [[sample_mask, post_depth_coverage]])
+{
+    main0_out out = {};
+    out.FragColor = float4(float(gl_SampleMaskIn));
+    return out;
+}
+

--- a/shaders-msl/frag/post-depth-coverage.msl23.frag
+++ b/shaders-msl/frag/post-depth-coverage.msl23.frag
@@ -1,0 +1,11 @@
+#version 450
+#extension GL_ARB_post_depth_coverage : require
+
+layout(post_depth_coverage) in;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = vec4(gl_SampleMaskIn[0]);
+}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -10092,9 +10092,9 @@ void CompilerMSL::entry_point_args_builtin(string &ep_args)
 				if (bi_type == BuiltInSampleMask && get_entry_point().flags.get(ExecutionModePostDepthCoverage))
 				{
 					if (!msl_options.supports_msl_version(2))
-						SPIRV_CROSS_THROW("Post-depth coverage requires Metal 2.0.");
-					if (!msl_options.is_ios())
-						SPIRV_CROSS_THROW("Post-depth coverage is only supported on iOS.");
+						SPIRV_CROSS_THROW("Post-depth coverage requires MSL 2.0.");
+					if (msl_options.is_macos() && !msl_options.supports_msl_version(2, 3))
+						SPIRV_CROSS_THROW("Post-depth coverage on Mac requires MSL 2.3.");
 					ep_args += ", post_depth_coverage";
 				}
 				ep_args += "]]";


### PR DESCRIPTION
It's still only supported on Apple GPUs, but Macs will have those soon.