### PR TITLE
Add comment after inf/nan float number for clarifying.

### DIFF
--- a/reference/opt/shaders-hlsl/asm/frag/inf-nan-constant.asm.frag
+++ b/reference/opt/shaders-hlsl/asm/frag/inf-nan-constant.asm.frag
@@ -7,7 +7,7 @@ struct SPIRV_Cross_Output
 
 void frag_main()
 {
-    FragColor = float3(asfloat(0x7f800000u), asfloat(0xff800000u), asfloat(0x7fc00000u));
+    FragColor = float3(asfloat(0x7f800000u /* inf */), asfloat(0xff800000u /* -inf */), asfloat(0x7fc00000u /* nan */));
 }
 
 SPIRV_Cross_Output main()

--- a/reference/opt/shaders-msl/asm/frag/inf-nan-constant.asm.frag
+++ b/reference/opt/shaders-msl/asm/frag/inf-nan-constant.asm.frag
@@ -11,7 +11,7 @@ struct main0_out
 fragment main0_out main0()
 {
     main0_out out = {};
-    out.FragColor = float3(as_type<float>(0x7f800000u), as_type<float>(0xff800000u), as_type<float>(0x7fc00000u));
+    out.FragColor = float3(as_type<float>(0x7f800000u /* inf */), as_type<float>(0xff800000u /* -inf */), as_type<float>(0x7fc00000u /* nan */));
     return out;
 }
 

--- a/reference/opt/shaders/asm/frag/inf-nan-constant-double.asm.frag
+++ b/reference/opt/shaders/asm/frag/inf-nan-constant-double.asm.frag
@@ -6,6 +6,6 @@ layout(location = 0) flat in double vTmp;
 
 void main()
 {
-    FragColor = vec3(dvec3(uint64BitsToDouble(0x7ff0000000000000ul), uint64BitsToDouble(0xfff0000000000000ul), uint64BitsToDouble(0x7ff8000000000000ul)) + dvec3(vTmp));
+    FragColor = vec3(dvec3(uint64BitsToDouble(0x7ff0000000000000ul /* inf */), uint64BitsToDouble(0xfff0000000000000ul /* -inf */), uint64BitsToDouble(0x7ff8000000000000ul /* nan */)) + dvec3(vTmp));
 }
 

--- a/reference/opt/shaders/asm/frag/inf-nan-constant.asm.frag
+++ b/reference/opt/shaders/asm/frag/inf-nan-constant.asm.frag
@@ -6,6 +6,6 @@ layout(location = 0) out highp vec3 FragColor;
 
 void main()
 {
-    FragColor = vec3(uintBitsToFloat(0x7f800000u), uintBitsToFloat(0xff800000u), uintBitsToFloat(0x7fc00000u));
+    FragColor = vec3(uintBitsToFloat(0x7f800000u /* inf */), uintBitsToFloat(0xff800000u /* -inf */), uintBitsToFloat(0x7fc00000u /* nan */));
 }
 

--- a/reference/shaders-hlsl/asm/frag/inf-nan-constant.asm.frag
+++ b/reference/shaders-hlsl/asm/frag/inf-nan-constant.asm.frag
@@ -7,7 +7,7 @@ struct SPIRV_Cross_Output
 
 void frag_main()
 {
-    FragColor = float3(asfloat(0x7f800000u), asfloat(0xff800000u), asfloat(0x7fc00000u));
+    FragColor = float3(asfloat(0x7f800000u /* inf */), asfloat(0xff800000u /* -inf */), asfloat(0x7fc00000u /* nan */));
 }
 
 SPIRV_Cross_Output main()

--- a/reference/shaders-msl/asm/frag/inf-nan-constant.asm.frag
+++ b/reference/shaders-msl/asm/frag/inf-nan-constant.asm.frag
@@ -11,7 +11,7 @@ struct main0_out
 fragment main0_out main0()
 {
     main0_out out = {};
-    out.FragColor = float3(as_type<float>(0x7f800000u), as_type<float>(0xff800000u), as_type<float>(0x7fc00000u));
+    out.FragColor = float3(as_type<float>(0x7f800000u /* inf */), as_type<float>(0xff800000u /* -inf */), as_type<float>(0x7fc00000u /* nan */));
     return out;
 }
 

--- a/reference/shaders/asm/frag/inf-nan-constant-double.asm.frag
+++ b/reference/shaders/asm/frag/inf-nan-constant-double.asm.frag
@@ -6,6 +6,6 @@ layout(location = 0) flat in double vTmp;
 
 void main()
 {
-    FragColor = vec3(dvec3(uint64BitsToDouble(0x7ff0000000000000ul), uint64BitsToDouble(0xfff0000000000000ul), uint64BitsToDouble(0x7ff8000000000000ul)) + dvec3(vTmp));
+    FragColor = vec3(dvec3(uint64BitsToDouble(0x7ff0000000000000ul /* inf */), uint64BitsToDouble(0xfff0000000000000ul /* -inf */), uint64BitsToDouble(0x7ff8000000000000ul /* nan */)) + dvec3(vTmp));
 }
 

--- a/reference/shaders/asm/frag/inf-nan-constant.asm.frag
+++ b/reference/shaders/asm/frag/inf-nan-constant.asm.frag
@@ -6,6 +6,6 @@ layout(location = 0) out highp vec3 FragColor;
 
 void main()
 {
-    FragColor = vec3(uintBitsToFloat(0x7f800000u), uintBitsToFloat(0xff800000u), uintBitsToFloat(0x7fc00000u));
+    FragColor = vec3(uintBitsToFloat(0x7f800000u /* inf */), uintBitsToFloat(0xff800000u /* -inf */), uintBitsToFloat(0x7fc00000u /* nan */));
 }
 

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -4948,7 +4948,13 @@ string CompilerGLSL::convert_float_to_string(const SPIRConstant &c, uint32_t col
 
 			char print_buffer[32];
 			sprintf(print_buffer, "0x%xu", c.scalar(col, row));
-			res = join(bitcast_glsl_op(out_type, in_type), "(", print_buffer, ")");
+
+			const char *comment = "inf";
+			if (float_value == -numeric_limits<float>::infinity())
+				comment = "-inf";
+			else if (std::isnan(float_value))
+				comment = "nan";
+			res = join(bitcast_glsl_op(out_type, in_type), "(", print_buffer, " /* ", comment, " */)");
 		}
 		else
 		{
@@ -5015,7 +5021,13 @@ std::string CompilerGLSL::convert_double_to_string(const SPIRConstant &c, uint32
 			char print_buffer[64];
 			sprintf(print_buffer, "0x%llx%s", static_cast<unsigned long long>(u64_value),
 			        backend.long_long_literal_suffix ? "ull" : "ul");
-			res = join(bitcast_glsl_op(out_type, in_type), "(", print_buffer, ")");
+
+			const char *comment = "inf";
+			if (double_value == -numeric_limits<double>::infinity())
+				comment = "-inf";
+			else if (std::isnan(double_value))
+				comment = "nan";
+			res = join(bitcast_glsl_op(out_type, in_type), "(", print_buffer, " /* ", comment, " */)");
 		}
 		else
 		{


### PR DESCRIPTION
Outputs like:
glsl: `float v = uintBitsToFloat(0xff800000u /* -inf */);`
msl: `float v = as_type<float>(0x7f800000u /* inf */);`