### PR TITLE
[MSL] Fix as_type casts being used to bitcast to different sizes

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -13898,15 +13898,15 @@ string CompilerMSL::bitcast_glsl_op(const SPIRType &out_type, const SPIRType &in
 	bool integral_cast = type_is_integral(out_type) && type_is_integral(in_type);
 	bool same_size_cast = out_type.width == in_type.width;
 
-	if (integral_cast && same_size_cast)
+	if (same_size_cast)
 	{
 		// Trivial bitcast case, casts between integers.
-		return type_to_glsl(out_type);
+		return "as_type<" + type_to_glsl(out_type) + ">";
 	}
 	else
 	{
 		// Fall back to the catch-all bitcast in MSL.
-		return "as_type<" + type_to_glsl(out_type) + ">";
+		return type_to_glsl(out_type);
 	}
 }
 


### PR DESCRIPTION
SPIRV-Cross incorrectly generates MSL `as_type` casts for source/target types that have different sizes, which is illegal in MSL.

We were encountering this issue with expressions such as `foo = uint64_t(my_64bit_int | my_32bit_int);` which would generate an `as_type` cast for `my_32bit_int` to a 64-bit integer.

Please let me know if there is a better solution to this issue, and how I can add a regression test for this issue.