### PR TITLE
GLSL: implement transpose() in GLSL 1.10 / ES 1.00

### DIFF
--- a/reference/opt/shaders/legacy/vert/transpose.legacy.vert
+++ b/reference/opt/shaders/legacy/vert/transpose.legacy.vert
@@ -13,8 +13,17 @@ attribute vec4 Position;
 
 mat4 SPIRV_Cross_workaround_load_row_major(mat4 wrap) { return wrap; }
 
+mat4 SPIRV_Cross_Transpose(mat4 m)
+{
+    return mat4(m[0][0], m[1][0], m[2][0], m[3][0], m[0][1], m[1][1], m[2][1], m[3][1], m[0][2], m[1][2], m[2][2], m[3][2], m[0][3], m[1][3], m[2][3], m[3][3]);
+}
+
 void main()
 {
-    gl_Position = (((SPIRV_Cross_workaround_load_row_major(_13.M) * (Position * _13.MVPRowMajor)) + (SPIRV_Cross_workaround_load_row_major(_13.M) * (SPIRV_Cross_workaround_load_row_major(_13.MVPColMajor) * Position))) + (SPIRV_Cross_workaround_load_row_major(_13.M) * (_13.MVPRowMajor * Position))) + (SPIRV_Cross_workaround_load_row_major(_13.M) * (Position * SPIRV_Cross_workaround_load_row_major(_13.MVPColMajor)));
+    mat4 _55 = _13.MVPRowMajor;
+    mat4 _61 = SPIRV_Cross_workaround_load_row_major(_13.MVPColMajor);
+    mat4 _80 = SPIRV_Cross_Transpose(_13.MVPRowMajor) * 2.0;
+    mat4 _87 = SPIRV_Cross_Transpose(_61) * 2.0;
+    gl_Position = (((((((((((SPIRV_Cross_workaround_load_row_major(_13.M) * (Position * _13.MVPRowMajor)) + (SPIRV_Cross_workaround_load_row_major(_13.M) * (SPIRV_Cross_workaround_load_row_major(_13.MVPColMajor) * Position))) + (SPIRV_Cross_workaround_load_row_major(_13.M) * (_13.MVPRowMajor * Position))) + (SPIRV_Cross_workaround_load_row_major(_13.M) * (Position * SPIRV_Cross_workaround_load_row_major(_13.MVPColMajor)))) + (_55 * Position)) + (Position * _61)) + (Position * _55)) + (_61 * Position)) + (_80 * Position)) + (_87 * Position)) + (Position * _80)) + (Position * _87);
 }
 

--- a/reference/shaders/legacy/vert/transpose.legacy.vert
+++ b/reference/shaders/legacy/vert/transpose.legacy.vert
@@ -13,12 +13,25 @@ attribute vec4 Position;
 
 mat4 SPIRV_Cross_workaround_load_row_major(mat4 wrap) { return wrap; }
 
+mat4 SPIRV_Cross_Transpose(mat4 m)
+{
+    return mat4(m[0][0], m[1][0], m[2][0], m[3][0], m[0][1], m[1][1], m[2][1], m[3][1], m[0][2], m[1][2], m[2][2], m[3][2], m[0][3], m[1][3], m[2][3], m[3][3]);
+}
+
 void main()
 {
     vec4 c0 = SPIRV_Cross_workaround_load_row_major(_13.M) * (Position * _13.MVPRowMajor);
     vec4 c1 = SPIRV_Cross_workaround_load_row_major(_13.M) * (SPIRV_Cross_workaround_load_row_major(_13.MVPColMajor) * Position);
     vec4 c2 = SPIRV_Cross_workaround_load_row_major(_13.M) * (_13.MVPRowMajor * Position);
     vec4 c3 = SPIRV_Cross_workaround_load_row_major(_13.M) * (Position * SPIRV_Cross_workaround_load_row_major(_13.MVPColMajor));
-    gl_Position = ((c0 + c1) + c2) + c3;
+    vec4 c4 = _13.MVPRowMajor * Position;
+    vec4 c5 = Position * SPIRV_Cross_workaround_load_row_major(_13.MVPColMajor);
+    vec4 c6 = Position * _13.MVPRowMajor;
+    vec4 c7 = SPIRV_Cross_workaround_load_row_major(_13.MVPColMajor) * Position;
+    vec4 c8 = (SPIRV_Cross_Transpose(_13.MVPRowMajor) * 2.0) * Position;
+    vec4 c9 = (SPIRV_Cross_Transpose(SPIRV_Cross_workaround_load_row_major(_13.MVPColMajor)) * 2.0) * Position;
+    vec4 c10 = Position * (SPIRV_Cross_Transpose(_13.MVPRowMajor) * 2.0);
+    vec4 c11 = Position * (SPIRV_Cross_Transpose(SPIRV_Cross_workaround_load_row_major(_13.MVPColMajor)) * 2.0);
+    gl_Position = ((((((((((c0 + c1) + c2) + c3) + c4) + c5) + c6) + c7) + c8) + c9) + c10) + c11;
 }
 

--- a/shaders/legacy/vert/transpose.legacy.vert
+++ b/shaders/legacy/vert/transpose.legacy.vert
@@ -15,6 +15,18 @@ void main()
 	vec4 c1 = M * (MVPColMajor * Position);
 	vec4 c2 = M * (Position * MVPRowMajor);
 	vec4 c3 = M * (Position * MVPColMajor);
-	gl_Position = c0 + c1 + c2 + c3;
+
+	vec4 c4 = transpose(MVPRowMajor) * Position;
+	vec4 c5 = transpose(MVPColMajor) * Position;
+	vec4 c6 = Position * transpose(MVPRowMajor);
+	vec4 c7 = Position * transpose(MVPColMajor);
+
+	// Multiplying by scalar forces resolution of the transposition
+	vec4 c8 = (MVPRowMajor * 2.0) * Position;
+	vec4 c9 = (transpose(MVPColMajor) * 2.0) * Position;
+	vec4 c10 = Position * (MVPRowMajor * 2.0);
+	vec4 c11 = Position * (transpose(MVPColMajor) * 2.0);
+
+	gl_Position = c0 + c1 + c2 + c3 + c4 + c5 + c6 + c7 + c8 + c9 + c10 + c11;
 }
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -806,6 +806,10 @@ protected:
 		return !options.es && options.version < 130;
 	}
 
+	bool requires_transpose_2x2 = false;
+	bool requires_transpose_3x3 = false;
+	bool requires_transpose_4x4 = false;
+
 	bool args_will_forward(uint32_t id, const uint32_t *args, uint32_t num_args, bool pure);
 	void register_call_out_argument(uint32_t id);
 	void register_impure_function_call();


### PR DESCRIPTION
GLSL 1.10 and ESSL 1.00 do not have `transpose()`.  However, it can be easily emulated—in most cases by flipping the `need_transpose` flag (which may just result in flipping multiplication order somewhere), or otherwise using a helper function.  It is made simpler by the fact that these versions only support square matrices, which leaves only three types to support.

I've followed the example of the HLSL inverse implementation for the helper function.

I do wonder if we should just handle OpTranspose this way for the other versions as well, as an optimisation, but that is outside the scope of this PR.  There are also other operations that are unnecessarily resolving the `need_transpose` (such as matrix-scalar multiplication, which could be performed without transposing the matrix).