### PR TITLE
MSL: Fix setting SPIRVCrossDecorationInterpolantComponentExpr decoration.

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -7449,7 +7449,7 @@ void CompilerMSL::fix_up_interpolant_access_chain(const uint32_t *ops, uint32_t 
 	// for that getting the base index.
 	for (uint32_t i = 3; i < length; ++i)
 	{
-		if (is_vector(*type) && is_scalar(result_type))
+		if (is_vector(*type) && !is_array(*type) && is_scalar(result_type))
 		{
 			// We don't want to combine the next index. Actually, we need to save it
 			// so we know to apply a swizzle to the result of the interpolation.


### PR DESCRIPTION
When setting `SPIRVCrossDecorationInterpolantComponentExpr` decoration, take into consideration a possible array of vectors in an access chain, and don't apply the decoration until we traverse through the array into the vector itself.