### PR TITLE
GLSL: Require GL_ARB_vertex_attrib_64bit for double input in pre-4.10

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -2305,6 +2305,12 @@ void CompilerGLSL::emit_interface_block(const SPIRVariable &var)
 {
 	auto &type = get<SPIRType>(var.basetype);
 
+	if (var.storage == StorageClassInput && type.basetype == SPIRType::Double &&
+	    !options.es && options.version < 410)
+	{
+		require_extension_internal("GL_ARB_vertex_attrib_64bit");
+	}
+
 	// Either make it plain in/out or in/out blocks depending on what shader is doing ...
 	bool block = ir.meta[type.self].decoration.decoration_flags.get(DecorationBlock);
 	const char *qual = to_storage_qualifiers_glsl(var);


### PR DESCRIPTION
This extension require is missing when using double vertex inputs with pre-4.10 versions.