### PR TITLE
GLSL: Provide round/roundEven for legacy GLSL

### DIFF
--- a/reference/opt/shaders/frag/round-even.frag
+++ b/reference/opt/shaders/frag/round-even.frag
@@ -1,0 +1,12 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) in vec4 vA;
+layout(location = 1) in float vB;
+
+void main()
+{
+    FragColor = roundEven(vA);
+    FragColor *= roundEven(vB);
+}
+

--- a/reference/opt/shaders/frag/round.frag
+++ b/reference/opt/shaders/frag/round.frag
@@ -1,0 +1,12 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) in vec4 vA;
+layout(location = 1) in float vB;
+
+void main()
+{
+    FragColor = round(vA);
+    FragColor *= round(vB);
+}
+

--- a/reference/opt/shaders/legacy/fragment/round.legacy.frag
+++ b/reference/opt/shaders/legacy/fragment/round.legacy.frag
@@ -1,0 +1,13 @@
+#version 100
+precision mediump float;
+precision highp int;
+
+varying highp vec4 vA;
+varying highp float vB;
+
+void main()
+{
+    gl_FragData[0] = floor(vA + vec4(0.5));
+    gl_FragData[0] *= floor(vB + float(0.5));
+}
+

--- a/reference/shaders/frag/round-even.frag
+++ b/reference/shaders/frag/round-even.frag
@@ -1,0 +1,12 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) in vec4 vA;
+layout(location = 1) in float vB;
+
+void main()
+{
+    FragColor = roundEven(vA);
+    FragColor *= roundEven(vB);
+}
+

--- a/reference/shaders/frag/round.frag
+++ b/reference/shaders/frag/round.frag
@@ -1,0 +1,12 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) in vec4 vA;
+layout(location = 1) in float vB;
+
+void main()
+{
+    FragColor = round(vA);
+    FragColor *= round(vB);
+}
+

--- a/reference/shaders/legacy/fragment/round.legacy.frag
+++ b/reference/shaders/legacy/fragment/round.legacy.frag
@@ -1,0 +1,13 @@
+#version 100
+precision mediump float;
+precision highp int;
+
+varying highp vec4 vA;
+varying highp float vB;
+
+void main()
+{
+    gl_FragData[0] = floor(vA + vec4(0.5));
+    gl_FragData[0] *= floor(vB + float(0.5));
+}
+

--- a/shaders/frag/round-even.frag
+++ b/shaders/frag/round-even.frag
@@ -1,0 +1,11 @@
+#version 450
+
+layout(location = 0) in vec4 vA;
+layout(location = 1) in float vB;
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = roundEven(vA);
+	FragColor *= roundEven(vB);
+}

--- a/shaders/frag/round.frag
+++ b/shaders/frag/round.frag
@@ -1,0 +1,11 @@
+#version 450
+
+layout(location = 0) in vec4 vA;
+layout(location = 1) in float vB;
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = round(vA);
+	FragColor *= round(vB);
+}

--- a/shaders/legacy/fragment/round.legacy.frag
+++ b/shaders/legacy/fragment/round.legacy.frag
@@ -1,0 +1,11 @@
+#version 450
+
+layout(location = 0) in vec4 vA;
+layout(location = 1) in float vB;
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	FragColor = round(vA);
+	FragColor *= round(vB);
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -6725,14 +6725,30 @@ void CompilerGLSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop,
 	{
 	// FP fiddling
 	case GLSLstd450Round:
-		emit_unary_func_op(result_type, id, args[0], "round");
+		if (!is_legacy())
+			emit_unary_func_op(result_type, id, args[0], "round");
+		else
+		{
+			auto op0 = to_enclosed_expression(args[0]);
+			auto &op0_type = expression_type(args[0]);
+			auto expr = join("floor(", op0, " + ", type_to_glsl_constructor(op0_type), "(0.5))");
+			bool forward = should_forward(args[0]);
+			emit_op(result_type, id, expr, forward);
+			inherit_expression_dependencies(id, args[0]);
+		}
 		break;
 
 	case GLSLstd450RoundEven:
-		if ((options.es && options.version >= 300) || (!options.es && options.version >= 130))
+		if (!is_legacy())
 			emit_unary_func_op(result_type, id, args[0], "roundEven");
+		else if (!options.es)
+		{
+			// This extension provides round() with round-to-even semantics.
+			require_extension_internal("GL_EXT_gpu_shader4");
+			emit_unary_func_op(result_type, id, args[0], "round");
+		}
 		else
-			SPIRV_CROSS_THROW("roundEven supported only in ESSL 300 and GLSL 130 and up.");
+			SPIRV_CROSS_THROW("roundEven supported only in ESSL 300.");
 		break;
 
 	case GLSLstd450Trunc:


### PR DESCRIPTION
Despite some drivers supporting it, `round()` isn't mentioned in any of the legacy GLSL versions' specs.  The SPIR-V spec says that the rounding direction is implementation-defined, so it should be safe to fall back to `floor(x + 0.5)`.

Also, the `round()` function given by [GL_EXT_gpu_shader4](https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_gpu_shader4.txt) guarantees round-to-even semantics: 
>     Returns a value equal to the closest integer to x. If the fractional
>     portion of the operand is 0.5, the nearest even integer is returned. For
>     example, round (1.0) returns 1.0.  round(-1.5) returns -2.0. round(3.5)
>     and round (4.5) both return 4.0.
So, in legacy desktop GLSL, I've added a fallback to that extension for roundEven.  (I would've added a test, but the test harness doesn't currently support testing legacy desktop GLSL shaders—it always forces them to be ES 100.)