### PR TITLE
MSL: Simplify spvSubgroupBallot().

### DIFF
--- a/reference/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl21.comp
+++ b/reference/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl21.comp
@@ -55,7 +55,7 @@ inline uint4 spvSubgroupBallot(bool value)
     // SPIR-V callers expect a uint4. We must convert.
     // FIXME: This won't include higher bits if Apple ever supports
     // 128 lanes in an SIMD-group.
-    return uint4((uint)((simd_vote::vote_t)vote & 0xFFFFFFFF), (uint)(((simd_vote::vote_t)vote >> 32) & 0xFFFFFFFF), 0, 0);
+    return uint4(as_type<uint2>((simd_vote::vote_t)vote), 0, 0);
 }
 
 inline bool spvSubgroupBallotBitExtract(uint4 ballot, uint bit)

--- a/reference/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl21.fixed-subgroup.comp
+++ b/reference/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl21.fixed-subgroup.comp
@@ -55,7 +55,7 @@ inline uint4 spvSubgroupBallot(bool value)
     // SPIR-V callers expect a uint4. We must convert.
     // FIXME: This won't include higher bits if Apple ever supports
     // 128 lanes in an SIMD-group.
-    return uint4((uint)((simd_vote::vote_t)vote & 0xFFFFFFFF), (uint)(((simd_vote::vote_t)vote >> 32) & 0xFFFFFFFF), 0, 0);
+    return uint4(as_type<uint2>((simd_vote::vote_t)vote), 0, 0);
 }
 
 inline bool spvSubgroupBallotBitExtract(uint4 ballot, uint bit)

--- a/reference/shaders-msl-no-opt/frag/subgroups.nocompat.invalid.vk.msl22.frag
+++ b/reference/shaders-msl-no-opt/frag/subgroups.nocompat.invalid.vk.msl22.frag
@@ -53,7 +53,7 @@ inline uint4 spvSubgroupBallot(bool value)
     // SPIR-V callers expect a uint4. We must convert.
     // FIXME: This won't include higher bits if Apple ever supports
     // 128 lanes in an SIMD-group.
-    return uint4((uint)((simd_vote::vote_t)vote & 0xFFFFFFFF), (uint)(((simd_vote::vote_t)vote >> 32) & 0xFFFFFFFF), 0, 0);
+    return uint4(as_type<uint2>((simd_vote::vote_t)vote), 0, 0);
 }
 
 inline bool spvSubgroupBallotBitExtract(uint4 ballot, uint bit)

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -5383,9 +5383,7 @@ void CompilerMSL::emit_custom_functions()
 				statement("// SPIR-V callers expect a uint4. We must convert.");
 				statement("// FIXME: This won't include higher bits if Apple ever supports");
 				statement("// 128 lanes in an SIMD-group.");
-				statement(
-				    "return uint4((uint)((simd_vote::vote_t)vote & 0xFFFFFFFF), (uint)(((simd_vote::vote_t)vote >> "
-				    "32) & 0xFFFFFFFF), 0, 0);");
+				statement("return uint4(as_type<uint2>((simd_vote::vote_t)vote), 0, 0);");
 			}
 			end_scope();
 			statement("");


### PR DESCRIPTION
A bitcast to `uint2` will do just fine. I honestly don't know why I
didn't do it this way earlier.