### PR TITLE
MSL: Fix casting in constant expressions with different sizes.

### DIFF
--- a/reference/opt/shaders-msl/comp/type_casting_i64.msl22.comp
+++ b/reference/opt/shaders-msl/comp/type_casting_i64.msl22.comp
@@ -1,0 +1,27 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct dst_buff_t
+{
+    int m0[1];
+};
+
+struct src_buff_t
+{
+    int m0[1];
+};
+
+constant int base_val_tmp [[function_constant(0)]];
+constant int base_val = is_function_constant_defined(base_val_tmp) ? base_val_tmp : 0;
+constant long shift_val_tmp [[function_constant(1)]];
+constant long shift_val = is_function_constant_defined(shift_val_tmp) ? shift_val_tmp : 0l;
+constant int offset = (base_val >> int(shift_val));
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
+
+kernel void main0(device dst_buff_t& dst_buff [[buffer(0)]], device src_buff_t& src_buff [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+{
+    dst_buff.m0[gl_GlobalInvocationID.x] = src_buff.m0[gl_GlobalInvocationID.x] + offset;
+}
+

--- a/reference/shaders-msl/comp/type_casting_i64.msl22.comp
+++ b/reference/shaders-msl/comp/type_casting_i64.msl22.comp
@@ -1,0 +1,27 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct dst_buff_t
+{
+    int m0[1];
+};
+
+struct src_buff_t
+{
+    int m0[1];
+};
+
+constant int base_val_tmp [[function_constant(0)]];
+constant int base_val = is_function_constant_defined(base_val_tmp) ? base_val_tmp : 0;
+constant long shift_val_tmp [[function_constant(1)]];
+constant long shift_val = is_function_constant_defined(shift_val_tmp) ? shift_val_tmp : 0l;
+constant int offset = (base_val >> int(shift_val));
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
+
+kernel void main0(device dst_buff_t& dst_buff [[buffer(0)]], device src_buff_t& src_buff [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+{
+    dst_buff.m0[gl_GlobalInvocationID.x] = src_buff.m0[gl_GlobalInvocationID.x] + offset;
+}
+

--- a/shaders-msl/comp/type_casting_i64.msl22.comp
+++ b/shaders-msl/comp/type_casting_i64.msl22.comp
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_ARB_gpu_shader_int64 : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const int base_val = 0;
+layout(constant_id = 1) const int64_t shift_val = 0;
+const int offset = base_val >> shift_val;
+
+layout(set = 0, binding = 0, std430) buffer src_buff_t
+{
+    int m0[];
+} src_buff;
+
+layout(set = 0, binding = 1, std430) buffer dst_buff_t
+{
+    int m0[];
+} dst_buff;
+
+void main()
+{
+    dst_buff.m0[gl_GlobalInvocationID.x] = src_buff.m0[gl_GlobalInvocationID.x] + offset;
+}
+


### PR DESCRIPTION
Previous casting in constant expressions allowed `as_type<>` between
types of different overall sizes.
Add check for overall size (width * vecsize) to ensure `as_type<>` will work,
otherwise use regular cast. Also beef up test of integer values to also check
vecsize, and use regular casts for those.

TBH...I'm not sure why we always go to bitcasting when emitting constant expressions. It seems most constant expressions would not have the need for bitcasting. Here I have just done the minimal surgery required to fix the issue at hand, which was to avoid using `as_type<>` when say casting a 64-bit expression value to a 32-bit result, etc.