### PR TITLE
MSL: Honor infinities in OpQuantizeToF16 when compiling using fast-math.

### DIFF
--- a/reference/opt/shaders-msl/asm/comp/quantize.asm.comp
+++ b/reference/opt/shaders-msl/asm/comp/quantize.asm.comp
@@ -15,9 +15,7 @@ struct SSBO0
 
 template <typename F> struct SpvHalfTypeSelector;
 template <> struct SpvHalfTypeSelector<float> { public: using H = half; };
-template <> struct SpvHalfTypeSelector<float2> { public: using H = half2; };
-template <> struct SpvHalfTypeSelector<float3> { public: using H = half3; };
-template <> struct SpvHalfTypeSelector<float4> { public: using H = half4; };
+template<uint N> struct SpvHalfTypeSelector<vec<float, N>> { using H = vec<half, N>; };
 template<typename F, typename H = typename SpvHalfTypeSelector<F>::H>
 [[clang::optnone]] F spvQuantizeToF16(F val)
 {

--- a/reference/opt/shaders-msl/asm/comp/quantize.asm.comp
+++ b/reference/opt/shaders-msl/asm/comp/quantize.asm.comp
@@ -1,3 +1,5 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
 #include <metal_stdlib>
 #include <simd/simd.h>
 
@@ -11,11 +13,31 @@ struct SSBO0
     float4 vec4_val;
 };
 
+[[clang::optnone]] float spvQuantizeToF16(float val)
+{
+    return float(half(val));
+}
+
+[[clang::optnone]] float2 spvQuantize2ToF16(float2 val)
+{
+    return float2(half2(val));
+}
+
+[[clang::optnone]] float3 spvQuantize3ToF16(float3 val)
+{
+    return float3(half3(val));
+}
+
+[[clang::optnone]] float4 spvQuantize4ToF16(float4 val)
+{
+    return float4(half4(val));
+}
+
 kernel void main0(device SSBO0& _4 [[buffer(0)]])
 {
-    _4.scalar = float(half(_4.scalar));
-    _4.vec2_val = float2(half2(_4.vec2_val));
-    _4.vec3_val = float3(half3(_4.vec3_val));
-    _4.vec4_val = float4(half4(_4.vec4_val));
+    _4.scalar = spvQuantizeToF16(_4.scalar);
+    _4.vec2_val = spvQuantize2ToF16(_4.vec2_val);
+    _4.vec3_val = spvQuantize3ToF16(_4.vec3_val);
+    _4.vec4_val = spvQuantize4ToF16(_4.vec4_val);
 }
 

--- a/reference/opt/shaders-msl/asm/comp/quantize.asm.comp
+++ b/reference/opt/shaders-msl/asm/comp/quantize.asm.comp
@@ -13,31 +13,22 @@ struct SSBO0
     float4 vec4_val;
 };
 
-[[clang::optnone]] float spvQuantizeToF16(float val)
+template <typename F> struct SpvHalfTypeSelector;
+template <> struct SpvHalfTypeSelector<float> { public: using H = half; };
+template <> struct SpvHalfTypeSelector<float2> { public: using H = half2; };
+template <> struct SpvHalfTypeSelector<float3> { public: using H = half3; };
+template <> struct SpvHalfTypeSelector<float4> { public: using H = half4; };
+template<typename F, typename H = typename SpvHalfTypeSelector<F>::H>
+[[clang::optnone]] F spvQuantizeToF16(F val)
 {
-    return float(half(val));
-}
-
-[[clang::optnone]] float2 spvQuantize2ToF16(float2 val)
-{
-    return float2(half2(val));
-}
-
-[[clang::optnone]] float3 spvQuantize3ToF16(float3 val)
-{
-    return float3(half3(val));
-}
-
-[[clang::optnone]] float4 spvQuantize4ToF16(float4 val)
-{
-    return float4(half4(val));
+    return F(H(val));
 }
 
 kernel void main0(device SSBO0& _4 [[buffer(0)]])
 {
     _4.scalar = spvQuantizeToF16(_4.scalar);
-    _4.vec2_val = spvQuantize2ToF16(_4.vec2_val);
-    _4.vec3_val = spvQuantize3ToF16(_4.vec3_val);
-    _4.vec4_val = spvQuantize4ToF16(_4.vec4_val);
+    _4.vec2_val = spvQuantizeToF16(_4.vec2_val);
+    _4.vec3_val = spvQuantizeToF16(_4.vec3_val);
+    _4.vec4_val = spvQuantizeToF16(_4.vec4_val);
 }
 

--- a/reference/shaders-msl/asm/comp/quantize.asm.comp
+++ b/reference/shaders-msl/asm/comp/quantize.asm.comp
@@ -15,9 +15,7 @@ struct SSBO0
 
 template <typename F> struct SpvHalfTypeSelector;
 template <> struct SpvHalfTypeSelector<float> { public: using H = half; };
-template <> struct SpvHalfTypeSelector<float2> { public: using H = half2; };
-template <> struct SpvHalfTypeSelector<float3> { public: using H = half3; };
-template <> struct SpvHalfTypeSelector<float4> { public: using H = half4; };
+template<uint N> struct SpvHalfTypeSelector<vec<float, N>> { using H = vec<half, N>; };
 template<typename F, typename H = typename SpvHalfTypeSelector<F>::H>
 [[clang::optnone]] F spvQuantizeToF16(F val)
 {

--- a/reference/shaders-msl/asm/comp/quantize.asm.comp
+++ b/reference/shaders-msl/asm/comp/quantize.asm.comp
@@ -1,3 +1,5 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
 #include <metal_stdlib>
 #include <simd/simd.h>
 
@@ -11,11 +13,31 @@ struct SSBO0
     float4 vec4_val;
 };
 
+[[clang::optnone]] float spvQuantizeToF16(float val)
+{
+    return float(half(val));
+}
+
+[[clang::optnone]] float2 spvQuantize2ToF16(float2 val)
+{
+    return float2(half2(val));
+}
+
+[[clang::optnone]] float3 spvQuantize3ToF16(float3 val)
+{
+    return float3(half3(val));
+}
+
+[[clang::optnone]] float4 spvQuantize4ToF16(float4 val)
+{
+    return float4(half4(val));
+}
+
 kernel void main0(device SSBO0& _4 [[buffer(0)]])
 {
-    _4.scalar = float(half(_4.scalar));
-    _4.vec2_val = float2(half2(_4.vec2_val));
-    _4.vec3_val = float3(half3(_4.vec3_val));
-    _4.vec4_val = float4(half4(_4.vec4_val));
+    _4.scalar = spvQuantizeToF16(_4.scalar);
+    _4.vec2_val = spvQuantize2ToF16(_4.vec2_val);
+    _4.vec3_val = spvQuantize3ToF16(_4.vec3_val);
+    _4.vec4_val = spvQuantize4ToF16(_4.vec4_val);
 }
 

--- a/reference/shaders-msl/asm/comp/quantize.asm.comp
+++ b/reference/shaders-msl/asm/comp/quantize.asm.comp
@@ -13,31 +13,22 @@ struct SSBO0
     float4 vec4_val;
 };
 
-[[clang::optnone]] float spvQuantizeToF16(float val)
+template <typename F> struct SpvHalfTypeSelector;
+template <> struct SpvHalfTypeSelector<float> { public: using H = half; };
+template <> struct SpvHalfTypeSelector<float2> { public: using H = half2; };
+template <> struct SpvHalfTypeSelector<float3> { public: using H = half3; };
+template <> struct SpvHalfTypeSelector<float4> { public: using H = half4; };
+template<typename F, typename H = typename SpvHalfTypeSelector<F>::H>
+[[clang::optnone]] F spvQuantizeToF16(F val)
 {
-    return float(half(val));
-}
-
-[[clang::optnone]] float2 spvQuantize2ToF16(float2 val)
-{
-    return float2(half2(val));
-}
-
-[[clang::optnone]] float3 spvQuantize3ToF16(float3 val)
-{
-    return float3(half3(val));
-}
-
-[[clang::optnone]] float4 spvQuantize4ToF16(float4 val)
-{
-    return float4(half4(val));
+    return F(H(val));
 }
 
 kernel void main0(device SSBO0& _4 [[buffer(0)]])
 {
     _4.scalar = spvQuantizeToF16(_4.scalar);
-    _4.vec2_val = spvQuantize2ToF16(_4.vec2_val);
-    _4.vec3_val = spvQuantize3ToF16(_4.vec3_val);
-    _4.vec4_val = spvQuantize4ToF16(_4.vec4_val);
+    _4.vec2_val = spvQuantizeToF16(_4.vec2_val);
+    _4.vec3_val = spvQuantizeToF16(_4.vec3_val);
+    _4.vec4_val = spvQuantizeToF16(_4.vec4_val);
 }
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -5006,9 +5006,7 @@ void CompilerMSL::emit_custom_functions()
 			// SpvHalfTypeSelector is used to match the half* template type to the float* template type.
 			statement("template <typename F> struct SpvHalfTypeSelector;");
 			statement("template <> struct SpvHalfTypeSelector<float> { public: using H = half; };");
-			statement("template <> struct SpvHalfTypeSelector<float2> { public: using H = half2; };");
-			statement("template <> struct SpvHalfTypeSelector<float3> { public: using H = half3; };");
-			statement("template <> struct SpvHalfTypeSelector<float4> { public: using H = half4; };");
+			statement("template<uint N> struct SpvHalfTypeSelector<vec<float, N>> { using H = vec<half, N>; };");
 			statement("template<typename F, typename H = typename SpvHalfTypeSelector<F>::H>");
 			statement("[[clang::optnone]] F spvQuantizeToF16(F val)");
 			begin_scope();

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -5001,6 +5001,33 @@ void CompilerMSL::emit_custom_functions()
 			statement("");
 			break;
 
+		case SPVFuncImplQuantizeToF16:
+			// Ensure fast-math is disabled to match Vulkan results.
+			statement("[[clang::optnone]] float spvQuantizeToF16(float val)");
+			begin_scope();
+			statement("return float(half(val));");
+			end_scope();
+			statement("");
+
+			statement("[[clang::optnone]] float2 spvQuantize2ToF16(float2 val)");
+			begin_scope();
+			statement("return float2(half2(val));");
+			end_scope();
+			statement("");
+
+			statement("[[clang::optnone]] float3 spvQuantize3ToF16(float3 val)");
+			begin_scope();
+			statement("return float3(half3(val));");
+			end_scope();
+			statement("");
+
+			statement("[[clang::optnone]] float4 spvQuantize4ToF16(float4 val)");
+			begin_scope();
+			statement("return float4(half4(val));");
+			end_scope();
+			statement("");
+			break;
+
 		// Emulate texturecube_array with texture2d_array for iOS where this type is not available
 		case SPVFuncImplCubemapTo2DArrayFace:
 			statement(force_inline);
@@ -8071,16 +8098,16 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		switch (type.vecsize)
 		{
 		case 1:
-			exp = join("float(half(", to_expression(arg), "))");
+			exp = join("spvQuantizeToF16(", to_expression(arg), ")");
 			break;
 		case 2:
-			exp = join("float2(half2(", to_expression(arg), "))");
+			exp = join("spvQuantize2ToF16(", to_expression(arg), ")");
 			break;
 		case 3:
-			exp = join("float3(half3(", to_expression(arg), "))");
+			exp = join("spvQuantize3ToF16(", to_expression(arg), ")");
 			break;
 		case 4:
-			exp = join("float4(half4(", to_expression(arg), "))");
+			exp = join("spvQuantize4ToF16(", to_expression(arg), ")");
 			break;
 		default:
 			SPIRV_CROSS_THROW("Illegal argument to OpQuantizeToF16.");
@@ -15053,6 +15080,9 @@ CompilerMSL::SPVFuncImpl CompilerMSL::OpCodePreprocessor::get_spv_func_impl(Op o
 			return SPVFuncImplFMul;
 		}
 		break;
+
+	case OpQuantizeToF16:
+		return SPVFuncImplQuantizeToF16;
 
 	case OpTypeArray:
 	{

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -656,6 +656,7 @@ protected:
 		SPVFuncImplFMul,
 		SPVFuncImplFAdd,
 		SPVFuncImplFSub,
+		SPVFuncImplQuantizeToF16,
 		SPVFuncImplCubemapTo2DArrayFace,
 		SPVFuncImplUnsafeArray, // Allow Metal to use the array<T> template to make arrays a value type
 		SPVFuncImplInverse4x4,


### PR DESCRIPTION
Add `spvQuantizeToF16()` family of synthetic functions to convert from float to half and back again, and add function attribute `[[clang::optnone]]` to honor infinities during conversions.

Adjust SPIRV-Cross unit test reference shaders to accommodate these changes.