### PR TITLE
Handle SPIR-V 1.4 selection constructs.

### DIFF
--- a/reference/opt/shaders-hlsl/asm/comp/bitcast_icmp.asm.comp
+++ b/reference/opt/shaders-hlsl/asm/comp/bitcast_icmp.asm.comp
@@ -3,22 +3,14 @@ RWByteAddressBuffer _6 : register(u1);
 
 void comp_main()
 {
-    bool4 _31 = bool4(int(_5.Load4(16).x) < int4(_5.Load4(0)).x, int(_5.Load4(16).y) < int4(_5.Load4(0)).y, int(_5.Load4(16).z) < int4(_5.Load4(0)).z, int(_5.Load4(16).w) < int4(_5.Load4(0)).w);
-    bool4 _32 = bool4(int(_5.Load4(16).x) <= int4(_5.Load4(0)).x, int(_5.Load4(16).y) <= int4(_5.Load4(0)).y, int(_5.Load4(16).z) <= int4(_5.Load4(0)).z, int(_5.Load4(16).w) <= int4(_5.Load4(0)).w);
-    bool4 _33 = bool4(_5.Load4(16).x < uint(int4(_5.Load4(0)).x), _5.Load4(16).y < uint(int4(_5.Load4(0)).y), _5.Load4(16).z < uint(int4(_5.Load4(0)).z), _5.Load4(16).w < uint(int4(_5.Load4(0)).w));
-    bool4 _34 = bool4(_5.Load4(16).x <= uint(int4(_5.Load4(0)).x), _5.Load4(16).y <= uint(int4(_5.Load4(0)).y), _5.Load4(16).z <= uint(int4(_5.Load4(0)).z), _5.Load4(16).w <= uint(int4(_5.Load4(0)).w));
-    bool4 _35 = bool4(int(_5.Load4(16).x) > int4(_5.Load4(0)).x, int(_5.Load4(16).y) > int4(_5.Load4(0)).y, int(_5.Load4(16).z) > int4(_5.Load4(0)).z, int(_5.Load4(16).w) > int4(_5.Load4(0)).w);
-    bool4 _36 = bool4(int(_5.Load4(16).x) >= int4(_5.Load4(0)).x, int(_5.Load4(16).y) >= int4(_5.Load4(0)).y, int(_5.Load4(16).z) >= int4(_5.Load4(0)).z, int(_5.Load4(16).w) >= int4(_5.Load4(0)).w);
-    bool4 _37 = bool4(_5.Load4(16).x > uint(int4(_5.Load4(0)).x), _5.Load4(16).y > uint(int4(_5.Load4(0)).y), _5.Load4(16).z > uint(int4(_5.Load4(0)).z), _5.Load4(16).w > uint(int4(_5.Load4(0)).w));
-    bool4 _38 = bool4(_5.Load4(16).x >= uint(int4(_5.Load4(0)).x), _5.Load4(16).y >= uint(int4(_5.Load4(0)).y), _5.Load4(16).z >= uint(int4(_5.Load4(0)).z), _5.Load4(16).w >= uint(int4(_5.Load4(0)).w));
-    _6.Store4(0, uint4(_31.x ? uint4(1u, 1u, 1u, 1u).x : uint4(0u, 0u, 0u, 0u).x, _31.y ? uint4(1u, 1u, 1u, 1u).y : uint4(0u, 0u, 0u, 0u).y, _31.z ? uint4(1u, 1u, 1u, 1u).z : uint4(0u, 0u, 0u, 0u).z, _31.w ? uint4(1u, 1u, 1u, 1u).w : uint4(0u, 0u, 0u, 0u).w));
-    _6.Store4(0, uint4(_32.x ? uint4(1u, 1u, 1u, 1u).x : uint4(0u, 0u, 0u, 0u).x, _32.y ? uint4(1u, 1u, 1u, 1u).y : uint4(0u, 0u, 0u, 0u).y, _32.z ? uint4(1u, 1u, 1u, 1u).z : uint4(0u, 0u, 0u, 0u).z, _32.w ? uint4(1u, 1u, 1u, 1u).w : uint4(0u, 0u, 0u, 0u).w));
-    _6.Store4(0, uint4(_33.x ? uint4(1u, 1u, 1u, 1u).x : uint4(0u, 0u, 0u, 0u).x, _33.y ? uint4(1u, 1u, 1u, 1u).y : uint4(0u, 0u, 0u, 0u).y, _33.z ? uint4(1u, 1u, 1u, 1u).z : uint4(0u, 0u, 0u, 0u).z, _33.w ? uint4(1u, 1u, 1u, 1u).w : uint4(0u, 0u, 0u, 0u).w));
-    _6.Store4(0, uint4(_34.x ? uint4(1u, 1u, 1u, 1u).x : uint4(0u, 0u, 0u, 0u).x, _34.y ? uint4(1u, 1u, 1u, 1u).y : uint4(0u, 0u, 0u, 0u).y, _34.z ? uint4(1u, 1u, 1u, 1u).z : uint4(0u, 0u, 0u, 0u).z, _34.w ? uint4(1u, 1u, 1u, 1u).w : uint4(0u, 0u, 0u, 0u).w));
-    _6.Store4(0, uint4(_35.x ? uint4(1u, 1u, 1u, 1u).x : uint4(0u, 0u, 0u, 0u).x, _35.y ? uint4(1u, 1u, 1u, 1u).y : uint4(0u, 0u, 0u, 0u).y, _35.z ? uint4(1u, 1u, 1u, 1u).z : uint4(0u, 0u, 0u, 0u).z, _35.w ? uint4(1u, 1u, 1u, 1u).w : uint4(0u, 0u, 0u, 0u).w));
-    _6.Store4(0, uint4(_36.x ? uint4(1u, 1u, 1u, 1u).x : uint4(0u, 0u, 0u, 0u).x, _36.y ? uint4(1u, 1u, 1u, 1u).y : uint4(0u, 0u, 0u, 0u).y, _36.z ? uint4(1u, 1u, 1u, 1u).z : uint4(0u, 0u, 0u, 0u).z, _36.w ? uint4(1u, 1u, 1u, 1u).w : uint4(0u, 0u, 0u, 0u).w));
-    _6.Store4(0, uint4(_37.x ? uint4(1u, 1u, 1u, 1u).x : uint4(0u, 0u, 0u, 0u).x, _37.y ? uint4(1u, 1u, 1u, 1u).y : uint4(0u, 0u, 0u, 0u).y, _37.z ? uint4(1u, 1u, 1u, 1u).z : uint4(0u, 0u, 0u, 0u).z, _37.w ? uint4(1u, 1u, 1u, 1u).w : uint4(0u, 0u, 0u, 0u).w));
-    _6.Store4(0, uint4(_38.x ? uint4(1u, 1u, 1u, 1u).x : uint4(0u, 0u, 0u, 0u).x, _38.y ? uint4(1u, 1u, 1u, 1u).y : uint4(0u, 0u, 0u, 0u).y, _38.z ? uint4(1u, 1u, 1u, 1u).z : uint4(0u, 0u, 0u, 0u).z, _38.w ? uint4(1u, 1u, 1u, 1u).w : uint4(0u, 0u, 0u, 0u).w));
+    _6.Store4(0, uint4(bool4(int(_5.Load4(16).x) < int4(_5.Load4(0)).x, int(_5.Load4(16).y) < int4(_5.Load4(0)).y, int(_5.Load4(16).z) < int4(_5.Load4(0)).z, int(_5.Load4(16).w) < int4(_5.Load4(0)).w)));
+    _6.Store4(0, uint4(bool4(int(_5.Load4(16).x) <= int4(_5.Load4(0)).x, int(_5.Load4(16).y) <= int4(_5.Load4(0)).y, int(_5.Load4(16).z) <= int4(_5.Load4(0)).z, int(_5.Load4(16).w) <= int4(_5.Load4(0)).w)));
+    _6.Store4(0, uint4(bool4(_5.Load4(16).x < uint(int4(_5.Load4(0)).x), _5.Load4(16).y < uint(int4(_5.Load4(0)).y), _5.Load4(16).z < uint(int4(_5.Load4(0)).z), _5.Load4(16).w < uint(int4(_5.Load4(0)).w))));
+    _6.Store4(0, uint4(bool4(_5.Load4(16).x <= uint(int4(_5.Load4(0)).x), _5.Load4(16).y <= uint(int4(_5.Load4(0)).y), _5.Load4(16).z <= uint(int4(_5.Load4(0)).z), _5.Load4(16).w <= uint(int4(_5.Load4(0)).w))));
+    _6.Store4(0, uint4(bool4(int(_5.Load4(16).x) > int4(_5.Load4(0)).x, int(_5.Load4(16).y) > int4(_5.Load4(0)).y, int(_5.Load4(16).z) > int4(_5.Load4(0)).z, int(_5.Load4(16).w) > int4(_5.Load4(0)).w)));
+    _6.Store4(0, uint4(bool4(int(_5.Load4(16).x) >= int4(_5.Load4(0)).x, int(_5.Load4(16).y) >= int4(_5.Load4(0)).y, int(_5.Load4(16).z) >= int4(_5.Load4(0)).z, int(_5.Load4(16).w) >= int4(_5.Load4(0)).w)));
+    _6.Store4(0, uint4(bool4(_5.Load4(16).x > uint(int4(_5.Load4(0)).x), _5.Load4(16).y > uint(int4(_5.Load4(0)).y), _5.Load4(16).z > uint(int4(_5.Load4(0)).z), _5.Load4(16).w > uint(int4(_5.Load4(0)).w))));
+    _6.Store4(0, uint4(bool4(_5.Load4(16).x >= uint(int4(_5.Load4(0)).x), _5.Load4(16).y >= uint(int4(_5.Load4(0)).y), _5.Load4(16).z >= uint(int4(_5.Load4(0)).z), _5.Load4(16).w >= uint(int4(_5.Load4(0)).w))));
 }
 
 [numthreads(1, 1, 1)]

--- a/reference/opt/shaders-msl/asm/comp/bitcast_icmp.asm.comp
+++ b/reference/opt/shaders-msl/asm/comp/bitcast_icmp.asm.comp
@@ -17,13 +17,13 @@ struct _4
 
 kernel void main0(device _3& restrict _5 [[buffer(0)]], device _4& restrict _6 [[buffer(1)]])
 {
-    _6._m0 = select(uint4(0u), uint4(1u), int4(_5._m1) < _5._m0);
-    _6._m0 = select(uint4(0u), uint4(1u), int4(_5._m1) <= _5._m0);
-    _6._m0 = select(uint4(0u), uint4(1u), _5._m1 < uint4(_5._m0));
-    _6._m0 = select(uint4(0u), uint4(1u), _5._m1 <= uint4(_5._m0));
-    _6._m0 = select(uint4(0u), uint4(1u), int4(_5._m1) > _5._m0);
-    _6._m0 = select(uint4(0u), uint4(1u), int4(_5._m1) >= _5._m0);
-    _6._m0 = select(uint4(0u), uint4(1u), _5._m1 > uint4(_5._m0));
-    _6._m0 = select(uint4(0u), uint4(1u), _5._m1 >= uint4(_5._m0));
+    _6._m0 = uint4(int4(_5._m1) < _5._m0);
+    _6._m0 = uint4(int4(_5._m1) <= _5._m0);
+    _6._m0 = uint4(_5._m1 < uint4(_5._m0));
+    _6._m0 = uint4(_5._m1 <= uint4(_5._m0));
+    _6._m0 = uint4(int4(_5._m1) > _5._m0);
+    _6._m0 = uint4(int4(_5._m1) >= _5._m0);
+    _6._m0 = uint4(_5._m1 > uint4(_5._m0));
+    _6._m0 = uint4(_5._m1 >= uint4(_5._m0));
 }
 

--- a/reference/opt/shaders-ue4/asm/frag/sample-mask-not-array.asm.frag
+++ b/reference/opt/shaders-ue4/asm/frag/sample-mask-not-array.asm.frag
@@ -470,7 +470,7 @@ fragment main0_out main0(main0_in in [[stage_in]], constant type_View& View [[bu
         float3 _245;
         if (any(abs(_142 - View_PrimitiveSceneData._m0[_222 + 5u].xyz) > (View_PrimitiveSceneData._m0[_222 + 19u].xyz + float3(1.0))))
         {
-            _245 = mix(float3(1.0, 1.0, 0.0), float3(0.0, 1.0, 1.0), select(float3(0.0), float3(1.0), float3(fract(dot(_142, float3(0.57700002193450927734375)) * 0.00200000009499490261077880859375)) > float3(0.5)));
+            _245 = mix(float3(1.0, 1.0, 0.0), float3(0.0, 1.0, 1.0), float3(float3(fract(dot(_142, float3(0.57700002193450927734375)) * 0.00200000009499490261077880859375)) > float3(0.5)));
         }
         else
         {

--- a/reference/opt/shaders-ue4/asm/tesc/hs-incorrect-base-type.asm.tesc
+++ b/reference/opt/shaders-ue4/asm/tesc/hs-incorrect-base-type.asm.tesc
@@ -369,7 +369,7 @@ kernel void main0(main0_in in [[stage_in]], constant type_View& View [[buffer(0)
             float4 _537 = View.View_TranslatedWorldToClip * float4(temp_var_hullMainRetVal[2u].WorldPosition[0].xyz, 1.0);
             float3 _538 = _537.xyz;
             float _540 = _537.w;
-            if (any((((select(int3(0), int3(1), (_495 - _496) < float3(_498 + _499)) + (int3(2) * select(int3(0), int3(1), (_495 + _496) > float3((-_498) - _499)))) | (select(int3(0), int3(1), (_517 - _496) < float3(_519 + _499)) + (int3(2) * select(int3(0), int3(1), (_517 + _496) > float3((-_519) - _499))))) | (select(int3(0), int3(1), (_538 - _496) < float3(_540 + _499)) + (int3(2) * select(int3(0), int3(1), (_538 + _496) > float3((-_540) - _499))))) != int3(3)))
+            if (any((((int3((_495 - _496) < float3(_498 + _499)) + (int3(2) * int3((_495 + _496) > float3((-_498) - _499)))) | (int3((_517 - _496) < float3(_519 + _499)) + (int3(2) * int3((_517 + _496) > float3((-_519) - _499))))) | (int3((_538 - _496) < float3(_540 + _499)) + (int3(2) * int3((_538 + _496) > float3((-_540) - _499))))) != int3(3)))
             {
                 _589 = float4(0.0);
                 break;

--- a/reference/opt/shaders-ue4/asm/tesc/hs-input-array-access.asm.tesc
+++ b/reference/opt/shaders-ue4/asm/tesc/hs-input-array-access.asm.tesc
@@ -437,7 +437,7 @@ kernel void main0(main0_in in [[stage_in]], constant type_View& View [[buffer(0)
             float4 _548 = View.View_TranslatedWorldToClip * float4(temp_var_hullMainRetVal[2u].WorldPosition[0].xyz, 1.0);
             float3 _549 = _548.xyz;
             float _551 = _548.w;
-            if (any((((select(int3(0), int3(1), (_506 - _507) < float3(_509 + _510)) + (int3(2) * select(int3(0), int3(1), (_506 + _507) > float3((-_509) - _510)))) | (select(int3(0), int3(1), (_528 - _507) < float3(_530 + _510)) + (int3(2) * select(int3(0), int3(1), (_528 + _507) > float3((-_530) - _510))))) | (select(int3(0), int3(1), (_549 - _507) < float3(_551 + _510)) + (int3(2) * select(int3(0), int3(1), (_549 + _507) > float3((-_551) - _510))))) != int3(3)))
+            if (any((((int3((_506 - _507) < float3(_509 + _510)) + (int3(2) * int3((_506 + _507) > float3((-_509) - _510)))) | (int3((_528 - _507) < float3(_530 + _510)) + (int3(2) * int3((_528 + _507) > float3((-_530) - _510))))) | (int3((_549 - _507) < float3(_551 + _510)) + (int3(2) * int3((_549 + _507) > float3((-_551) - _510))))) != int3(3)))
             {
                 _600 = float4(0.0);
                 break;

--- a/reference/opt/shaders-ue4/asm/tesc/hs-texcoord-array.asm.tesc
+++ b/reference/opt/shaders-ue4/asm/tesc/hs-texcoord-array.asm.tesc
@@ -381,7 +381,7 @@ kernel void main0(main0_in in [[stage_in]], constant type_View& View [[buffer(0)
             float4 _472 = View.View_TranslatedWorldToClip * float4(temp_var_hullMainRetVal[2u].WorldPosition[0].xyz, 1.0);
             float3 _473 = _472.xyz;
             float _475 = _472.w;
-            if (any((((select(int3(0), int3(1), (_430 - _431) < float3(_433 + _434)) + (int3(2) * select(int3(0), int3(1), (_430 + _431) > float3((-_433) - _434)))) | (select(int3(0), int3(1), (_452 - _431) < float3(_454 + _434)) + (int3(2) * select(int3(0), int3(1), (_452 + _431) > float3((-_454) - _434))))) | (select(int3(0), int3(1), (_473 - _431) < float3(_475 + _434)) + (int3(2) * select(int3(0), int3(1), (_473 + _431) > float3((-_475) - _434))))) != int3(3)))
+            if (any((((int3((_430 - _431) < float3(_433 + _434)) + (int3(2) * int3((_430 + _431) > float3((-_433) - _434)))) | (int3((_452 - _431) < float3(_454 + _434)) + (int3(2) * int3((_452 + _431) > float3((-_454) - _434))))) | (int3((_473 - _431) < float3(_475 + _434)) + (int3(2) * int3((_473 + _431) > float3((-_475) - _434))))) != int3(3)))
             {
                 _524 = float4(0.0);
                 break;

--- a/reference/opt/shaders/asm/comp/bitcast_icmp.asm.comp
+++ b/reference/opt/shaders/asm/comp/bitcast_icmp.asm.comp
@@ -15,13 +15,13 @@ layout(binding = 1, std430) restrict buffer _4_6
 
 void main()
 {
-    _6._m0 = mix(uvec4(0u), uvec4(1u), lessThan(ivec4(_5._m1), _5._m0));
-    _6._m0 = mix(uvec4(0u), uvec4(1u), lessThanEqual(ivec4(_5._m1), _5._m0));
-    _6._m0 = mix(uvec4(0u), uvec4(1u), lessThan(_5._m1, uvec4(_5._m0)));
-    _6._m0 = mix(uvec4(0u), uvec4(1u), lessThanEqual(_5._m1, uvec4(_5._m0)));
-    _6._m0 = mix(uvec4(0u), uvec4(1u), greaterThan(ivec4(_5._m1), _5._m0));
-    _6._m0 = mix(uvec4(0u), uvec4(1u), greaterThanEqual(ivec4(_5._m1), _5._m0));
-    _6._m0 = mix(uvec4(0u), uvec4(1u), greaterThan(_5._m1, uvec4(_5._m0)));
-    _6._m0 = mix(uvec4(0u), uvec4(1u), greaterThanEqual(_5._m1, uvec4(_5._m0)));
+    _6._m0 = uvec4(lessThan(ivec4(_5._m1), _5._m0));
+    _6._m0 = uvec4(lessThanEqual(ivec4(_5._m1), _5._m0));
+    _6._m0 = uvec4(lessThan(_5._m1, uvec4(_5._m0)));
+    _6._m0 = uvec4(lessThanEqual(_5._m1, uvec4(_5._m0)));
+    _6._m0 = uvec4(greaterThan(ivec4(_5._m1), _5._m0));
+    _6._m0 = uvec4(greaterThanEqual(ivec4(_5._m1), _5._m0));
+    _6._m0 = uvec4(greaterThan(_5._m1, uvec4(_5._m0)));
+    _6._m0 = uvec4(greaterThanEqual(_5._m1, uvec4(_5._m0)));
 }
 

--- a/reference/opt/shaders/asm/comp/bitcast_iequal.asm.comp
+++ b/reference/opt/shaders/asm/comp/bitcast_iequal.asm.comp
@@ -21,13 +21,13 @@ void main()
     bvec4 _35 = equal(_30, ivec4(_31));
     bvec4 _36 = equal(_31, _31);
     bvec4 _37 = equal(_30, _30);
-    _6._m0 = mix(uvec4(0u), uvec4(1u), _34);
-    _6._m0 = mix(uvec4(0u), uvec4(1u), _35);
-    _6._m0 = mix(uvec4(0u), uvec4(1u), _36);
-    _6._m0 = mix(uvec4(0u), uvec4(1u), _37);
-    _6._m1 = mix(ivec4(0), ivec4(1), _34);
-    _6._m1 = mix(ivec4(0), ivec4(1), _35);
-    _6._m1 = mix(ivec4(0), ivec4(1), _36);
-    _6._m1 = mix(ivec4(0), ivec4(1), _37);
+    _6._m0 = uvec4(_34);
+    _6._m0 = uvec4(_35);
+    _6._m0 = uvec4(_36);
+    _6._m0 = uvec4(_37);
+    _6._m1 = ivec4(_34);
+    _6._m1 = ivec4(_35);
+    _6._m1 = ivec4(_36);
+    _6._m1 = ivec4(_37);
 }
 

--- a/reference/opt/shaders/comp/casts.comp
+++ b/reference/opt/shaders/comp/casts.comp
@@ -13,6 +13,6 @@ layout(binding = 0, std430) buffer SSBO0
 
 void main()
 {
-    _21.outputs[gl_GlobalInvocationID.x] = mix(ivec4(0), ivec4(1), notEqual((_27.inputs[gl_GlobalInvocationID.x] & ivec4(3)), ivec4(uvec4(0u))));
+    _21.outputs[gl_GlobalInvocationID.x] = ivec4(notEqual((_27.inputs[gl_GlobalInvocationID.x] & ivec4(3)), ivec4(uvec4(0u))));
 }
 

--- a/reference/shaders-hlsl-no-opt/asm/frag/scalar-select.spv14.asm.frag
+++ b/reference/shaders-hlsl-no-opt/asm/frag/scalar-select.spv14.asm.frag
@@ -1,0 +1,62 @@
+struct _15
+{
+    float _m0;
+};
+
+static const _15 _25 = { 0.0f };
+static const _15 _26 = { 1.0f };
+static const float _29[2] = { 0.0f, 1.0f };
+static const float _30[2] = { 1.0f, 0.0f };
+
+static float4 FragColor;
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+void spvSelectComposite(out _15 out_value, bool cond, _15 true_val, _15 false_val)
+{
+    if (cond)
+    {
+        out_value = true_val;
+    }
+    else
+    {
+        out_value = false_val;
+    }
+}
+
+void spvSelectComposite(out float out_value[2], bool cond, float true_val[2], float false_val[2])
+{
+    if (cond)
+    {
+        out_value = true_val;
+    }
+    else
+    {
+        out_value = false_val;
+    }
+}
+
+void frag_main()
+{
+    FragColor = false ? float4(1.0f, 1.0f, 0.0f, 1.0f) : float4(0.0f, 0.0f, 0.0f, 1.0f);
+    FragColor = false ? 1.0f.xxxx : 0.0f.xxxx;
+    FragColor = float4(bool4(false, true, false, true).x ? float4(1.0f, 1.0f, 0.0f, 1.0f).x : float4(0.0f, 0.0f, 0.0f, 1.0f).x, bool4(false, true, false, true).y ? float4(1.0f, 1.0f, 0.0f, 1.0f).y : float4(0.0f, 0.0f, 0.0f, 1.0f).y, bool4(false, true, false, true).z ? float4(1.0f, 1.0f, 0.0f, 1.0f).z : float4(0.0f, 0.0f, 0.0f, 1.0f).z, bool4(false, true, false, true).w ? float4(1.0f, 1.0f, 0.0f, 1.0f).w : float4(0.0f, 0.0f, 0.0f, 1.0f).w);
+    FragColor = float4(bool4(false, true, false, true));
+    _15 _38;
+    spvSelectComposite(_38, false, _25, _26);
+    _15 _32 = _38;
+    float _39[2];
+    spvSelectComposite(_39, true, _29, _30);
+    float _33[2] = _39;
+}
+
+SPIRV_Cross_Output main()
+{
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-hlsl-no-opt/asm/frag/unordered-compare.asm.frag
+++ b/reference/shaders-hlsl-no-opt/asm/frag/unordered-compare.asm.frag
@@ -21,7 +21,7 @@ float4 test_vector()
     bool4 geq = bool4(!(A.x < B.x), !(A.y < B.y), !(A.z < B.z), !(A.w < B.w));
     bool4 eq = bool4(A.x == B.x, A.y == B.y, A.z == B.z, A.w == B.w);
     bool4 neq = bool4(A.x != B.x, A.y != B.y, A.z != B.z, A.w != B.w);
-    return ((((float4(le.x ? 1.0f.xxxx.x : 0.0f.xxxx.x, le.y ? 1.0f.xxxx.y : 0.0f.xxxx.y, le.z ? 1.0f.xxxx.z : 0.0f.xxxx.z, le.w ? 1.0f.xxxx.w : 0.0f.xxxx.w) + float4(leq.x ? 1.0f.xxxx.x : 0.0f.xxxx.x, leq.y ? 1.0f.xxxx.y : 0.0f.xxxx.y, leq.z ? 1.0f.xxxx.z : 0.0f.xxxx.z, leq.w ? 1.0f.xxxx.w : 0.0f.xxxx.w)) + float4(ge.x ? 1.0f.xxxx.x : 0.0f.xxxx.x, ge.y ? 1.0f.xxxx.y : 0.0f.xxxx.y, ge.z ? 1.0f.xxxx.z : 0.0f.xxxx.z, ge.w ? 1.0f.xxxx.w : 0.0f.xxxx.w)) + float4(geq.x ? 1.0f.xxxx.x : 0.0f.xxxx.x, geq.y ? 1.0f.xxxx.y : 0.0f.xxxx.y, geq.z ? 1.0f.xxxx.z : 0.0f.xxxx.z, geq.w ? 1.0f.xxxx.w : 0.0f.xxxx.w)) + float4(eq.x ? 1.0f.xxxx.x : 0.0f.xxxx.x, eq.y ? 1.0f.xxxx.y : 0.0f.xxxx.y, eq.z ? 1.0f.xxxx.z : 0.0f.xxxx.z, eq.w ? 1.0f.xxxx.w : 0.0f.xxxx.w)) + float4(neq.x ? 1.0f.xxxx.x : 0.0f.xxxx.x, neq.y ? 1.0f.xxxx.y : 0.0f.xxxx.y, neq.z ? 1.0f.xxxx.z : 0.0f.xxxx.z, neq.w ? 1.0f.xxxx.w : 0.0f.xxxx.w);
+    return ((((float4(le) + float4(leq)) + float4(ge)) + float4(geq)) + float4(eq)) + float4(neq);
 }
 
 float test_scalar()

--- a/reference/shaders-hlsl-no-opt/comp/subgroups-boolean.invalid.nofxc.sm60.comp
+++ b/reference/shaders-hlsl-no-opt/comp/subgroups-boolean.invalid.nofxc.sm60.comp
@@ -16,7 +16,7 @@ void comp_main()
     v4.y = bool(WaveActiveBitAnd(uint(v)));
     v4.z = bool(WaveActiveBitXor(uint(v)));
     v4.w = WaveActiveAllEqual(v);
-    uint4 w = uint4(v4.x ? uint4(1u, 1u, 1u, 1u).x : uint4(0u, 0u, 0u, 0u).x, v4.y ? uint4(1u, 1u, 1u, 1u).y : uint4(0u, 0u, 0u, 0u).y, v4.z ? uint4(1u, 1u, 1u, 1u).z : uint4(0u, 0u, 0u, 0u).z, v4.w ? uint4(1u, 1u, 1u, 1u).w : uint4(0u, 0u, 0u, 0u).w);
+    uint4 w = uint4(v4);
     _46.Store(gl_GlobalInvocationID.x * 4 + 0, ((w.x + w.y) + w.z) + w.w);
 }
 

--- a/reference/shaders-hlsl/asm/comp/bitcast_icmp.asm.comp
+++ b/reference/shaders-hlsl/asm/comp/bitcast_icmp.asm.comp
@@ -3,22 +3,14 @@ RWByteAddressBuffer _6 : register(u1);
 
 void comp_main()
 {
-    bool4 _31 = bool4(int(_5.Load4(16).x) < int4(_5.Load4(0)).x, int(_5.Load4(16).y) < int4(_5.Load4(0)).y, int(_5.Load4(16).z) < int4(_5.Load4(0)).z, int(_5.Load4(16).w) < int4(_5.Load4(0)).w);
-    bool4 _32 = bool4(int(_5.Load4(16).x) <= int4(_5.Load4(0)).x, int(_5.Load4(16).y) <= int4(_5.Load4(0)).y, int(_5.Load4(16).z) <= int4(_5.Load4(0)).z, int(_5.Load4(16).w) <= int4(_5.Load4(0)).w);
-    bool4 _33 = bool4(_5.Load4(16).x < uint(int4(_5.Load4(0)).x), _5.Load4(16).y < uint(int4(_5.Load4(0)).y), _5.Load4(16).z < uint(int4(_5.Load4(0)).z), _5.Load4(16).w < uint(int4(_5.Load4(0)).w));
-    bool4 _34 = bool4(_5.Load4(16).x <= uint(int4(_5.Load4(0)).x), _5.Load4(16).y <= uint(int4(_5.Load4(0)).y), _5.Load4(16).z <= uint(int4(_5.Load4(0)).z), _5.Load4(16).w <= uint(int4(_5.Load4(0)).w));
-    bool4 _35 = bool4(int(_5.Load4(16).x) > int4(_5.Load4(0)).x, int(_5.Load4(16).y) > int4(_5.Load4(0)).y, int(_5.Load4(16).z) > int4(_5.Load4(0)).z, int(_5.Load4(16).w) > int4(_5.Load4(0)).w);
-    bool4 _36 = bool4(int(_5.Load4(16).x) >= int4(_5.Load4(0)).x, int(_5.Load4(16).y) >= int4(_5.Load4(0)).y, int(_5.Load4(16).z) >= int4(_5.Load4(0)).z, int(_5.Load4(16).w) >= int4(_5.Load4(0)).w);
-    bool4 _37 = bool4(_5.Load4(16).x > uint(int4(_5.Load4(0)).x), _5.Load4(16).y > uint(int4(_5.Load4(0)).y), _5.Load4(16).z > uint(int4(_5.Load4(0)).z), _5.Load4(16).w > uint(int4(_5.Load4(0)).w));
-    bool4 _38 = bool4(_5.Load4(16).x >= uint(int4(_5.Load4(0)).x), _5.Load4(16).y >= uint(int4(_5.Load4(0)).y), _5.Load4(16).z >= uint(int4(_5.Load4(0)).z), _5.Load4(16).w >= uint(int4(_5.Load4(0)).w));
-    _6.Store4(0, uint4(_31.x ? uint4(1u, 1u, 1u, 1u).x : uint4(0u, 0u, 0u, 0u).x, _31.y ? uint4(1u, 1u, 1u, 1u).y : uint4(0u, 0u, 0u, 0u).y, _31.z ? uint4(1u, 1u, 1u, 1u).z : uint4(0u, 0u, 0u, 0u).z, _31.w ? uint4(1u, 1u, 1u, 1u).w : uint4(0u, 0u, 0u, 0u).w));
-    _6.Store4(0, uint4(_32.x ? uint4(1u, 1u, 1u, 1u).x : uint4(0u, 0u, 0u, 0u).x, _32.y ? uint4(1u, 1u, 1u, 1u).y : uint4(0u, 0u, 0u, 0u).y, _32.z ? uint4(1u, 1u, 1u, 1u).z : uint4(0u, 0u, 0u, 0u).z, _32.w ? uint4(1u, 1u, 1u, 1u).w : uint4(0u, 0u, 0u, 0u).w));
-    _6.Store4(0, uint4(_33.x ? uint4(1u, 1u, 1u, 1u).x : uint4(0u, 0u, 0u, 0u).x, _33.y ? uint4(1u, 1u, 1u, 1u).y : uint4(0u, 0u, 0u, 0u).y, _33.z ? uint4(1u, 1u, 1u, 1u).z : uint4(0u, 0u, 0u, 0u).z, _33.w ? uint4(1u, 1u, 1u, 1u).w : uint4(0u, 0u, 0u, 0u).w));
-    _6.Store4(0, uint4(_34.x ? uint4(1u, 1u, 1u, 1u).x : uint4(0u, 0u, 0u, 0u).x, _34.y ? uint4(1u, 1u, 1u, 1u).y : uint4(0u, 0u, 0u, 0u).y, _34.z ? uint4(1u, 1u, 1u, 1u).z : uint4(0u, 0u, 0u, 0u).z, _34.w ? uint4(1u, 1u, 1u, 1u).w : uint4(0u, 0u, 0u, 0u).w));
-    _6.Store4(0, uint4(_35.x ? uint4(1u, 1u, 1u, 1u).x : uint4(0u, 0u, 0u, 0u).x, _35.y ? uint4(1u, 1u, 1u, 1u).y : uint4(0u, 0u, 0u, 0u).y, _35.z ? uint4(1u, 1u, 1u, 1u).z : uint4(0u, 0u, 0u, 0u).z, _35.w ? uint4(1u, 1u, 1u, 1u).w : uint4(0u, 0u, 0u, 0u).w));
-    _6.Store4(0, uint4(_36.x ? uint4(1u, 1u, 1u, 1u).x : uint4(0u, 0u, 0u, 0u).x, _36.y ? uint4(1u, 1u, 1u, 1u).y : uint4(0u, 0u, 0u, 0u).y, _36.z ? uint4(1u, 1u, 1u, 1u).z : uint4(0u, 0u, 0u, 0u).z, _36.w ? uint4(1u, 1u, 1u, 1u).w : uint4(0u, 0u, 0u, 0u).w));
-    _6.Store4(0, uint4(_37.x ? uint4(1u, 1u, 1u, 1u).x : uint4(0u, 0u, 0u, 0u).x, _37.y ? uint4(1u, 1u, 1u, 1u).y : uint4(0u, 0u, 0u, 0u).y, _37.z ? uint4(1u, 1u, 1u, 1u).z : uint4(0u, 0u, 0u, 0u).z, _37.w ? uint4(1u, 1u, 1u, 1u).w : uint4(0u, 0u, 0u, 0u).w));
-    _6.Store4(0, uint4(_38.x ? uint4(1u, 1u, 1u, 1u).x : uint4(0u, 0u, 0u, 0u).x, _38.y ? uint4(1u, 1u, 1u, 1u).y : uint4(0u, 0u, 0u, 0u).y, _38.z ? uint4(1u, 1u, 1u, 1u).z : uint4(0u, 0u, 0u, 0u).z, _38.w ? uint4(1u, 1u, 1u, 1u).w : uint4(0u, 0u, 0u, 0u).w));
+    _6.Store4(0, uint4(bool4(int(_5.Load4(16).x) < int4(_5.Load4(0)).x, int(_5.Load4(16).y) < int4(_5.Load4(0)).y, int(_5.Load4(16).z) < int4(_5.Load4(0)).z, int(_5.Load4(16).w) < int4(_5.Load4(0)).w)));
+    _6.Store4(0, uint4(bool4(int(_5.Load4(16).x) <= int4(_5.Load4(0)).x, int(_5.Load4(16).y) <= int4(_5.Load4(0)).y, int(_5.Load4(16).z) <= int4(_5.Load4(0)).z, int(_5.Load4(16).w) <= int4(_5.Load4(0)).w)));
+    _6.Store4(0, uint4(bool4(_5.Load4(16).x < uint(int4(_5.Load4(0)).x), _5.Load4(16).y < uint(int4(_5.Load4(0)).y), _5.Load4(16).z < uint(int4(_5.Load4(0)).z), _5.Load4(16).w < uint(int4(_5.Load4(0)).w))));
+    _6.Store4(0, uint4(bool4(_5.Load4(16).x <= uint(int4(_5.Load4(0)).x), _5.Load4(16).y <= uint(int4(_5.Load4(0)).y), _5.Load4(16).z <= uint(int4(_5.Load4(0)).z), _5.Load4(16).w <= uint(int4(_5.Load4(0)).w))));
+    _6.Store4(0, uint4(bool4(int(_5.Load4(16).x) > int4(_5.Load4(0)).x, int(_5.Load4(16).y) > int4(_5.Load4(0)).y, int(_5.Load4(16).z) > int4(_5.Load4(0)).z, int(_5.Load4(16).w) > int4(_5.Load4(0)).w)));
+    _6.Store4(0, uint4(bool4(int(_5.Load4(16).x) >= int4(_5.Load4(0)).x, int(_5.Load4(16).y) >= int4(_5.Load4(0)).y, int(_5.Load4(16).z) >= int4(_5.Load4(0)).z, int(_5.Load4(16).w) >= int4(_5.Load4(0)).w)));
+    _6.Store4(0, uint4(bool4(_5.Load4(16).x > uint(int4(_5.Load4(0)).x), _5.Load4(16).y > uint(int4(_5.Load4(0)).y), _5.Load4(16).z > uint(int4(_5.Load4(0)).z), _5.Load4(16).w > uint(int4(_5.Load4(0)).w))));
+    _6.Store4(0, uint4(bool4(_5.Load4(16).x >= uint(int4(_5.Load4(0)).x), _5.Load4(16).y >= uint(int4(_5.Load4(0)).y), _5.Load4(16).z >= uint(int4(_5.Load4(0)).z), _5.Load4(16).w >= uint(int4(_5.Load4(0)).w))));
 }
 
 [numthreads(1, 1, 1)]

--- a/reference/shaders-msl-no-opt/asm/frag/scalar-select.spv14.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/scalar-select.spv14.asm.frag
@@ -1,0 +1,72 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wmissing-braces"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+template<typename T, size_t Num>
+struct spvUnsafeArray
+{
+    T elements[Num ? Num : 1];
+    
+    thread T& operator [] (size_t pos) thread
+    {
+        return elements[pos];
+    }
+    constexpr const thread T& operator [] (size_t pos) const thread
+    {
+        return elements[pos];
+    }
+    
+    device T& operator [] (size_t pos) device
+    {
+        return elements[pos];
+    }
+    constexpr const device T& operator [] (size_t pos) const device
+    {
+        return elements[pos];
+    }
+    
+    constexpr const constant T& operator [] (size_t pos) const constant
+    {
+        return elements[pos];
+    }
+    
+    threadgroup T& operator [] (size_t pos) threadgroup
+    {
+        return elements[pos];
+    }
+    constexpr const threadgroup T& operator [] (size_t pos) const threadgroup
+    {
+        return elements[pos];
+    }
+};
+
+struct _15
+{
+    float _m0;
+};
+
+constant spvUnsafeArray<float, 2> _29 = spvUnsafeArray<float, 2>({ 0.0, 1.0 });
+constant spvUnsafeArray<float, 2> _30 = spvUnsafeArray<float, 2>({ 1.0, 0.0 });
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0()
+{
+    main0_out out = {};
+    out.FragColor = false ? float4(1.0, 1.0, 0.0, 1.0) : float4(0.0, 0.0, 0.0, 1.0);
+    out.FragColor = float4(false);
+    out.FragColor = select(float4(0.0, 0.0, 0.0, 1.0), float4(1.0, 1.0, 0.0, 1.0), bool4(false, true, false, true));
+    out.FragColor = float4(bool4(false, true, false, true));
+    _15 _32 = false ? (_15{ 0.0 }) : (_15{ 1.0 });
+    spvUnsafeArray<float, 2> _33;
+    _33 = true ? _29 : _30;
+    return out;
+}
+

--- a/reference/shaders-msl/asm/comp/bitcast_icmp.asm.comp
+++ b/reference/shaders-msl/asm/comp/bitcast_icmp.asm.comp
@@ -17,13 +17,13 @@ struct _4
 
 kernel void main0(device _3& restrict _5 [[buffer(0)]], device _4& restrict _6 [[buffer(1)]])
 {
-    _6._m0 = select(uint4(0u), uint4(1u), int4(_5._m1) < _5._m0);
-    _6._m0 = select(uint4(0u), uint4(1u), int4(_5._m1) <= _5._m0);
-    _6._m0 = select(uint4(0u), uint4(1u), _5._m1 < uint4(_5._m0));
-    _6._m0 = select(uint4(0u), uint4(1u), _5._m1 <= uint4(_5._m0));
-    _6._m0 = select(uint4(0u), uint4(1u), int4(_5._m1) > _5._m0);
-    _6._m0 = select(uint4(0u), uint4(1u), int4(_5._m1) >= _5._m0);
-    _6._m0 = select(uint4(0u), uint4(1u), _5._m1 > uint4(_5._m0));
-    _6._m0 = select(uint4(0u), uint4(1u), _5._m1 >= uint4(_5._m0));
+    _6._m0 = uint4(int4(_5._m1) < _5._m0);
+    _6._m0 = uint4(int4(_5._m1) <= _5._m0);
+    _6._m0 = uint4(_5._m1 < uint4(_5._m0));
+    _6._m0 = uint4(_5._m1 <= uint4(_5._m0));
+    _6._m0 = uint4(int4(_5._m1) > _5._m0);
+    _6._m0 = uint4(int4(_5._m1) >= _5._m0);
+    _6._m0 = uint4(_5._m1 > uint4(_5._m0));
+    _6._m0 = uint4(_5._m1 >= uint4(_5._m0));
 }
 

--- a/reference/shaders-no-opt/asm/frag/scalar-select.spv14.asm.frag
+++ b/reference/shaders-no-opt/asm/frag/scalar-select.spv14.asm.frag
@@ -1,0 +1,19 @@
+#version 450
+
+struct _15
+{
+    float _m0;
+};
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    FragColor = false ? vec4(1.0, 1.0, 0.0, 1.0) : vec4(0.0, 0.0, 0.0, 1.0);
+    FragColor = vec4(false);
+    FragColor = mix(vec4(0.0, 0.0, 0.0, 1.0), vec4(1.0, 1.0, 0.0, 1.0), bvec4(false, true, false, true));
+    FragColor = vec4(bvec4(false, true, false, true));
+    _15 _32 = false ? _15(0.0) : _15(1.0);
+    float _33[2] = true ? float[](0.0, 1.0) : float[](1.0, 0.0);
+}
+

--- a/reference/shaders-no-opt/asm/frag/unordered-compare.asm.frag
+++ b/reference/shaders-no-opt/asm/frag/unordered-compare.asm.frag
@@ -12,7 +12,7 @@ vec4 test_vector()
     bvec4 geq = not(lessThan(A, B));
     bvec4 eq = not(notEqual(A, B));
     bvec4 neq = not(equal(A, B));
-    return ((((mix(vec4(0.0), vec4(1.0), le) + mix(vec4(0.0), vec4(1.0), leq)) + mix(vec4(0.0), vec4(1.0), ge)) + mix(vec4(0.0), vec4(1.0), geq)) + mix(vec4(0.0), vec4(1.0), eq)) + mix(vec4(0.0), vec4(1.0), neq);
+    return ((((vec4(le) + vec4(leq)) + vec4(ge)) + vec4(geq)) + vec4(eq)) + vec4(neq);
 }
 
 float test_scalar()

--- a/reference/shaders-ue4/asm/frag/sample-mask-not-array.asm.frag
+++ b/reference/shaders-ue4/asm/frag/sample-mask-not-array.asm.frag
@@ -470,7 +470,7 @@ fragment main0_out main0(main0_in in [[stage_in]], constant type_View& View [[bu
         float3 _245;
         if (any(abs(_142 - View_PrimitiveSceneData._m0[_222 + 5u].xyz) > (View_PrimitiveSceneData._m0[_222 + 19u].xyz + float3(1.0))))
         {
-            _245 = mix(float3(1.0, 1.0, 0.0), float3(0.0, 1.0, 1.0), select(float3(0.0), float3(1.0), float3(fract(dot(_142, float3(0.57700002193450927734375)) * 0.00200000009499490261077880859375)) > float3(0.5)));
+            _245 = mix(float3(1.0, 1.0, 0.0), float3(0.0, 1.0, 1.0), float3(float3(fract(dot(_142, float3(0.57700002193450927734375)) * 0.00200000009499490261077880859375)) > float3(0.5)));
         }
         else
         {

--- a/reference/shaders-ue4/asm/tesc/hs-incorrect-base-type.asm.tesc
+++ b/reference/shaders-ue4/asm/tesc/hs-incorrect-base-type.asm.tesc
@@ -369,7 +369,7 @@ kernel void main0(main0_in in [[stage_in]], constant type_View& View [[buffer(0)
             float4 _537 = View.View_TranslatedWorldToClip * float4(temp_var_hullMainRetVal[2u].WorldPosition[0].xyz, 1.0);
             float3 _538 = _537.xyz;
             float _540 = _537.w;
-            if (any((((select(int3(0), int3(1), (_495 - _496) < float3(_498 + _499)) + (int3(2) * select(int3(0), int3(1), (_495 + _496) > float3((-_498) - _499)))) | (select(int3(0), int3(1), (_517 - _496) < float3(_519 + _499)) + (int3(2) * select(int3(0), int3(1), (_517 + _496) > float3((-_519) - _499))))) | (select(int3(0), int3(1), (_538 - _496) < float3(_540 + _499)) + (int3(2) * select(int3(0), int3(1), (_538 + _496) > float3((-_540) - _499))))) != int3(3)))
+            if (any((((int3((_495 - _496) < float3(_498 + _499)) + (int3(2) * int3((_495 + _496) > float3((-_498) - _499)))) | (int3((_517 - _496) < float3(_519 + _499)) + (int3(2) * int3((_517 + _496) > float3((-_519) - _499))))) | (int3((_538 - _496) < float3(_540 + _499)) + (int3(2) * int3((_538 + _496) > float3((-_540) - _499))))) != int3(3)))
             {
                 _589 = float4(0.0);
                 break;

--- a/reference/shaders-ue4/asm/tesc/hs-input-array-access.asm.tesc
+++ b/reference/shaders-ue4/asm/tesc/hs-input-array-access.asm.tesc
@@ -437,7 +437,7 @@ kernel void main0(main0_in in [[stage_in]], constant type_View& View [[buffer(0)
             float4 _548 = View.View_TranslatedWorldToClip * float4(temp_var_hullMainRetVal[2u].WorldPosition[0].xyz, 1.0);
             float3 _549 = _548.xyz;
             float _551 = _548.w;
-            if (any((((select(int3(0), int3(1), (_506 - _507) < float3(_509 + _510)) + (int3(2) * select(int3(0), int3(1), (_506 + _507) > float3((-_509) - _510)))) | (select(int3(0), int3(1), (_528 - _507) < float3(_530 + _510)) + (int3(2) * select(int3(0), int3(1), (_528 + _507) > float3((-_530) - _510))))) | (select(int3(0), int3(1), (_549 - _507) < float3(_551 + _510)) + (int3(2) * select(int3(0), int3(1), (_549 + _507) > float3((-_551) - _510))))) != int3(3)))
+            if (any((((int3((_506 - _507) < float3(_509 + _510)) + (int3(2) * int3((_506 + _507) > float3((-_509) - _510)))) | (int3((_528 - _507) < float3(_530 + _510)) + (int3(2) * int3((_528 + _507) > float3((-_530) - _510))))) | (int3((_549 - _507) < float3(_551 + _510)) + (int3(2) * int3((_549 + _507) > float3((-_551) - _510))))) != int3(3)))
             {
                 _600 = float4(0.0);
                 break;

--- a/reference/shaders-ue4/asm/tesc/hs-texcoord-array.asm.tesc
+++ b/reference/shaders-ue4/asm/tesc/hs-texcoord-array.asm.tesc
@@ -381,7 +381,7 @@ kernel void main0(main0_in in [[stage_in]], constant type_View& View [[buffer(0)
             float4 _472 = View.View_TranslatedWorldToClip * float4(temp_var_hullMainRetVal[2u].WorldPosition[0].xyz, 1.0);
             float3 _473 = _472.xyz;
             float _475 = _472.w;
-            if (any((((select(int3(0), int3(1), (_430 - _431) < float3(_433 + _434)) + (int3(2) * select(int3(0), int3(1), (_430 + _431) > float3((-_433) - _434)))) | (select(int3(0), int3(1), (_452 - _431) < float3(_454 + _434)) + (int3(2) * select(int3(0), int3(1), (_452 + _431) > float3((-_454) - _434))))) | (select(int3(0), int3(1), (_473 - _431) < float3(_475 + _434)) + (int3(2) * select(int3(0), int3(1), (_473 + _431) > float3((-_475) - _434))))) != int3(3)))
+            if (any((((int3((_430 - _431) < float3(_433 + _434)) + (int3(2) * int3((_430 + _431) > float3((-_433) - _434)))) | (int3((_452 - _431) < float3(_454 + _434)) + (int3(2) * int3((_452 + _431) > float3((-_454) - _434))))) | (int3((_473 - _431) < float3(_475 + _434)) + (int3(2) * int3((_473 + _431) > float3((-_475) - _434))))) != int3(3)))
             {
                 _524 = float4(0.0);
                 break;

--- a/reference/shaders/asm/comp/bitcast_icmp.asm.comp
+++ b/reference/shaders/asm/comp/bitcast_icmp.asm.comp
@@ -15,13 +15,13 @@ layout(binding = 1, std430) restrict buffer _4_6
 
 void main()
 {
-    _6._m0 = mix(uvec4(0u), uvec4(1u), lessThan(ivec4(_5._m1), _5._m0));
-    _6._m0 = mix(uvec4(0u), uvec4(1u), lessThanEqual(ivec4(_5._m1), _5._m0));
-    _6._m0 = mix(uvec4(0u), uvec4(1u), lessThan(_5._m1, uvec4(_5._m0)));
-    _6._m0 = mix(uvec4(0u), uvec4(1u), lessThanEqual(_5._m1, uvec4(_5._m0)));
-    _6._m0 = mix(uvec4(0u), uvec4(1u), greaterThan(ivec4(_5._m1), _5._m0));
-    _6._m0 = mix(uvec4(0u), uvec4(1u), greaterThanEqual(ivec4(_5._m1), _5._m0));
-    _6._m0 = mix(uvec4(0u), uvec4(1u), greaterThan(_5._m1, uvec4(_5._m0)));
-    _6._m0 = mix(uvec4(0u), uvec4(1u), greaterThanEqual(_5._m1, uvec4(_5._m0)));
+    _6._m0 = uvec4(lessThan(ivec4(_5._m1), _5._m0));
+    _6._m0 = uvec4(lessThanEqual(ivec4(_5._m1), _5._m0));
+    _6._m0 = uvec4(lessThan(_5._m1, uvec4(_5._m0)));
+    _6._m0 = uvec4(lessThanEqual(_5._m1, uvec4(_5._m0)));
+    _6._m0 = uvec4(greaterThan(ivec4(_5._m1), _5._m0));
+    _6._m0 = uvec4(greaterThanEqual(ivec4(_5._m1), _5._m0));
+    _6._m0 = uvec4(greaterThan(_5._m1, uvec4(_5._m0)));
+    _6._m0 = uvec4(greaterThanEqual(_5._m1, uvec4(_5._m0)));
 }
 

--- a/reference/shaders/asm/comp/bitcast_iequal.asm.comp
+++ b/reference/shaders/asm/comp/bitcast_iequal.asm.comp
@@ -21,13 +21,13 @@ void main()
     bvec4 _35 = equal(_30, ivec4(_31));
     bvec4 _36 = equal(_31, _31);
     bvec4 _37 = equal(_30, _30);
-    _6._m0 = mix(uvec4(0u), uvec4(1u), _34);
-    _6._m0 = mix(uvec4(0u), uvec4(1u), _35);
-    _6._m0 = mix(uvec4(0u), uvec4(1u), _36);
-    _6._m0 = mix(uvec4(0u), uvec4(1u), _37);
-    _6._m1 = mix(ivec4(0), ivec4(1), _34);
-    _6._m1 = mix(ivec4(0), ivec4(1), _35);
-    _6._m1 = mix(ivec4(0), ivec4(1), _36);
-    _6._m1 = mix(ivec4(0), ivec4(1), _37);
+    _6._m0 = uvec4(_34);
+    _6._m0 = uvec4(_35);
+    _6._m0 = uvec4(_36);
+    _6._m0 = uvec4(_37);
+    _6._m1 = ivec4(_34);
+    _6._m1 = ivec4(_35);
+    _6._m1 = ivec4(_36);
+    _6._m1 = ivec4(_37);
 }
 

--- a/reference/shaders/comp/casts.comp
+++ b/reference/shaders/comp/casts.comp
@@ -14,6 +14,6 @@ layout(binding = 0, std430) buffer SSBO0
 void main()
 {
     uint ident = gl_GlobalInvocationID.x;
-    _21.outputs[ident] = mix(ivec4(0), ivec4(1), notEqual((_27.inputs[ident] & ivec4(3)), ivec4(uvec4(0u))));
+    _21.outputs[ident] = ivec4(notEqual((_27.inputs[ident] & ivec4(3)), ivec4(uvec4(0u))));
 }
 

--- a/shaders-hlsl-no-opt/asm/frag/scalar-select.spv14.asm.frag
+++ b/shaders-hlsl-no-opt/asm/frag/scalar-select.spv14.asm.frag
@@ -1,0 +1,62 @@
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %FragColor "FragColor"
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %bool = OpTypeBool
+      %false = OpConstantFalse %bool
+	  %uint = OpTypeInt 32 0
+	  %uint_1 = OpConstant %uint 1
+	  %uint_2 = OpConstant %uint 2
+      %true = OpConstantTrue %bool
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+		 %s = OpTypeStruct %float
+		 %arr = OpTypeArray %float %uint_2
+%_ptr_Function_s = OpTypePointer Function %s
+%_ptr_Function_arr = OpTypePointer Function %arr
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+    %float_0 = OpConstant %float 0
+    %float_1 = OpConstant %float 1
+         %17 = OpConstantComposite %v4float %float_1 %float_1 %float_0 %float_1
+         %18 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_1
+         %19 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
+         %20 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
+		 %s0 = OpConstantComposite %s %float_0
+		 %s1 = OpConstantComposite %s %float_1
+     %v4bool = OpTypeVector %bool 4
+	 	%b4	= OpConstantComposite %v4bool %false %true %false %true
+		%arr1 = OpConstantComposite %arr %float_0 %float_1
+		%arr2 = OpConstantComposite %arr %float_1 %float_0
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+		  %ss = OpVariable %_ptr_Function_s Function
+		  %arrvar = OpVariable %_ptr_Function_arr Function
+		  ; Not trivial
+         %21 = OpSelect %v4float %false %17 %18
+               OpStore %FragColor %21
+		  ; Trivial
+         %22 = OpSelect %v4float %false %19 %20
+               OpStore %FragColor %22
+			; Vector not trivial
+         %23 = OpSelect %v4float %b4 %17 %18
+               OpStore %FragColor %23
+			; Vector trivial
+         %24 = OpSelect %v4float %b4 %19 %20
+               OpStore %FragColor %24
+		  ; Struct selection
+         %sout = OpSelect %s %false %s0 %s1
+               OpStore %ss %sout
+		; Array selection
+         %arrout = OpSelect %arr %true %arr1 %arr2
+               OpStore %arrvar %arrout
+
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/frag/scalar-select.spv14.asm.frag
+++ b/shaders-msl-no-opt/asm/frag/scalar-select.spv14.asm.frag
@@ -1,0 +1,62 @@
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %FragColor "FragColor"
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %bool = OpTypeBool
+      %false = OpConstantFalse %bool
+	  %uint = OpTypeInt 32 0
+	  %uint_1 = OpConstant %uint 1
+	  %uint_2 = OpConstant %uint 2
+      %true = OpConstantTrue %bool
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+		 %s = OpTypeStruct %float
+		 %arr = OpTypeArray %float %uint_2
+%_ptr_Function_s = OpTypePointer Function %s
+%_ptr_Function_arr = OpTypePointer Function %arr
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+    %float_0 = OpConstant %float 0
+    %float_1 = OpConstant %float 1
+         %17 = OpConstantComposite %v4float %float_1 %float_1 %float_0 %float_1
+         %18 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_1
+         %19 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
+         %20 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
+		 %s0 = OpConstantComposite %s %float_0
+		 %s1 = OpConstantComposite %s %float_1
+     %v4bool = OpTypeVector %bool 4
+	 	%b4	= OpConstantComposite %v4bool %false %true %false %true
+		%arr1 = OpConstantComposite %arr %float_0 %float_1
+		%arr2 = OpConstantComposite %arr %float_1 %float_0
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+		  %ss = OpVariable %_ptr_Function_s Function
+		  %arrvar = OpVariable %_ptr_Function_arr Function
+		  ; Not trivial
+         %21 = OpSelect %v4float %false %17 %18
+               OpStore %FragColor %21
+		  ; Trivial
+         %22 = OpSelect %v4float %false %19 %20
+               OpStore %FragColor %22
+			; Vector not trivial
+         %23 = OpSelect %v4float %b4 %17 %18
+               OpStore %FragColor %23
+			; Vector trivial
+         %24 = OpSelect %v4float %b4 %19 %20
+               OpStore %FragColor %24
+		  ; Struct selection
+         %sout = OpSelect %s %false %s0 %s1
+               OpStore %ss %sout
+		; Array selection
+         %arrout = OpSelect %arr %true %arr1 %arr2
+               OpStore %arrvar %arrout
+
+               OpReturn
+               OpFunctionEnd

--- a/shaders-no-opt/asm/frag/scalar-select.spv14.asm.frag
+++ b/shaders-no-opt/asm/frag/scalar-select.spv14.asm.frag
@@ -1,0 +1,62 @@
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %FragColor "FragColor"
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %bool = OpTypeBool
+      %false = OpConstantFalse %bool
+	  %uint = OpTypeInt 32 0
+	  %uint_1 = OpConstant %uint 1
+	  %uint_2 = OpConstant %uint 2
+      %true = OpConstantTrue %bool
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+		 %s = OpTypeStruct %float
+		 %arr = OpTypeArray %float %uint_2
+%_ptr_Function_s = OpTypePointer Function %s
+%_ptr_Function_arr = OpTypePointer Function %arr
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+    %float_0 = OpConstant %float 0
+    %float_1 = OpConstant %float 1
+         %17 = OpConstantComposite %v4float %float_1 %float_1 %float_0 %float_1
+         %18 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_1
+         %19 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
+         %20 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
+		 %s0 = OpConstantComposite %s %float_0
+		 %s1 = OpConstantComposite %s %float_1
+     %v4bool = OpTypeVector %bool 4
+	 	%b4	= OpConstantComposite %v4bool %false %true %false %true
+		%arr1 = OpConstantComposite %arr %float_0 %float_1
+		%arr2 = OpConstantComposite %arr %float_1 %float_0
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+		  %ss = OpVariable %_ptr_Function_s Function
+		  %arrvar = OpVariable %_ptr_Function_arr Function
+		  ; Not trivial
+         %21 = OpSelect %v4float %false %17 %18
+               OpStore %FragColor %21
+		  ; Trivial
+         %22 = OpSelect %v4float %false %19 %20
+               OpStore %FragColor %22
+			; Vector not trivial
+         %23 = OpSelect %v4float %b4 %17 %18
+               OpStore %FragColor %23
+			; Vector trivial
+         %24 = OpSelect %v4float %b4 %19 %20
+               OpStore %FragColor %24
+		  ; Struct selection
+         %sout = OpSelect %s %false %s0 %s1
+               OpStore %ss %sout
+		; Array selection
+         %arrout = OpSelect %arr %true %arr1 %arr2
+               OpStore %arrvar %arrout
+
+               OpReturn
+               OpFunctionEnd

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -6191,44 +6191,57 @@ bool CompilerGLSL::to_trivial_mix_op(const SPIRType &type, string &op, uint32_t 
 	if (cleft->specialization || cright->specialization)
 		return false;
 
-	// We can only use trivial construction if we have a scalar
-	// (should be possible to do it for vectors as well, but that is overkill for now).
-	if (lerptype.basetype != SPIRType::Boolean || lerptype.vecsize > 1)
+	auto &value_type = get<SPIRType>(cleft->constant_type);
+
+	if (lerptype.basetype != SPIRType::Boolean)
+		return false;
+	if (value_type.basetype == SPIRType::Struct || is_array(value_type))
+		return false;
+	if (!backend.use_constructor_splatting && value_type.vecsize != lerptype.vecsize)
 		return false;
 
 	// If our bool selects between 0 and 1, we can cast from bool instead, making our trivial constructor.
-	bool ret = false;
-	switch (type.basetype)
+	bool ret = true;
+	for (uint32_t col = 0; col < value_type.columns; col++)
 	{
-	case SPIRType::Short:
-	case SPIRType::UShort:
-		ret = cleft->scalar_u16() == 0 && cright->scalar_u16() == 1;
-		break;
+		for (uint32_t row = 0; row < value_type.vecsize; row++)
+		{
+			switch (type.basetype)
+			{
+			case SPIRType::Short:
+			case SPIRType::UShort:
+				ret = cleft->scalar_u16(col, row) == 0 && cright->scalar_u16(col, row) == 1;
+				break;
 
-	case SPIRType::Int:
-	case SPIRType::UInt:
-		ret = cleft->scalar() == 0 && cright->scalar() == 1;
-		break;
+			case SPIRType::Int:
+			case SPIRType::UInt:
+				ret = cleft->scalar(col, row) == 0 && cright->scalar(col, row) == 1;
+				break;
 
-	case SPIRType::Half:
-		ret = cleft->scalar_f16() == 0.0f && cright->scalar_f16() == 1.0f;
-		break;
+			case SPIRType::Half:
+				ret = cleft->scalar_f16(col, row) == 0.0f && cright->scalar_f16(col, row) == 1.0f;
+				break;
 
-	case SPIRType::Float:
-		ret = cleft->scalar_f32() == 0.0f && cright->scalar_f32() == 1.0f;
-		break;
+			case SPIRType::Float:
+				ret = cleft->scalar_f32(col, row) == 0.0f && cright->scalar_f32(col, row) == 1.0f;
+				break;
 
-	case SPIRType::Double:
-		ret = cleft->scalar_f64() == 0.0 && cright->scalar_f64() == 1.0;
-		break;
+			case SPIRType::Double:
+				ret = cleft->scalar_f64(col, row) == 0.0 && cright->scalar_f64(col, row) == 1.0;
+				break;
 
-	case SPIRType::Int64:
-	case SPIRType::UInt64:
-		ret = cleft->scalar_u64() == 0 && cright->scalar_u64() == 1;
-		break;
+			case SPIRType::Int64:
+			case SPIRType::UInt64:
+				ret = cleft->scalar_u64(col, row) == 0 && cright->scalar_u64(col, row) == 1;
+				break;
 
-	default:
-		break;
+			default:
+				return false;
+			}
+		}
+
+		if (!ret)
+			break;
 	}
 
 	if (ret)

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -369,6 +369,8 @@ private:
 
 	// Returns true for BuiltInSampleMask because gl_SampleMask[] is an array in SPIR-V, but SV_Coverage is a scalar in HLSL.
 	bool builtin_translates_to_nonarray(spv::BuiltIn builtin) const override;
+
+	std::vector<TypeID> composite_selection_workaround_types;
 };
 } // namespace SPIRV_CROSS_NAMESPACE
 


### PR DESCRIPTION
Fix bug in to_trivial_mix_op, where we made a pre-1.4 assumption that
component count of selector is equal to value component count.

Fix #1694.