### PR TITLE
Refactor active variable consideration

### DIFF
--- a/reference/opt/shaders-msl/asm/vert/fake-builtin-input.asm.vert
+++ b/reference/opt/shaders-msl/asm/vert/fake-builtin-input.asm.vert
@@ -5,6 +5,7 @@ using namespace metal;
 
 struct main0_out
 {
+    half4 out_var_SV_Target [[user(locn0)]];
     float4 gl_Position [[position]];
 };
 

--- a/reference/opt/shaders/asm/vert/empty-io.asm.vert
+++ b/reference/opt/shaders/asm/vert/empty-io.asm.vert
@@ -6,6 +6,7 @@ struct VSOutput
 };
 
 layout(location = 0) in vec4 position;
+layout(location = 0) out VSOutput _entryPointOutput;
 
 void main()
 {

--- a/reference/shaders-hlsl-no-opt/asm/frag/only-initializer-frag-depth.asm.frag
+++ b/reference/shaders-hlsl-no-opt/asm/frag/only-initializer-frag-depth.asm.frag
@@ -1,0 +1,17 @@
+static float gl_FragDepth = 0.5f;
+struct SPIRV_Cross_Output
+{
+    float gl_FragDepth : SV_Depth;
+};
+
+void frag_main()
+{
+}
+
+SPIRV_Cross_Output main()
+{
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_FragDepth = gl_FragDepth;
+    return stage_output;
+}

--- a/reference/shaders-hlsl-no-opt/asm/vert/builtin-output-initializer.asm.vert
+++ b/reference/shaders-hlsl-no-opt/asm/vert/builtin-output-initializer.asm.vert
@@ -2,9 +2,14 @@ static const float _23[1] = { 0.0f };
 static const float _24[1] = { 0.0f };
 
 static float4 gl_Position = 0.0f.xxxx;
+static float gl_PointSize = 0.0f;
+static float gl_ClipDistance[1] = _23;
+static float gl_CullDistance[1] = _24;
 struct SPIRV_Cross_Output
 {
     float4 gl_Position : SV_Position;
+    float gl_ClipDistance0 : SV_ClipDistance0;
+    float gl_CullDistance0 : SV_CullDistance0;
 };
 
 void vert_main()
@@ -17,5 +22,7 @@ SPIRV_Cross_Output main()
     vert_main();
     SPIRV_Cross_Output stage_output;
     stage_output.gl_Position = gl_Position;
+    stage_output.gl_ClipDistance0.x = gl_ClipDistance[0];
+    stage_output.gl_CullDistance0.x = gl_CullDistance[0];
     return stage_output;
 }

--- a/reference/shaders-msl-no-opt/asm/frag/only-initializer-frag-depth.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/only-initializer-frag-depth.asm.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float gl_FragDepth [[depth(any)]];
+};
+
+fragment main0_out main0()
+{
+    main0_out out = {};
+    out.gl_FragDepth = 0.5;
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/asm/tesc/builtin-control-point-initializer.asm.tesc
+++ b/reference/shaders-msl-no-opt/asm/tesc/builtin-control-point-initializer.asm.tesc
@@ -48,8 +48,6 @@ struct _RESERVED_IDENTIFIER_FIXUP_gl_PerVertex
 {
     float4 _RESERVED_IDENTIFIER_FIXUP_gl_Position;
     float _RESERVED_IDENTIFIER_FIXUP_gl_PointSize;
-    spvUnsafeArray<float, 1> _RESERVED_IDENTIFIER_FIXUP_gl_ClipDistance;
-    spvUnsafeArray<float, 1> _RESERVED_IDENTIFIER_FIXUP_gl_CullDistance;
 };
 
 struct Verts
@@ -58,25 +56,24 @@ struct Verts
     float2 b;
 };
 
-constant spvUnsafeArray<float, 1> _40 = spvUnsafeArray<float, 1>({ 0.0 });
-constant spvUnsafeArray<float, 1> _41 = spvUnsafeArray<float, 1>({ 0.0 });
-
 struct main0_out
 {
     float Verts_a;
     float2 Verts_b;
     float4 gl_Position;
+    float gl_PointSize;
 };
 
 kernel void main0(uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], device main0_out* spvOut [[buffer(28)]], constant uint* spvIndirectParams [[buffer(29)]], device MTLQuadTessellationFactorsHalf* spvTessLevel [[buffer(26)]])
 {
-    spvUnsafeArray<_RESERVED_IDENTIFIER_FIXUP_gl_PerVertex, 4> _18 = spvUnsafeArray<_RESERVED_IDENTIFIER_FIXUP_gl_PerVertex, 4>({ _RESERVED_IDENTIFIER_FIXUP_gl_PerVertex{ float4(0.0), 0.0, spvUnsafeArray<float, 1>({ 0.0 }), spvUnsafeArray<float, 1>({ 0.0 }) }, _RESERVED_IDENTIFIER_FIXUP_gl_PerVertex{ float4(0.0), 0.0, spvUnsafeArray<float, 1>({ 0.0 }), spvUnsafeArray<float, 1>({ 0.0 }) }, _RESERVED_IDENTIFIER_FIXUP_gl_PerVertex{ float4(0.0), 0.0, spvUnsafeArray<float, 1>({ 0.0 }), spvUnsafeArray<float, 1>({ 0.0 }) }, _RESERVED_IDENTIFIER_FIXUP_gl_PerVertex{ float4(0.0), 0.0, spvUnsafeArray<float, 1>({ 0.0 }), spvUnsafeArray<float, 1>({ 0.0 }) } });
-    spvUnsafeArray<Verts, 4> _28 = spvUnsafeArray<Verts, 4>({ Verts{ 0.0, float2(0.0) }, Verts{ 0.0, float2(0.0) }, Verts{ 0.0, float2(0.0) }, Verts{ 0.0, float2(0.0) } });
+    spvUnsafeArray<_RESERVED_IDENTIFIER_FIXUP_gl_PerVertex, 4> _17 = spvUnsafeArray<_RESERVED_IDENTIFIER_FIXUP_gl_PerVertex, 4>({ _RESERVED_IDENTIFIER_FIXUP_gl_PerVertex{ float4(0.0), 0.0 }, _RESERVED_IDENTIFIER_FIXUP_gl_PerVertex{ float4(0.0), 0.0 }, _RESERVED_IDENTIFIER_FIXUP_gl_PerVertex{ float4(0.0), 0.0 }, _RESERVED_IDENTIFIER_FIXUP_gl_PerVertex{ float4(0.0), 0.0 } });
+    spvUnsafeArray<Verts, 4> _27 = spvUnsafeArray<Verts, 4>({ Verts{ 0.0, float2(0.0) }, Verts{ 0.0, float2(0.0) }, Verts{ 0.0, float2(0.0) }, Verts{ 0.0, float2(0.0) } });
     
     device main0_out* gl_out = &spvOut[gl_PrimitiveID * 4];
-    gl_out[gl_InvocationID].gl_Position = _18[gl_InvocationID]._RESERVED_IDENTIFIER_FIXUP_gl_Position;
-    gl_out[gl_InvocationID].Verts_a = _28[gl_InvocationID].a;
-    gl_out[gl_InvocationID].Verts_b = _28[gl_InvocationID].b;
+    gl_out[gl_InvocationID].gl_Position = _17[gl_InvocationID]._RESERVED_IDENTIFIER_FIXUP_gl_Position;
+    gl_out[gl_InvocationID].gl_PointSize = _17[gl_InvocationID]._RESERVED_IDENTIFIER_FIXUP_gl_PointSize;
+    gl_out[gl_InvocationID].Verts_a = _27[gl_InvocationID].a;
+    gl_out[gl_InvocationID].Verts_b = _27[gl_InvocationID].b;
     gl_out[gl_InvocationID].gl_Position = float4(1.0);
     gl_out[gl_InvocationID].Verts_a = float(gl_InvocationID);
 }

--- a/reference/shaders-msl-no-opt/asm/vert/builtin-output-initializer.asm.vert
+++ b/reference/shaders-msl-no-opt/asm/vert/builtin-output-initializer.asm.vert
@@ -1,61 +1,19 @@
-#pragma clang diagnostic ignored "-Wmissing-prototypes"
-#pragma clang diagnostic ignored "-Wmissing-braces"
-
 #include <metal_stdlib>
 #include <simd/simd.h>
 
 using namespace metal;
 
-template<typename T, size_t Num>
-struct spvUnsafeArray
-{
-    T elements[Num ? Num : 1];
-    
-    thread T& operator [] (size_t pos) thread
-    {
-        return elements[pos];
-    }
-    constexpr const thread T& operator [] (size_t pos) const thread
-    {
-        return elements[pos];
-    }
-    
-    device T& operator [] (size_t pos) device
-    {
-        return elements[pos];
-    }
-    constexpr const device T& operator [] (size_t pos) const device
-    {
-        return elements[pos];
-    }
-    
-    constexpr const constant T& operator [] (size_t pos) const constant
-    {
-        return elements[pos];
-    }
-    
-    threadgroup T& operator [] (size_t pos) threadgroup
-    {
-        return elements[pos];
-    }
-    constexpr const threadgroup T& operator [] (size_t pos) const threadgroup
-    {
-        return elements[pos];
-    }
-};
-
-constant spvUnsafeArray<float, 1> _23 = spvUnsafeArray<float, 1>({ 0.0 });
-constant spvUnsafeArray<float, 1> _24 = spvUnsafeArray<float, 1>({ 0.0 });
-
 struct main0_out
 {
     float4 gl_Position [[position]];
+    float gl_PointSize [[point_size]];
 };
 
 vertex main0_out main0()
 {
     main0_out out = {};
     out.gl_Position = float4(0.0);
+    out.gl_PointSize = 0.0;
     out.gl_Position = float4(1.0);
     return out;
 }

--- a/reference/shaders-msl-no-opt/asm/vert/duplicate-view-index.asm.vert
+++ b/reference/shaders-msl-no-opt/asm/vert/duplicate-view-index.asm.vert
@@ -1,0 +1,19 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+    uint gl_Layer [[render_target_array_index]];
+};
+
+vertex main0_out main0(uint gl_InstanceIndex [[instance_id]], uint gl_BaseInstance [[base_instance]])
+{
+    main0_out out = {};
+    const uint gl_ViewIndex = 0;
+    out.gl_Position = float4(float(int(gl_ViewIndex)));
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/vert/uninitialized-vertex-output.vert
+++ b/reference/shaders-msl-no-opt/vert/uninitialized-vertex-output.vert
@@ -1,0 +1,18 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 Pos [[user(locn0)]];
+    float4 gl_Position [[position]];
+};
+
+vertex main0_out main0()
+{
+    main0_out out = {};
+    out.gl_Position = float4(1.0);
+    return out;
+}
+

--- a/reference/shaders-msl/asm/vert/fake-builtin-input.asm.vert
+++ b/reference/shaders-msl/asm/vert/fake-builtin-input.asm.vert
@@ -5,6 +5,7 @@ using namespace metal;
 
 struct main0_out
 {
+    half4 out_var_SV_Target [[user(locn0)]];
     float4 gl_Position [[position]];
 };
 

--- a/reference/shaders-no-opt/asm/frag/only-initializer-frag-depth.asm.frag
+++ b/reference/shaders-no-opt/asm/frag/only-initializer-frag-depth.asm.frag
@@ -1,0 +1,8 @@
+#version 450
+
+const float _3_init = 0.5;
+void main()
+{
+    gl_FragDepth = _3_init;
+}
+

--- a/reference/shaders-no-opt/asm/tesc/array-of-block-output-initializer.asm.tesc
+++ b/reference/shaders-no-opt/asm/tesc/array-of-block-output-initializer.asm.tesc
@@ -1,6 +1,14 @@
 #version 450
 layout(vertices = 4) out;
 
+out gl_PerVertex
+{
+    vec4 gl_Position;
+    float gl_PointSize;
+    float gl_ClipDistance[1];
+    float gl_CullDistance[1];
+} gl_out[4];
+
 layout(location = 0) patch out vert
 {
     float v0;
@@ -23,6 +31,8 @@ layout(location = 8) out vert2
 
 const vec4 _3_0_init[4] = vec4[](vec4(0.0), vec4(0.0), vec4(0.0), vec4(0.0));
 const float _3_1_init[4] = float[](0.0, 0.0, 0.0, 0.0);
+const float _3_2_init[4][1] = float[][](float[](0.0), float[](0.0), float[](0.0), float[](0.0));
+const float _3_3_init[4][1] = float[][](float[](0.0), float[](0.0), float[](0.0), float[](0.0));
 const float _6_0_init[2] = float[](0.0, 0.0);
 const float _6_1_init[2] = float[](0.0, 0.0);
 const float _7_init = 0.0;
@@ -34,6 +44,8 @@ void main()
 {
     gl_out[gl_InvocationID].gl_Position = _3_0_init[gl_InvocationID];
     gl_out[gl_InvocationID].gl_PointSize = _3_1_init[gl_InvocationID];
+    gl_out[gl_InvocationID].gl_ClipDistance = _3_2_init[gl_InvocationID];
+    gl_out[gl_InvocationID].gl_CullDistance = _3_3_init[gl_InvocationID];
     if (gl_InvocationID == 0)
     {
         _5.v0 = 0.0;

--- a/reference/shaders-no-opt/asm/vert/builtin-output-initializer.asm.vert
+++ b/reference/shaders-no-opt/asm/vert/builtin-output-initializer.asm.vert
@@ -1,9 +1,14 @@
 #version 450
 
+out float gl_ClipDistance[1];
+out float gl_CullDistance[1];
+
 void main()
 {
     gl_Position = vec4(0.0);
     gl_PointSize = 0.0;
+    gl_ClipDistance = float[](0.0);
+    gl_CullDistance = float[](0.0);
     gl_Position = vec4(1.0);
 }
 

--- a/reference/shaders/asm/vert/empty-io.asm.vert
+++ b/reference/shaders/asm/vert/empty-io.asm.vert
@@ -16,6 +16,7 @@ struct VSOutput_1
 };
 
 layout(location = 0) in vec4 position;
+layout(location = 0) out VSOutput_1 _entryPointOutput;
 
 VSOutput _main(VSInput _input)
 {

--- a/shaders-hlsl-no-opt/asm/frag/only-initializer-frag-depth.asm.frag
+++ b/shaders-hlsl-no-opt/asm/frag/only-initializer-frag-depth.asm.frag
@@ -1,0 +1,25 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 10
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %gl_FragDepth
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main DepthReplacing
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %gl_FragDepth "gl_FragDepth"
+               OpDecorate %gl_FragDepth BuiltIn FragDepth
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_ptr_Output_float = OpTypePointer Output %float
+  %float_0_5 = OpConstant %float 0.5
+%gl_FragDepth = OpVariable %_ptr_Output_float Output %float_0_5
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/frag/only-initializer-frag-depth.asm.frag
+++ b/shaders-msl-no-opt/asm/frag/only-initializer-frag-depth.asm.frag
@@ -1,0 +1,25 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 10
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %gl_FragDepth
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main DepthReplacing
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %gl_FragDepth "gl_FragDepth"
+               OpDecorate %gl_FragDepth BuiltIn FragDepth
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_ptr_Output_float = OpTypePointer Output %float
+  %float_0_5 = OpConstant %float 0.5
+%gl_FragDepth = OpVariable %_ptr_Output_float Output %float_0_5
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/tesc/builtin-control-point-initializer.asm.tesc
+++ b/shaders-msl-no-opt/asm/tesc/builtin-control-point-initializer.asm.tesc
@@ -13,8 +13,6 @@
                OpName %gl_PerVertex "gl_PerVertex"
                OpMemberName %gl_PerVertex 0 "gl_Position"
                OpMemberName %gl_PerVertex 1 "gl_PointSize"
-               OpMemberName %gl_PerVertex 2 "gl_ClipDistance"
-               OpMemberName %gl_PerVertex 3 "gl_CullDistance"
                OpName %gl_out "gl_out"
                OpName %gl_InvocationID "gl_InvocationID"
                OpName %Verts "Verts"
@@ -23,8 +21,6 @@
                OpName %verts "verts"
                OpMemberDecorate %gl_PerVertex 0 BuiltIn Position
                OpMemberDecorate %gl_PerVertex 1 BuiltIn PointSize
-               OpMemberDecorate %gl_PerVertex 2 BuiltIn ClipDistance
-               OpMemberDecorate %gl_PerVertex 3 BuiltIn CullDistance
                OpDecorate %gl_PerVertex Block
                OpDecorate %gl_InvocationID BuiltIn InvocationId
                OpDecorate %Verts Block
@@ -35,8 +31,7 @@
     %v4float = OpTypeVector %float 4
        %uint = OpTypeInt 32 0
      %uint_1 = OpConstant %uint 1
-%_arr_float_uint_1 = OpTypeArray %float %uint_1
-%gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
+%gl_PerVertex = OpTypeStruct %v4float %float
      %uint_4 = OpConstant %uint 4
 %_arr_gl_PerVertex_uint_4 = OpTypeArray %gl_PerVertex %uint_4
 %_ptr_Output__arr_gl_PerVertex_uint_4 = OpTypePointer Output %_arr_gl_PerVertex_uint_4

--- a/shaders-msl-no-opt/asm/vert/builtin-output-initializer.asm.vert
+++ b/shaders-msl-no-opt/asm/vert/builtin-output-initializer.asm.vert
@@ -12,13 +12,9 @@
                OpName %gl_PerVertex "gl_PerVertex"
                OpMemberName %gl_PerVertex 0 "gl_Position"
                OpMemberName %gl_PerVertex 1 "gl_PointSize"
-               OpMemberName %gl_PerVertex 2 "gl_ClipDistance"
-               OpMemberName %gl_PerVertex 3 "gl_CullDistance"
                OpName %_ ""
                OpMemberDecorate %gl_PerVertex 0 BuiltIn Position
                OpMemberDecorate %gl_PerVertex 1 BuiltIn PointSize
-               OpMemberDecorate %gl_PerVertex 2 BuiltIn ClipDistance
-               OpMemberDecorate %gl_PerVertex 3 BuiltIn CullDistance
                OpDecorate %gl_PerVertex Block
        %void = OpTypeVoid
           %3 = OpTypeFunction %void
@@ -26,8 +22,7 @@
     %v4float = OpTypeVector %float 4
        %uint = OpTypeInt 32 0
      %uint_1 = OpConstant %uint 1
-%_arr_float_uint_1 = OpTypeArray %float %uint_1
-%gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
+%gl_PerVertex = OpTypeStruct %v4float %float
 %_ptr_Output_gl_PerVertex = OpTypePointer Output %gl_PerVertex
 	%zero = OpConstantNull %gl_PerVertex
           %_ = OpVariable %_ptr_Output_gl_PerVertex Output %zero

--- a/shaders-msl-no-opt/asm/vert/duplicate-view-index.asm.vert
+++ b/shaders-msl-no-opt/asm/vert/duplicate-view-index.asm.vert
@@ -1,0 +1,66 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 23
+; Schema: 0
+               OpCapability Shader
+               OpCapability MultiView
+               OpExtension "SPV_KHR_multiview"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main" %_ %gl_ViewIndex
+               OpEntryPoint Vertex %main2 "main2" %_ %gl_ViewIndex2
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_multiview"
+               OpName %main "main"
+               OpName %gl_PerVertex "gl_PerVertex"
+               OpMemberName %gl_PerVertex 0 "gl_Position"
+               OpMemberName %gl_PerVertex 1 "gl_PointSize"
+               OpMemberName %gl_PerVertex 2 "gl_ClipDistance"
+               OpMemberName %gl_PerVertex 3 "gl_CullDistance"
+               OpName %_ ""
+               OpName %gl_ViewIndex "gl_ViewIndex"
+               OpMemberDecorate %gl_PerVertex 0 BuiltIn Position
+               OpMemberDecorate %gl_PerVertex 1 BuiltIn PointSize
+               OpMemberDecorate %gl_PerVertex 2 BuiltIn ClipDistance
+               OpMemberDecorate %gl_PerVertex 3 BuiltIn CullDistance
+               OpDecorate %gl_PerVertex Block
+               OpDecorate %gl_ViewIndex BuiltIn ViewIndex
+               OpDecorate %gl_ViewIndex2 BuiltIn ViewIndex
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+       %uint = OpTypeInt 32 0
+     %uint_1 = OpConstant %uint 1
+%_arr_float_uint_1 = OpTypeArray %float %uint_1
+%gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
+%_ptr_Output_gl_PerVertex = OpTypePointer Output %gl_PerVertex
+          %_ = OpVariable %_ptr_Output_gl_PerVertex Output
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Input_int = OpTypePointer Input %int
+%gl_ViewIndex = OpVariable %_ptr_Input_int Input
+%gl_ViewIndex2 = OpVariable %_ptr_Input_int Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %18 = OpLoad %int %gl_ViewIndex
+         %19 = OpConvertSToF %float %18
+         %20 = OpCompositeConstruct %v4float %19 %19 %19 %19
+         %22 = OpAccessChain %_ptr_Output_v4float %_ %int_0
+               OpStore %22 %20
+               OpReturn
+               OpFunctionEnd
+
+       %main2 = OpFunction %void None %3
+          %100 = OpLabel
+         %101 = OpLoad %int %gl_ViewIndex2
+         %102 = OpConvertSToF %float %101
+         %103 = OpCompositeConstruct %v4float %102 %102 %102 %102
+         %104 = OpAccessChain %_ptr_Output_v4float %_ %int_0
+               OpStore %104 %103
+
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/vert/uninitialized-vertex-output.vert
+++ b/shaders-msl-no-opt/vert/uninitialized-vertex-output.vert
@@ -1,0 +1,8 @@
+#version 450
+
+layout(location = 0) out vec4 Pos;
+
+void main()
+{
+	gl_Position = vec4(1.0);
+}

--- a/shaders-no-opt/asm/frag/only-initializer-frag-depth.asm.frag
+++ b/shaders-no-opt/asm/frag/only-initializer-frag-depth.asm.frag
@@ -1,0 +1,25 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 10
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %gl_FragDepth
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main DepthReplacing
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %gl_FragDepth "gl_FragDepth"
+               OpDecorate %gl_FragDepth BuiltIn FragDepth
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_ptr_Output_float = OpTypePointer Output %float
+  %float_0_5 = OpConstant %float 0.5
+%gl_FragDepth = OpVariable %_ptr_Output_float Output %float_0_5
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -833,6 +833,9 @@ protected:
 		Compiler &compiler;
 
 		void handle_builtin(const SPIRType &type, spv::BuiltIn builtin, const Bitset &decoration_flags);
+		void add_if_builtin(uint32_t id);
+		void add_if_builtin_or_block(uint32_t id);
+		void add_if_builtin(uint32_t id, bool allow_blocks);
 	};
 
 	bool traverse_all_reachable_opcodes(const SPIRBlock &block, OpcodeHandler &handler) const;

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -2801,6 +2801,13 @@ bool CompilerGLSL::should_force_emit_builtin_block(StorageClass storage)
 		}
 	});
 
+	// If we're declaring clip/cull planes with control points we need to force block declaration.
+	if (get_execution_model() == ExecutionModelTessellationControl &&
+	    (clip_distance_count || cull_distance_count))
+	{
+		should_force = true;
+	}
+
 	return should_force;
 }
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -10586,11 +10586,14 @@ void CompilerMSL::entry_point_args_builtin(string &ep_args)
 	// Builtin variables
 	SmallVector<pair<SPIRVariable *, BuiltIn>, 8> active_builtins;
 	ir.for_each_typed_id<SPIRVariable>([&](uint32_t var_id, SPIRVariable &var) {
+		if (var.storage != StorageClassInput)
+			return;
+
 		auto bi_type = BuiltIn(get_decoration(var_id, DecorationBuiltIn));
 
 		// Don't emit SamplePosition as a separate parameter. In the entry
 		// point, we get that by calling get_sample_position() on the sample ID.
-		if (var.storage == StorageClassInput && is_builtin_variable(var) &&
+		if (is_builtin_variable(var) &&
 		    get_variable_data_type(var).basetype != SPIRType::Struct &&
 		    get_variable_data_type(var).basetype != SPIRType::ControlPointArray)
 		{
@@ -10624,8 +10627,7 @@ void CompilerMSL::entry_point_args_builtin(string &ep_args)
 			}
 		}
 
-		if (var.storage == StorageClassInput &&
-		    has_extended_decoration(var_id, SPIRVCrossDecorationBuiltInDispatchBase))
+		if (has_extended_decoration(var_id, SPIRVCrossDecorationBuiltInDispatchBase))
 		{
 			// This is a special implicit builtin, not corresponding to any SPIR-V builtin,
 			// which holds the base that was passed to vkCmdDispatchBase() or vkCmdDrawIndexed(). If it's present,
@@ -10637,8 +10639,7 @@ void CompilerMSL::entry_point_args_builtin(string &ep_args)
 			ep_args += type_to_glsl(get_variable_data_type(var)) + " " + to_expression(var_id) + " [[grid_origin]]";
 		}
 
-		if (var.storage == StorageClassInput &&
-		    has_extended_decoration(var_id, SPIRVCrossDecorationBuiltInStageInputSize))
+		if (has_extended_decoration(var_id, SPIRVCrossDecorationBuiltInStageInputSize))
 		{
 			// This is another special implicit builtin, not corresponding to any SPIR-V builtin,
 			// which holds the number of vertices and instances to draw. If it's present,


### PR DESCRIPTION
- Only consider builtin variables if they are part of IO interface. It was possible for builtins to be registers multiple times as we only looked at active_builtins and not if the variable was active in the entry point.
- Ensure that initialized builtin outputs (but not accessed) were also considered active.
- Always enable outputs from non-fragment stages as fragment stage can read the variable, and this invokes undefined behavior.

Fix #1586.
Fix #1580.