### PR TITLE
Fix IVariant -Wdeprecated-copy-with-dtor

### DIFF
--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -417,6 +417,11 @@ struct IVariant
 	virtual ~IVariant() = default;
 	virtual IVariant *clone(ObjectPoolBase *pool) = 0;
 	ID self = 0;
+
+protected:
+	IVariant() = default;
+	IVariant(const IVariant&) = default;
+	IVariant &operator=(const IVariant&) = default;
 };
 
 #define SPIRV_CROSS_DECLARE_CLONE(T)                                \


### PR DESCRIPTION
Since C++11 the generation of implicit copy constructor is deprecated if
the type has a user-defined constructor or destructor (even if defaulted).

Fix this by adding a defaulted copy-constructor for IVariant that remove
the implicit default constructor, so add it too.