### PR TITLE
Rewrite how non-uniform qualifiers are handled.

### DIFF
--- a/reference/opt/shaders-hlsl/frag/nonuniform-qualifier.nonuniformresource.sm51.frag
+++ b/reference/opt/shaders-hlsl/frag/nonuniform-qualifier.nonuniformresource.sm51.frag
@@ -3,12 +3,15 @@ struct UBO_1_1
     float4 v[64];
 };
 
-ConstantBuffer<UBO_1_1> ubos[] : register(b0, space3);
-ByteAddressBuffer ssbos[] : register(t0, space4);
+ConstantBuffer<UBO_1_1> ubos[] : register(b2, space9);
+RWByteAddressBuffer ssbos[] : register(u3, space10);
 Texture2D<float4> uSamplers[] : register(t0, space0);
-SamplerState uSamps[] : register(s0, space2);
-Texture2D<float4> uCombinedSamplers[] : register(t0, space1);
-SamplerState _uCombinedSamplers_sampler[] : register(s0, space1);
+SamplerState uSamps[] : register(s1, space3);
+Texture2D<float4> uCombinedSamplers[] : register(t4, space2);
+SamplerState _uCombinedSamplers_sampler[] : register(s4, space2);
+Texture2DMS<float4> uSamplersMS[] : register(t0, space1);
+RWTexture2D<float> uImages[] : register(u5, space7);
+RWTexture2D<uint> uImagesU32[] : register(u5, space8);
 
 static int vIndex;
 static float4 FragColor;
@@ -25,17 +28,70 @@ struct SPIRV_Cross_Output
     float4 FragColor : SV_Target0;
 };
 
+uint2 spvTextureSize(Texture2D<float4> Tex, uint Level, out uint Param)
+{
+    uint2 ret;
+    Tex.GetDimensions(Level, ret.x, ret.y, Param);
+    return ret;
+}
+
+uint2 spvTextureSize(Texture2DMS<float4> Tex, uint Level, out uint Param)
+{
+    uint2 ret;
+    Tex.GetDimensions(ret.x, ret.y, Param);
+    return ret;
+}
+
+uint2 spvImageSize(RWTexture2D<float> Tex, out uint Param)
+{
+    uint2 ret;
+    Tex.GetDimensions(ret.x, ret.y);
+    Param = 0u;
+    return ret;
+}
+
 void frag_main()
 {
-    int _23 = vIndex + 10;
-    int _34 = vIndex + 40;
-    FragColor = uSamplers[NonUniformResourceIndex(_23)].Sample(uSamps[NonUniformResourceIndex(_34)], vUV);
-    FragColor = uCombinedSamplers[NonUniformResourceIndex(_23)].Sample(_uCombinedSamplers_sampler[NonUniformResourceIndex(_23)], vUV);
-    int _66 = vIndex + 20;
-    FragColor += ubos[NonUniformResourceIndex(_66)].v[_34];
-    int _84 = vIndex + 50;
+    int _22 = vIndex + 10;
+    int _32 = vIndex + 40;
+    FragColor = uSamplers[NonUniformResourceIndex(_22)].Sample(uSamps[NonUniformResourceIndex(_32)], vUV);
+    int _49 = _22;
+    FragColor = uCombinedSamplers[NonUniformResourceIndex(_49)].Sample(_uCombinedSamplers_sampler[NonUniformResourceIndex(_49)], vUV);
+    int _65 = vIndex + 20;
+    int _69 = _32;
+    FragColor += ubos[NonUniformResourceIndex(_65)].v[_69];
+    int _83 = vIndex + 50;
     int _88 = vIndex + 60;
-    FragColor += asfloat(ssbos[NonUniformResourceIndex(_84)].Load4(_88 * 16 + 0));
+    FragColor += asfloat(ssbos[NonUniformResourceIndex(_83)].Load4(_88 * 16 + 16));
+    int _100 = vIndex + 70;
+    ssbos[NonUniformResourceIndex(_88)].Store4(_100 * 16 + 16, asuint(20.0f.xxxx));
+    int2 _111 = int2(vUV);
+    FragColor = uSamplers[NonUniformResourceIndex(_49)].Load(int3(_111, 0));
+    int _116 = vIndex + 100;
+    uint _122;
+    ssbos[_116].InterlockedAdd(0, 100u, _122);
+    float _136_tmp = uSamplers[NonUniformResourceIndex(_22)].CalculateLevelOfDetail(uSamps[NonUniformResourceIndex(_32)], vUV);
+    float2 _136 = _136_tmp.xx;
+    float _143_tmp = uCombinedSamplers[NonUniformResourceIndex(_49)].CalculateLevelOfDetail(_uCombinedSamplers_sampler[NonUniformResourceIndex(_49)], vUV);
+    float2 _143 = _143_tmp.xx;
+    float2 _149 = FragColor.xy + (_136 + _143);
+    FragColor = float4(_149.x, _149.y, FragColor.z, FragColor.w);
+    int _157;
+    spvTextureSize(uSamplers[NonUniformResourceIndex(_65)], 0u, _157);
+    FragColor.x += float(int(_157));
+    int _174;
+    spvTextureSize(uSamplersMS[NonUniformResourceIndex(_65)], 0u, _174);
+    FragColor.y += float(int(_174));
+    uint _185_dummy_parameter;
+    float2 _189 = FragColor.xy + float2(int2(spvTextureSize(uSamplers[NonUniformResourceIndex(_65)], uint(0), _185_dummy_parameter)));
+    FragColor = float4(_189.x, _189.y, FragColor.z, FragColor.w);
+    FragColor += uImages[NonUniformResourceIndex(_83)][_111].xxxx;
+    uint _212_dummy_parameter;
+    float2 _216 = FragColor.xy + float2(int2(spvImageSize(uImages[NonUniformResourceIndex(_65)], _212_dummy_parameter)));
+    FragColor = float4(_216.x, _216.y, FragColor.z, FragColor.w);
+    uImages[NonUniformResourceIndex(_88)][_111] = 50.0f.x;
+    uint _242;
+    InterlockedAdd(uImagesU32[NonUniformResourceIndex(_100)][_111], 40u, _242);
 }
 
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)

--- a/reference/opt/shaders-msl/frag/nonuniform-qualifier.msl2.frag
+++ b/reference/opt/shaders-msl/frag/nonuniform-qualifier.msl2.frag
@@ -44,10 +44,10 @@ fragment main0_out main0(main0_in in [[stage_in]], constant UBO* ubos_0 [[buffer
     out.FragColor = uSamplers[_25].sample(uSamps[_37], in.vUV);
     out.FragColor = uCombinedSamplers[_25].sample(uCombinedSamplersSmplr[_25], in.vUV);
     int _69 = in.vIndex + 20;
-    out.FragColor += ubos[(_69)]->v[_37];
+    out.FragColor += ubos[_69]->v[_37];
     int _87 = in.vIndex + 50;
     int _91 = in.vIndex + 60;
-    out.FragColor += ssbos[(_87)]->v[_91];
+    out.FragColor += ssbos[_87]->v[_91];
     return out;
 }
 

--- a/reference/opt/shaders/vulkan/frag/nonuniform-qualifier.vk.nocompat.frag.vk
+++ b/reference/opt/shaders/vulkan/frag/nonuniform-qualifier.vk.nocompat.frag.vk
@@ -1,19 +1,24 @@
 #version 450
 #extension GL_EXT_nonuniform_qualifier : require
+#extension GL_EXT_samplerless_texture_functions : require
 
 layout(set = 0, binding = 2, std140) uniform UBO
 {
     vec4 v[64];
 } ubos[];
 
-layout(set = 0, binding = 3, std430) readonly buffer SSBO
+layout(set = 0, binding = 3, std430) buffer SSBO
 {
+    uint counter;
     vec4 v[];
 } ssbos[];
 
 layout(set = 0, binding = 0) uniform texture2D uSamplers[];
 layout(set = 0, binding = 1) uniform sampler uSamps[];
 layout(set = 0, binding = 4) uniform sampler2D uCombinedSamplers[];
+layout(set = 0, binding = 0) uniform texture2DMS uSamplersMS[];
+layout(set = 0, binding = 5, r32f) uniform image2D uImages[];
+layout(set = 0, binding = 5, r32ui) uniform uimage2D uImagesU32[];
 
 layout(location = 0) flat in int vIndex;
 layout(location = 0) out vec4 FragColor;
@@ -21,14 +26,33 @@ layout(location = 1) in vec2 vUV;
 
 void main()
 {
-    int _23 = vIndex + 10;
-    int _34 = vIndex + 40;
-    FragColor = texture(sampler2D(uSamplers[nonuniformEXT(_23)], uSamps[nonuniformEXT(_34)]), vUV);
-    FragColor = texture(uCombinedSamplers[nonuniformEXT(_23)], vUV);
-    int _66 = vIndex + 20;
-    FragColor += ubos[nonuniformEXT(_66)].v[_34];
-    int _84 = vIndex + 50;
+    int _22 = vIndex + 10;
+    int _32 = vIndex + 40;
+    FragColor = texture(nonuniformEXT(sampler2D(uSamplers[_22], uSamps[_32])), vUV);
+    int _49 = _22;
+    FragColor = texture(uCombinedSamplers[nonuniformEXT(_49)], vUV);
+    int _65 = vIndex + 20;
+    int _69 = _32;
+    FragColor += ubos[nonuniformEXT(_65)].v[_69];
+    int _83 = vIndex + 50;
     int _88 = vIndex + 60;
-    FragColor += ssbos[nonuniformEXT(_84)].v[_88];
+    FragColor += ssbos[nonuniformEXT(_83)].v[_88];
+    int _100 = vIndex + 70;
+    ssbos[nonuniformEXT(_88)].v[_100] = vec4(20.0);
+    ivec2 _111 = ivec2(vUV);
+    FragColor = texelFetch(uSamplers[nonuniformEXT(_49)], _111, 0);
+    int _116 = vIndex + 100;
+    uint _122 = atomicAdd(ssbos[_116].counter, 100u);
+    vec2 _149 = FragColor.xy + (textureQueryLod(nonuniformEXT(sampler2D(uSamplers[_22], uSamps[_32])), vUV) + textureQueryLod(uCombinedSamplers[nonuniformEXT(_49)], vUV));
+    FragColor = vec4(_149.x, _149.y, FragColor.z, FragColor.w);
+    FragColor.x += float(textureQueryLevels(uSamplers[nonuniformEXT(_65)]));
+    FragColor.y += float(textureSamples(uSamplersMS[nonuniformEXT(_65)]));
+    vec2 _189 = FragColor.xy + vec2(textureSize(uSamplers[nonuniformEXT(_65)], 0));
+    FragColor = vec4(_189.x, _189.y, FragColor.z, FragColor.w);
+    FragColor += imageLoad(uImages[nonuniformEXT(_83)], _111);
+    vec2 _216 = FragColor.xy + vec2(imageSize(uImages[nonuniformEXT(_65)]));
+    FragColor = vec4(_216.x, _216.y, FragColor.z, FragColor.w);
+    imageStore(uImages[nonuniformEXT(_88)], _111, vec4(50.0));
+    uint _242 = imageAtomicAdd(uImagesU32[nonuniformEXT(_100)], _111, 40u);
 }
 

--- a/reference/shaders-hlsl-no-opt/asm/frag/nonuniform-qualifier-propagation.nonuniformresource.sm51.asm.frag
+++ b/reference/shaders-hlsl-no-opt/asm/frag/nonuniform-qualifier-propagation.nonuniformresource.sm51.asm.frag
@@ -1,9 +1,9 @@
-struct UBO_1_1
+struct UBO_1
 {
     float4 v[64];
 };
 
-ConstantBuffer<UBO_1_1> ubos[] : register(b0, space2);
+ConstantBuffer<UBO_1> ubos[] : register(b0, space2);
 ByteAddressBuffer ssbos[] : register(t0, space3);
 Texture2D<float4> uSamplers[] : register(t0, space0);
 SamplerState uSamps[] : register(s0, space1);

--- a/reference/shaders-hlsl-no-opt/asm/frag/nonuniform-ssbo.sm51.nonuniformresource.asm.frag
+++ b/reference/shaders-hlsl-no-opt/asm/frag/nonuniform-ssbo.sm51.nonuniformresource.asm.frag
@@ -1,0 +1,39 @@
+RWByteAddressBuffer ssbos[] : register(u3, space0);
+
+static int vIndex;
+static float4 FragColor;
+
+struct SPIRV_Cross_Input
+{
+    nointerpolation int vIndex : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    int i = vIndex;
+    int _42 = i + 60;
+    int _45 = i + 70;
+    ssbos[NonUniformResourceIndex(_42)].Store4(_45 * 16 + 16, asuint(20.0f.xxxx));
+    int _48 = i + 100;
+    uint _49;
+    ssbos[NonUniformResourceIndex(_48)].InterlockedAdd(0, 100u, _49);
+    int _51 = i;
+    uint _52;
+    ssbos[NonUniformResourceIndex(_51)].GetDimensions(_52);
+    _52 = (_52 - 16) / 16;
+    FragColor.z += float(int(_52));
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    vIndex = stage_input.vIndex;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/frag/nonuniform-qualifier.nonuniformresource.sm51.frag
+++ b/reference/shaders-hlsl/frag/nonuniform-qualifier.nonuniformresource.sm51.frag
@@ -3,12 +3,15 @@ struct UBO_1_1
     float4 v[64];
 };
 
-ConstantBuffer<UBO_1_1> ubos[] : register(b0, space3);
-ByteAddressBuffer ssbos[] : register(t0, space4);
+ConstantBuffer<UBO_1_1> ubos[] : register(b2, space9);
+RWByteAddressBuffer ssbos[] : register(u3, space10);
 Texture2D<float4> uSamplers[] : register(t0, space0);
-SamplerState uSamps[] : register(s0, space2);
-Texture2D<float4> uCombinedSamplers[] : register(t0, space1);
-SamplerState _uCombinedSamplers_sampler[] : register(s0, space1);
+SamplerState uSamps[] : register(s1, space3);
+Texture2D<float4> uCombinedSamplers[] : register(t4, space2);
+SamplerState _uCombinedSamplers_sampler[] : register(s4, space2);
+Texture2DMS<float4> uSamplersMS[] : register(t0, space1);
+RWTexture2D<float> uImages[] : register(u5, space7);
+RWTexture2D<uint> uImagesU32[] : register(u5, space8);
 
 static int vIndex;
 static float4 FragColor;
@@ -25,20 +28,80 @@ struct SPIRV_Cross_Output
     float4 FragColor : SV_Target0;
 };
 
+uint2 spvTextureSize(Texture2D<float4> Tex, uint Level, out uint Param)
+{
+    uint2 ret;
+    Tex.GetDimensions(Level, ret.x, ret.y, Param);
+    return ret;
+}
+
+uint2 spvTextureSize(Texture2DMS<float4> Tex, uint Level, out uint Param)
+{
+    uint2 ret;
+    Tex.GetDimensions(ret.x, ret.y, Param);
+    return ret;
+}
+
+uint2 spvImageSize(RWTexture2D<float> Tex, out uint Param)
+{
+    uint2 ret;
+    Tex.GetDimensions(ret.x, ret.y);
+    Param = 0u;
+    return ret;
+}
+
 void frag_main()
 {
     int i = vIndex;
-    int _23 = i + 10;
-    int _34 = i + 40;
-    FragColor = uSamplers[NonUniformResourceIndex(_23)].Sample(uSamps[NonUniformResourceIndex(_34)], vUV);
-    int _50 = i + 10;
-    FragColor = uCombinedSamplers[NonUniformResourceIndex(_50)].Sample(_uCombinedSamplers_sampler[NonUniformResourceIndex(_50)], vUV);
-    int _66 = i + 20;
-    int _70 = i + 40;
-    FragColor += ubos[NonUniformResourceIndex(_66)].v[_70];
-    int _84 = i + 50;
+    FragColor = uSamplers[NonUniformResourceIndex(i + 10)].Sample(uSamps[NonUniformResourceIndex(i + 40)], vUV);
+    int _49 = i + 10;
+    FragColor = uCombinedSamplers[NonUniformResourceIndex(_49)].Sample(_uCombinedSamplers_sampler[NonUniformResourceIndex(_49)], vUV);
+    int _65 = i + 20;
+    int _69 = i + 40;
+    FragColor += ubos[NonUniformResourceIndex(_65)].v[_69];
+    int _83 = i + 50;
     int _88 = i + 60;
-    FragColor += asfloat(ssbos[NonUniformResourceIndex(_84)].Load4(_88 * 16 + 0));
+    FragColor += asfloat(ssbos[NonUniformResourceIndex(_83)].Load4(_88 * 16 + 16));
+    int _96 = i + 60;
+    int _100 = i + 70;
+    ssbos[NonUniformResourceIndex(_96)].Store4(_100 * 16 + 16, asuint(20.0f.xxxx));
+    int _106 = i + 10;
+    FragColor = uSamplers[NonUniformResourceIndex(_106)].Load(int3(int2(vUV), 0));
+    int _116 = i + 100;
+    uint _122;
+    ssbos[_116].InterlockedAdd(0, 100u, _122);
+    float _136_tmp = uSamplers[NonUniformResourceIndex(i + 10)].CalculateLevelOfDetail(uSamps[NonUniformResourceIndex(i + 40)], vUV);
+    float2 _136 = _136_tmp.xx;
+    float2 queried = _136;
+    int _139 = i + 10;
+    float _143_tmp = uCombinedSamplers[NonUniformResourceIndex(_139)].CalculateLevelOfDetail(_uCombinedSamplers_sampler[NonUniformResourceIndex(_139)], vUV);
+    float2 _143 = _143_tmp.xx;
+    queried += _143;
+    float2 _149 = FragColor.xy + queried;
+    FragColor = float4(_149.x, _149.y, FragColor.z, FragColor.w);
+    int _154 = i + 20;
+    int _157;
+    spvTextureSize(uSamplers[NonUniformResourceIndex(_154)], 0u, _157);
+    FragColor.x += float(int(_157));
+    int _170 = i + 20;
+    int _174;
+    spvTextureSize(uSamplersMS[NonUniformResourceIndex(_170)], 0u, _174);
+    FragColor.y += float(int(_174));
+    int _182 = i + 20;
+    uint _185_dummy_parameter;
+    float2 _189 = FragColor.xy + float2(int2(spvTextureSize(uSamplers[NonUniformResourceIndex(_182)], uint(0), _185_dummy_parameter)));
+    FragColor = float4(_189.x, _189.y, FragColor.z, FragColor.w);
+    int _198 = i + 50;
+    FragColor += uImages[NonUniformResourceIndex(_198)][int2(vUV)].xxxx;
+    int _209 = i + 20;
+    uint _212_dummy_parameter;
+    float2 _216 = FragColor.xy + float2(int2(spvImageSize(uImages[NonUniformResourceIndex(_209)], _212_dummy_parameter)));
+    FragColor = float4(_216.x, _216.y, FragColor.z, FragColor.w);
+    int _221 = i + 60;
+    uImages[NonUniformResourceIndex(_221)][int2(vUV)] = 50.0f.x;
+    int _234 = i + 70;
+    uint _242;
+    InterlockedAdd(uImagesU32[NonUniformResourceIndex(_234)][int2(vUV)], 40u, _242);
 }
 
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)

--- a/reference/shaders-msl/frag/nonuniform-qualifier.msl2.frag
+++ b/reference/shaders-msl/frag/nonuniform-qualifier.msl2.frag
@@ -47,10 +47,10 @@ fragment main0_out main0(main0_in in [[stage_in]], constant UBO* ubos_0 [[buffer
     out.FragColor = uCombinedSamplers[_53].sample(uCombinedSamplersSmplr[_53], in.vUV);
     int _69 = i + 20;
     int _73 = i + 40;
-    out.FragColor += ubos[(_69)]->v[_73];
+    out.FragColor += ubos[_69]->v[_73];
     int _87 = i + 50;
     int _91 = i + 60;
-    out.FragColor += ssbos[(_87)]->v[_91];
+    out.FragColor += ssbos[_87]->v[_91];
     return out;
 }
 

--- a/reference/shaders-no-opt/asm/comp/nonuniform-bracket-handling.vk.nocompat.asm.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/nonuniform-bracket-handling.vk.nocompat.asm.comp.vk
@@ -27,29 +27,29 @@ layout(set = 4, binding = 0, r32ui) uniform uimageBuffer _10[];
 
 void main()
 {
-    uint _60 = registers._m4 + 2u;
-    uint _63 = subgroupBroadcastFirst(_60);
-    uint _70 = subgroupBroadcastFirst(registers._m4);
-    uint _75 = registers._m1 + 1u;
-    uint _78 = subgroupBroadcastFirst(_75);
-    uint _87 = gl_GlobalInvocationID.x + 4u;
-    uint _98 = gl_GlobalInvocationID.x + 1024u;
-    imageStore(_9[registers._m4], int((_98 < _7._m0[_70].y) ? (_98 + _7._m0[_70].x) : 4294967295u), vec4(imageLoad(_9[registers._m4], int((_87 < _7._m0[_70].y) ? (_87 + _7._m0[_70].x) : 4294967295u))));
-    uint _105 = gl_GlobalInvocationID.x + 2u;
-    uint _116 = gl_GlobalInvocationID.x + 2048u;
-    imageStore(_9[registers._m4], int((_116 < _7._m0[_70].y) ? (_116 + _7._m0[_70].x) : 4294967295u), vec4(texelFetch(_8[_75], int((_105 < _7._m0[_78].y) ? (_105 + _7._m0[_78].x) : 4294967295u))));
-    uint _129 = imageAtomicAdd(_10[_60], int((gl_GlobalInvocationID.x < _7._m0[_63].y) ? (gl_GlobalInvocationID.x + _7._m0[_63].x) : 4294967295u), 40u);
-    uint _136 = imageAtomicCompSwap(_10[_60], int((gl_GlobalInvocationID.y < _7._m0[_63].y) ? (gl_GlobalInvocationID.y + _7._m0[_63].x) : 4294967295u), 40u, 50u);
-    imageStore(_9[registers._m4], int((0u < _7._m0[_70].y) ? (0u + _7._m0[_70].x) : 4294967295u), vec4(float(_7._m0[_70].y)));
-    imageStore(_9[registers._m4], int((1u < _7._m0[_70].y) ? (1u + _7._m0[_70].x) : 4294967295u), vec4(float(_7._m0[_78].y)));
+    uint _61 = registers._m4 + 2u;
+    uint _64 = subgroupBroadcastFirst(_61);
+    uint _71 = subgroupBroadcastFirst(registers._m4);
+    uint _76 = registers._m1 + 1u;
+    uint _79 = subgroupBroadcastFirst(_76);
+    uint _88 = gl_GlobalInvocationID.x + 4u;
+    uint _99 = gl_GlobalInvocationID.x + 1024u;
+    imageStore(_9[registers._m4], int((_99 < _7._m0[_71].y) ? (_99 + _7._m0[_71].x) : 4294967295u), vec4(imageLoad(_9[registers._m4], int((_88 < _7._m0[_71].y) ? (_88 + _7._m0[_71].x) : 4294967295u))));
+    uint _106 = gl_GlobalInvocationID.x + 2u;
+    uint _117 = gl_GlobalInvocationID.x + 2048u;
+    imageStore(_9[registers._m4], int((_117 < _7._m0[_71].y) ? (_117 + _7._m0[_71].x) : 4294967295u), vec4(texelFetch(_8[_76], int((_106 < _7._m0[_79].y) ? (_106 + _7._m0[_79].x) : 4294967295u))));
+    uint _130 = imageAtomicAdd(_10[_61], int((gl_GlobalInvocationID.x < _7._m0[_64].y) ? (gl_GlobalInvocationID.x + _7._m0[_64].x) : 4294967295u), 40u);
+    uint _137 = imageAtomicCompSwap(_10[_61], int((gl_GlobalInvocationID.y < _7._m0[_64].y) ? (gl_GlobalInvocationID.y + _7._m0[_64].x) : 4294967295u), 40u, 50u);
+    imageStore(_9[registers._m4], int((0u < _7._m0[_71].y) ? (0u + _7._m0[_71].x) : 4294967295u), vec4(float(_7._m0[_71].y)));
+    imageStore(_9[registers._m4], int((1u < _7._m0[_71].y) ? (1u + _7._m0[_71].x) : 4294967295u), vec4(float(_7._m0[_79].y)));
     uint _11 = registers._m4 + (gl_GlobalInvocationID.z + 0u);
-    imageStore(_9[nonuniformEXT(_11)], int((_98 < _7._m0[_11].y) ? (_98 + _7._m0[_11].x) : 4294967295u), vec4(imageLoad(_9[nonuniformEXT(_11)], int((_87 < _7._m0[_11].y) ? (_87 + _7._m0[_11].x) : 4294967295u))));
+    imageStore(_9[nonuniformEXT(_11)], int((_99 < _7._m0[_11].y) ? (_99 + _7._m0[_11].x) : 4294967295u), vec4(imageLoad(_9[nonuniformEXT(_11)], int((_88 < _7._m0[_11].y) ? (_88 + _7._m0[_11].x) : 4294967295u))));
     uint _13 = registers._m1 + (gl_GlobalInvocationID.z + 0u);
-    imageStore(_9[nonuniformEXT(_11)], int((_116 < _7._m0[_11].y) ? (_116 + _7._m0[_11].x) : 4294967295u), vec4(texelFetch(_8[nonuniformEXT(_13)], int((_87 < _7._m0[_13].y) ? (_87 + _7._m0[_13].x) : 4294967295u))));
+    imageStore(_9[nonuniformEXT(_11)], int((_117 < _7._m0[_11].y) ? (_117 + _7._m0[_11].x) : 4294967295u), vec4(texelFetch(_8[nonuniformEXT(_13)], int((_88 < _7._m0[_13].y) ? (_88 + _7._m0[_13].x) : 4294967295u))));
     uint _15 = registers._m4 + (gl_GlobalInvocationID.z + 0u);
-    uint _208 = imageAtomicAdd(_10[nonuniformEXT(_15)], int((gl_GlobalInvocationID.y < _7._m0[_15].y) ? (gl_GlobalInvocationID.y + _7._m0[_15].x) : 4294967295u), 40u);
+    uint _209 = imageAtomicAdd(_10[nonuniformEXT(_15)], int((gl_GlobalInvocationID.y < _7._m0[_15].y) ? (gl_GlobalInvocationID.y + _7._m0[_15].x) : 4294967295u), 40u);
     uint _215 = imageAtomicCompSwap(_10[nonuniformEXT(_15)], int((gl_GlobalInvocationID.y < _7._m0[_15].y) ? (gl_GlobalInvocationID.y + _7._m0[_15].x) : 4294967295u), 40u, 70u);
-    imageStore(_9[registers._m4], int((2u < _7._m0[_70].y) ? (2u + _7._m0[_70].x) : 4294967295u), vec4(float(_7._m0[_11].y)));
-    imageStore(_9[registers._m4], int((3u < _7._m0[_70].y) ? (3u + _7._m0[_70].x) : 4294967295u), vec4(float(_7._m0[_13].y)));
+    imageStore(_9[registers._m4], int((2u < _7._m0[_71].y) ? (2u + _7._m0[_71].x) : 4294967295u), vec4(float(_7._m0[_11].y)));
+    imageStore(_9[registers._m4], int((3u < _7._m0[_71].y) ? (3u + _7._m0[_71].x) : 4294967295u), vec4(float(_7._m0[_13].y)));
 }
 

--- a/reference/shaders-no-opt/asm/frag/nonuniform-ssbo.nocompat.vk.asm.frag.vk
+++ b/reference/shaders-no-opt/asm/frag/nonuniform-ssbo.nocompat.vk.asm.frag.vk
@@ -1,0 +1,24 @@
+#version 450
+#extension GL_EXT_nonuniform_qualifier : require
+
+layout(set = 0, binding = 3, std430) buffer SSBO
+{
+    uint counter;
+    vec4 v[];
+} ssbos[];
+
+layout(location = 0) flat in int vIndex;
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    int i = vIndex;
+    int _42 = i + 60;
+    int _45 = i + 70;
+    ssbos[nonuniformEXT(_42)].v[_45] = vec4(20.0);
+    int _48 = i + 100;
+    uint _49 = atomicAdd(ssbos[nonuniformEXT(_48)].counter, 100u);
+    int _51 = i;
+    FragColor.z += float(int(uint(ssbos[nonuniformEXT(_51)].v.length())));
+}
+

--- a/reference/shaders/vulkan/frag/nonuniform-qualifier.vk.nocompat.frag.vk
+++ b/reference/shaders/vulkan/frag/nonuniform-qualifier.vk.nocompat.frag.vk
@@ -1,19 +1,24 @@
 #version 450
 #extension GL_EXT_nonuniform_qualifier : require
+#extension GL_EXT_samplerless_texture_functions : require
 
 layout(set = 0, binding = 2, std140) uniform UBO
 {
     vec4 v[64];
 } ubos[];
 
-layout(set = 0, binding = 3, std430) readonly buffer SSBO
+layout(set = 0, binding = 3, std430) buffer SSBO
 {
+    uint counter;
     vec4 v[];
 } ssbos[];
 
 layout(set = 0, binding = 0) uniform texture2D uSamplers[];
 layout(set = 0, binding = 1) uniform sampler uSamps[];
 layout(set = 0, binding = 4) uniform sampler2D uCombinedSamplers[];
+layout(set = 0, binding = 0) uniform texture2DMS uSamplersMS[];
+layout(set = 0, binding = 5, r32f) uniform image2D uImages[];
+layout(set = 0, binding = 5, r32ui) uniform uimage2D uImagesU32[];
 
 layout(location = 0) flat in int vIndex;
 layout(location = 0) out vec4 FragColor;
@@ -22,16 +27,42 @@ layout(location = 1) in vec2 vUV;
 void main()
 {
     int i = vIndex;
-    int _23 = i + 10;
-    int _34 = i + 40;
-    FragColor = texture(sampler2D(uSamplers[nonuniformEXT(_23)], uSamps[nonuniformEXT(_34)]), vUV);
-    int _50 = i + 10;
-    FragColor = texture(uCombinedSamplers[nonuniformEXT(_50)], vUV);
-    int _66 = i + 20;
-    int _70 = i + 40;
-    FragColor += ubos[nonuniformEXT(_66)].v[_70];
-    int _84 = i + 50;
+    FragColor = texture(nonuniformEXT(sampler2D(uSamplers[i + 10], uSamps[i + 40])), vUV);
+    int _49 = i + 10;
+    FragColor = texture(uCombinedSamplers[nonuniformEXT(_49)], vUV);
+    int _65 = i + 20;
+    int _69 = i + 40;
+    FragColor += ubos[nonuniformEXT(_65)].v[_69];
+    int _83 = i + 50;
     int _88 = i + 60;
-    FragColor += ssbos[nonuniformEXT(_84)].v[_88];
+    FragColor += ssbos[nonuniformEXT(_83)].v[_88];
+    int _96 = i + 60;
+    int _100 = i + 70;
+    ssbos[nonuniformEXT(_96)].v[_100] = vec4(20.0);
+    int _106 = i + 10;
+    FragColor = texelFetch(uSamplers[nonuniformEXT(_106)], ivec2(vUV), 0);
+    int _116 = i + 100;
+    uint _122 = atomicAdd(ssbos[_116].counter, 100u);
+    vec2 queried = textureQueryLod(nonuniformEXT(sampler2D(uSamplers[i + 10], uSamps[i + 40])), vUV);
+    int _139 = i + 10;
+    queried += textureQueryLod(uCombinedSamplers[nonuniformEXT(_139)], vUV);
+    vec2 _149 = FragColor.xy + queried;
+    FragColor = vec4(_149.x, _149.y, FragColor.z, FragColor.w);
+    int _154 = i + 20;
+    FragColor.x += float(textureQueryLevels(uSamplers[nonuniformEXT(_154)]));
+    int _170 = i + 20;
+    FragColor.y += float(textureSamples(uSamplersMS[nonuniformEXT(_170)]));
+    int _182 = i + 20;
+    vec2 _189 = FragColor.xy + vec2(textureSize(uSamplers[nonuniformEXT(_182)], 0));
+    FragColor = vec4(_189.x, _189.y, FragColor.z, FragColor.w);
+    int _198 = i + 50;
+    FragColor += imageLoad(uImages[nonuniformEXT(_198)], ivec2(vUV));
+    int _209 = i + 20;
+    vec2 _216 = FragColor.xy + vec2(imageSize(uImages[nonuniformEXT(_209)]));
+    FragColor = vec4(_216.x, _216.y, FragColor.z, FragColor.w);
+    int _221 = i + 60;
+    imageStore(uImages[nonuniformEXT(_221)], ivec2(vUV), vec4(50.0));
+    int _234 = i + 70;
+    uint _242 = imageAtomicAdd(uImagesU32[nonuniformEXT(_234)], ivec2(vUV), 40u);
 }
 

--- a/shaders-hlsl-no-opt/asm/frag/nonuniform-ssbo.sm51.nonuniformresource.asm.frag
+++ b/shaders-hlsl-no-opt/asm/frag/nonuniform-ssbo.sm51.nonuniformresource.asm.frag
@@ -1,0 +1,99 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 59
+; Schema: 0
+               OpCapability Shader
+               OpCapability ShaderNonUniform
+               OpCapability RuntimeDescriptorArray
+               OpCapability StorageBufferArrayNonUniformIndexing
+               OpExtension "SPV_EXT_descriptor_indexing"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %vIndex %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_nonuniform_qualifier"
+               OpSourceExtension "GL_EXT_samplerless_texture_functions"
+               OpName %main "main"
+               OpName %i "i"
+               OpName %vIndex "vIndex"
+               OpName %SSBO "SSBO"
+               OpMemberName %SSBO 0 "counter"
+               OpMemberName %SSBO 1 "v"
+               OpName %ssbos "ssbos"
+               OpName %FragColor "FragColor"
+               OpDecorate %vIndex Flat
+               OpDecorate %vIndex Location 0
+               OpDecorate %_runtimearr_v4float ArrayStride 16
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpMemberDecorate %SSBO 1 Offset 16
+               OpDecorate %SSBO BufferBlock
+               OpDecorate %ssbos DescriptorSet 0
+               OpDecorate %ssbos Binding 3
+               OpDecorate %32 NonUniform
+               OpDecorate %39 NonUniform
+               OpDecorate %49 NonUniform
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+%_ptr_Input_int = OpTypePointer Input %int
+     %vIndex = OpVariable %_ptr_Input_int Input
+       %uint = OpTypeInt 32 0
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_runtimearr_v4float = OpTypeRuntimeArray %v4float
+       %SSBO = OpTypeStruct %uint %_runtimearr_v4float
+%_runtimearr_SSBO = OpTypeRuntimeArray %SSBO
+%_ptr_Uniform__runtimearr_SSBO = OpTypePointer Uniform %_runtimearr_SSBO
+      %ssbos = OpVariable %_ptr_Uniform__runtimearr_SSBO Uniform
+     %int_60 = OpConstant %int 60
+      %int_1 = OpConstant %int 1
+     %int_70 = OpConstant %int 70
+   %float_20 = OpConstant %float 20
+         %30 = OpConstantComposite %v4float %float_20 %float_20 %float_20 %float_20
+%_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
+    %int_100 = OpConstant %int 100
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_uint = OpTypePointer Uniform %uint
+   %uint_100 = OpConstant %uint 100
+     %uint_1 = OpConstant %uint 1
+     %uint_0 = OpConstant %uint 0
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+%_ptr_Uniform_SSBO = OpTypePointer Uniform %SSBO
+     %uint_2 = OpConstant %uint 2
+%_ptr_Output_float = OpTypePointer Output %float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %i = OpVariable %_ptr_Function_int Function
+         %11 = OpLoad %int %vIndex
+               OpStore %i %11
+         %20 = OpLoad %int %i
+         %22 = OpIAdd %int %20 %int_60
+         %23 = OpCopyObject %int %22
+         %25 = OpLoad %int %i
+         %27 = OpIAdd %int %25 %int_70
+         %28 = OpCopyObject %int %27
+         %32 = OpAccessChain %_ptr_Uniform_v4float %ssbos %23 %int_1 %28
+               OpStore %32 %30
+         %33 = OpLoad %int %i
+         %35 = OpIAdd %int %33 %int_100
+         %36 = OpCopyObject %int %35
+         %39 = OpAccessChain %_ptr_Uniform_uint %ssbos %36 %int_0
+         %43 = OpAtomicIAdd %uint %39 %uint_1 %uint_0 %uint_100
+         %46 = OpLoad %int %i
+         %47 = OpCopyObject %int %46
+         %49 = OpAccessChain %_ptr_Uniform_SSBO %ssbos %47
+         %50 = OpArrayLength %uint %49 1
+         %51 = OpBitcast %int %50
+         %52 = OpConvertSToF %float %51
+         %55 = OpAccessChain %_ptr_Output_float %FragColor %uint_2
+         %56 = OpLoad %float %55
+         %57 = OpFAdd %float %56 %52
+         %58 = OpAccessChain %_ptr_Output_float %FragColor %uint_2
+               OpStore %58 %57
+               OpReturn
+               OpFunctionEnd

--- a/shaders-hlsl/frag/nonuniform-qualifier.nonuniformresource.sm51.frag
+++ b/shaders-hlsl/frag/nonuniform-qualifier.nonuniformresource.sm51.frag
@@ -1,28 +1,52 @@
 #version 450
 #extension GL_EXT_nonuniform_qualifier : require
+#extension GL_EXT_samplerless_texture_functions : require
 
 layout(set = 0, binding = 0) uniform texture2D uSamplers[];
-layout(set = 1, binding = 0) uniform sampler2D uCombinedSamplers[];
-layout(set = 2, binding = 0) uniform sampler uSamps[];
-layout(location = 0) flat in int vIndex;
-layout(location = 1) in vec2 vUV;
-layout(location = 0) out vec4 FragColor;
+layout(set = 1, binding = 0) uniform texture2DMS uSamplersMS[];
+layout(set = 2, binding = 4) uniform sampler2D uCombinedSamplers[];
+layout(set = 3, binding = 1) uniform sampler uSamps[];
+layout(set = 4, location = 0) flat in int vIndex;
+layout(set = 5, location = 1) in vec2 vUV;
+layout(set = 6, location = 0) out vec4 FragColor;
 
-layout(set = 3, binding = 0) uniform UBO 
+layout(r32f, set = 7, binding = 5) uniform image2D uImages[];
+layout(r32ui, set = 8, binding = 5) uniform uimage2D uImagesU32[];
+
+layout(set = 9, binding = 2) uniform UBO 
 {
 	vec4 v[64];
 } ubos[];
 
-layout(set = 4, binding = 0) readonly buffer SSBO
+layout(set = 10, binding = 3) buffer SSBO
 {
+	uint counter;
 	vec4 v[];
 } ssbos[];
 
 void main()
 {
 	int i = vIndex;
-	FragColor = texture(sampler2D(uSamplers[nonuniformEXT(i + 10)], uSamps[nonuniformEXT(i + 40)]), vUV);
+	FragColor = texture(nonuniformEXT(sampler2D(uSamplers[i + 10], uSamps[i + 40])), vUV);
 	FragColor = texture(uCombinedSamplers[nonuniformEXT(i + 10)], vUV);
 	FragColor += ubos[nonuniformEXT(i + 20)].v[nonuniformEXT(i + 40)];
 	FragColor += ssbos[nonuniformEXT(i + 50)].v[nonuniformEXT(i + 60)];
+	ssbos[nonuniformEXT(i + 60)].v[nonuniformEXT(i + 70)] = vec4(20.0);
+
+	FragColor = texelFetch(uSamplers[nonuniformEXT(i + 10)], ivec2(vUV), 0);
+	atomicAdd(ssbos[nonuniformEXT(i + 100)].counter, 100u);
+
+	vec2 queried = textureQueryLod(nonuniformEXT(sampler2D(uSamplers[i + 10], uSamps[i + 40])), vUV);
+	queried += textureQueryLod(uCombinedSamplers[nonuniformEXT(i + 10)], vUV);
+	FragColor.xy += queried;
+
+	FragColor.x += float(textureQueryLevels(uSamplers[nonuniformEXT(i + 20)]));
+	FragColor.y += float(textureSamples(uSamplersMS[nonuniformEXT(i + 20)]));
+	FragColor.xy += vec2(textureSize(uSamplers[nonuniformEXT(i + 20)], 0));
+
+	FragColor += imageLoad(uImages[nonuniformEXT(i + 50)], ivec2(vUV));
+	FragColor.xy += vec2(imageSize(uImages[nonuniformEXT(i + 20)]));
+	imageStore(uImages[nonuniformEXT(i + 60)], ivec2(vUV), vec4(50.0));
+
+	imageAtomicAdd(uImagesU32[nonuniformEXT(i + 70)], ivec2(vUV), 40u);
 }

--- a/shaders-no-opt/asm/comp/nonuniform-bracket-handling.vk.nocompat.asm.comp
+++ b/shaders-no-opt/asm/comp/nonuniform-bracket-handling.vk.nocompat.asm.comp
@@ -54,6 +54,7 @@
                OpDecorate %196 NonUniform
                OpDecorate %197 NonUniform
                OpDecorate %205 NonUniform
+               OpDecorate %212 NonUniform
        %void = OpTypeVoid
           %2 = OpTypeFunction %void
        %uint = OpTypeInt 32 0

--- a/shaders-no-opt/asm/frag/nonuniform-ssbo.nocompat.vk.asm.frag
+++ b/shaders-no-opt/asm/frag/nonuniform-ssbo.nocompat.vk.asm.frag
@@ -1,0 +1,99 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 59
+; Schema: 0
+               OpCapability Shader
+               OpCapability ShaderNonUniform
+               OpCapability RuntimeDescriptorArray
+               OpCapability StorageBufferArrayNonUniformIndexing
+               OpExtension "SPV_EXT_descriptor_indexing"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %vIndex %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_nonuniform_qualifier"
+               OpSourceExtension "GL_EXT_samplerless_texture_functions"
+               OpName %main "main"
+               OpName %i "i"
+               OpName %vIndex "vIndex"
+               OpName %SSBO "SSBO"
+               OpMemberName %SSBO 0 "counter"
+               OpMemberName %SSBO 1 "v"
+               OpName %ssbos "ssbos"
+               OpName %FragColor "FragColor"
+               OpDecorate %vIndex Flat
+               OpDecorate %vIndex Location 0
+               OpDecorate %_runtimearr_v4float ArrayStride 16
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpMemberDecorate %SSBO 1 Offset 16
+               OpDecorate %SSBO BufferBlock
+               OpDecorate %ssbos DescriptorSet 0
+               OpDecorate %ssbos Binding 3
+               OpDecorate %32 NonUniform
+               OpDecorate %39 NonUniform
+               OpDecorate %49 NonUniform
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+%_ptr_Input_int = OpTypePointer Input %int
+     %vIndex = OpVariable %_ptr_Input_int Input
+       %uint = OpTypeInt 32 0
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_runtimearr_v4float = OpTypeRuntimeArray %v4float
+       %SSBO = OpTypeStruct %uint %_runtimearr_v4float
+%_runtimearr_SSBO = OpTypeRuntimeArray %SSBO
+%_ptr_Uniform__runtimearr_SSBO = OpTypePointer Uniform %_runtimearr_SSBO
+      %ssbos = OpVariable %_ptr_Uniform__runtimearr_SSBO Uniform
+     %int_60 = OpConstant %int 60
+      %int_1 = OpConstant %int 1
+     %int_70 = OpConstant %int 70
+   %float_20 = OpConstant %float 20
+         %30 = OpConstantComposite %v4float %float_20 %float_20 %float_20 %float_20
+%_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
+    %int_100 = OpConstant %int 100
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_uint = OpTypePointer Uniform %uint
+   %uint_100 = OpConstant %uint 100
+     %uint_1 = OpConstant %uint 1
+     %uint_0 = OpConstant %uint 0
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+%_ptr_Uniform_SSBO = OpTypePointer Uniform %SSBO
+     %uint_2 = OpConstant %uint 2
+%_ptr_Output_float = OpTypePointer Output %float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %i = OpVariable %_ptr_Function_int Function
+         %11 = OpLoad %int %vIndex
+               OpStore %i %11
+         %20 = OpLoad %int %i
+         %22 = OpIAdd %int %20 %int_60
+         %23 = OpCopyObject %int %22
+         %25 = OpLoad %int %i
+         %27 = OpIAdd %int %25 %int_70
+         %28 = OpCopyObject %int %27
+         %32 = OpAccessChain %_ptr_Uniform_v4float %ssbos %23 %int_1 %28
+               OpStore %32 %30
+         %33 = OpLoad %int %i
+         %35 = OpIAdd %int %33 %int_100
+         %36 = OpCopyObject %int %35
+         %39 = OpAccessChain %_ptr_Uniform_uint %ssbos %36 %int_0
+         %43 = OpAtomicIAdd %uint %39 %uint_1 %uint_0 %uint_100
+         %46 = OpLoad %int %i
+         %47 = OpCopyObject %int %46
+         %49 = OpAccessChain %_ptr_Uniform_SSBO %ssbos %47
+         %50 = OpArrayLength %uint %49 1
+         %51 = OpBitcast %int %50
+         %52 = OpConvertSToF %float %51
+         %55 = OpAccessChain %_ptr_Output_float %FragColor %uint_2
+         %56 = OpLoad %float %55
+         %57 = OpFAdd %float %56 %52
+         %58 = OpAccessChain %_ptr_Output_float %FragColor %uint_2
+               OpStore %58 %57
+               OpReturn
+               OpFunctionEnd

--- a/shaders/vulkan/frag/nonuniform-qualifier.vk.nocompat.frag
+++ b/shaders/vulkan/frag/nonuniform-qualifier.vk.nocompat.frag
@@ -1,28 +1,52 @@
 #version 450
 #extension GL_EXT_nonuniform_qualifier : require
+#extension GL_EXT_samplerless_texture_functions : require
 
 layout(binding = 0) uniform texture2D uSamplers[];
+layout(binding = 0) uniform texture2DMS uSamplersMS[];
 layout(binding = 4) uniform sampler2D uCombinedSamplers[];
 layout(binding = 1) uniform sampler uSamps[];
 layout(location = 0) flat in int vIndex;
 layout(location = 1) in vec2 vUV;
 layout(location = 0) out vec4 FragColor;
 
+layout(r32f, binding = 5) uniform image2D uImages[];
+layout(r32ui, binding = 5) uniform uimage2D uImagesU32[];
+
 layout(set = 0, binding = 2) uniform UBO 
 {
 	vec4 v[64];
 } ubos[];
 
-layout(set = 0, binding = 3) readonly buffer SSBO
+layout(set = 0, binding = 3) buffer SSBO
 {
+	uint counter;
 	vec4 v[];
 } ssbos[];
 
 void main()
 {
 	int i = vIndex;
-	FragColor = texture(sampler2D(uSamplers[nonuniformEXT(i + 10)], uSamps[nonuniformEXT(i + 40)]), vUV);
+	FragColor = texture(nonuniformEXT(sampler2D(uSamplers[i + 10], uSamps[i + 40])), vUV);
 	FragColor = texture(uCombinedSamplers[nonuniformEXT(i + 10)], vUV);
 	FragColor += ubos[nonuniformEXT(i + 20)].v[nonuniformEXT(i + 40)];
 	FragColor += ssbos[nonuniformEXT(i + 50)].v[nonuniformEXT(i + 60)];
+	ssbos[nonuniformEXT(i + 60)].v[nonuniformEXT(i + 70)] = vec4(20.0);
+
+	FragColor = texelFetch(uSamplers[nonuniformEXT(i + 10)], ivec2(vUV), 0);
+	atomicAdd(ssbos[nonuniformEXT(i + 100)].counter, 100u);
+
+	vec2 queried = textureQueryLod(nonuniformEXT(sampler2D(uSamplers[i + 10], uSamps[i + 40])), vUV);
+	queried += textureQueryLod(uCombinedSamplers[nonuniformEXT(i + 10)], vUV);
+	FragColor.xy += queried;
+
+	FragColor.x += float(textureQueryLevels(uSamplers[nonuniformEXT(i + 20)]));
+	FragColor.y += float(textureSamples(uSamplersMS[nonuniformEXT(i + 20)]));
+	FragColor.xy += vec2(textureSize(uSamplers[nonuniformEXT(i + 20)], 0));
+
+	FragColor += imageLoad(uImages[nonuniformEXT(i + 50)], ivec2(vUV));
+	FragColor.xy += vec2(imageSize(uImages[nonuniformEXT(i + 20)]));
+	imageStore(uImages[nonuniformEXT(i + 60)], ivec2(vUV), vec4(50.0));
+
+	imageAtomicAdd(uImagesU32[nonuniformEXT(i + 70)], ivec2(vUV), 40u);
 }

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -628,6 +628,8 @@ protected:
 	void emit_trinary_func_op(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, uint32_t op2,
 	                          const char *op);
 	void emit_binary_func_op(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, const char *op);
+	void emit_atomic_func_op(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, const char *op);
+	void emit_atomic_func_op(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, uint32_t op2, const char *op);
 
 	void emit_unary_func_op_cast(uint32_t result_type, uint32_t result_id, uint32_t op0, const char *op,
 	                             SPIRType::BaseType input_type, SPIRType::BaseType expected_result_type);
@@ -706,6 +708,7 @@ protected:
 	void emit_uninitialized_temporary(uint32_t type, uint32_t id);
 	SPIRExpression &emit_uninitialized_temporary_expression(uint32_t type, uint32_t id);
 	void append_global_func_args(const SPIRFunction &func, uint32_t index, SmallVector<std::string> &arglist);
+	std::string to_non_uniform_aware_expression(uint32_t id);
 	std::string to_expression(uint32_t id, bool register_expression_read = true);
 	std::string to_composite_constructor_expression(uint32_t id, bool uses_buffer_offset);
 	std::string to_rerolled_array_expression(const std::string &expr, const SPIRType &type);
@@ -897,7 +900,7 @@ protected:
 	virtual void cast_from_builtin_load(uint32_t source_id, std::string &expr, const SPIRType &expr_type);
 	void unroll_array_from_complex_load(uint32_t target_id, uint32_t source_id, std::string &expr);
 	bool unroll_array_to_complex_store(uint32_t target_id, uint32_t source_id);
-	void convert_non_uniform_expression(const SPIRType &type, std::string &expr);
+	void convert_non_uniform_expression(std::string &expr, uint32_t ptr_id);
 
 	void handle_store_to_invariant_variable(uint32_t store_id, uint32_t value_id);
 	void disallow_forwarding_in_expression_chain(const SPIRExpression &expr);
@@ -915,8 +918,6 @@ protected:
 
 	void fixup_type_alias();
 	void reorder_type_alias();
-
-	void propagate_nonuniform_qualifier(uint32_t id);
 
 	static const char *vector_swizzle(int vecsize, int index);
 

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -2235,7 +2235,7 @@ void CompilerHLSL::emit_push_constant_block(const SPIRVariable &var)
 
 string CompilerHLSL::to_sampler_expression(uint32_t id)
 {
-	auto expr = join("_", to_expression(id));
+	auto expr = join("_", to_non_uniform_aware_expression(id));
 	auto index = expr.find_first_of('[');
 	if (index == string::npos)
 	{
@@ -2740,13 +2740,16 @@ void CompilerHLSL::emit_texture_op(const Instruction &i, bool sparse)
 	bool proj = false;
 	const uint32_t *opt = nullptr;
 	auto *combined_image = maybe_get<SPIRCombinedImageSampler>(img);
-	auto img_expr = to_expression(combined_image ? combined_image->image : img);
+
+	if (combined_image && has_decoration(img, DecorationNonUniform))
+	{
+		set_decoration(combined_image->image, DecorationNonUniform);
+		set_decoration(combined_image->sampler, DecorationNonUniform);
+	}
+
+	auto img_expr = to_non_uniform_aware_expression(combined_image ? combined_image->image : img);
 
 	inherited_expressions.push_back(coord);
-
-	// Make sure non-uniform decoration is back-propagated to where it needs to be.
-	if (has_decoration(img, DecorationNonUniformEXT))
-		propagate_nonuniform_qualifier(img);
 
 	switch (op)
 	{
@@ -3002,7 +3005,7 @@ void CompilerHLSL::emit_texture_op(const Instruction &i, bool sparse)
 	{
 		string sampler_expr;
 		if (combined_image)
-			sampler_expr = to_expression(combined_image->sampler);
+			sampler_expr = to_non_uniform_aware_expression(combined_image->sampler);
 		else
 			sampler_expr = to_sampler_expression(img);
 		expr += sampler_expr;
@@ -3798,6 +3801,10 @@ void CompilerHLSL::read_access_chain(string *expr, const string &lhs, const SPIR
 		SPIRV_CROSS_THROW("Reading types other than 32-bit from ByteAddressBuffer not yet supported, unless SM 6.2 and "
 		                  "native 16-bit types are enabled.");
 
+	string base = chain.base;
+	if (has_decoration(chain.self, DecorationNonUniform))
+		convert_non_uniform_expression(base, chain.self);
+
 	bool templated_load = hlsl_options.shader_model >= 62;
 	string load_expr;
 
@@ -3830,7 +3837,7 @@ void CompilerHLSL::read_access_chain(string *expr, const string &lhs, const SPIR
 		if (templated_load)
 			load_op = "Load";
 
-		load_expr = join(chain.base, ".", load_op, template_expr, "(", chain.dynamic_index, chain.static_index, ")");
+		load_expr = join(base, ".", load_op, template_expr, "(", chain.dynamic_index, chain.static_index, ")");
 	}
 	else if (type.columns == 1)
 	{
@@ -3852,7 +3859,7 @@ void CompilerHLSL::read_access_chain(string *expr, const string &lhs, const SPIR
 
 		for (uint32_t r = 0; r < type.vecsize; r++)
 		{
-			load_expr += join(chain.base, ".Load", template_expr, "(", chain.dynamic_index,
+			load_expr += join(base, ".Load", template_expr, "(", chain.dynamic_index,
 			                  chain.static_index + r * chain.matrix_stride, ")");
 			if (r + 1 < type.vecsize)
 				load_expr += ", ";
@@ -3901,7 +3908,7 @@ void CompilerHLSL::read_access_chain(string *expr, const string &lhs, const SPIR
 
 		for (uint32_t c = 0; c < type.columns; c++)
 		{
-			load_expr += join(chain.base, ".", load_op, template_expr, "(", chain.dynamic_index,
+			load_expr += join(base, ".", load_op, template_expr, "(", chain.dynamic_index,
 			                  chain.static_index + c * chain.matrix_stride, ")");
 			if (c + 1 < type.columns)
 				load_expr += ", ";
@@ -3930,7 +3937,7 @@ void CompilerHLSL::read_access_chain(string *expr, const string &lhs, const SPIR
 		{
 			for (uint32_t r = 0; r < type.vecsize; r++)
 			{
-				load_expr += join(chain.base, ".Load", template_expr, "(", chain.dynamic_index,
+				load_expr += join(base, ".Load", template_expr, "(", chain.dynamic_index,
 				                  chain.static_index + c * (type.width / 8) + r * chain.matrix_stride, ")");
 
 				if ((r + 1 < type.vecsize) || (c + 1 < type.columns))
@@ -3966,9 +3973,6 @@ void CompilerHLSL::emit_load(const Instruction &instruction)
 		uint32_t result_type = ops[0];
 		uint32_t id = ops[1];
 		uint32_t ptr = ops[2];
-
-		if (has_decoration(ptr, DecorationNonUniformEXT))
-			propagate_nonuniform_qualifier(ptr);
 
 		auto &type = get<SPIRType>(result_type);
 		bool composite_load = !type.array.empty() || type.basetype == SPIRType::Struct;
@@ -4108,9 +4112,6 @@ void CompilerHLSL::write_access_chain(const SPIRAccessChain &chain, uint32_t val
 	// Make sure we trigger a read of the constituents in the access chain.
 	track_expression_read(chain.self);
 
-	if (has_decoration(chain.self, DecorationNonUniformEXT))
-		propagate_nonuniform_qualifier(chain.self);
-
 	SPIRType target_type;
 	target_type.basetype = SPIRType::UInt;
 	target_type.vecsize = type.vecsize;
@@ -4133,6 +4134,10 @@ void CompilerHLSL::write_access_chain(const SPIRAccessChain &chain, uint32_t val
 		                  "native 16-bit types are enabled.");
 
 	bool templated_store = hlsl_options.shader_model >= 62;
+
+	auto base = chain.base;
+	if (has_decoration(chain.self, DecorationNonUniform))
+		convert_non_uniform_expression(base, chain.self);
 
 	string template_expr;
 	if (templated_store)
@@ -4169,7 +4174,7 @@ void CompilerHLSL::write_access_chain(const SPIRAccessChain &chain, uint32_t val
 		}
 		else
 			store_op = "Store";
-		statement(chain.base, ".", store_op, template_expr, "(", chain.dynamic_index, chain.static_index, ", ",
+		statement(base, ".", store_op, template_expr, "(", chain.dynamic_index, chain.static_index, ", ",
 		          store_expr, ");");
 	}
 	else if (type.columns == 1)
@@ -4200,7 +4205,7 @@ void CompilerHLSL::write_access_chain(const SPIRAccessChain &chain, uint32_t val
 					store_expr = join(bitcast_op, "(", store_expr, ")");
 			}
 
-			statement(chain.base, ".Store", template_expr, "(", chain.dynamic_index,
+			statement(base, ".Store", template_expr, "(", chain.dynamic_index,
 			          chain.static_index + chain.matrix_stride * r, ", ", store_expr, ");");
 		}
 	}
@@ -4244,7 +4249,7 @@ void CompilerHLSL::write_access_chain(const SPIRAccessChain &chain, uint32_t val
 					store_expr = join(bitcast_op, "(", store_expr, ")");
 			}
 
-			statement(chain.base, ".", store_op, template_expr, "(", chain.dynamic_index,
+			statement(base, ".", store_op, template_expr, "(", chain.dynamic_index,
 			          chain.static_index + c * chain.matrix_stride, ", ", store_expr, ");");
 		}
 	}
@@ -4268,7 +4273,7 @@ void CompilerHLSL::write_access_chain(const SPIRAccessChain &chain, uint32_t val
 				auto bitcast_op = bitcast_glsl_op(target_type, type);
 				if (!bitcast_op.empty())
 					store_expr = join(bitcast_op, "(", store_expr, ")");
-				statement(chain.base, ".Store", template_expr, "(", chain.dynamic_index,
+				statement(base, ".Store", template_expr, "(", chain.dynamic_index,
 				          chain.static_index + c * (type.width / 8) + r * chain.matrix_stride, ", ", store_expr, ");");
 			}
 		}
@@ -4370,9 +4375,6 @@ void CompilerHLSL::emit_access_chain(const Instruction &instruction)
 			inherit_expression_dependencies(ops[1], ops[i]);
 			add_implied_read_expression(e, ops[i]);
 		}
-
-		if (has_decoration(ops[1], DecorationNonUniformEXT))
-			propagate_nonuniform_qualifier(ops[1]);
 	}
 	else
 	{
@@ -4472,13 +4474,16 @@ void CompilerHLSL::emit_atomic(const uint32_t *ops, uint32_t length, spv::Op op)
 
 		if (data_type.storage == StorageClassImage || !chain)
 		{
-			statement(atomic_op, "(", to_expression(ops[0]), ", ", to_expression(ops[3]), ", ", to_expression(tmp_id),
-			          ");");
+			statement(atomic_op, "(", to_non_uniform_aware_expression(ops[0]), ", ",
+			          to_expression(ops[3]), ", ", to_expression(tmp_id), ");");
 		}
 		else
 		{
+			string base = chain->base;
+			if (has_decoration(chain->self, DecorationNonUniform))
+				convert_non_uniform_expression(base, chain->self);
 			// RWByteAddress buffer is always uint in its underlying type.
-			statement(chain->base, ".", atomic_op, "(", chain->dynamic_index, chain->static_index, ", ",
+			statement(base, ".", atomic_op, "(", chain->dynamic_index, chain->static_index, ", ",
 			          to_expression(ops[3]), ", ", to_expression(tmp_id), ");");
 		}
 	}
@@ -4496,14 +4501,17 @@ void CompilerHLSL::emit_atomic(const uint32_t *ops, uint32_t length, spv::Op op)
 		SPIRType::BaseType expr_type;
 		if (data_type.storage == StorageClassImage || !chain)
 		{
-			statement(atomic_op, "(", to_expression(ops[2]), ", ", value_expr, ", ", to_name(id), ");");
+			statement(atomic_op, "(", to_non_uniform_aware_expression(ops[2]), ", ", value_expr, ", ", to_name(id), ");");
 			expr_type = data_type.basetype;
 		}
 		else
 		{
 			// RWByteAddress buffer is always uint in its underlying type.
+			string base = chain->base;
+			if (has_decoration(chain->self, DecorationNonUniform))
+				convert_non_uniform_expression(base, chain->self);
 			expr_type = SPIRType::UInt;
-			statement(chain->base, ".", atomic_op, "(", chain->dynamic_index, chain->static_index, ", ", value_expr,
+			statement(base, ".", atomic_op, "(", chain->dynamic_index, chain->static_index, ", ", value_expr,
 			          ", ", to_name(id), ");");
 		}
 
@@ -5136,7 +5144,7 @@ void CompilerHLSL::emit_instruction(const Instruction &instruction)
 		auto dummy_samples_levels = join(get_fallback_name(id), "_dummy_parameter");
 		statement("uint ", dummy_samples_levels, ";");
 
-		auto expr = join("spvTextureSize(", to_expression(ops[2]), ", ",
+		auto expr = join("spvTextureSize(", to_non_uniform_aware_expression(ops[2]), ", ",
 		                 bitcast_expression(SPIRType::UInt, ops[3]), ", ", dummy_samples_levels, ")");
 
 		auto &restype = get<SPIRType>(ops[0]);
@@ -5162,9 +5170,9 @@ void CompilerHLSL::emit_instruction(const Instruction &instruction)
 
 		string expr;
 		if (uav)
-			expr = join("spvImageSize(", to_expression(ops[2]), ", ", dummy_samples_levels, ")");
+			expr = join("spvImageSize(", to_non_uniform_aware_expression(ops[2]), ", ", dummy_samples_levels, ")");
 		else
-			expr = join("spvTextureSize(", to_expression(ops[2]), ", 0u, ", dummy_samples_levels, ")");
+			expr = join("spvTextureSize(", to_non_uniform_aware_expression(ops[2]), ", 0u, ", dummy_samples_levels, ")");
 
 		auto &restype = get<SPIRType>(ops[0]);
 		expr = bitcast_expression(restype, SPIRType::UInt, expr);
@@ -5194,9 +5202,9 @@ void CompilerHLSL::emit_instruction(const Instruction &instruction)
 		statement(variable_decl(type, to_name(id)), ";");
 
 		if (uav)
-			statement("spvImageSize(", to_expression(ops[2]), ", ", to_name(id), ");");
+			statement("spvImageSize(", to_non_uniform_aware_expression(ops[2]), ", ", to_name(id), ");");
 		else
-			statement("spvTextureSize(", to_expression(ops[2]), ", 0u, ", to_name(id), ");");
+			statement("spvTextureSize(", to_non_uniform_aware_expression(ops[2]), ", 0u, ", to_name(id), ");");
 
 		auto &restype = get<SPIRType>(ops[0]);
 		auto expr = bitcast_expression(restype, SPIRType::UInt, to_name(id));
@@ -5227,16 +5235,16 @@ void CompilerHLSL::emit_instruction(const Instruction &instruction)
 				if (operands != ImageOperandsSampleMask || instruction.length != 6)
 					SPIRV_CROSS_THROW("Multisampled image used in OpImageRead, but unexpected operand mask was used.");
 				uint32_t sample = ops[5];
-				imgexpr = join(to_expression(ops[2]), ".Load(int2(gl_FragCoord.xy), ", to_expression(sample), ")");
+				imgexpr = join(to_non_uniform_aware_expression(ops[2]), ".Load(int2(gl_FragCoord.xy), ", to_expression(sample), ")");
 			}
 			else
-				imgexpr = join(to_expression(ops[2]), ".Load(int3(int2(gl_FragCoord.xy), 0))");
+				imgexpr = join(to_non_uniform_aware_expression(ops[2]), ".Load(int3(int2(gl_FragCoord.xy), 0))");
 
 			pure = true;
 		}
 		else
 		{
-			imgexpr = join(to_expression(ops[2]), "[", to_expression(ops[3]), "]");
+			imgexpr = join(to_non_uniform_aware_expression(ops[2]), "[", to_expression(ops[3]), "]");
 			// The underlying image type in HLSL depends on the image format, unlike GLSL, where all images are "vec4",
 			// except that the underlying type changes how the data is interpreted.
 
@@ -5285,7 +5293,7 @@ void CompilerHLSL::emit_instruction(const Instruction &instruction)
 			value_expr = remap_swizzle(narrowed_type, expression_type(ops[2]).vecsize, value_expr);
 		}
 
-		statement(to_expression(ops[0]), "[", to_expression(ops[1]), "] = ", value_expr, ";");
+		statement(to_non_uniform_aware_expression(ops[0]), "[", to_expression(ops[1]), "] = ", value_expr, ";");
 		if (var && variable_storage_is_aliased(*var))
 			flush_all_aliased_variables();
 		break;
@@ -5297,10 +5305,7 @@ void CompilerHLSL::emit_instruction(const Instruction &instruction)
 		uint32_t id = ops[1];
 
 		auto expr = to_expression(ops[2]);
-		if (has_decoration(id, DecorationNonUniformEXT) || has_decoration(ops[2], DecorationNonUniformEXT))
-			convert_non_uniform_expression(expression_type(ops[2]), expr);
 		expr += join("[", to_expression(ops[3]), "]");
-
 		auto &e = set<SPIRExpression>(id, expr, result_type, true);
 
 		// When using the pointer, we need to know which variable it is actually loaded from.
@@ -5478,7 +5483,7 @@ void CompilerHLSL::emit_instruction(const Instruction &instruction)
 
 	case OpArrayLength:
 	{
-		auto *var = maybe_get<SPIRVariable>(ops[2]);
+		auto *var = maybe_get_backing_variable(ops[2]);
 		if (!var)
 			SPIRV_CROSS_THROW("Array length must point directly to an SSBO block.");
 
@@ -5488,7 +5493,7 @@ void CompilerHLSL::emit_instruction(const Instruction &instruction)
 
 		// This must be 32-bit uint, so we're good to go.
 		emit_uninitialized_temporary_expression(ops[0], ops[1]);
-		statement(to_expression(ops[2]), ".GetDimensions(", to_expression(ops[1]), ");");
+		statement(to_non_uniform_aware_expression(ops[2]), ".GetDimensions(", to_expression(ops[1]), ");");
 		uint32_t offset = type_struct_member_offset(type, ops[3]);
 		uint32_t stride = type_struct_member_array_stride(type, ops[3]);
 		statement(to_expression(ops[1]), " = (", to_expression(ops[1]), " - ", offset, ") / ", stride, ";");


### PR DESCRIPTION
Remove all shenanigans with propagation, and only consume nonuniform
qualifiers exactly where needed (last minute).

Fix #1607.