### PR TITLE
MSL: Honor DecorationNoContraction when compiling using fast-math.

### DIFF
--- a/reference/opt/shaders-msl/vert/float-math.invariant-float-math.vert
+++ b/reference/opt/shaders-msl/vert/float-math.invariant-float-math.vert
@@ -69,13 +69,13 @@ struct main0_in
 };
 
 template<typename T>
-T spvFMul(T l, T r)
+[[clang::optnone]] T spvFMul(T l, T r)
 {
     return fma(l, r, T(0));
 }
 
 template<typename T, int Cols, int Rows>
-vec<T, Cols> spvFMulVectorMatrix(vec<T, Rows> v, matrix<T, Cols, Rows> m)
+[[clang::optnone]] vec<T, Cols> spvFMulVectorMatrix(vec<T, Rows> v, matrix<T, Cols, Rows> m)
 {
     vec<T, Cols> res = vec<T, Cols>(0);
     for (uint i = Rows; i > 0; --i)
@@ -91,7 +91,7 @@ vec<T, Cols> spvFMulVectorMatrix(vec<T, Rows> v, matrix<T, Cols, Rows> m)
 }
 
 template<typename T, int Cols, int Rows>
-vec<T, Rows> spvFMulMatrixVector(matrix<T, Cols, Rows> m, vec<T, Cols> v)
+[[clang::optnone]] vec<T, Rows> spvFMulMatrixVector(matrix<T, Cols, Rows> m, vec<T, Cols> v)
 {
     vec<T, Rows> res = vec<T, Rows>(0);
     for (uint i = Cols; i > 0; --i)
@@ -102,7 +102,7 @@ vec<T, Rows> spvFMulMatrixVector(matrix<T, Cols, Rows> m, vec<T, Cols> v)
 }
 
 template<typename T, int LCols, int LRows, int RCols, int RRows>
-matrix<T, RCols, LRows> spvFMulMatrixMatrix(matrix<T, LCols, LRows> l, matrix<T, RCols, RRows> r)
+[[clang::optnone]] matrix<T, RCols, LRows> spvFMulMatrixMatrix(matrix<T, LCols, LRows> l, matrix<T, RCols, RRows> r)
 {
     matrix<T, RCols, LRows> res;
     for (uint i = 0; i < RCols; i++)

--- a/reference/opt/shaders-msl/vert/no-contraction.vert
+++ b/reference/opt/shaders-msl/vert/no-contraction.vert
@@ -18,13 +18,13 @@ struct main0_in
 };
 
 template<typename T>
-T spvFMul(T l, T r)
+[[clang::optnone]] T spvFMul(T l, T r)
 {
     return fma(l, r, T(0));
 }
 
 template<typename T, int Cols, int Rows>
-vec<T, Cols> spvFMulVectorMatrix(vec<T, Rows> v, matrix<T, Cols, Rows> m)
+[[clang::optnone]] vec<T, Cols> spvFMulVectorMatrix(vec<T, Rows> v, matrix<T, Cols, Rows> m)
 {
     vec<T, Cols> res = vec<T, Cols>(0);
     for (uint i = Rows; i > 0; --i)
@@ -40,7 +40,7 @@ vec<T, Cols> spvFMulVectorMatrix(vec<T, Rows> v, matrix<T, Cols, Rows> m)
 }
 
 template<typename T, int Cols, int Rows>
-vec<T, Rows> spvFMulMatrixVector(matrix<T, Cols, Rows> m, vec<T, Cols> v)
+[[clang::optnone]] vec<T, Rows> spvFMulMatrixVector(matrix<T, Cols, Rows> m, vec<T, Cols> v)
 {
     vec<T, Rows> res = vec<T, Rows>(0);
     for (uint i = Cols; i > 0; --i)
@@ -51,7 +51,7 @@ vec<T, Rows> spvFMulMatrixVector(matrix<T, Cols, Rows> m, vec<T, Cols> v)
 }
 
 template<typename T, int LCols, int LRows, int RCols, int RRows>
-matrix<T, RCols, LRows> spvFMulMatrixMatrix(matrix<T, LCols, LRows> l, matrix<T, RCols, RRows> r)
+[[clang::optnone]] matrix<T, RCols, LRows> spvFMulMatrixMatrix(matrix<T, LCols, LRows> l, matrix<T, RCols, RRows> r)
 {
     matrix<T, RCols, LRows> res;
     for (uint i = 0; i < RCols; i++)
@@ -67,13 +67,13 @@ matrix<T, RCols, LRows> spvFMulMatrixMatrix(matrix<T, LCols, LRows> l, matrix<T,
 }
 
 template<typename T>
-T spvFAdd(T l, T r)
+[[clang::optnone]] T spvFAdd(T l, T r)
 {
     return fma(T(1), l, r);
 }
 
 template<typename T>
-T spvFSub(T l, T r)
+[[clang::optnone]] T spvFSub(T l, T r)
 {
     return fma(T(-1), r, l);
 }

--- a/reference/shaders-msl/vert/float-math.invariant-float-math.vert
+++ b/reference/shaders-msl/vert/float-math.invariant-float-math.vert
@@ -69,13 +69,13 @@ struct main0_in
 };
 
 template<typename T>
-T spvFMul(T l, T r)
+[[clang::optnone]] T spvFMul(T l, T r)
 {
     return fma(l, r, T(0));
 }
 
 template<typename T, int Cols, int Rows>
-vec<T, Cols> spvFMulVectorMatrix(vec<T, Rows> v, matrix<T, Cols, Rows> m)
+[[clang::optnone]] vec<T, Cols> spvFMulVectorMatrix(vec<T, Rows> v, matrix<T, Cols, Rows> m)
 {
     vec<T, Cols> res = vec<T, Cols>(0);
     for (uint i = Rows; i > 0; --i)
@@ -91,7 +91,7 @@ vec<T, Cols> spvFMulVectorMatrix(vec<T, Rows> v, matrix<T, Cols, Rows> m)
 }
 
 template<typename T, int Cols, int Rows>
-vec<T, Rows> spvFMulMatrixVector(matrix<T, Cols, Rows> m, vec<T, Cols> v)
+[[clang::optnone]] vec<T, Rows> spvFMulMatrixVector(matrix<T, Cols, Rows> m, vec<T, Cols> v)
 {
     vec<T, Rows> res = vec<T, Rows>(0);
     for (uint i = Cols; i > 0; --i)
@@ -102,7 +102,7 @@ vec<T, Rows> spvFMulMatrixVector(matrix<T, Cols, Rows> m, vec<T, Cols> v)
 }
 
 template<typename T, int LCols, int LRows, int RCols, int RRows>
-matrix<T, RCols, LRows> spvFMulMatrixMatrix(matrix<T, LCols, LRows> l, matrix<T, RCols, RRows> r)
+[[clang::optnone]] matrix<T, RCols, LRows> spvFMulMatrixMatrix(matrix<T, LCols, LRows> l, matrix<T, RCols, RRows> r)
 {
     matrix<T, RCols, LRows> res;
     for (uint i = 0; i < RCols; i++)

--- a/reference/shaders-msl/vert/no-contraction.vert
+++ b/reference/shaders-msl/vert/no-contraction.vert
@@ -18,13 +18,13 @@ struct main0_in
 };
 
 template<typename T>
-T spvFMul(T l, T r)
+[[clang::optnone]] T spvFMul(T l, T r)
 {
     return fma(l, r, T(0));
 }
 
 template<typename T, int Cols, int Rows>
-vec<T, Cols> spvFMulVectorMatrix(vec<T, Rows> v, matrix<T, Cols, Rows> m)
+[[clang::optnone]] vec<T, Cols> spvFMulVectorMatrix(vec<T, Rows> v, matrix<T, Cols, Rows> m)
 {
     vec<T, Cols> res = vec<T, Cols>(0);
     for (uint i = Rows; i > 0; --i)
@@ -40,7 +40,7 @@ vec<T, Cols> spvFMulVectorMatrix(vec<T, Rows> v, matrix<T, Cols, Rows> m)
 }
 
 template<typename T, int Cols, int Rows>
-vec<T, Rows> spvFMulMatrixVector(matrix<T, Cols, Rows> m, vec<T, Cols> v)
+[[clang::optnone]] vec<T, Rows> spvFMulMatrixVector(matrix<T, Cols, Rows> m, vec<T, Cols> v)
 {
     vec<T, Rows> res = vec<T, Rows>(0);
     for (uint i = Cols; i > 0; --i)
@@ -51,7 +51,7 @@ vec<T, Rows> spvFMulMatrixVector(matrix<T, Cols, Rows> m, vec<T, Cols> v)
 }
 
 template<typename T, int LCols, int LRows, int RCols, int RRows>
-matrix<T, RCols, LRows> spvFMulMatrixMatrix(matrix<T, LCols, LRows> l, matrix<T, RCols, RRows> r)
+[[clang::optnone]] matrix<T, RCols, LRows> spvFMulMatrixMatrix(matrix<T, LCols, LRows> l, matrix<T, RCols, RRows> r)
 {
     matrix<T, RCols, LRows> res;
     for (uint i = 0; i < RCols; i++)
@@ -67,13 +67,13 @@ matrix<T, RCols, LRows> spvFMulMatrixMatrix(matrix<T, LCols, LRows> l, matrix<T,
 }
 
 template<typename T>
-T spvFAdd(T l, T r)
+[[clang::optnone]] T spvFAdd(T l, T r)
 {
     return fma(T(1), l, r);
 }
 
 template<typename T>
-T spvFSub(T l, T r)
+[[clang::optnone]] T spvFSub(T l, T r)
 {
     return fma(T(-1), r, l);
 }

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -4928,7 +4928,7 @@ void CompilerMSL::emit_custom_functions()
 		// "fadd" intrinsic support
 		case SPVFuncImplFAdd:
 			statement("template<typename T>");
-			statement("T spvFAdd(T l, T r)");
+			statement("[[clang::optnone]] T spvFAdd(T l, T r)");
 			begin_scope();
 			statement("return fma(T(1), l, r);");
 			end_scope();
@@ -4938,7 +4938,7 @@ void CompilerMSL::emit_custom_functions()
 		// "fsub" intrinsic support
 		case SPVFuncImplFSub:
 			statement("template<typename T>");
-			statement("T spvFSub(T l, T r)");
+			statement("[[clang::optnone]] T spvFSub(T l, T r)");
 			begin_scope();
 			statement("return fma(T(-1), r, l);");
 			end_scope();
@@ -4948,14 +4948,14 @@ void CompilerMSL::emit_custom_functions()
 		// "fmul' intrinsic support
 		case SPVFuncImplFMul:
 			statement("template<typename T>");
-			statement("T spvFMul(T l, T r)");
+			statement("[[clang::optnone]] T spvFMul(T l, T r)");
 			begin_scope();
 			statement("return fma(l, r, T(0));");
 			end_scope();
 			statement("");
 
 			statement("template<typename T, int Cols, int Rows>");
-			statement("vec<T, Cols> spvFMulVectorMatrix(vec<T, Rows> v, matrix<T, Cols, Rows> m)");
+			statement("[[clang::optnone]] vec<T, Cols> spvFMulVectorMatrix(vec<T, Rows> v, matrix<T, Cols, Rows> m)");
 			begin_scope();
 			statement("vec<T, Cols> res = vec<T, Cols>(0);");
 			statement("for (uint i = Rows; i > 0; --i)");
@@ -4972,7 +4972,7 @@ void CompilerMSL::emit_custom_functions()
 			statement("");
 
 			statement("template<typename T, int Cols, int Rows>");
-			statement("vec<T, Rows> spvFMulMatrixVector(matrix<T, Cols, Rows> m, vec<T, Cols> v)");
+			statement("[[clang::optnone]] vec<T, Rows> spvFMulMatrixVector(matrix<T, Cols, Rows> m, vec<T, Cols> v)");
 			begin_scope();
 			statement("vec<T, Rows> res = vec<T, Rows>(0);");
 			statement("for (uint i = Cols; i > 0; --i)");
@@ -4984,8 +4984,7 @@ void CompilerMSL::emit_custom_functions()
 			statement("");
 
 			statement("template<typename T, int LCols, int LRows, int RCols, int RRows>");
-			statement(
-			    "matrix<T, RCols, LRows> spvFMulMatrixMatrix(matrix<T, LCols, LRows> l, matrix<T, RCols, RRows> r)");
+			statement("[[clang::optnone]] matrix<T, RCols, LRows> spvFMulMatrixMatrix(matrix<T, LCols, LRows> l, matrix<T, RCols, RRows> r)");
 			begin_scope();
 			statement("matrix<T, RCols, LRows> res;");
 			statement("for (uint i = 0; i < RCols; i++)");


### PR DESCRIPTION
Add `[[clang::optnone]]` attribute to `spvF*()` functions used for handling floating point operations decorated with `DecorationNoContraction`.

Just using precise::fma() did not work.

Adjust SPIRV-Cross unit test reference shaders to accommodate these changes.