### PR TITLE
Parser: Don't assume OpTypePointer will always take a SPIRType.

### DIFF
--- a/reference/shaders-reflection/comp/function-pointer.invalid.asm.comp.json
+++ b/reference/shaders-reflection/comp/function-pointer.invalid.asm.comp.json
@@ -1,0 +1,18 @@
+{
+    "entryPoints" : [
+        {
+            "name" : "main",
+            "mode" : "comp",
+            "workgroup_size" : [
+                1,
+                1,
+                1
+            ],
+            "workgroup_size_is_spec_constant_id" : [
+                false,
+                false,
+                false
+            ]
+        }
+    ]
+}

--- a/shaders-reflection/comp/function-pointer.invalid.asm.comp
+++ b/shaders-reflection/comp/function-pointer.invalid.asm.comp
@@ -1,0 +1,19 @@
+; SPIR-V
+; Version: 1.5
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 7
+; Schema: 0
+OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %2 "main"
+OpExecutionMode %2 LocalSize 1 1 1
+OpSource GLSL 450
+OpName %2 "main"
+%3 = OpTypeVoid
+%4 = OpTypeFunction %3
+%5 = OpTypePointer Private %4
+%2 = OpFunction %3 None %4
+%6 = OpLabel
+OpReturn
+OpFunctionEnd

--- a/spirv_parser.cpp
+++ b/spirv_parser.cpp
@@ -623,10 +623,15 @@ void Parser::parse(const Instruction &instruction)
 	{
 		uint32_t id = ops[0];
 
-		auto &base = get<SPIRType>(ops[2]);
+		// Very rarely, we might receive a FunctionPrototype here.
+		// We won't be able to compile it, but we shouldn't crash when parsing.
+		// We should be able to reflect.
+		auto *base = maybe_get<SPIRType>(ops[2]);
 		auto &ptrbase = set<SPIRType>(id);
 
-		ptrbase = base;
+		if (base)
+			ptrbase = *base;
+
 		ptrbase.pointer = true;
 		ptrbase.pointer_depth++;
 		ptrbase.storage = static_cast<StorageClass>(ops[1]);
@@ -634,7 +639,7 @@ void Parser::parse(const Instruction &instruction)
 		if (ptrbase.storage == StorageClassAtomicCounter)
 			ptrbase.basetype = SPIRType::AtomicCounter;
 
-		if (base.forward_pointer)
+		if (base && base->forward_pointer)
 			forward_pointer_fixups.push_back({ id, ops[2] });
 
 		ptrbase.parent_type = ops[2];


### PR DESCRIPTION
Possible to receive a function prototype here. Don't try to do anything
smart here, just don't crash during parsing.

Fix #1510.