### PR TITLE
MSL: Added fmin3 and fmax3 library functions to the illegal name list.

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -12019,6 +12019,8 @@ void CompilerMSL::replace_illegal_names()
 		"main",
 		"saturate",
 		"assert",
+		"fmin3",
+		"fmax3",
 		"VARIABLE_TRACEPOINT",
 		"STATIC_DATA_TRACEPOINT",
 		"STATIC_DATA_TRACEPOINT_V",


### PR DESCRIPTION
Found used in the wild by Wolfenstein II.