### PR TITLE
spirv_msl: Don't add fixup hooks for builtin variables if they're unused.

### DIFF
--- a/reference/shaders-msl-no-opt/vert/unused-subgroup-builtin.msl22.vert
+++ b/reference/shaders-msl-no-opt/vert/unused-subgroup-builtin.msl22.vert
@@ -1,0 +1,9 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+vertex void main0()
+{
+}
+

--- a/shaders-msl-no-opt/vert/unused-subgroup-builtin.msl22.vert
+++ b/shaders-msl-no-opt/vert/unused-subgroup-builtin.msl22.vert
@@ -1,0 +1,7 @@
+#version 450
+#extension GL_KHR_shader_subgroup_ballot : require
+
+void main()
+{
+	gl_SubgroupEqMask;
+}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -11052,7 +11052,7 @@ void CompilerMSL::fix_up_shader_inputs_outputs()
 		uint32_t var_id = var.self;
 		BuiltIn bi_type = ir.meta[var_id].decoration.builtin_type;
 
-		if (var.storage == StorageClassInput && is_builtin_variable(var))
+		if (var.storage == StorageClassInput && is_builtin_variable(var) && active_input_builtins.get(bi_type))
 		{
 			switch (bi_type)
 			{
@@ -11518,7 +11518,7 @@ void CompilerMSL::fix_up_shader_inputs_outputs()
 				break;
 			}
 		}
-		else if (var.storage == StorageClassOutput && is_builtin_variable(var))
+		else if (var.storage == StorageClassOutput && is_builtin_variable(var) && active_output_builtins.get(bi_type))
 		{
 			if (bi_type == BuiltInSampleMask && get_execution_model() == ExecutionModelFragment &&
 			    msl_options.additional_fixed_sample_mask != 0xffffffff)


### PR DESCRIPTION
This is necessary to avoid invalid output because of how implicit dependencies on builtins work.

For example, the fixup for `BuiltInSubgroupEqMask` initializes the variable based on `builtin_subgroup_invocation_id_id`, a field storing the ID for a variable with decoration `BuiltInSubgroupLocalInvocationId`.  This could be either a variable that already exists in the input (spirv_msl.cpp:300) or, if necessary, a newly created one (spirv_msl.cpp:621).  In both cases, though, `builtin_subgroup_invocation_id_id` is only set under the condition `need_subgroup_mask || needs_subgroup_invocation_id`.  `need_subgroup_mask` is true if any of the `BuiltInSubgroupXXMask` are set in `active_input_builtins`.

Normally, if the program contains `BuiltInSubgroupEqMask`, `Compiler::ActiveBuiltinHandler` will set it in `active_input_builtins`.  But this only happens if the variable is actually used, whereas `fix_up_shader_inputs_outputs` loops over all variables in the program regardless of whether they're used.

If `BuiltInSubgroupEqMask` is not used, `builtin_subgroup_invocation_id_id` is never set, but before this patch the fixup hook would try to use it anyway, producing MSL that references a nonexistent variable named `_0`.

Avoid this by changing `fix_up_shader_inputs_outputs` to skip builtins which are not set in `active_input_builtins` or `active_output_builtins`.  And add a test case.
