### PR TITLE
MSL: Support long ulong types in buffers in 2.3+.

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -14092,12 +14092,6 @@ uint32_t CompilerMSL::get_declared_type_alignment_msl(const SPIRType &type, bool
 	case SPIRType::Sampler:
 		SPIRV_CROSS_THROW("Querying alignment of opaque object.");
 
-	case SPIRType::Int64:
-		if (!msl_options.supports_msl_version(2, 3))
-			SPIRV_CROSS_THROW("long types in buffers are only supported in MSL 2.3 and above.");
-	case SPIRType::UInt64:
-		if (!msl_options.supports_msl_version(2, 3))
-			SPIRV_CROSS_THROW("ulong types in buffers are only supported in MSL 2.3 and above.");
 	case SPIRType::Double:
 		SPIRV_CROSS_THROW("double types are not supported in buffers in MSL.");
 
@@ -14112,6 +14106,10 @@ uint32_t CompilerMSL::get_declared_type_alignment_msl(const SPIRType &type, bool
 
 	default:
 	{
+		if (type.basetype == SPIRType::Int64 && !msl_options.supports_msl_version(2, 3))
+			SPIRV_CROSS_THROW("long types in buffers are only supported in MSL 2.3 and above.");
+		if (type.basetype == SPIRType::UInt64 && !msl_options.supports_msl_version(2, 3))
+			SPIRV_CROSS_THROW("ulong types in buffers are only supported in MSL 2.3 and above.");
 		// Alignment of packed type is the same as the underlying component or column size.
 		// Alignment of unpacked type is the same as the vector size.
 		// Alignment of 3-elements vector is the same as 4-elements (including packed using column).

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -14093,9 +14093,11 @@ uint32_t CompilerMSL::get_declared_type_alignment_msl(const SPIRType &type, bool
 		SPIRV_CROSS_THROW("Querying alignment of opaque object.");
 
 	case SPIRType::Int64:
-		SPIRV_CROSS_THROW("long types are not supported in buffers in MSL.");
+		if (!msl_options.supports_msl_version(2, 3))
+			SPIRV_CROSS_THROW("long types in buffers are only supported in MSL 2.3 and above.");
 	case SPIRType::UInt64:
-		SPIRV_CROSS_THROW("ulong types are not supported in buffers in MSL.");
+		if (!msl_options.supports_msl_version(2, 3))
+			SPIRV_CROSS_THROW("ulong types in buffers are only supported in MSL 2.3 and above.");
 	case SPIRType::Double:
 		SPIRV_CROSS_THROW("double types are not supported in buffers in MSL.");
 


### PR DESCRIPTION
[Metal Shading Language Specification](https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf) states that:

> Note: As of Metal 2.3, Metal supports buffers that contain long or ulong data types.

This PR aims to support long and ulong data types in buffers for Metal 2.3+.