### PR TITLE
HLSL: Support Shuffle wave ops.

### DIFF
--- a/reference/shaders-hlsl-no-opt/comp/subgroups.invalid.nofxc.sm60.comp
+++ b/reference/shaders-hlsl-no-opt/comp/subgroups.invalid.nofxc.sm60.comp
@@ -21,6 +21,10 @@ void comp_main()
     float3 first = WaveReadLaneFirst(20.0f.xxx);
     uint4 ballot_value = WaveActiveBallot(true);
     uint bit_count = countbits(ballot_value.x) + countbits(ballot_value.y) + countbits(ballot_value.z) + countbits(ballot_value.w);
+    uint shuffled = WaveReadLaneAt(10u, 8u);
+    uint shuffled_xor = WaveReadLaneAt(30u, WaveGetLaneIndex() ^ 8u);
+    uint shuffled_up = WaveReadLaneAt(20u, WaveGetLaneIndex() - 4u);
+    uint shuffled_down = WaveReadLaneAt(20u, WaveGetLaneIndex() + 4u);
     bool has_all = WaveActiveAllTrue(true);
     bool has_any = WaveActiveAnyTrue(true);
     bool has_equal = WaveActiveAllEqual(true);

--- a/shaders-hlsl-no-opt/comp/subgroups.invalid.nofxc.sm60.comp
+++ b/shaders-hlsl-no-opt/comp/subgroups.invalid.nofxc.sm60.comp
@@ -46,12 +46,12 @@ void main()
 	//uint msb = subgroupBallotFindMSB(ballot_value);
 
 	// shuffle
-	//uint shuffled = subgroupShuffle(10u, 8u);
-	//uint shuffled_xor = subgroupShuffleXor(30u, 8u);
+	uint shuffled = subgroupShuffle(10u, 8u);
+	uint shuffled_xor = subgroupShuffleXor(30u, 8u);
 
 	// shuffle relative 
-	//uint shuffled_up = subgroupShuffleUp(20u, 4u);
-	//uint shuffled_down = subgroupShuffleDown(20u, 4u);
+	uint shuffled_up = subgroupShuffleUp(20u, 4u);
+	uint shuffled_down = subgroupShuffleDown(20u, 4u);
 
 	// vote
 	bool has_all = subgroupAll(true);

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -4612,13 +4612,35 @@ void CompilerHLSL::emit_subgroup_op(const Instruction &i)
 	}
 
 	case OpGroupNonUniformShuffle:
-		SPIRV_CROSS_THROW("Cannot trivially implement Shuffle in HLSL.");
+		emit_binary_func_op(result_type, id, ops[3], ops[4], "WaveReadLaneAt");
+		break;
 	case OpGroupNonUniformShuffleXor:
-		SPIRV_CROSS_THROW("Cannot trivially implement ShuffleXor in HLSL.");
+	{
+		bool forward = should_forward(ops[3]);
+		emit_op(ops[0], ops[1],
+		        join("WaveReadLaneAt(", to_unpacked_expression(ops[3]), ", ",
+		             "WaveGetLaneIndex() ^ ", to_enclosed_expression(ops[4]), ")"), forward);
+		inherit_expression_dependencies(ops[1], ops[3]);
+		break;
+	}
 	case OpGroupNonUniformShuffleUp:
-		SPIRV_CROSS_THROW("Cannot trivially implement ShuffleUp in HLSL.");
+	{
+		bool forward = should_forward(ops[3]);
+		emit_op(ops[0], ops[1],
+		        join("WaveReadLaneAt(", to_unpacked_expression(ops[3]), ", ",
+		             "WaveGetLaneIndex() - ", to_enclosed_expression(ops[4]), ")"), forward);
+		inherit_expression_dependencies(ops[1], ops[3]);
+		break;
+	}
 	case OpGroupNonUniformShuffleDown:
-		SPIRV_CROSS_THROW("Cannot trivially implement ShuffleDown in HLSL.");
+	{
+		bool forward = should_forward(ops[3]);
+		emit_op(ops[0], ops[1],
+		        join("WaveReadLaneAt(", to_unpacked_expression(ops[3]), ", ",
+		             "WaveGetLaneIndex() + ", to_enclosed_expression(ops[4]), ")"), forward);
+		inherit_expression_dependencies(ops[1], ops[3]);
+		break;
+	}
 
 	case OpGroupNonUniformAll:
 		emit_unary_func_op(result_type, id, ops[3], "WaveActiveAllTrue");


### PR DESCRIPTION
WaveReadLaneAt is no longer restricted to dynamically uniform index,
so can implement the other shuffle ops.

Fix #1659.