### PR TITLE
HLSL: Rewrite how block IO is emitted.

### DIFF
--- a/reference/opt/shaders-hlsl/frag/io-block.frag
+++ b/reference/opt/shaders-hlsl/frag/io-block.frag
@@ -1,12 +1,17 @@
-static float4 FragColor;
-
 struct VertexOut
 {
-    float4 a : TEXCOORD1;
-    float4 b : TEXCOORD2;
+    float4 a;
+    float4 b;
 };
 
+static float4 FragColor;
 static VertexOut _12;
+
+struct SPIRV_Cross_Input
+{
+    float4 VertexOut_a : TEXCOORD1;
+    float4 VertexOut_b : TEXCOORD2;
+};
 
 struct SPIRV_Cross_Output
 {
@@ -18,9 +23,10 @@ void frag_main()
     FragColor = _12.a + _12.b;
 }
 
-SPIRV_Cross_Output main(in VertexOut stage_input_12)
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
-    _12 = stage_input_12;
+    _12.a = stage_input.VertexOut_a;
+    _12.b = stage_input.VertexOut_b;
     frag_main();
     SPIRV_Cross_Output stage_output;
     stage_output.FragColor = FragColor;

--- a/reference/opt/shaders-hlsl/vert/locations.vert
+++ b/reference/opt/shaders-hlsl/vert/locations.vert
@@ -5,6 +5,12 @@ struct Foo
     float3 c;
 };
 
+struct VertexOut
+{
+    float3 color;
+    float3 foo;
+};
+
 static const Foo _71 = { 1.0f.xxx, 1.0f.xxx, 1.0f.xxx };
 
 static float4 gl_Position;
@@ -16,13 +22,6 @@ static float vLocation1;
 static float vLocation2[2];
 static Foo vLocation4;
 static float vLocation9;
-
-struct VertexOut
-{
-    float3 color : TEXCOORD7;
-    float3 foo : TEXCOORD8;
-};
-
 static VertexOut vout;
 
 struct SPIRV_Cross_Input
@@ -38,6 +37,8 @@ struct SPIRV_Cross_Output
     float vLocation1 : TEXCOORD1;
     float vLocation2[2] : TEXCOORD2;
     Foo vLocation4 : TEXCOORD4;
+    float3 VertexOut_color : TEXCOORD7;
+    float3 VertexOut_foo : TEXCOORD8;
     float vLocation9 : TEXCOORD9;
     float4 gl_Position : SV_Position;
 };
@@ -55,13 +56,12 @@ void vert_main()
     vout.foo = 4.0f.xxx;
 }
 
-SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input, out VertexOut stage_outputvout)
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
     Input2 = stage_input.Input2;
     Input4 = stage_input.Input4;
     Input0 = stage_input.Input0;
     vert_main();
-    stage_outputvout = vout;
     SPIRV_Cross_Output stage_output;
     stage_output.gl_Position = gl_Position;
     stage_output.vLocation0 = vLocation0;
@@ -69,5 +69,7 @@ SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input, out VertexOut stage_outpu
     stage_output.vLocation2 = vLocation2;
     stage_output.vLocation4 = vLocation4;
     stage_output.vLocation9 = vLocation9;
+    stage_output.VertexOut_color = vout.color;
+    stage_output.VertexOut_foo = vout.foo;
     return stage_output;
 }

--- a/reference/opt/shaders-hlsl/vert/qualifiers.vert
+++ b/reference/opt/shaders-hlsl/vert/qualifiers.vert
@@ -1,17 +1,16 @@
+struct Block
+{
+    float vFlat;
+    float vCentroid;
+    float vSample;
+    float vNoperspective;
+};
+
 static float4 gl_Position;
 static float vFlat;
 static float vCentroid;
 static float vSample;
 static float vNoperspective;
-
-struct Block
-{
-    nointerpolation float vFlat : TEXCOORD4;
-    centroid float vCentroid : TEXCOORD5;
-    sample float vSample : TEXCOORD6;
-    noperspective float vNoperspective : TEXCOORD7;
-};
-
 static Block vout;
 
 struct SPIRV_Cross_Output
@@ -20,6 +19,10 @@ struct SPIRV_Cross_Output
     centroid float vCentroid : TEXCOORD1;
     sample float vSample : TEXCOORD2;
     noperspective float vNoperspective : TEXCOORD3;
+    nointerpolation float Block_vFlat : TEXCOORD4;
+    centroid float Block_vCentroid : TEXCOORD5;
+    sample float Block_vSample : TEXCOORD6;
+    noperspective float Block_vNoperspective : TEXCOORD7;
     float4 gl_Position : SV_Position;
 };
 
@@ -36,15 +39,18 @@ void vert_main()
     vout.vNoperspective = 3.0f;
 }
 
-SPIRV_Cross_Output main(out Block stage_outputvout)
+SPIRV_Cross_Output main()
 {
     vert_main();
-    stage_outputvout = vout;
     SPIRV_Cross_Output stage_output;
     stage_output.gl_Position = gl_Position;
     stage_output.vFlat = vFlat;
     stage_output.vCentroid = vCentroid;
     stage_output.vSample = vSample;
     stage_output.vNoperspective = vNoperspective;
+    stage_output.Block_vFlat = vout.vFlat;
+    stage_output.Block_vCentroid = vout.vCentroid;
+    stage_output.Block_vSample = vout.vSample;
+    stage_output.Block_vNoperspective = vout.vNoperspective;
     return stage_output;
 }

--- a/reference/shaders-hlsl-no-opt/asm/vert/block-struct-initializer.asm.vert
+++ b/reference/shaders-hlsl-no-opt/asm/vert/block-struct-initializer.asm.vert
@@ -1,23 +1,25 @@
+struct Vert
+{
+    float a;
+    float b;
+};
+
 struct Foo
 {
     float c;
     float d;
 };
 
+static const Vert _11 = { 0.0f, 0.0f };
 static const Foo _13 = { 0.0f, 0.0f };
 
-static Foo foo = _13;
-
-struct Vert
-{
-    float a : TEXCOORD0;
-    float b : TEXCOORD1;
-};
-
 static Vert _3 = { 0.0f, 0.0f };
+static Foo foo = _13;
 
 struct SPIRV_Cross_Output
 {
+    float Vert_a : TEXCOORD0;
+    float Vert_b : TEXCOORD1;
     Foo foo : TEXCOORD2;
 };
 
@@ -25,11 +27,12 @@ void vert_main()
 {
 }
 
-SPIRV_Cross_Output main(out Vert stage_output_3)
+SPIRV_Cross_Output main()
 {
     vert_main();
-    stage_output_3 = _3;
     SPIRV_Cross_Output stage_output;
+    stage_output.Vert_a = _3.a;
+    stage_output.Vert_b = _3.b;
     stage_output.foo = foo;
     return stage_output;
 }

--- a/reference/shaders-hlsl-no-opt/asm/vert/complex-link-by-name.asm.vert
+++ b/reference/shaders-hlsl-no-opt/asm/vert/complex-link-by-name.asm.vert
@@ -3,6 +3,12 @@ struct Struct_vec4
     float4 m0;
 };
 
+struct VertexOut
+{
+    Struct_vec4 m0;
+    Struct_vec4 m1;
+};
+
 cbuffer UBO : register(b0)
 {
     Struct_vec4 ubo_binding_0_m0 : packoffset(c0);
@@ -11,19 +17,14 @@ cbuffer UBO : register(b0)
 
 
 static float4 gl_Position;
+static VertexOut output_location_0;
 static Struct_vec4 output_location_2;
 static Struct_vec4 output_location_3;
 
-struct VertexOut
-{
-    Struct_vec4 m0 : TEXCOORD0;
-    Struct_vec4 m1 : TEXCOORD1;
-};
-
-static VertexOut output_location_0;
-
 struct SPIRV_Cross_Output
 {
+    Struct_vec4 VertexOut_m0 : TEXCOORD0;
+    Struct_vec4 VertexOut_m1 : TEXCOORD1;
     Struct_vec4 output_location_2 : TEXCOORD2;
     Struct_vec4 output_location_3 : TEXCOORD3;
     float4 gl_Position : SV_Position;
@@ -42,12 +43,13 @@ void vert_main()
     output_location_3 = b;
 }
 
-SPIRV_Cross_Output main(out VertexOut stage_outputoutput_location_0)
+SPIRV_Cross_Output main()
 {
     vert_main();
-    stage_outputoutput_location_0 = output_location_0;
     SPIRV_Cross_Output stage_output;
     stage_output.gl_Position = gl_Position;
+    stage_output.VertexOut_m0 = output_location_0.m0;
+    stage_output.VertexOut_m1 = output_location_0.m1;
     stage_output.output_location_2 = output_location_2;
     stage_output.output_location_3 = output_location_3;
     return stage_output;

--- a/reference/shaders-hlsl-no-opt/vert/block-io-auto-location-assignment.vert
+++ b/reference/shaders-hlsl-no-opt/vert/block-io-auto-location-assignment.vert
@@ -6,13 +6,21 @@ struct Bar
 
 struct V
 {
-    float a : TEXCOORD0;
-    float b[2] : TEXCOORD1;
-    Bar c[2] : TEXCOORD3;
-    Bar d : TEXCOORD9;
+    float a;
+    float b[2];
+    Bar c[2];
+    Bar d;
 };
 
 static V _14;
+
+struct SPIRV_Cross_Output
+{
+    float V_a : TEXCOORD0;
+    float V_b[2] : TEXCOORD1;
+    Bar V_c[2] : TEXCOORD3;
+    Bar V_d : TEXCOORD9;
+};
 
 void vert_main()
 {
@@ -30,8 +38,13 @@ void vert_main()
     _14.d.w = 12.0f;
 }
 
-void main(out V stage_output_14)
+SPIRV_Cross_Output main()
 {
     vert_main();
-    stage_output_14 = _14;
+    SPIRV_Cross_Output stage_output;
+    stage_output.V_a = _14.a;
+    stage_output.V_b = _14.b;
+    stage_output.V_c = _14.c;
+    stage_output.V_d = _14.d;
+    return stage_output;
 }

--- a/reference/shaders-hlsl/frag/io-block.frag
+++ b/reference/shaders-hlsl/frag/io-block.frag
@@ -1,12 +1,17 @@
-static float4 FragColor;
-
 struct VertexOut
 {
-    float4 a : TEXCOORD1;
-    float4 b : TEXCOORD2;
+    float4 a;
+    float4 b;
 };
 
+static float4 FragColor;
 static VertexOut _12;
+
+struct SPIRV_Cross_Input
+{
+    float4 VertexOut_a : TEXCOORD1;
+    float4 VertexOut_b : TEXCOORD2;
+};
 
 struct SPIRV_Cross_Output
 {
@@ -18,9 +23,10 @@ void frag_main()
     FragColor = _12.a + _12.b;
 }
 
-SPIRV_Cross_Output main(in VertexOut stage_input_12)
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
-    _12 = stage_input_12;
+    _12.a = stage_input.VertexOut_a;
+    _12.b = stage_input.VertexOut_b;
     frag_main();
     SPIRV_Cross_Output stage_output;
     stage_output.FragColor = FragColor;

--- a/reference/shaders-hlsl/vert/locations.vert
+++ b/reference/shaders-hlsl/vert/locations.vert
@@ -5,6 +5,12 @@ struct Foo
     float3 c;
 };
 
+struct VertexOut
+{
+    float3 color;
+    float3 foo;
+};
+
 static float4 gl_Position;
 static float4 Input2;
 static float4 Input4;
@@ -14,13 +20,6 @@ static float vLocation1;
 static float vLocation2[2];
 static Foo vLocation4;
 static float vLocation9;
-
-struct VertexOut
-{
-    float3 color : TEXCOORD7;
-    float3 foo : TEXCOORD8;
-};
-
 static VertexOut vout;
 
 struct SPIRV_Cross_Input
@@ -36,6 +35,8 @@ struct SPIRV_Cross_Output
     float vLocation1 : TEXCOORD1;
     float vLocation2[2] : TEXCOORD2;
     Foo vLocation4 : TEXCOORD4;
+    float3 VertexOut_color : TEXCOORD7;
+    float3 VertexOut_foo : TEXCOORD8;
     float vLocation9 : TEXCOORD9;
     float4 gl_Position : SV_Position;
 };
@@ -57,13 +58,12 @@ void vert_main()
     vout.foo = 4.0f.xxx;
 }
 
-SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input, out VertexOut stage_outputvout)
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
     Input2 = stage_input.Input2;
     Input4 = stage_input.Input4;
     Input0 = stage_input.Input0;
     vert_main();
-    stage_outputvout = vout;
     SPIRV_Cross_Output stage_output;
     stage_output.gl_Position = gl_Position;
     stage_output.vLocation0 = vLocation0;
@@ -71,5 +71,7 @@ SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input, out VertexOut stage_outpu
     stage_output.vLocation2 = vLocation2;
     stage_output.vLocation4 = vLocation4;
     stage_output.vLocation9 = vLocation9;
+    stage_output.VertexOut_color = vout.color;
+    stage_output.VertexOut_foo = vout.foo;
     return stage_output;
 }

--- a/reference/shaders-hlsl/vert/qualifiers.vert
+++ b/reference/shaders-hlsl/vert/qualifiers.vert
@@ -1,17 +1,16 @@
+struct Block
+{
+    float vFlat;
+    float vCentroid;
+    float vSample;
+    float vNoperspective;
+};
+
 static float4 gl_Position;
 static float vFlat;
 static float vCentroid;
 static float vSample;
 static float vNoperspective;
-
-struct Block
-{
-    nointerpolation float vFlat : TEXCOORD4;
-    centroid float vCentroid : TEXCOORD5;
-    sample float vSample : TEXCOORD6;
-    noperspective float vNoperspective : TEXCOORD7;
-};
-
 static Block vout;
 
 struct SPIRV_Cross_Output
@@ -20,6 +19,10 @@ struct SPIRV_Cross_Output
     centroid float vCentroid : TEXCOORD1;
     sample float vSample : TEXCOORD2;
     noperspective float vNoperspective : TEXCOORD3;
+    nointerpolation float Block_vFlat : TEXCOORD4;
+    centroid float Block_vCentroid : TEXCOORD5;
+    sample float Block_vSample : TEXCOORD6;
+    noperspective float Block_vNoperspective : TEXCOORD7;
     float4 gl_Position : SV_Position;
 };
 
@@ -36,15 +39,18 @@ void vert_main()
     vout.vNoperspective = 3.0f;
 }
 
-SPIRV_Cross_Output main(out Block stage_outputvout)
+SPIRV_Cross_Output main()
 {
     vert_main();
-    stage_outputvout = vout;
     SPIRV_Cross_Output stage_output;
     stage_output.gl_Position = gl_Position;
     stage_output.vFlat = vFlat;
     stage_output.vCentroid = vCentroid;
     stage_output.vSample = vSample;
     stage_output.vNoperspective = vNoperspective;
+    stage_output.Block_vFlat = vout.vFlat;
+    stage_output.Block_vCentroid = vout.vCentroid;
+    stage_output.Block_vSample = vout.vSample;
+    stage_output.Block_vNoperspective = vout.vNoperspective;
     return stage_output;
 }

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1147,8 +1147,7 @@ string CompilerGLSL::layout_for_member(const SPIRType &type, uint32_t index)
 	if (is_legacy())
 		return "";
 
-	bool is_block = ir.meta[type.self].decoration.decoration_flags.get(DecorationBlock) ||
-	                ir.meta[type.self].decoration.decoration_flags.get(DecorationBufferBlock);
+	bool is_block = has_decoration(type.self, DecorationBlock) || has_decoration(type.self, DecorationBufferBlock);
 	if (!is_block)
 		return "";
 

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -854,34 +854,25 @@ std::string CompilerHLSL::to_initializer_expression(const SPIRVariable &var)
 		return CompilerGLSL::to_initializer_expression(var);
 }
 
-void CompilerHLSL::emit_io_block(const SPIRVariable &var)
+void CompilerHLSL::emit_interface_block_member_in_struct(const SPIRVariable &var, uint32_t member_index,
+                                                         uint32_t location,
+                                                         std::unordered_set<uint32_t> &active_locations)
 {
 	auto &execution = get_entry_point();
+	auto type = get<SPIRType>(var.basetype);
+	auto semantic = to_semantic(location, execution.model, var.storage);
+	auto mbr_name = join(to_name(type.self), "_", to_member_name(type, member_index));
+	auto &mbr_type = get<SPIRType>(type.member_types[member_index]);
 
-	auto &type = get<SPIRType>(var.basetype);
-	add_resource_name(type.self);
+	statement(to_interpolation_qualifiers(get_member_decoration_bitset(type.self, member_index)),
+	          type_to_glsl(mbr_type),
+	          " ", mbr_name, type_to_array_glsl(mbr_type),
+	          " : ", semantic, ";");
 
-	statement("struct ", to_name(type.self));
-	begin_scope();
-	type.member_name_cache.clear();
-
-	for (uint32_t i = 0; i < uint32_t(type.member_types.size()); i++)
-	{
-		uint32_t location = get_accumulated_member_location(var, i, false);
-		string semantic = join(" : ", to_semantic(location, execution.model, var.storage));
-
-		add_member_name(type, i);
-
-		auto &membertype = get<SPIRType>(type.member_types[i]);
-		statement(to_interpolation_qualifiers(get_member_decoration_bitset(type.self, i)),
-		          variable_decl(membertype, to_member_name(type, i)), semantic, ";");
-	}
-
-	end_scope_decl();
-	statement("");
-
-	statement("static ", variable_decl(var), ";");
-	statement("");
+	// Structs and arrays should consume more locations.
+	uint32_t consumed_locations = type_to_consumed_locations(mbr_type);
+	for (uint32_t i = 0; i < consumed_locations; i++)
+		active_locations.insert(location + i);
 }
 
 void CompilerHLSL::emit_interface_block_in_struct(const SPIRVariable &var, unordered_set<uint32_t> &active_locations)
@@ -916,7 +907,6 @@ void CompilerHLSL::emit_interface_block_in_struct(const SPIRVariable &var, unord
 
 	bool need_matrix_unroll = var.storage == StorageClassInput && execution.model == ExecutionModelVertex;
 
-	auto &m = ir.meta[var.self].decoration;
 	auto name = to_name(var.self);
 	if (use_location_number)
 	{
@@ -924,8 +914,8 @@ void CompilerHLSL::emit_interface_block_in_struct(const SPIRVariable &var, unord
 
 		// If an explicit location exists, use it with TEXCOORD[N] semantic.
 		// Otherwise, pick a vacant location.
-		if (m.decoration_flags.get(DecorationLocation))
-			location_number = m.location;
+		if (has_decoration(var.self, DecorationLocation))
+			location_number = get_decoration(var.self, DecorationLocation);
 		else
 			location_number = get_vacant_location();
 
@@ -1174,10 +1164,10 @@ void CompilerHLSL::emit_composite_constants()
 
 		auto &type = this->get<SPIRType>(c.constant_type);
 
-		// Cannot declare block type constants here.
-		// We do not have the struct type yet.
-		bool is_block = has_decoration(type.self, DecorationBlock);
-		if (!is_block && (type.basetype == SPIRType::Struct || !type.array.empty()))
+		if (type.basetype == SPIRType::Struct && is_builtin_type(type))
+			return;
+
+		if (type.basetype == SPIRType::Struct || !type.array.empty())
 		{
 			auto name = to_name(c.self);
 			statement("static const ", variable_decl(type, name), " = ", constant_expression(c), ";");
@@ -1194,6 +1184,18 @@ void CompilerHLSL::emit_specialization_constants_and_structs()
 	bool emitted = false;
 	SpecializationConstant wg_x, wg_y, wg_z;
 	ID workgroup_size_id = get_work_group_size_specialization_constants(wg_x, wg_y, wg_z);
+
+	std::unordered_set<TypeID> io_block_types;
+	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, const SPIRVariable &var) {
+		auto &type = this->get<SPIRType>(var.basetype);
+		if ((var.storage == StorageClassInput || var.storage == StorageClassOutput) &&
+		    !var.remapped_variable && type.pointer && !is_builtin_variable(var) &&
+		    interface_variable_exists_in_entry_point(var.self) &&
+		    has_decoration(type.self, DecorationBlock))
+		{
+			io_block_types.insert(type.self);
+		}
+	});
 
 	auto loop_lock = ir.create_loop_hard_lock();
 	for (auto &id_ : ir.ids_for_constant_or_type)
@@ -1237,9 +1239,11 @@ void CompilerHLSL::emit_specialization_constants_and_structs()
 		else if (id.get_type() == TypeType)
 		{
 			auto &type = id.get<SPIRType>();
-			if (type.basetype == SPIRType::Struct && type.array.empty() && !type.pointer &&
-			    (!ir.meta[type.self].decoration.decoration_flags.get(DecorationBlock) &&
-			     !ir.meta[type.self].decoration.decoration_flags.get(DecorationBufferBlock)))
+			bool is_non_io_block = has_decoration(type.self, DecorationBlock) &&
+			                       io_block_types.count(type.self) == 0;
+			bool is_buffer_block = has_decoration(type.self, DecorationBufferBlock);
+			if (type.basetype == SPIRType::Struct && type.array.empty() &&
+			    !type.pointer && !is_non_io_block && !is_buffer_block)
 			{
 				if (emitted)
 					statement("");
@@ -1365,16 +1369,12 @@ void CompilerHLSL::emit_resources()
 
 	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, SPIRVariable &var) {
 		auto &type = this->get<SPIRType>(var.basetype);
-		bool block = ir.meta[type.self].decoration.decoration_flags.get(DecorationBlock);
 
-		// Do not emit I/O blocks here.
-		// I/O blocks can be arrayed, so we must deal with them separately to support geometry shaders
-		// and tessellation down the line.
-		if (!block && var.storage != StorageClassFunction && !var.remapped_variable && type.pointer &&
+		if (var.storage != StorageClassFunction && !var.remapped_variable && type.pointer &&
 		    (var.storage == StorageClassInput || var.storage == StorageClassOutput) && !is_builtin_variable(var) &&
 		    interface_variable_exists_in_entry_point(var.self))
 		{
-			// Only emit non-builtins which are not blocks here. Builtin variables are handled separately.
+			// Builtin variables are handled separately.
 			emit_interface_block_globally(var);
 			emitted = true;
 		}
@@ -1388,69 +1388,72 @@ void CompilerHLSL::emit_resources()
 	require_output = false;
 	unordered_set<uint32_t> active_inputs;
 	unordered_set<uint32_t> active_outputs;
-	SmallVector<SPIRVariable *> input_variables;
-	SmallVector<SPIRVariable *> output_variables;
+
+	struct IOVariable
+	{
+		const SPIRVariable *var;
+		uint32_t location;
+		uint32_t block_member_index;
+		bool block;
+	};
+
+	SmallVector<IOVariable> input_variables;
+	SmallVector<IOVariable> output_variables;
+
 	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, SPIRVariable &var) {
 		auto &type = this->get<SPIRType>(var.basetype);
-		bool block = ir.meta[type.self].decoration.decoration_flags.get(DecorationBlock);
+		bool block = has_decoration(type.self, DecorationBlock);
 
 		if (var.storage != StorageClassInput && var.storage != StorageClassOutput)
 			return;
 
-		// Do not emit I/O blocks here.
-		// I/O blocks can be arrayed, so we must deal with them separately to support geometry shaders
-		// and tessellation down the line.
-		if (!block && !var.remapped_variable && type.pointer && !is_builtin_variable(var) &&
+		if (!var.remapped_variable && type.pointer && !is_builtin_variable(var) &&
 		    interface_variable_exists_in_entry_point(var.self))
 		{
-			if (var.storage == StorageClassInput)
-				input_variables.push_back(&var);
-			else
-				output_variables.push_back(&var);
-		}
-
-		// Reserve input and output locations for block variables as necessary.
-		if (block && !is_builtin_variable(var) && interface_variable_exists_in_entry_point(var.self))
-		{
-			auto &active = var.storage == StorageClassInput ? active_inputs : active_outputs;
-			for (uint32_t i = 0; i < uint32_t(type.member_types.size()); i++)
+			if (block)
 			{
-				if (has_member_decoration(type.self, i, DecorationLocation))
+				for (uint32_t i = 0; i < uint32_t(type.member_types.size()); i++)
 				{
-					uint32_t location = get_member_decoration(type.self, i, DecorationLocation);
-					active.insert(location);
+					uint32_t location = get_declared_member_location(var, i, false);
+					if (var.storage == StorageClassInput)
+						input_variables.push_back({ &var, location, i, true });
+					else
+						output_variables.push_back({ &var, location, i, true });
 				}
 			}
-
-			// Emit the block struct and a global variable here.
-			emit_io_block(var);
+			else
+			{
+				uint32_t location = get_decoration(var.self, DecorationLocation);
+				if (var.storage == StorageClassInput)
+					input_variables.push_back({ &var, location, 0, false });
+				else
+					output_variables.push_back({ &var, location, 0, false });
+			}
 		}
 	});
 
-	const auto variable_compare = [&](const SPIRVariable *a, const SPIRVariable *b) -> bool {
+	const auto variable_compare = [&](const IOVariable &a, const IOVariable &b) -> bool {
 		// Sort input and output variables based on, from more robust to less robust:
 		// - Location
 		// - Variable has a location
 		// - Name comparison
 		// - Variable has a name
 		// - Fallback: ID
-		bool has_location_a = has_decoration(a->self, DecorationLocation);
-		bool has_location_b = has_decoration(b->self, DecorationLocation);
+		bool has_location_a = a.block || has_decoration(a.var->self, DecorationLocation);
+		bool has_location_b = b.block || has_decoration(b.var->self, DecorationLocation);
 
 		if (has_location_a && has_location_b)
-		{
-			return get_decoration(a->self, DecorationLocation) < get_decoration(b->self, DecorationLocation);
-		}
+			return a.location < b.location;
 		else if (has_location_a && !has_location_b)
 			return true;
 		else if (!has_location_a && has_location_b)
 			return false;
 
-		const auto &name1 = to_name(a->self);
-		const auto &name2 = to_name(b->self);
+		const auto &name1 = to_name(a.var->self);
+		const auto &name2 = to_name(b.var->self);
 
 		if (name1.empty() && name2.empty())
-			return a->self < b->self;
+			return a.var->self < b.var->self;
 		else if (name1.empty())
 			return true;
 		else if (name2.empty())
@@ -1477,8 +1480,13 @@ void CompilerHLSL::emit_resources()
 
 		begin_scope();
 		sort(input_variables.begin(), input_variables.end(), variable_compare);
-		for (auto var : input_variables)
-			emit_interface_block_in_struct(*var, active_inputs);
+		for (auto &var : input_variables)
+		{
+			if (var.block)
+				emit_interface_block_member_in_struct(*var.var, var.block_member_index, var.location, active_inputs);
+			else
+				emit_interface_block_in_struct(*var.var, active_inputs);
+		}
 		emit_builtin_inputs_in_struct();
 		end_scope_decl();
 		statement("");
@@ -1490,10 +1498,14 @@ void CompilerHLSL::emit_resources()
 		statement("struct SPIRV_Cross_Output");
 
 		begin_scope();
-		// FIXME: Use locations properly if they exist.
 		sort(output_variables.begin(), output_variables.end(), variable_compare);
-		for (auto var : output_variables)
-			emit_interface_block_in_struct(*var, active_outputs);
+		for (auto &var : output_variables)
+		{
+			if (var.block)
+				emit_interface_block_member_in_struct(*var.var, var.block_member_index, var.location, active_outputs);
+			else
+				emit_interface_block_in_struct(*var.var, active_outputs);
+		}
 		emit_builtin_outputs_in_struct();
 		end_scope_decl();
 		statement("");
@@ -2059,13 +2071,6 @@ void CompilerHLSL::emit_struct_member(const SPIRType &type, uint32_t member_type
 	if (index < memb.size())
 		memberflags = memb[index].decoration_flags;
 
-	string qualifiers;
-	bool is_block = ir.meta[type.self].decoration.decoration_flags.get(DecorationBlock) ||
-	                ir.meta[type.self].decoration.decoration_flags.get(DecorationBufferBlock);
-
-	if (is_block)
-		qualifiers = to_interpolation_qualifiers(memberflags);
-
 	string packing_offset;
 	bool is_push_constant = type.storage == StorageClassPushConstant;
 
@@ -2080,7 +2085,7 @@ void CompilerHLSL::emit_struct_member(const SPIRType &type, uint32_t member_type
 		packing_offset = join(" : packoffset(c", offset / 16, packing_swizzle[(offset & 15) >> 2], ")");
 	}
 
-	statement(layout_for_member(type, index), qualifiers, qualifier,
+	statement(layout_for_member(type, index), qualifier,
 	          variable_decl(membertype, to_member_name(type, index)), packing_offset, ";");
 }
 
@@ -2415,27 +2420,6 @@ void CompilerHLSL::emit_hlsl_entry_point()
 	if (require_input)
 		arguments.push_back("SPIRV_Cross_Input stage_input");
 
-	// Add I/O blocks as separate arguments with appropriate storage qualifier.
-	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, SPIRVariable &var) {
-		auto &type = this->get<SPIRType>(var.basetype);
-		bool block = ir.meta[type.self].decoration.decoration_flags.get(DecorationBlock);
-
-		if (var.storage != StorageClassInput && var.storage != StorageClassOutput)
-			return;
-
-		if (block && !is_builtin_variable(var) && interface_variable_exists_in_entry_point(var.self))
-		{
-			if (var.storage == StorageClassInput)
-			{
-				arguments.push_back(join("in ", variable_decl(type, join("stage_input", to_name(var.self)))));
-			}
-			else if (var.storage == StorageClassOutput)
-			{
-				arguments.push_back(join("out ", variable_decl(type, join("stage_output", to_name(var.self)))));
-			}
-		}
-	});
-
 	auto &execution = get_entry_point();
 
 	switch (execution.model)
@@ -2596,35 +2580,42 @@ void CompilerHLSL::emit_hlsl_entry_point()
 	// Copy from stage input struct to globals.
 	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, SPIRVariable &var) {
 		auto &type = this->get<SPIRType>(var.basetype);
-		bool block = ir.meta[type.self].decoration.decoration_flags.get(DecorationBlock);
+		bool block = has_decoration(type.self, DecorationBlock);
 
 		if (var.storage != StorageClassInput)
 			return;
 
 		bool need_matrix_unroll = var.storage == StorageClassInput && execution.model == ExecutionModelVertex;
 
-		if (!block && !var.remapped_variable && type.pointer && !is_builtin_variable(var) &&
+		if (!var.remapped_variable && type.pointer && !is_builtin_variable(var) &&
 		    interface_variable_exists_in_entry_point(var.self))
 		{
-			auto name = to_name(var.self);
-			auto &mtype = this->get<SPIRType>(var.basetype);
-			if (need_matrix_unroll && mtype.columns > 1)
+			if (block)
 			{
-				// Unroll matrices.
-				for (uint32_t col = 0; col < mtype.columns; col++)
-					statement(name, "[", col, "] = stage_input.", name, "_", col, ";");
+				auto type_name = to_name(type.self);
+				auto var_name = to_name(var.self);
+				for (uint32_t mbr_idx = 0; mbr_idx < uint32_t(type.member_types.size()); mbr_idx++)
+				{
+					auto mbr_name = to_member_name(type, mbr_idx);
+					auto flat_name = join(type_name, "_", mbr_name);
+					statement(var_name, ".", mbr_name, " = stage_input.", flat_name, ";");
+				}
 			}
 			else
 			{
-				statement(name, " = stage_input.", name, ";");
+				auto name = to_name(var.self);
+				auto &mtype = this->get<SPIRType>(var.basetype);
+				if (need_matrix_unroll && mtype.columns > 1)
+				{
+					// Unroll matrices.
+					for (uint32_t col = 0; col < mtype.columns; col++)
+						statement(name, "[", col, "] = stage_input.", name, "_", col, ";");
+				}
+				else
+				{
+					statement(name, " = stage_input.", name, ";");
+				}
 			}
-		}
-
-		// I/O blocks don't use the common stage input/output struct, but separate outputs.
-		if (block && !is_builtin_variable(var) && interface_variable_exists_in_entry_point(var.self))
-		{
-			auto name = to_name(var.self);
-			statement(name, " = stage_input", name, ";");
 		}
 	});
 
@@ -2637,22 +2628,6 @@ void CompilerHLSL::emit_hlsl_entry_point()
 		statement("comp_main();");
 	else
 		SPIRV_CROSS_THROW("Unsupported shader stage.");
-
-	// Copy block outputs.
-	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, SPIRVariable &var) {
-		auto &type = this->get<SPIRType>(var.basetype);
-		bool block = ir.meta[type.self].decoration.decoration_flags.get(DecorationBlock);
-
-		if (var.storage != StorageClassOutput)
-			return;
-
-		// I/O blocks don't use the common stage input/output struct, but separate outputs.
-		if (block && !is_builtin_variable(var) && interface_variable_exists_in_entry_point(var.self))
-		{
-			auto name = to_name(var.self);
-			statement("stage_output", name, " = ", name, ";");
-		}
-	});
 
 	// Copy stage outputs.
 	if (require_output)
@@ -2690,27 +2665,43 @@ void CompilerHLSL::emit_hlsl_entry_point()
 
 		ir.for_each_typed_id<SPIRVariable>([&](uint32_t, SPIRVariable &var) {
 			auto &type = this->get<SPIRType>(var.basetype);
-			bool block = ir.meta[type.self].decoration.decoration_flags.get(DecorationBlock);
+			bool block = has_decoration(type.self, DecorationBlock);
 
 			if (var.storage != StorageClassOutput)
 				return;
 
-			if (!block && var.storage != StorageClassFunction && !var.remapped_variable && type.pointer &&
-			    !is_builtin_variable(var) && interface_variable_exists_in_entry_point(var.self))
+			if (!var.remapped_variable && type.pointer &&
+			    !is_builtin_variable(var) &&
+			    interface_variable_exists_in_entry_point(var.self))
 			{
-				auto name = to_name(var.self);
-
-				if (legacy && execution.model == ExecutionModelFragment)
+				if (block)
 				{
-					string output_filler;
-					for (uint32_t size = type.vecsize; size < 4; ++size)
-						output_filler += ", 0.0";
-
-					statement("stage_output.", name, " = float4(", name, output_filler, ");");
+					// I/O blocks need to flatten output.
+					auto type_name = to_name(type.self);
+					auto var_name = to_name(var.self);
+					for (uint32_t mbr_idx = 0; mbr_idx < uint32_t(type.member_types.size()); mbr_idx++)
+					{
+						auto mbr_name = to_member_name(type, mbr_idx);
+						auto flat_name = join(type_name, "_", mbr_name);
+						statement("stage_output.", flat_name, " = ", var_name, ".", mbr_name, ";");
+					}
 				}
 				else
 				{
-					statement("stage_output.", name, " = ", name, ";");
+					auto name = to_name(var.self);
+
+					if (legacy && execution.model == ExecutionModelFragment)
+					{
+						string output_filler;
+						for (uint32_t size = type.vecsize; size < 4; ++size)
+							output_filler += ", 0.0";
+
+						statement("stage_output.", name, " = float4(", name, output_filler, ");");
+					}
+					else
+					{
+						statement("stage_output.", name, " = ", name, ";");
+					}
 				}
 			}
 		});

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -219,7 +219,10 @@ private:
 	void emit_resources();
 	void declare_undefined_values() override;
 	void emit_interface_block_globally(const SPIRVariable &type);
-	void emit_interface_block_in_struct(const SPIRVariable &type, std::unordered_set<uint32_t> &active_locations);
+	void emit_interface_block_in_struct(const SPIRVariable &var, std::unordered_set<uint32_t> &active_locations);
+	void emit_interface_block_member_in_struct(const SPIRVariable &var, uint32_t member_index,
+	                                           uint32_t location,
+	                                           std::unordered_set<uint32_t> &active_locations);
 	void emit_builtin_inputs_in_struct();
 	void emit_builtin_outputs_in_struct();
 	void emit_texture_op(const Instruction &i, bool sparse) override;
@@ -347,7 +350,6 @@ private:
 
 	uint32_t type_to_consumed_locations(const SPIRType &type) const;
 
-	void emit_io_block(const SPIRVariable &var);
 	std::string to_semantic(uint32_t location, spv::ExecutionModel em, spv::StorageClass sc);
 
 	uint32_t num_workgroups_builtin = 0;


### PR DESCRIPTION
Emit block members directly in the IO structs and sort them.
Ensures we can get some kind of stable order between stages.

To complete the story, we'll need to be able to inject unused inputs /
builtins, or eliminate unused outputs (probably easiest solution).

Fix #1691.