### PR TITLE
Fix build errors on Windows

### DIFF
--- a/gn/BUILD.gn
+++ b/gn/BUILD.gn
@@ -46,7 +46,9 @@ source_set("spirv_cross_sources") {
     "../spirv_reflect.hpp",
   ]
 
-  cflags = [ "-fno-exceptions" ]
+  if (!is_win) {
+    cflags = [ "-fno-exceptions" ]
+  }
 
   if (is_clang) {
     cflags_cc = [


### PR DESCRIPTION
error:
clang-cl: error: unknown argument ignored in clang-cl: '-fno-exceptions'