### PR TITLE
MSL: Allow Bias and Grad arguments with comparison on Mac in MSL 2.3.

### DIFF
--- a/reference/opt/shaders-msl/frag/sampler-compare-bias.msl23.1d-as-2d.frag
+++ b/reference/opt/shaders-msl/frag/sampler-compare-bias.msl23.1d-as-2d.frag
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 vUV [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], depth2d_array<float> uTex [[texture(0)]], sampler uShadow [[sampler(0)]])
+{
+    main0_out out = {};
+    out.FragColor = uTex.sample_compare(uShadow, float2(in.vUV.x, 0.5), uint(round(in.vUV.y)), in.vUV.z, bias(1.0));
+    return out;
+}
+

--- a/reference/opt/shaders-msl/frag/sampler-compare-cascade-gradient.msl23.frag
+++ b/reference/opt/shaders-msl/frag/sampler-compare-cascade-gradient.msl23.frag
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vUV [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], depth2d_array<float> uTex [[texture(0)]], sampler uShadow [[sampler(0)]])
+{
+    main0_out out = {};
+    out.FragColor = uTex.sample_compare(uShadow, in.vUV.xy, uint(round(in.vUV.z)), in.vUV.w, level(0)) + uTex.sample_compare(uShadow, in.vUV.xy, uint(round(in.vUV.z)), in.vUV.w, gradient2d(float2(1.0), float2(1.0)));
+    return out;
+}
+

--- a/reference/shaders-msl/frag/sampler-compare-bias.msl23.1d-as-2d.frag
+++ b/reference/shaders-msl/frag/sampler-compare-bias.msl23.1d-as-2d.frag
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 vUV [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], depth2d_array<float> uTex [[texture(0)]], sampler uShadow [[sampler(0)]])
+{
+    main0_out out = {};
+    out.FragColor = uTex.sample_compare(uShadow, float2(in.vUV.x, 0.5), uint(round(in.vUV.y)), in.vUV.z, bias(1.0));
+    return out;
+}
+

--- a/reference/shaders-msl/frag/sampler-compare-cascade-gradient.msl23.frag
+++ b/reference/shaders-msl/frag/sampler-compare-cascade-gradient.msl23.frag
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 vUV [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], depth2d_array<float> uTex [[texture(0)]], sampler uShadow [[sampler(0)]])
+{
+    main0_out out = {};
+    out.FragColor = uTex.sample_compare(uShadow, in.vUV.xy, uint(round(in.vUV.z)), in.vUV.w, level(0)) + uTex.sample_compare(uShadow, in.vUV.xy, uint(round(in.vUV.z)), in.vUV.w, gradient2d(float2(1.0), float2(1.0)));
+    return out;
+}
+

--- a/shaders-msl/frag/sampler-compare-bias.msl23.1d-as-2d.frag
+++ b/shaders-msl/frag/sampler-compare-bias.msl23.1d-as-2d.frag
@@ -1,0 +1,11 @@
+#version 450
+
+layout(binding = 0) uniform texture1DArray uTex;
+layout(binding = 1) uniform samplerShadow uShadow;
+layout(location = 0) in vec3 vUV;
+layout(location = 0) out float FragColor;
+
+void main()
+{
+	FragColor = texture(sampler1DArrayShadow(uTex, uShadow), vUV, 1.0);
+}

--- a/shaders-msl/frag/sampler-compare-cascade-gradient.msl23.frag
+++ b/shaders-msl/frag/sampler-compare-cascade-gradient.msl23.frag
@@ -1,0 +1,11 @@
+#version 450
+
+layout(binding = 0) uniform texture2DArray uTex;
+layout(binding = 1) uniform samplerShadow uShadow;
+layout(location = 0) in vec4 vUV;
+layout(location = 0) out float FragColor;
+
+void main()
+{
+	FragColor = textureGrad(sampler2DArrayShadow(uTex, uShadow), vUV, vec2(0.0), vec2(0.0)) + textureGrad(sampler2DArrayShadow(uTex, uShadow), vUV, vec2(1.0), vec2(1.0));
+}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -8642,10 +8642,10 @@ string CompilerMSL::to_function_args(const TextureFunctionArguments &args, bool 
 				grad_y = 0;
 				farg_str += ", level(0)";
 			}
-			else
+			else if (!msl_options.supports_msl_version(2, 3))
 			{
 				SPIRV_CROSS_THROW("Using non-constant 0.0 gradient() qualifier for sample_compare. This is not "
-				                  "supported in MSL macOS.");
+				                  "supported on macOS prior to MSL 2.3.");
 			}
 		}
 
@@ -8657,10 +8657,10 @@ string CompilerMSL::to_function_args(const TextureFunctionArguments &args, bool 
 			{
 				bias = 0;
 			}
-			else
+			else if (!msl_options.supports_msl_version(2, 3))
 			{
 				SPIRV_CROSS_THROW(
-				    "Using non-constant 0.0 bias() qualifier for sample_compare. This is not supported in MSL macOS.");
+				    "Using non-constant 0.0 bias() qualifier for sample_compare. This is not supported on macOS prior to MSL 2.3.");
 			}
 		}
 	}


### PR DESCRIPTION
I kept the code to replace constant zero arguments, because `Bias`
and `Grad` still have some problems on desktop GPUs.

`Bias` works on AMD GPUs. `Grad` does not. Both work on Intel. Still
needs testing on NV. It will definitely work with Apple GPUs.

Curiously, `texture()` in GLSL has no overload that accepts both
`sampler2DArrayShadow` and a bias argument. But, it does have a
`sampler1DArrayShadow` with bias overload.