### PR TITLE
HLSL: Add option to flatten matrix vertex input semantics.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,7 +323,7 @@ if (SPIRV_CROSS_STATIC)
 endif()
 
 set(spirv-cross-abi-major 0)
-set(spirv-cross-abi-minor 41)
+set(spirv-cross-abi-minor 42)
 set(spirv-cross-abi-patch 0)
 
 if (SPIRV_CROSS_SHARED)

--- a/main.cpp
+++ b/main.cpp
@@ -607,6 +607,7 @@ struct CLIArguments
 	bool hlsl_force_storage_buffer_as_uav = false;
 	bool hlsl_nonwritable_uav_texture_as_srv = false;
 	bool hlsl_enable_16bit_types = false;
+	bool hlsl_flatten_matrix_vertex_input_semantics = false;
 	HLSLBindingFlags hlsl_binding_flags = 0;
 	bool vulkan_semantics = false;
 	bool flatten_multidimensional_arrays = false;
@@ -705,6 +706,7 @@ static void print_help_hlsl()
 	                "\t[--set-hlsl-vertex-input-semantic <location> <semantic>]:\n\t\tEmits a specific vertex input semantic for a given location.\n"
 	                "\t\tOtherwise, TEXCOORD# is used as semantics, where # is location.\n"
 	                "\t[--hlsl-enable-16bit-types]:\n\t\tEnables native use of half/int16_t/uint16_t and ByteAddressBuffer interaction with these types. Requires SM 6.2.\n"
+	                "\t[--hlsl-flatten-matrix-vertex-input-semantics]:\n\t\tEmits matrix vertex inputs with input semantics as if they were independent vectors, e.g. TEXCOORD{2,3,4} rather than matrix form TEXCOORD2_{0,1,2}.\n"
 	);
 	// clang-format on
 }
@@ -1195,6 +1197,7 @@ static string compile_iteration(const CLIArguments &args, std::vector<uint32_t> 
 		hlsl_opts.force_storage_buffer_as_uav = args.hlsl_force_storage_buffer_as_uav;
 		hlsl_opts.nonwritable_uav_texture_as_srv = args.hlsl_nonwritable_uav_texture_as_srv;
 		hlsl_opts.enable_16bit_types = args.hlsl_enable_16bit_types;
+		hlsl_opts.flatten_matrix_vertex_input_semantics = args.hlsl_flatten_matrix_vertex_input_semantics;
 		hlsl->set_hlsl_options(hlsl_opts);
 		hlsl->set_resource_binding_flags(args.hlsl_binding_flags);
 	}
@@ -1367,6 +1370,7 @@ static int main_inner(int argc, char *argv[])
 	cbs.add("--hlsl-nonwritable-uav-texture-as-srv",
 	        [&args](CLIParser &) { args.hlsl_nonwritable_uav_texture_as_srv = true; });
 	cbs.add("--hlsl-enable-16bit-types", [&args](CLIParser &) { args.hlsl_enable_16bit_types = true; });
+	cbs.add("--hlsl-flatten-matrix-vertex-input-semantics", [&args](CLIParser &) { args.hlsl_flatten_matrix_vertex_input_semantics = true; });
 	cbs.add("--vulkan-semantics", [&args](CLIParser &) { args.vulkan_semantics = true; });
 	cbs.add("-V", [&args](CLIParser &) { args.vulkan_semantics = true; });
 	cbs.add("--flatten-multidimensional-arrays", [&args](CLIParser &) { args.flatten_multidimensional_arrays = true; });

--- a/reference/shaders-hlsl-no-opt/vert/flatten-matrix-input.flatten-matrix-vertex-input.vert
+++ b/reference/shaders-hlsl-no-opt/vert/flatten-matrix-input.flatten-matrix-vertex-input.vert
@@ -1,0 +1,51 @@
+static float4 gl_Position;
+static float4x4 m4;
+static float4 v;
+static float3x3 m3;
+static float2x2 m2;
+
+struct SPIRV_Cross_Input
+{
+    float4 m4_0 : TEXCOORD0;
+    float4 m4_1 : TEXCOORD1;
+    float4 m4_2 : TEXCOORD2;
+    float4 m4_3 : TEXCOORD3;
+    float3 m3_0 : TEXCOORD4;
+    float3 m3_1 : TEXCOORD5;
+    float3 m3_2 : TEXCOORD6;
+    float2 m2_0 : TEXCOORD7;
+    float2 m2_1 : TEXCOORD8;
+    float4 v : TEXCOORD9;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 gl_Position : SV_Position;
+};
+
+void vert_main()
+{
+    gl_Position = mul(v, m4);
+    float3 _37 = gl_Position.xyz + mul(v.xyz, m3);
+    gl_Position = float4(_37.x, _37.y, _37.z, gl_Position.w);
+    float2 _52 = gl_Position.xy + mul(v.xy, m2);
+    gl_Position = float4(_52.x, _52.y, gl_Position.z, gl_Position.w);
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    m4[0] = stage_input.m4_0;
+    m4[1] = stage_input.m4_1;
+    m4[2] = stage_input.m4_2;
+    m4[3] = stage_input.m4_3;
+    v = stage_input.v;
+    m3[0] = stage_input.m3_0;
+    m3[1] = stage_input.m3_1;
+    m3[2] = stage_input.m3_2;
+    m2[0] = stage_input.m2_0;
+    m2[1] = stage_input.m2_1;
+    vert_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    return stage_output;
+}

--- a/shaders-hlsl-no-opt/vert/flatten-matrix-input.flatten-matrix-vertex-input.vert
+++ b/shaders-hlsl-no-opt/vert/flatten-matrix-input.flatten-matrix-vertex-input.vert
@@ -1,0 +1,13 @@
+#version 450
+
+layout(location = 0) in mat4 m4;
+layout(location = 4) in mat3 m3;
+layout(location = 7) in mat2 m2;
+layout(location = 9) in vec4 v;
+
+void main()
+{
+	gl_Position = m4 * v;
+	gl_Position.xyz += m3 * v.xyz;
+	gl_Position.xy += m2 * v.xy;
+}

--- a/spirv_cross_c.cpp
+++ b/spirv_cross_c.cpp
@@ -492,6 +492,10 @@ spvc_result spvc_compiler_options_set_uint(spvc_compiler_options options, spvc_c
 	case SPVC_COMPILER_OPTION_HLSL_ENABLE_16BIT_TYPES:
 		options->hlsl.enable_16bit_types = value != 0;
 		break;
+
+	case SPVC_COMPILER_OPTION_HLSL_FLATTEN_MATRIX_VERTEX_INPUT_SEMANTICS:
+		options->hlsl.flatten_matrix_vertex_input_semantics = value != 0;
+		break;
 #endif
 
 #if SPIRV_CROSS_C_API_MSL

--- a/spirv_cross_c.h
+++ b/spirv_cross_c.h
@@ -33,7 +33,7 @@ extern "C" {
 /* Bumped if ABI or API breaks backwards compatibility. */
 #define SPVC_C_API_VERSION_MAJOR 0
 /* Bumped if APIs or enumerations are added in a backwards compatible way. */
-#define SPVC_C_API_VERSION_MINOR 41
+#define SPVC_C_API_VERSION_MINOR 42
 /* Bumped if internal implementation details change. */
 #define SPVC_C_API_VERSION_PATCH 0
 
@@ -644,6 +644,8 @@ typedef enum spvc_compiler_option
 	SPVC_COMPILER_OPTION_MSL_ARRAYED_SUBPASS_INPUT = 68 | SPVC_COMPILER_OPTION_MSL_BIT,
 	SPVC_COMPILER_OPTION_MSL_R32UI_LINEAR_TEXTURE_ALIGNMENT = 69 | SPVC_COMPILER_OPTION_MSL_BIT,
 	SPVC_COMPILER_OPTION_MSL_R32UI_ALIGNMENT_CONSTANT_ID = 70 | SPVC_COMPILER_OPTION_MSL_BIT,
+
+	SPVC_COMPILER_OPTION_HLSL_FLATTEN_MATRIX_VERTEX_INPUT_SEMANTICS = 71 | SPVC_COMPILER_OPTION_HLSL_BIT,
 
 	SPVC_COMPILER_OPTION_INT_MAX = 0x7fffffff
 } spvc_compiler_option;

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -935,8 +935,15 @@ void CompilerHLSL::emit_interface_block_in_struct(const SPIRVariable &var, unord
 			{
 				SPIRType newtype = type;
 				newtype.columns = 1;
+
+				string effective_semantic;
+				if (hlsl_options.flatten_matrix_vertex_input_semantics)
+					effective_semantic = to_semantic(location_number, execution.model, var.storage);
+				else
+					effective_semantic = join(semantic, "_", i);
+
 				statement(to_interpolation_qualifiers(get_decoration_bitset(var.self)),
-				          variable_decl(newtype, join(name, "_", i)), " : ", semantic, "_", i, ";");
+				          variable_decl(newtype, join(name, "_", i)), " : ", effective_semantic, ";");
 				active_locations.insert(location_number++);
 			}
 		}

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -124,6 +124,12 @@ public:
 		// Uses half/int16_t/uint16_t instead of min16* types.
 		// Also adds support for 16-bit load-store from (RW)ByteAddressBuffer.
 		bool enable_16bit_types = false;
+
+		// If matrices are used as IO variables, flatten the attribute declaration to use
+		// TEXCOORD{N,N+1,N+2,...} rather than TEXCOORDN_{0,1,2,3}.
+		// If add_vertex_attribute_remap is used and this feature is used,
+		// the semantic name will be queried once per active location.
+		bool flatten_matrix_vertex_input_semantics = false;
 	};
 
 	explicit CompilerHLSL(std::vector<uint32_t> spirv_)

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -425,6 +425,8 @@ def cross_compile_hlsl(shader, spirv, opt, force_no_external_validation, iterati
         hlsl_args.append('--hlsl-nonwritable-uav-texture-as-srv')
     if '.native-16bit.' in shader:
         hlsl_args.append('--hlsl-enable-16bit-types')
+    if '.flatten-matrix-vertex-input.' in shader:
+        hlsl_args.append('--hlsl-flatten-matrix-vertex-input-semantics')
 
     subprocess.check_call(hlsl_args)
 


### PR DESCRIPTION
Helps translation layers where we expect inputs to be multiple float
vectors rather than an indexed matrix.

Fix #1512.