### PR TITLE
Add support for additional ops in OpSpecConstantOp.

### DIFF
--- a/reference/opt/shaders-msl/asm/vert/spec-constant-op-composite.asm.vert
+++ b/reference/opt/shaders-msl/asm/vert/spec-constant-op-composite.asm.vert
@@ -9,9 +9,10 @@ constant int _20 = (_7 + 2);
 constant uint _8_tmp [[function_constant(202)]];
 constant uint _8 = is_function_constant_defined(_8_tmp) ? _8_tmp : 100u;
 constant uint _25 = (_8 % 5u);
-constant int4 _30 = int4(20, 30, _20, _20);
-constant int2 _32 = int2(_30.y, _30.x);
-constant int _33 = _30.y;
+constant int _30 = _7 - (-3) * (_7 / (-3));
+constant int4 _32 = int4(20, 30, _20, _30);
+constant int2 _34 = int2(_32.y, _32.x);
+constant int _35 = _32.y;
 
 struct main0_out
 {
@@ -22,14 +23,14 @@ struct main0_out
 vertex main0_out main0()
 {
     main0_out out = {};
-    float4 _63 = float4(0.0);
-    _63.y = float(_20);
-    float4 _66 = _63;
-    _66.z = float(_25);
-    float4 _52 = _66 + float4(_30);
-    float2 _56 = _52.xy + float2(_32);
-    out.gl_Position = float4(_56.x, _56.y, _52.z, _52.w);
-    out.m_4 = _33;
+    float4 _66 = float4(0.0);
+    _66.y = float(_20);
+    float4 _69 = _66;
+    _69.z = float(_25);
+    float4 _55 = _69 + float4(_32);
+    float2 _59 = _55.xy + float2(_34);
+    out.gl_Position = float4(_59.x, _59.y, _55.z, _55.w);
+    out.m_4 = _35;
     return out;
 }
 

--- a/reference/opt/shaders/asm/vert/spec-constant-op-composite.asm.vk.vert
+++ b/reference/opt/shaders/asm/vert/spec-constant-op-composite.asm.vk.vert
@@ -10,21 +10,22 @@ const int _20 = (_7 + 2);
 #endif
 const uint _8 = SPIRV_CROSS_CONSTANT_ID_202;
 const uint _25 = (_8 % 5u);
-const ivec4 _30 = ivec4(20, 30, _20, _20);
-const ivec2 _32 = ivec2(_30.y, _30.x);
-const int _33 = _30.y;
+const int _30 = _7 - (-3) * (_7 / (-3));
+const ivec4 _32 = ivec4(20, 30, _20, _30);
+const ivec2 _34 = ivec2(_32.y, _32.x);
+const int _35 = _32.y;
 
 layout(location = 0) flat out int _4;
 
 void main()
 {
-    vec4 _63 = vec4(0.0);
-    _63.y = float(_20);
-    vec4 _66 = _63;
-    _66.z = float(_25);
-    vec4 _52 = _66 + vec4(_30);
-    vec2 _56 = _52.xy + vec2(_32);
-    gl_Position = vec4(_56.x, _56.y, _52.z, _52.w);
-    _4 = _33;
+    vec4 _65 = vec4(0.0);
+    _65.y = float(_20);
+    vec4 _68 = _65;
+    _68.z = float(_25);
+    vec4 _54 = _68 + vec4(_32);
+    vec2 _58 = _54.xy + vec2(_34);
+    gl_Position = vec4(_58.x, _58.y, _54.z, _54.w);
+    _4 = _35;
 }
 

--- a/reference/opt/shaders/asm/vert/spec-constant-op-composite.asm.vk.vert.vk
+++ b/reference/opt/shaders/asm/vert/spec-constant-op-composite.asm.vk.vert.vk
@@ -4,21 +4,22 @@ layout(constant_id = 201) const int _7 = -10;
 const int _20 = (_7 + 2);
 layout(constant_id = 202) const uint _8 = 100u;
 const uint _25 = (_8 % 5u);
-const ivec4 _30 = ivec4(20, 30, _20, _20);
-const ivec2 _32 = ivec2(_30.y, _30.x);
-const int _33 = _30.y;
+const int _30 = _7 - (-3) * (_7 / (-3));
+const ivec4 _32 = ivec4(20, 30, _20, _30);
+const ivec2 _34 = ivec2(_32.y, _32.x);
+const int _35 = _32.y;
 
 layout(location = 0) flat out int _4;
 
 void main()
 {
-    vec4 _63 = vec4(0.0);
-    _63.y = float(_20);
-    vec4 _66 = _63;
-    _66.z = float(_25);
-    vec4 _52 = _66 + vec4(_30);
-    vec2 _56 = _52.xy + vec2(_32);
-    gl_Position = vec4(_56.x, _56.y, _52.z, _52.w);
-    _4 = _33;
+    vec4 _65 = vec4(0.0);
+    _65.y = float(_20);
+    vec4 _68 = _65;
+    _68.z = float(_25);
+    vec4 _54 = _68 + vec4(_32);
+    vec2 _58 = _54.xy + vec2(_34);
+    gl_Position = vec4(_58.x, _58.y, _54.z, _54.w);
+    _4 = _35;
 }
 

--- a/reference/shaders-msl/asm/vert/spec-constant-op-composite.asm.vert
+++ b/reference/shaders-msl/asm/vert/spec-constant-op-composite.asm.vert
@@ -9,11 +9,13 @@ constant int _20 = (_7 + 2);
 constant uint _8_tmp [[function_constant(202)]];
 constant uint _8 = is_function_constant_defined(_8_tmp) ? _8_tmp : 100u;
 constant uint _25 = (_8 % 5u);
-constant int4 _30 = int4(20, 30, _20, _20);
-constant int2 _32 = int2(_30.y, _30.x);
-constant int _33 = _30.y;
+constant int _30 = _7 - (-3) * (_7 / (-3));
+constant int4 _32 = int4(20, 30, _20, _30);
+constant int2 _34 = int2(_32.y, _32.x);
+constant int _35 = _32.y;
 constant float _9_tmp [[function_constant(200)]];
 constant float _9 = is_function_constant_defined(_9_tmp) ? _9_tmp : 3.141590118408203125;
+constant float _41 = float(half(_9));
 
 struct main0_out
 {
@@ -27,11 +29,11 @@ vertex main0_out main0()
     float4 pos = float4(0.0);
     pos.y += float(_20);
     pos.z += float(_25);
-    pos += float4(_30);
-    float2 _56 = pos.xy + float2(_32);
-    pos = float4(_56.x, _56.y, pos.z, pos.w);
+    pos += float4(_32);
+    float2 _59 = pos.xy + float2(_34);
+    pos = float4(_59.x, _59.y, pos.z, pos.w);
     out.gl_Position = pos;
-    out.m_4 = _33;
+    out.m_4 = _35;
     return out;
 }
 

--- a/reference/shaders/asm/vert/spec-constant-op-composite.asm.vk.vert
+++ b/reference/shaders/asm/vert/spec-constant-op-composite.asm.vk.vert
@@ -10,9 +10,10 @@ const int _20 = (_7 + 2);
 #endif
 const uint _8 = SPIRV_CROSS_CONSTANT_ID_202;
 const uint _25 = (_8 % 5u);
-const ivec4 _30 = ivec4(20, 30, _20, _20);
-const ivec2 _32 = ivec2(_30.y, _30.x);
-const int _33 = _30.y;
+const int _30 = _7 - (-3) * (_7 / (-3));
+const ivec4 _32 = ivec4(20, 30, _20, _30);
+const ivec2 _34 = ivec2(_32.y, _32.x);
+const int _35 = _32.y;
 #ifndef SPIRV_CROSS_CONSTANT_ID_200
 #define SPIRV_CROSS_CONSTANT_ID_200 3.141590118408203125
 #endif
@@ -25,10 +26,10 @@ void main()
     vec4 pos = vec4(0.0);
     pos.y += float(_20);
     pos.z += float(_25);
-    pos += vec4(_30);
-    vec2 _56 = pos.xy + vec2(_32);
-    pos = vec4(_56.x, _56.y, pos.z, pos.w);
+    pos += vec4(_32);
+    vec2 _58 = pos.xy + vec2(_34);
+    pos = vec4(_58.x, _58.y, pos.z, pos.w);
     gl_Position = pos;
-    _4 = _33;
+    _4 = _35;
 }
 

--- a/reference/shaders/asm/vert/spec-constant-op-composite.asm.vk.vert.vk
+++ b/reference/shaders/asm/vert/spec-constant-op-composite.asm.vk.vert.vk
@@ -4,9 +4,10 @@ layout(constant_id = 201) const int _7 = -10;
 const int _20 = (_7 + 2);
 layout(constant_id = 202) const uint _8 = 100u;
 const uint _25 = (_8 % 5u);
-const ivec4 _30 = ivec4(20, 30, _20, _20);
-const ivec2 _32 = ivec2(_30.y, _30.x);
-const int _33 = _30.y;
+const int _30 = _7 - (-3) * (_7 / (-3));
+const ivec4 _32 = ivec4(20, 30, _20, _30);
+const ivec2 _34 = ivec2(_32.y, _32.x);
+const int _35 = _32.y;
 layout(constant_id = 200) const float _9 = 3.141590118408203125;
 
 layout(location = 0) flat out int _4;
@@ -16,10 +17,10 @@ void main()
     vec4 pos = vec4(0.0);
     pos.y += float(_20);
     pos.z += float(_25);
-    pos += vec4(_30);
-    vec2 _56 = pos.xy + vec2(_32);
-    pos = vec4(_56.x, _56.y, pos.z, pos.w);
+    pos += vec4(_32);
+    vec2 _58 = pos.xy + vec2(_34);
+    pos = vec4(_58.x, _58.y, pos.z, pos.w);
     gl_Position = pos;
-    _4 = _33;
+    _4 = _35;
 }
 

--- a/shaders-msl/asm/vert/spec-constant-op-composite.asm.vert
+++ b/shaders-msl/asm/vert/spec-constant-op-composite.asm.vert
@@ -49,8 +49,10 @@
          %28 = OpConstant %17 2
          %33 = OpConstant %12 20
          %34 = OpConstant %12 30
+      %int_3 = OpConstant %12 -3
+        %bar = OpSpecConstantOp %12 SRem %13 %int_3
          %35 = OpTypeVector %12 4
-         %36 = OpSpecConstantComposite %35 %33 %34 %15 %15
+         %36 = OpSpecConstantComposite %35 %33 %34 %15 %bar
          %40 = OpTypeVector %12 2
          %41 = OpSpecConstantOp %40 VectorShuffle %36 %36 1 0
 		 %foo = OpSpecConstantOp %12 CompositeExtract %36 1
@@ -63,6 +65,7 @@
          %53 = OpConstant %12 0
          %55 = OpTypePointer Output %7
          %57 = OpSpecConstant %6 3.14159
+        %baz = OpSpecConstantOp %6 QuantizeToF16 %57
           %4 = OpFunction %2 None %3
           %5 = OpLabel
           %9 = OpVariable %8 Function

--- a/shaders/asm/vert/spec-constant-op-composite.asm.vk.vert
+++ b/shaders/asm/vert/spec-constant-op-composite.asm.vk.vert
@@ -49,8 +49,10 @@
          %28 = OpConstant %17 2
          %33 = OpConstant %12 20
          %34 = OpConstant %12 30
+      %int_3 = OpConstant %12 -3
+        %bar = OpSpecConstantOp %12 SRem %13 %int_3
          %35 = OpTypeVector %12 4
-         %36 = OpSpecConstantComposite %35 %33 %34 %15 %15
+         %36 = OpSpecConstantComposite %35 %33 %34 %15 %bar
          %40 = OpTypeVector %12 2
          %41 = OpSpecConstantOp %40 VectorShuffle %36 %36 1 0
 		 %foo = OpSpecConstantOp %12 CompositeExtract %36 1

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -4712,6 +4712,14 @@ string CompilerGLSL::constant_op_expression(const SPIRConstantOp &cop)
 		GLSL_BOP(UGreaterThanEqual, ">=");
 		GLSL_BOP(SGreaterThanEqual, ">=");
 
+	case OpSRem:
+	{
+		uint32_t op0 = cop.arguments[0];
+		uint32_t op1 = cop.arguments[1];
+		return join(to_enclosed_expression(op0), " - ", to_enclosed_expression(op1), " * ", "(",
+		                 to_enclosed_expression(op0), " / ", to_enclosed_expression(op1), ")");
+	}
+
 	case OpSelect:
 	{
 		if (cop.arguments.size() < 3)

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -386,7 +386,7 @@ protected:
 	virtual void emit_struct_padding_target(const SPIRType &type);
 	virtual std::string image_type_glsl(const SPIRType &type, uint32_t id = 0);
 	std::string constant_expression(const SPIRConstant &c);
-	std::string constant_op_expression(const SPIRConstantOp &cop);
+	virtual std::string constant_op_expression(const SPIRConstantOp &cop);
 	virtual std::string constant_expression_vector(const SPIRConstant &c, uint32_t vector);
 	virtual void emit_fixup();
 	virtual std::string variable_decl(const SPIRType &type, const std::string &name, uint32_t id = 0);

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -13327,6 +13327,38 @@ string CompilerMSL::type_to_array_glsl(const SPIRType &type)
 	}
 }
 
+string CompilerMSL::constant_op_expression(const SPIRConstantOp &cop)
+{
+	auto &type = get<SPIRType>(cop.basetype);
+	string op;
+
+	switch (cop.opcode)
+	{
+	case OpQuantizeToF16:
+		switch (type.vecsize)
+		{
+		case 1:
+			op = "float(half(";
+			break;
+		case 2:
+			op = "float2(half2(";
+			break;
+		case 3:
+			op = "float3(half3(";
+			break;
+		case 4:
+			op = "float4(half4(";
+			break;
+		default:
+			SPIRV_CROSS_THROW("Illegal argument to OpSpecConstantOp QuantizeToF16.");
+		}
+		return join(op, to_expression(cop.arguments[0]), "))");
+
+	default:
+		return CompilerGLSL::constant_op_expression(cop);
+	}
+}
+
 bool CompilerMSL::variable_decl_is_remapped_storage(const SPIRVariable &variable, spv::StorageClass storage) const
 {
 	if (variable.storage == storage)

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -734,6 +734,7 @@ protected:
 
 	// Allow Metal to use the array<T> template to make arrays a value type
 	std::string type_to_array_glsl(const SPIRType &type) override;
+	std::string constant_op_expression(const SPIRConstantOp &cop) override;
 
 	// Threadgroup arrays can't have a wrapper type
 	std::string variable_decl(const SPIRVariable &variable) override;


### PR DESCRIPTION
MSL: Support op `OpQuantizeToF16` in `OpSpecConstantOp`.
All: Support op `OpSRem` in `OpSpecConstantOp`.

I was not able add new tests, as these would require SPIR-V Assembly shaders, which I'm not familiar with creating.