### PR TITLE
Per spec, support undefined behavior for out-of-bounds swizzles.

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -8525,7 +8525,7 @@ const char *CompilerGLSL::index_to_swizzle(uint32_t index)
 	case 3:
 		return "w";
 	default:
-		SPIRV_CROSS_THROW("Swizzle index out of range");
+		return "x";		// Don't crash, but engage the "undefined behavior" described for out-of-bounds logical addressing in spec.
 	}
 }
 


### PR DESCRIPTION
Per spec, instead of throwing exception for out-of-bounds swizzles, engage undefined behavior by defaulting to the `.x` swizzle.

Fixes the specific case that drove issue #1778. 