### PR TITLE
MSL:  convert depth buffer fetch to regular texture read.

### DIFF
--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -4163,6 +4163,8 @@ void Compiler::analyze_image_and_sampler_usage()
 
 	comparison_ids = move(handler.comparison_ids);
 	need_subpass_input = handler.need_subpass_input;
+	need_subpass_color_input = handler.need_subpass_color_input;
+	need_subpass_depth_input = handler.need_subpass_depth_input;
 
 	// Forward information from separate images and samplers into combined image samplers.
 	for (auto &combined : combined_image_samplers)
@@ -4329,7 +4331,13 @@ bool Compiler::CombinedImageSamplerUsageHandler::handle(Op opcode, const uint32_
 		// If we load an image, we're going to use it and there is little harm in declaring an unused gl_FragCoord.
 		auto &type = compiler.get<SPIRType>(args[0]);
 		if (type.image.dim == DimSubpassData)
+		{
 			need_subpass_input = true;
+			if (type.image.depth)
+				need_subpass_depth_input = true;
+			else
+				need_subpass_color_input = true;
+		}
 
 		// If we load a SampledImage and it will be used with Dref, propagate the state up.
 		if (dref_combined_samplers.count(args[1]) != 0)

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -911,6 +911,8 @@ protected:
 	// Similar is implemented for images, as well as if subpass inputs are needed.
 	std::unordered_set<uint32_t> comparison_ids;
 	bool need_subpass_input = false;
+	bool need_subpass_color_input = false;
+	bool need_subpass_depth_input = false;
 
 	// In certain backends, we will need to use a dummy sampler to be able to emit code.
 	// GLSL does not support texelFetch on texture2D objects, but SPIR-V does,
@@ -950,6 +952,8 @@ protected:
 
 		void add_hierarchy_to_comparison_ids(uint32_t ids);
 		bool need_subpass_input = false;
+		bool need_subpass_color_input = false;
+		bool need_subpass_depth_input = false;
 		void add_dependency(uint32_t dst, uint32_t src);
 	};
 


### PR DESCRIPTION
Metal doesn't support depth buffer fetch, so here gives a chance to convert those subpassLoads from depth buffer to regular texture reads.