### PR TITLE
MSL: Support row-major transpose when storing matrix from constant RHS matrix.

### DIFF
--- a/reference/opt/shaders-msl/comp/mat3-row-maj-read-write-const.comp
+++ b/reference/opt/shaders-msl/comp/mat3-row-maj-read-write-const.comp
@@ -1,0 +1,21 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct model_t
+{
+    float3x3 mtx_rm;
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
+
+kernel void main0(device model_t& model [[buffer(0)]])
+{
+    float _38 = (transpose(model.mtx_rm) * float3x3(float3(4.0, -3.0, 1.0), float3(-7.0, 7.0, -7.0), float3(-5.0, 6.0, -8.0)))[0].x;
+    if ((isunordered(_38, 0.0) || _38 != 0.0))
+    {
+        model.mtx_rm = transpose(float3x3(float3(-5.0, -3.0, -5.0), float3(-2.0, 2.0, -5.0), float3(6.0, 3.0, -8.0)));
+    }
+}
+

--- a/reference/shaders-msl/comp/mat3-row-maj-read-write-const.comp
+++ b/reference/shaders-msl/comp/mat3-row-maj-read-write-const.comp
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct model_t
+{
+    float3x3 mtx_rm;
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
+
+kernel void main0(device model_t& model [[buffer(0)]])
+{
+    float3x3 mtx_cm = transpose(model.mtx_rm);
+    float3x3 mtx1 = mtx_cm * float3x3(float3(4.0, -3.0, 1.0), float3(-7.0, 7.0, -7.0), float3(-5.0, 6.0, -8.0));
+    if ((isunordered(mtx1[0].x, 0.0) || mtx1[0].x != 0.0))
+    {
+        model.mtx_rm = transpose(float3x3(float3(-5.0, -3.0, -5.0), float3(-2.0, 2.0, -5.0), float3(6.0, 3.0, -8.0)));
+    }
+}
+

--- a/shaders-msl/comp/mat3-row-maj-read-write-const.comp
+++ b/shaders-msl/comp/mat3-row-maj-read-write-const.comp
@@ -1,0 +1,17 @@
+#version 450
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(set = 0, binding = 1, std430) buffer model_t
+{
+    layout(row_major) mediump mat3 mtx_rm;
+} model;
+
+void main()
+{
+    mat3 mtx_cm = model.mtx_rm;
+    mat3 mtx1 = mtx_cm * mat3(vec3(4.0, -3.0, 1.0), vec3(-7.0, 7.0, -7.0), vec3(-5.0, 6.0, -8.0));
+    if (mtx1[0][0] != 0.0)
+    {
+	    model.mtx_rm = mat3(vec3(-5.0, -3.0, -5.0), vec3(-2.0, 2.0, -5.0), vec3(6.0, 3.0, -8.0));
+    }
+}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -4262,9 +4262,6 @@ void CompilerMSL::emit_store_statement(uint32_t lhs_expression, uint32_t rhs_exp
 		// In this case, we just flip transpose states, and emit the store, a transpose must be in the RHS expression, if any.
 		if (is_matrix(type) && lhs_e && lhs_e->need_transpose)
 		{
-			if (!rhs_e)
-				SPIRV_CROSS_THROW("Need to transpose right-side expression of a store to row-major matrix, but it is "
-				                  "not a SPIRExpression.");
 			lhs_e->need_transpose = false;
 
 			if (rhs_e && rhs_e->need_transpose)


### PR DESCRIPTION
- Remove test and exception when storing row-major matrix from RHS that is not a `SPIRExpression`.
- Add test shaders.

Fixes #1719, and several hundred CTS tests.

The removed test and exception doesn't seem to have a purpose, since subsequent code allows non-SPIRExpression to succeed. After the removal of the test, no SPIRVCross or CTS tests encounter problems.

However, if there are conditions that require this test and exception, we could replace the test, but accommodate a RHS that permits `OpConstantComposite` in addition to `SPIRExpression`. The failing CTS tests, including in #1719 were a result of attempting to store a `OpConstantComposite` into a row-major matrix.
