### PR TITLE
CMake: fix cross-build to iOS/tvOS/watchOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,7 +442,7 @@ if (SPIRV_CROSS_CLI)
 	target_compile_definitions(spirv-cross PRIVATE ${spirv-compiler-defines} HAVE_SPIRV_CROSS_GIT_VERSION)
 	set_target_properties(spirv-cross PROPERTIES LINK_FLAGS "${spirv-cross-link-flags}")
 	if (NOT SPIRV_CROSS_SKIP_INSTALL)
-		install(TARGETS spirv-cross RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+		install(TARGETS spirv-cross DESTINATION ${CMAKE_INSTALL_BINDIR})
 	endif()
 	target_link_libraries(spirv-cross PRIVATE
 			spirv-cross-glsl


### PR DESCRIPTION
Probably not conventional hosts of SPIRV-Cross, but this PR fixes CMake configuration with recent CMake versions when host is iOS/tvOS/watchOS.

see https://cmake.org/cmake/help/latest/policy/CMP0006.html