### PR TITLE
CMake: Disable compiler extensions explicitly.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@
 
 cmake_minimum_required(VERSION 3.0)
 set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Avoid a warning if parent project sets VERSION in project().
 if (${CMAKE_VERSION} VERSION_GREATER "3.0.1")


### PR DESCRIPTION
Compiles fine with just -std=c++11.

Fix #1574.