### PR TITLE
HLSL: Support roundEven() in HLSL SM 4.0 and above

### DIFF
--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -3444,7 +3444,10 @@ void CompilerHLSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop,
 		break;
 
 	case GLSLstd450RoundEven:
-		SPIRV_CROSS_THROW("roundEven is not supported on HLSL.");
+		if (hlsl_options.shader_model < 40)
+			SPIRV_CROSS_THROW("roundEven is not supported in HLSL shader model 2/3.");
+		emit_unary_func_op(result_type, id, args[0], "round");
+		break;
 
 	case GLSLstd450Acosh:
 	case GLSLstd450Asinh:


### PR DESCRIPTION
According to the [HLSL documentation](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-round), `round()` always rounds .5 to the nearest even integer.  This would satisfy the specification of both the GLSL `round()` and `roundEven()` functions (the former not being specific about rounding, and the latter matching the HLSL behaviour).

I have verified experimentally that FXC, targeting SM 4.0 and higher, does indeed emit a [round_ne](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/round-ne--sm4---asm-) instruction for `round()`.  Older shader models do not have this instruction, and FXC instead emits the equivalent of `floor(x + 0.5)`.  Hence I've added a version check accordingly.

I figured this didn't need a special test (I did verify manually that it does generate the proper call) but am happy to add one if you like.

It's probably worth noting that glslang's HLSL front-end also maps round to roundEven:
https://github.com/KhronosGroup/glslang/blob/478b23295244c9f33eb90a47a99fb3b5cc6e0370/glslang/HLSL/hlslParseables.cpp#L1126