### PR TITLE
MSL: Fix broken reserved identifier handling for entry points

### DIFF
--- a/reference/shaders-hlsl-no-opt/asm/frag/reserved-function-identifier.asm.frag
+++ b/reference/shaders-hlsl-no-opt/asm/frag/reserved-function-identifier.asm.frag
@@ -1,0 +1,31 @@
+static float FragColor;
+
+struct SPIRV_Cross_Output
+{
+    float FragColor : SV_Target0;
+};
+
+float _mat3(float a)
+{
+    return a + 1.0f;
+}
+
+float _RESERVED_IDENTIFIER_FIXUP_gl_Foo(int a)
+{
+    return float(a) + 1.0f;
+}
+
+void frag_main()
+{
+    float param = 2.0f;
+    int param_1 = 4;
+    FragColor = _mat3(param) + _RESERVED_IDENTIFIER_FIXUP_gl_Foo(param_1);
+}
+
+SPIRV_Cross_Output main()
+{
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-msl-no-opt/asm/frag/fixup-entry-point-identifier.nomain.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/fixup-entry-point-identifier.nomain.asm.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct _5ma_in_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment _5ma_in_out _5ma_in()
+{
+    _5ma_in_out out = {};
+    out.FragColor = float4(1.0);
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/asm/frag/reserved-function-identifier.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/reserved-function-identifier.asm.frag
@@ -1,0 +1,33 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float FragColor [[color(0)]];
+};
+
+static inline __attribute__((always_inline))
+float _mat3(thread const float& a)
+{
+    return a + 1.0;
+}
+
+static inline __attribute__((always_inline))
+float _RESERVED_IDENTIFIER_FIXUP_gl_Foo(thread const int& a)
+{
+    return float(a) + 1.0;
+}
+
+fragment main0_out main0()
+{
+    main0_out out = {};
+    float param = 2.0;
+    int param_1 = 4;
+    out.FragColor = _mat3(param) + _RESERVED_IDENTIFIER_FIXUP_gl_Foo(param_1);
+    return out;
+}
+

--- a/reference/shaders-no-opt/asm/frag/reserved-function-identifier.asm.frag
+++ b/reference/shaders-no-opt/asm/frag/reserved-function-identifier.asm.frag
@@ -1,0 +1,21 @@
+#version 450
+
+layout(location = 0) out float FragColor;
+
+float _mat3(float a)
+{
+    return a + 1.0;
+}
+
+float _RESERVED_IDENTIFIER_FIXUP_gl_Foo(int a)
+{
+    return float(a) + 1.0;
+}
+
+void main()
+{
+    float param = 2.0;
+    int param_1 = 4;
+    FragColor = _mat3(param) + _RESERVED_IDENTIFIER_FIXUP_gl_Foo(param_1);
+}
+

--- a/shaders-hlsl-no-opt/asm/frag/reserved-function-identifier.asm.frag
+++ b/shaders-hlsl-no-opt/asm/frag/reserved-function-identifier.asm.frag
@@ -1,0 +1,60 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 37
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %ACOS_f1_ "mat3"
+               OpName %a "a"
+               OpName %ACOS_i1_ "gl_Foo"
+               OpName %a_0 "a"
+               OpName %FragColor "FragColor"
+               OpName %param "param"
+               OpName %param_0 "param"
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_ptr_Function_float = OpTypePointer Function %float
+          %8 = OpTypeFunction %float %_ptr_Function_float
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+         %14 = OpTypeFunction %float %_ptr_Function_int
+    %float_1 = OpConstant %float 1
+%_ptr_Output_float = OpTypePointer Output %float
+  %FragColor = OpVariable %_ptr_Output_float Output
+    %float_2 = OpConstant %float 2
+      %int_4 = OpConstant %int 4
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+      %param = OpVariable %_ptr_Function_float Function
+    %param_0 = OpVariable %_ptr_Function_int Function
+               OpStore %param %float_2
+         %32 = OpFunctionCall %float %ACOS_f1_ %param
+               OpStore %param_0 %int_4
+         %35 = OpFunctionCall %float %ACOS_i1_ %param_0
+         %36 = OpFAdd %float %32 %35
+               OpStore %FragColor %36
+               OpReturn
+               OpFunctionEnd
+   %ACOS_f1_ = OpFunction %float None %8
+          %a = OpFunctionParameter %_ptr_Function_float
+         %11 = OpLabel
+         %18 = OpLoad %float %a
+         %20 = OpFAdd %float %18 %float_1
+               OpReturnValue %20
+               OpFunctionEnd
+   %ACOS_i1_ = OpFunction %float None %14
+        %a_0 = OpFunctionParameter %_ptr_Function_int
+         %17 = OpLabel
+         %23 = OpLoad %int %a_0
+         %24 = OpConvertSToF %float %23
+         %25 = OpFAdd %float %24 %float_1
+               OpReturnValue %25
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/frag/fixup-entry-point-identifier.nomain.asm.frag
+++ b/shaders-msl-no-opt/asm/frag/fixup-entry-point-identifier.nomain.asm.frag
@@ -1,0 +1,27 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 12
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %foo "_5ma@@in" %FragColor
+               OpExecutionMode %foo OriginUpperLeft
+               OpSource GLSL 450
+               OpName %foo "FOO"
+               OpName %FragColor "FragColor"
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+    %float_1 = OpConstant %float 1
+         %11 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
+       %foo = OpFunction %void None %3
+          %5 = OpLabel
+               OpStore %FragColor %11
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/frag/reserved-function-identifier.asm.frag
+++ b/shaders-msl-no-opt/asm/frag/reserved-function-identifier.asm.frag
@@ -1,0 +1,60 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 37
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %ACOS_f1_ "mat3"
+               OpName %a "a"
+               OpName %ACOS_i1_ "gl_Foo"
+               OpName %a_0 "a"
+               OpName %FragColor "FragColor"
+               OpName %param "param"
+               OpName %param_0 "param"
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_ptr_Function_float = OpTypePointer Function %float
+          %8 = OpTypeFunction %float %_ptr_Function_float
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+         %14 = OpTypeFunction %float %_ptr_Function_int
+    %float_1 = OpConstant %float 1
+%_ptr_Output_float = OpTypePointer Output %float
+  %FragColor = OpVariable %_ptr_Output_float Output
+    %float_2 = OpConstant %float 2
+      %int_4 = OpConstant %int 4
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+      %param = OpVariable %_ptr_Function_float Function
+    %param_0 = OpVariable %_ptr_Function_int Function
+               OpStore %param %float_2
+         %32 = OpFunctionCall %float %ACOS_f1_ %param
+               OpStore %param_0 %int_4
+         %35 = OpFunctionCall %float %ACOS_i1_ %param_0
+         %36 = OpFAdd %float %32 %35
+               OpStore %FragColor %36
+               OpReturn
+               OpFunctionEnd
+   %ACOS_f1_ = OpFunction %float None %8
+          %a = OpFunctionParameter %_ptr_Function_float
+         %11 = OpLabel
+         %18 = OpLoad %float %a
+         %20 = OpFAdd %float %18 %float_1
+               OpReturnValue %20
+               OpFunctionEnd
+   %ACOS_i1_ = OpFunction %float None %14
+        %a_0 = OpFunctionParameter %_ptr_Function_int
+         %17 = OpLabel
+         %23 = OpLoad %int %a_0
+         %24 = OpConvertSToF %float %23
+         %25 = OpFAdd %float %24 %float_1
+               OpReturnValue %25
+               OpFunctionEnd

--- a/shaders-no-opt/asm/frag/reserved-function-identifier.asm.frag
+++ b/shaders-no-opt/asm/frag/reserved-function-identifier.asm.frag
@@ -1,0 +1,60 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 37
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %ACOS_f1_ "mat3"
+               OpName %a "a"
+               OpName %ACOS_i1_ "gl_Foo"
+               OpName %a_0 "a"
+               OpName %FragColor "FragColor"
+               OpName %param "param"
+               OpName %param_0 "param"
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_ptr_Function_float = OpTypePointer Function %float
+          %8 = OpTypeFunction %float %_ptr_Function_float
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+         %14 = OpTypeFunction %float %_ptr_Function_int
+    %float_1 = OpConstant %float 1
+%_ptr_Output_float = OpTypePointer Output %float
+  %FragColor = OpVariable %_ptr_Output_float Output
+    %float_2 = OpConstant %float 2
+      %int_4 = OpConstant %int 4
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+      %param = OpVariable %_ptr_Function_float Function
+    %param_0 = OpVariable %_ptr_Function_int Function
+               OpStore %param %float_2
+         %32 = OpFunctionCall %float %ACOS_f1_ %param
+               OpStore %param_0 %int_4
+         %35 = OpFunctionCall %float %ACOS_i1_ %param_0
+         %36 = OpFAdd %float %32 %35
+               OpStore %FragColor %36
+               OpReturn
+               OpFunctionEnd
+   %ACOS_f1_ = OpFunction %float None %8
+          %a = OpFunctionParameter %_ptr_Function_float
+         %11 = OpLabel
+         %18 = OpLoad %float %a
+         %20 = OpFAdd %float %18 %float_1
+               OpReturnValue %20
+               OpFunctionEnd
+   %ACOS_i1_ = OpFunction %float None %14
+        %a_0 = OpFunctionParameter %_ptr_Function_int
+         %17 = OpLabel
+         %23 = OpLoad %int %a_0
+         %24 = OpConvertSToF %float %23
+         %25 = OpFAdd %float %24 %float_1
+               OpReturnValue %25
+               OpFunctionEnd

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -2551,7 +2551,17 @@ void CompilerGLSL::replace_illegal_names(const unordered_set<string> &keywords)
 			return;
 
 		auto &m = meta->decoration;
-		if (m.alias.compare(0, 3, "gl_") == 0 || keywords.find(m.alias) != end(keywords))
+		if (keywords.find(m.alias) != end(keywords))
+			m.alias = join("_", m.alias);
+	});
+
+	ir.for_each_typed_id<SPIRFunction>([&](uint32_t, const SPIRFunction &func) {
+		auto *meta = ir.find_meta(func.self);
+		if (!meta)
+			return;
+
+		auto &m = meta->decoration;
+		if (keywords.find(m.alias) != end(keywords))
 			m.alias = join("_", m.alias);
 	});
 
@@ -2561,11 +2571,11 @@ void CompilerGLSL::replace_illegal_names(const unordered_set<string> &keywords)
 			return;
 
 		auto &m = meta->decoration;
-		if (m.alias.compare(0, 3, "gl_") == 0 || keywords.find(m.alias) != end(keywords))
+		if (keywords.find(m.alias) != end(keywords))
 			m.alias = join("_", m.alias);
 
 		for (auto &memb : meta->members)
-			if (memb.alias.compare(0, 3, "gl_") == 0 || keywords.find(memb.alias) != end(keywords))
+			if (keywords.find(memb.alias) != end(keywords))
 				memb.alias = join("_", memb.alias);
 	});
 }

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -735,6 +735,12 @@ protected:
 	void declare_undefined_values() override;
 	void declare_constant_arrays();
 
+	void replace_illegal_entry_point_names();
+	void sync_entry_point_aliases_and_names();
+
+	static const std::unordered_set<std::string> &get_reserved_keyword_set();
+	static const std::unordered_set<std::string> &get_illegal_func_names();
+
 	// Constant arrays of non-primitive types (i.e. matrices) won't link properly into Metal libraries
 	void declare_complex_constant_arrays();
 

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -203,9 +203,12 @@ def cross_compile_msl(shader, spirv, opt, iterations, paths):
 
     spirv_cross_path = paths.spirv_cross
 
-    msl_args = [spirv_cross_path, '--entry', 'main', '--output', msl_path, spirv_path, '--msl', '--iterations', str(iterations)]
+    msl_args = [spirv_cross_path, '--output', msl_path, spirv_path, '--msl', '--iterations', str(iterations)]
     msl_args.append('--msl-version')
     msl_args.append(path_to_msl_standard_cli(shader))
+    if not '.nomain.' in shader:
+        msl_args.append('--entry')
+        msl_args.append('main')
     if '.swizzle.' in shader:
         msl_args.append('--msl-swizzle-texture-samples')
     if '.ios.' in shader:


### PR DESCRIPTION
We only considered invalid names, and overwrote the alias for the
function. The correct fix is to replace illegal names early, do the
reserved fixup, then copy back alias to entry point name.

Also fixes a minor bug with reserved identifier handling for SPIRFunction.

Fix #1571.