### PR TITLE
MSL: Fix duplicate gl_Position outputs when gl_Position defined but unused.

### DIFF
--- a/reference/opt/shaders-msl/vert/unused-position.vert
+++ b/reference/opt/shaders-msl/vert/unused-position.vert
@@ -1,0 +1,18 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+    float gl_PointSize [[point_size]];
+};
+
+vertex main0_out main0()
+{
+    main0_out out = {};
+    out.gl_PointSize = 1.0;
+    return out;
+}
+

--- a/reference/shaders-msl/vert/unused-position.vert
+++ b/reference/shaders-msl/vert/unused-position.vert
@@ -1,0 +1,18 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+    float gl_PointSize [[point_size]];
+};
+
+vertex main0_out main0()
+{
+    main0_out out = {};
+    out.gl_PointSize = 1.0;
+    return out;
+}
+

--- a/shaders-msl/vert/unused-position.vert
+++ b/shaders-msl/vert/unused-position.vert
@@ -1,0 +1,13 @@
+#version 450
+
+out gl_PerVertex
+{
+    vec4 gl_Position;
+    float gl_PointSize;
+    float gl_ClipDistance[1];
+};
+
+void main()
+{
+    gl_PointSize = 1.0;
+}


### PR DESCRIPTION
When `gl_Position` is defined by SPIR-V, but neither used nor initialized, it appeared twice in the MSL output, as `gl_Position` and `glPosition_1`.

The existing tests for whether an output is active check only that it is used by an op, or initialized. Adding the implicit `gl_Position` also marked the existing `gl_Position` as active, duplicating the output variable.

Fix is that when checking for the need to add an implicit `gl_Position` output, also check if the var is already defined in the shader, and just needs to be marked as active.
Add test shader.