### PR TITLE
MSL: Fixup type when using tessellation levels in TESC functions.

### DIFF
--- a/reference/shaders-msl-no-opt/asm/tesc/tess-level-read-write-in-function-tri.asm.tesc
+++ b/reference/shaders-msl-no-opt/asm/tesc/tess-level-read-write-in-function-tri.asm.tesc
@@ -1,0 +1,35 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position;
+};
+
+static inline __attribute__((always_inline))
+void store_tess_level_in_func(device half &gl_TessLevelInner, device half (&gl_TessLevelOuter)[3])
+{
+    gl_TessLevelInner = half(1.0);
+    gl_TessLevelOuter[0] = half(3.0);
+    gl_TessLevelOuter[1] = half(4.0);
+    gl_TessLevelOuter[2] = half(5.0);
+}
+
+static inline __attribute__((always_inline))
+float load_tess_level_in_func(device half &gl_TessLevelInner, device half (&gl_TessLevelOuter)[3])
+{
+    return float(gl_TessLevelInner) + float(gl_TessLevelOuter[1]);
+}
+
+kernel void main0(uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], device main0_out* spvOut [[buffer(28)]], constant uint* spvIndirectParams [[buffer(29)]], device MTLTriangleTessellationFactorsHalf* spvTessLevel [[buffer(26)]])
+{
+    device main0_out* gl_out = &spvOut[gl_PrimitiveID * 1];
+    store_tess_level_in_func(spvTessLevel[gl_PrimitiveID].insideTessellationFactor, spvTessLevel[gl_PrimitiveID].edgeTessellationFactor);
+    float v = load_tess_level_in_func(spvTessLevel[gl_PrimitiveID].insideTessellationFactor, spvTessLevel[gl_PrimitiveID].edgeTessellationFactor);
+    gl_out[gl_InvocationID].gl_Position = float4(v);
+}
+

--- a/reference/shaders-msl-no-opt/tesc/tess-level-read-write-in-function-quad.tesc
+++ b/reference/shaders-msl-no-opt/tesc/tess-level-read-write-in-function-quad.tesc
@@ -1,0 +1,37 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position;
+};
+
+static inline __attribute__((always_inline))
+void store_tess_level_in_func(device half (&gl_TessLevelInner)[2], device half (&gl_TessLevelOuter)[4])
+{
+    gl_TessLevelInner[0] = half(1.0);
+    gl_TessLevelInner[1] = half(2.0);
+    gl_TessLevelOuter[0] = half(3.0);
+    gl_TessLevelOuter[1] = half(4.0);
+    gl_TessLevelOuter[2] = half(5.0);
+    gl_TessLevelOuter[3] = half(6.0);
+}
+
+static inline __attribute__((always_inline))
+float load_tess_level_in_func(device half (&gl_TessLevelInner)[2], device half (&gl_TessLevelOuter)[4])
+{
+    return float(gl_TessLevelInner[0]) + float(gl_TessLevelOuter[1]);
+}
+
+kernel void main0(uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], device main0_out* spvOut [[buffer(28)]], constant uint* spvIndirectParams [[buffer(29)]], device MTLQuadTessellationFactorsHalf* spvTessLevel [[buffer(26)]])
+{
+    device main0_out* gl_out = &spvOut[gl_PrimitiveID * 1];
+    store_tess_level_in_func(spvTessLevel[gl_PrimitiveID].insideTessellationFactor, spvTessLevel[gl_PrimitiveID].edgeTessellationFactor);
+    float v = load_tess_level_in_func(spvTessLevel[gl_PrimitiveID].insideTessellationFactor, spvTessLevel[gl_PrimitiveID].edgeTessellationFactor);
+    gl_out[gl_InvocationID].gl_Position = float4(v);
+}
+

--- a/shaders-msl-no-opt/asm/tesc/tess-level-read-write-in-function-tri.asm.tesc
+++ b/shaders-msl-no-opt/asm/tesc/tess-level-read-write-in-function-tri.asm.tesc
@@ -1,0 +1,109 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 64
+; Schema: 0
+               OpCapability Tessellation
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint TessellationControl %main "main" %gl_TessLevelInner %gl_TessLevelOuter %gl_out %gl_InvocationID
+               OpExecutionMode %main OutputVertices 1
+			   OpExecutionMode %main Triangles
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %load_tess_level_in_func_ "load_tess_level_in_func("
+               OpName %store_tess_level_in_func_ "store_tess_level_in_func("
+               OpName %gl_TessLevelInner "gl_TessLevelInner"
+               OpName %gl_TessLevelOuter "gl_TessLevelOuter"
+               OpName %v "v"
+               OpName %gl_PerVertex "gl_PerVertex"
+               OpMemberName %gl_PerVertex 0 "gl_Position"
+               OpMemberName %gl_PerVertex 1 "gl_PointSize"
+               OpMemberName %gl_PerVertex 2 "gl_ClipDistance"
+               OpMemberName %gl_PerVertex 3 "gl_CullDistance"
+               OpName %gl_out "gl_out"
+               OpName %gl_InvocationID "gl_InvocationID"
+               OpDecorate %gl_TessLevelInner Patch
+               OpDecorate %gl_TessLevelInner BuiltIn TessLevelInner
+               OpDecorate %gl_TessLevelOuter Patch
+               OpDecorate %gl_TessLevelOuter BuiltIn TessLevelOuter
+               OpMemberDecorate %gl_PerVertex 0 BuiltIn Position
+               OpMemberDecorate %gl_PerVertex 1 BuiltIn PointSize
+               OpMemberDecorate %gl_PerVertex 2 BuiltIn ClipDistance
+               OpMemberDecorate %gl_PerVertex 3 BuiltIn CullDistance
+               OpDecorate %gl_PerVertex Block
+               OpDecorate %gl_InvocationID BuiltIn InvocationId
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+          %7 = OpTypeFunction %float
+       %uint = OpTypeInt 32 0
+     %uint_2 = OpConstant %uint 2
+%_arr_float_uint_2 = OpTypeArray %float %uint_2
+%_ptr_Output__arr_float_uint_2 = OpTypePointer Output %_arr_float_uint_2
+%gl_TessLevelInner = OpVariable %_ptr_Output__arr_float_uint_2 Output
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Output_float = OpTypePointer Output %float
+     %uint_4 = OpConstant %uint 4
+%_arr_float_uint_4 = OpTypeArray %float %uint_4
+%_ptr_Output__arr_float_uint_4 = OpTypePointer Output %_arr_float_uint_4
+%gl_TessLevelOuter = OpVariable %_ptr_Output__arr_float_uint_4 Output
+      %int_1 = OpConstant %int 1
+    %float_1 = OpConstant %float 1
+    %float_2 = OpConstant %float 2
+    %float_3 = OpConstant %float 3
+    %float_4 = OpConstant %float 4
+      %int_2 = OpConstant %int 2
+    %float_5 = OpConstant %float 5
+      %int_3 = OpConstant %int 3
+    %float_6 = OpConstant %float 6
+%_ptr_Function_float = OpTypePointer Function %float
+    %v4float = OpTypeVector %float 4
+     %uint_1 = OpConstant %uint 1
+%_arr_float_uint_1 = OpTypeArray %float %uint_1
+%gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
+%_arr_gl_PerVertex_uint_1 = OpTypeArray %gl_PerVertex %uint_1
+%_ptr_Output__arr_gl_PerVertex_uint_1 = OpTypePointer Output %_arr_gl_PerVertex_uint_1
+     %gl_out = OpVariable %_ptr_Output__arr_gl_PerVertex_uint_1 Output
+%_ptr_Input_int = OpTypePointer Input %int
+%gl_InvocationID = OpVariable %_ptr_Input_int Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %v = OpVariable %_ptr_Function_float Function
+         %46 = OpFunctionCall %void %store_tess_level_in_func_
+         %49 = OpFunctionCall %float %load_tess_level_in_func_
+               OpStore %v %49
+         %59 = OpLoad %int %gl_InvocationID
+         %60 = OpLoad %float %v
+         %61 = OpCompositeConstruct %v4float %60 %60 %60 %60
+         %63 = OpAccessChain %_ptr_Output_v4float %gl_out %59 %int_0
+               OpStore %63 %61
+               OpReturn
+               OpFunctionEnd
+%load_tess_level_in_func_ = OpFunction %float None %7
+          %9 = OpLabel
+         %20 = OpAccessChain %_ptr_Output_float %gl_TessLevelInner %int_0
+         %21 = OpLoad %float %20
+         %27 = OpAccessChain %_ptr_Output_float %gl_TessLevelOuter %int_1
+         %28 = OpLoad %float %27
+         %29 = OpFAdd %float %21 %28
+               OpReturnValue %29
+               OpFunctionEnd
+%store_tess_level_in_func_ = OpFunction %void None %3
+         %11 = OpLabel
+         %33 = OpAccessChain %_ptr_Output_float %gl_TessLevelInner %int_0
+               OpStore %33 %float_1
+         %35 = OpAccessChain %_ptr_Output_float %gl_TessLevelInner %int_1
+               OpStore %35 %float_2
+         %37 = OpAccessChain %_ptr_Output_float %gl_TessLevelOuter %int_0
+               OpStore %37 %float_3
+         %39 = OpAccessChain %_ptr_Output_float %gl_TessLevelOuter %int_1
+               OpStore %39 %float_4
+         %42 = OpAccessChain %_ptr_Output_float %gl_TessLevelOuter %int_2
+               OpStore %42 %float_5
+         %45 = OpAccessChain %_ptr_Output_float %gl_TessLevelOuter %int_3
+               OpStore %45 %float_6
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/tesc/tess-level-read-write-in-function-quad.tesc
+++ b/shaders-msl-no-opt/tesc/tess-level-read-write-in-function-quad.tesc
@@ -1,0 +1,24 @@
+#version 450
+layout(vertices = 1) out;
+
+float load_tess_level_in_func()
+{
+	return gl_TessLevelInner[0] + gl_TessLevelOuter[1];
+}
+
+void store_tess_level_in_func()
+{
+	gl_TessLevelInner[0] = 1.0;
+	gl_TessLevelInner[1] = 2.0;
+	gl_TessLevelOuter[0] = 3.0;
+	gl_TessLevelOuter[1] = 4.0;
+	gl_TessLevelOuter[2] = 5.0;
+	gl_TessLevelOuter[3] = 6.0;
+}
+
+void main()
+{
+	store_tess_level_in_func();
+	float v = load_tess_level_in_func();
+	gl_out[gl_InvocationID].gl_Position = vec4(v);
+}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -11834,6 +11834,7 @@ string CompilerMSL::argument_decl(const SPIRFunction::Parameter &arg)
 	// Allow Metal to use the array<T> template to make arrays a value type
 	string address_space = get_argument_address_space(var);
 	bool builtin = is_builtin_variable(var);
+	auto builtin_type = BuiltIn(get_decoration(arg.id, DecorationBuiltIn));
 	is_using_builtin_array = builtin;
 	if (address_space == "threadgroup")
 		is_using_builtin_array = true;
@@ -11841,7 +11842,7 @@ string CompilerMSL::argument_decl(const SPIRFunction::Parameter &arg)
 	if (var.basevariable && (var.basevariable == stage_in_ptr_var_id || var.basevariable == stage_out_ptr_var_id))
 		decl += type_to_glsl(type, arg.id);
 	else if (builtin)
-		decl += builtin_type_decl(static_cast<BuiltIn>(get_decoration(arg.id, DecorationBuiltIn)), arg.id);
+		decl += builtin_type_decl(builtin_type, arg.id);
 	else if ((storage == StorageClassUniform || storage == StorageClassStorageBuffer) && is_array(type))
 	{
 		is_using_builtin_array = true;
@@ -11922,16 +11923,44 @@ string CompilerMSL::argument_decl(const SPIRFunction::Parameter &arg)
 			}
 		}
 
-		decl += " (&";
-		const char *restrict_kw = to_restrict(name_id);
-		if (*restrict_kw)
+		// Special case, need to override the array size here if we're using tess level as an argument.
+		if (get_execution_model() == ExecutionModelTessellationControl && builtin &&
+		    (builtin_type == BuiltInTessLevelInner || builtin_type == BuiltInTessLevelOuter))
 		{
-			decl += " ";
-			decl += restrict_kw;
+			if (get_entry_point().flags.get(ExecutionModeTriangles) && builtin_type == BuiltInTessLevelInner)
+			{
+				decl += " &";
+				decl += to_expression(name_id);
+			}
+			else
+			{
+				uint32_t array_size;
+				if (get_entry_point().flags.get(ExecutionModeTriangles))
+					array_size = 3;
+				else if (builtin_type == BuiltInTessLevelInner)
+					array_size = 2;
+				else
+					array_size = 4;
+
+				decl += " (&";
+				decl += to_expression(name_id);
+				decl += ")";
+				decl += join("[", array_size, "]");
+			}
 		}
-		decl += to_expression(name_id);
-		decl += ")";
-		decl += type_to_array_glsl(type);
+		else
+		{
+			decl += " (&";
+			const char *restrict_kw = to_restrict(name_id);
+			if (*restrict_kw)
+			{
+				decl += " ";
+				decl += restrict_kw;
+			}
+			decl += to_expression(name_id);
+			decl += ")";
+			decl += type_to_array_glsl(type);
+		}
 	}
 	else if (!opaque_handle && (!pull_model_inputs.count(var.basevariable) || type.basetype == SPIRType::Struct))
 	{


### PR DESCRIPTION
Need to rewrite array size depending on execution mode.

Fix #1608.