### PR TITLE
MSL: Minor last minute patch for MoltenVK Vulkan SDK release tomorrow (Tuesday) - RUSH

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -15583,10 +15583,6 @@ void CompilerMSL::analyze_argument_buffers()
 				if (elem_cnt == 0)
 					elem_cnt = get_resource_array_size(var.self);
 
-				// And if the member is a combined image sampler, it takes double the slots
-				if (type.basetype == SPIRType::SampledImage)
-					elem_cnt *= 2;
-
 				next_arg_buff_index += elem_cnt;
 			}
 


### PR DESCRIPTION
Padding for Metal argument buffers should not double-count `SampledImages`.

This is a minor last minute patch for MoltenVK SDK release tomorrow (Tuesday) that does not impact anything other than MoltenVK's use of padding on Metal argument buffers.

If this is good, can we pull it into SPIRV-Cross Tuesday morning, so that it can propagate through MoltenVK to the Vulkan SDK build this week?

Apologies for the last minute rush. It showed up during final build testing.