### PR TITLE
GLSL: Handle complex load/store scenarios to gl_SampleMask.

### DIFF
--- a/reference/shaders-no-opt/asm/frag/array-builtin-bitcast-load-store.asm.frag
+++ b/reference/shaders-no-opt/asm/frag/array-builtin-bitcast-load-store.asm.frag
@@ -1,0 +1,28 @@
+#version 450
+
+layout(binding = 0, std140) uniform uBuffer
+{
+    vec4 color;
+} x_12;
+
+layout(location = 0) out vec4 fragColor;
+const vec4 _2_init = vec4(0.0);
+
+void main()
+{
+    fragColor = _2_init;
+    gl_SampleMask[0] = 0;
+    fragColor = x_12.color;
+    gl_SampleMask[0] = int(uint(6));
+    gl_SampleMask[0] = int(uint(gl_SampleMask[0]));
+    uint _30_unrolled[1];
+    for (int i = 0; i < int(1); i++)
+    {
+        _30_unrolled[i] = int(gl_SampleMask[i]);
+    }
+    for (int i = 0; i < int(1); i++)
+    {
+        gl_SampleMask[i] = int(_30_unrolled[i]);
+    }
+}
+

--- a/shaders-no-opt/asm/frag/array-builtin-bitcast-load-store.asm.frag
+++ b/shaders-no-opt/asm/frag/array-builtin-bitcast-load-store.asm.frag
@@ -1,0 +1,57 @@
+; SPIR-V
+; Version: 1.3
+; Generator: Google Tint Compiler; 0
+; Bound: 29
+; Schema: 0
+                                OpCapability Shader
+                                OpMemoryModel Logical GLSL450
+                                OpEntryPoint Fragment %main "main" %fragColor %gl_SampleMask
+                                OpExecutionMode %main OriginUpperLeft
+                                OpName %fragColor "fragColor"
+                                OpName %uBuffer "uBuffer"
+                                OpMemberName %uBuffer 0 "color"
+                                OpName %x_12 "x_12"
+                                OpName %gl_SampleMask "gl_SampleMask"
+                                OpName %main "main"
+                                OpDecorate %fragColor Location 0
+                                OpDecorate %uBuffer Block
+                                OpMemberDecorate %uBuffer 0 Offset 0
+                                OpDecorate %x_12 DescriptorSet 0
+                                OpDecorate %x_12 Binding 0
+                                OpDecorate %gl_SampleMask BuiltIn SampleMask
+                       %float = OpTypeFloat 32
+                     %v4float = OpTypeVector %float 4
+         %_ptr_Output_v4float = OpTypePointer Output %v4float
+                           %5 = OpConstantNull %v4float
+                   %fragColor = OpVariable %_ptr_Output_v4float Output %5
+                     %uBuffer = OpTypeStruct %v4float
+        %_ptr_Uniform_uBuffer = OpTypePointer Uniform %uBuffer
+                        %x_12 = OpVariable %_ptr_Uniform_uBuffer Uniform
+                        %uint = OpTypeInt 32 0
+                      %uint_1 = OpConstant %uint 1
+            %_arr_uint_uint_1 = OpTypeArray %uint %uint_1
+%_ptr_Output__arr_uint_uint_1 = OpTypePointer Output %_arr_uint_uint_1
+                          %14 = OpConstantNull %_arr_uint_uint_1
+               %gl_SampleMask = OpVariable %_ptr_Output__arr_uint_uint_1 Output %14
+                        %void = OpTypeVoid
+                          %15 = OpTypeFunction %void
+                      %uint_0 = OpConstant %uint 0
+        %_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
+                         %int = OpTypeInt 32 1
+                       %int_0 = OpConstant %int 0
+            %_ptr_Output_uint = OpTypePointer Output %uint
+                       %int_6 = OpConstant %int 6
+                        %main = OpFunction %void None %15
+                          %18 = OpLabel
+                          %21 = OpAccessChain %_ptr_Uniform_v4float %x_12 %uint_0
+                          %22 = OpLoad %v4float %21
+                                OpStore %fragColor %22
+                          %26 = OpAccessChain %_ptr_Output_uint %gl_SampleMask %int_0
+                          %27 = OpBitcast %uint %int_6
+                                OpStore %26 %27
+                            %loaded_scalar = OpLoad %uint %26
+								OpStore %26 %loaded_scalar
+                             %loaded = OpLoad %_arr_uint_uint_1 %gl_SampleMask
+                                OpStore %gl_SampleMask %loaded
+                                OpReturn
+                                OpFunctionEnd

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -880,6 +880,7 @@ protected:
 	virtual void cast_to_builtin_store(uint32_t target_id, std::string &expr, const SPIRType &expr_type);
 	virtual void cast_from_builtin_load(uint32_t source_id, std::string &expr, const SPIRType &expr_type);
 	void unroll_array_from_complex_load(uint32_t target_id, uint32_t source_id, std::string &expr);
+	bool unroll_array_to_complex_store(uint32_t target_id, uint32_t source_id);
 	void convert_non_uniform_expression(const SPIRType &type, std::string &expr);
 
 	void handle_store_to_invariant_variable(uint32_t store_id, uint32_t value_id);


### PR DESCRIPTION
Need special workarounds to handle array load/store since array size is
unsized in GLSL, and array copy is not possible.
Also, consider bitcast for scalar loads and stores.

Fix #1626.