### PR TITLE
GLSL: Fix support for textureLod in legacy vertex shaders

### DIFF
--- a/reference/opt/shaders/legacy/fragment/explicit-lod.legacy.vert
+++ b/reference/opt/shaders/legacy/fragment/explicit-lod.legacy.vert
@@ -1,0 +1,11 @@
+#version 100
+
+uniform mediump sampler2D tex;
+
+varying mediump vec4 FragColor;
+
+void main()
+{
+    FragColor = texture2DLod(tex, vec2(0.4000000059604644775390625, 0.60000002384185791015625), 3.0);
+}
+

--- a/reference/opt/shaders/legacy/vert/implicit-lod.legacy.vert
+++ b/reference/opt/shaders/legacy/vert/implicit-lod.legacy.vert
@@ -4,6 +4,6 @@ uniform mediump sampler2D tex;
 
 void main()
 {
-    gl_Position = texture2D(tex, vec2(0.4000000059604644775390625, 0.60000002384185791015625));
+    gl_Position = texture2DLod(tex, vec2(0.4000000059604644775390625, 0.60000002384185791015625), 0.0);
 }
 

--- a/reference/shaders/legacy/fragment/explicit-lod.legacy.vert
+++ b/reference/shaders/legacy/fragment/explicit-lod.legacy.vert
@@ -1,0 +1,11 @@
+#version 100
+
+uniform mediump sampler2D tex;
+
+varying mediump vec4 FragColor;
+
+void main()
+{
+    FragColor = texture2DLod(tex, vec2(0.4000000059604644775390625, 0.60000002384185791015625), 3.0);
+}
+

--- a/reference/shaders/legacy/vert/implicit-lod.legacy.vert
+++ b/reference/shaders/legacy/vert/implicit-lod.legacy.vert
@@ -4,6 +4,6 @@ uniform mediump sampler2D tex;
 
 void main()
 {
-    gl_Position = texture2D(tex, vec2(0.4000000059604644775390625, 0.60000002384185791015625));
+    gl_Position = texture2DLod(tex, vec2(0.4000000059604644775390625, 0.60000002384185791015625), 0.0);
 }
 

--- a/shaders/legacy/fragment/explicit-lod.legacy.vert
+++ b/shaders/legacy/fragment/explicit-lod.legacy.vert
@@ -1,0 +1,12 @@
+#version 310 es
+
+precision mediump float;
+
+layout(binding = 0) uniform sampler2D tex;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = textureLod(tex, vec2(0.4, 0.6), 3.0);
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -5641,7 +5641,7 @@ void CompilerGLSL::emit_bitfield_insert_op(uint32_t result_type, uint32_t result
 	inherit_expression_dependencies(result_id, op3);
 }
 
-string CompilerGLSL::legacy_tex_op(const std::string &op, const SPIRType &imgtype, uint32_t lod, uint32_t tex)
+string CompilerGLSL::legacy_tex_op(const std::string &op, const SPIRType &imgtype, uint32_t tex)
 {
 	const char *type;
 	switch (imgtype.image.dim)
@@ -6411,7 +6411,7 @@ string CompilerGLSL::to_function_name(const TextureFunctionNameArguments &args)
 	if (args.is_sparse_feedback || args.has_min_lod)
 		fname += "ARB";
 
-	return is_legacy() ? legacy_tex_op(fname, imgtype, args.lod, tex) : fname;
+	return is_legacy() ? legacy_tex_op(fname, imgtype, tex) : fname;
 }
 
 std::string CompilerGLSL::convert_separate_image_to_expression(uint32_t id)

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -750,7 +750,6 @@ protected:
 
 	void replace_fragment_output(SPIRVariable &var);
 	void replace_fragment_outputs();
-	bool check_explicit_lod_allowed(uint32_t lod);
 	std::string legacy_tex_op(const std::string &op, const SPIRType &imgtype, uint32_t lod, uint32_t id);
 
 	uint32_t indent = 0;

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -750,7 +750,7 @@ protected:
 
 	void replace_fragment_output(SPIRVariable &var);
 	void replace_fragment_outputs();
-	std::string legacy_tex_op(const std::string &op, const SPIRType &imgtype, uint32_t lod, uint32_t id);
+	std::string legacy_tex_op(const std::string &op, const SPIRType &imgtype, uint32_t id);
 
 	uint32_t indent = 0;
 


### PR DESCRIPTION
The change in #148 was made with the faulty assumption that textureLod was not supported in legacy GLSL vertex shaders.  
However, LOD sampling in the vertex shader has actually been available in both GLSL and ESSL from the beginning.  See section 8.7 of the [GLSL 1.10 spec](https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.1.10.pdf) and [ESSL 1.00 spec](https://www.khronos.org/files/opengles_shading_language.pdf).

The [GL_ARB_shader_texture_lod](https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_shader_texture_lod.txt) and [GL_EXT_shader_texture_lod](https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_shader_texture_lod.txt) extensions extend the use of these existing functions to fragment shaders, and introduce the Grad variants to both vertex and fragment shaders.

This means that the fallback that has been implemented for vertex shaders (which fell back to the regular texture functions, requiring that lod=0) is entirely unnecessary.  I have removed it and instated the proper use of the texture2DLod, etc. functions that are available in legacy GLSL.