### PR TITLE
fixed compile error with -std=c++20.

### DIFF
--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -357,28 +357,6 @@ public:
 		return TypedID<U>(*this);
 	}
 
-	bool operator==(const TypedID &other) const
-	{
-		return id == other.id;
-	}
-
-	bool operator!=(const TypedID &other) const
-	{
-		return id != other.id;
-	}
-
-	template <Types type>
-	bool operator==(const TypedID<type> &other) const
-	{
-		return id == uint32_t(other);
-	}
-
-	template <Types type>
-	bool operator!=(const TypedID<type> &other) const
-	{
-		return id != uint32_t(other);
-	}
-
 private:
 	uint32_t id = 0;
 };
@@ -401,26 +379,6 @@ public:
 	operator uint32_t() const
 	{
 		return id;
-	}
-
-	bool operator==(const TypedID &other) const
-	{
-		return id == other.id;
-	}
-
-	bool operator!=(const TypedID &other) const
-	{
-		return id != other.id;
-	}
-
-	bool operator==(const TypedID<TypeNone> &other) const
-	{
-		return id == uint32_t(other);
-	}
-
-	bool operator!=(const TypedID<TypeNone> &other) const
-	{
-		return id != uint32_t(other);
 	}
 
 private:


### PR DESCRIPTION
C++20 has different overload resolution rules for comparison operators, which breaks some old code.

- [Code compiles ok on c++17 but fails on c++20](https://godbolt.org/z/458eaP)

- [Simply delete those operators seems to make the compiler happy](https://godbolt.org/z/MvKq14)