### PR TITLE
MSL: Correctly emit user(clip/cullN) for clip/cull builtins in tess output struct.

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -2251,7 +2251,7 @@ void CompilerMSL::add_plain_variable_to_interface_block(StorageClass storage, co
 			set_member_decoration(ib_type.self, ib_mbr_idx, DecorationComponent, comp);
 		mark_location_as_used_by_shader(locn, get<SPIRType>(type_id), storage);
 	}
-	else if (is_builtin && is_tessellation_shader() && inputs_by_builtin.count(builtin))
+	else if (is_builtin && is_tessellation_shader() && storage == StorageClassInput && inputs_by_builtin.count(builtin))
 	{
 		uint32_t locn = inputs_by_builtin[builtin].location;
 		set_member_decoration(ib_type.self, ib_mbr_idx, DecorationLocation, locn);
@@ -2416,7 +2416,7 @@ void CompilerMSL::add_composite_variable_to_interface_block(StorageClass storage
 				set_member_decoration(ib_type.self, ib_mbr_idx, DecorationComponent, comp);
 			mark_location_as_used_by_shader(locn, *usable_type, storage);
 		}
-		else if (is_builtin && is_tessellation_shader() && inputs_by_builtin.count(builtin))
+		else if (is_builtin && is_tessellation_shader() && storage == StorageClassInput && inputs_by_builtin.count(builtin))
 		{
 			uint32_t locn = inputs_by_builtin[builtin].location + i;
 			set_member_decoration(ib_type.self, ib_mbr_idx, DecorationLocation, locn);
@@ -2589,7 +2589,7 @@ void CompilerMSL::add_composite_member_variable_to_interface_block(StorageClass 
 			set_member_decoration(ib_type.self, ib_mbr_idx, DecorationLocation, locn);
 			mark_location_as_used_by_shader(locn, *usable_type, storage);
 		}
-		else if (is_builtin && is_tessellation_shader() && inputs_by_builtin.count(builtin))
+		else if (is_builtin && is_tessellation_shader() && storage == StorageClassInput && inputs_by_builtin.count(builtin))
 		{
 			uint32_t locn = inputs_by_builtin[builtin].location + i;
 			set_member_decoration(ib_type.self, ib_mbr_idx, DecorationLocation, locn);
@@ -2780,7 +2780,7 @@ void CompilerMSL::add_plain_member_variable_to_interface_block(StorageClass stor
 		set_member_decoration(ib_type.self, ib_mbr_idx, DecorationLocation, locn);
 		mark_location_as_used_by_shader(locn, get<SPIRType>(mbr_type_id), storage);
 	}
-	else if (is_builtin && is_tessellation_shader() && inputs_by_builtin.count(builtin))
+	else if (is_builtin && is_tessellation_shader() && storage == StorageClassInput && inputs_by_builtin.count(builtin))
 	{
 		uint32_t locn = 0;
 		auto builtin_itr = inputs_by_builtin.find(builtin);


### PR DESCRIPTION
Only emit `user(locnN)` for tess builtin input variables, and allow output builtin to emit `user(clip/cullN)`. Previously, output builtin would emit location if input builtin also existed.

Fixes the following CTS tests:

```
dEQP-VK.clipping.user_defined.clip_distance.vert_tess.1_fragmentshader_read
dEQP-VK.clipping.user_defined.clip_distance.vert_tess.2_fragmentshader_read
dEQP-VK.clipping.user_defined.clip_distance.vert_tess.3_fragmentshader_read
dEQP-VK.clipping.user_defined.clip_distance.vert_tess.4_fragmentshader_read
dEQP-VK.clipping.user_defined.clip_distance.vert_tess.5_fragmentshader_read
dEQP-VK.clipping.user_defined.clip_distance.vert_tess.6_fragmentshader_read
dEQP-VK.clipping.user_defined.clip_distance.vert_tess.7_fragmentshader_read
dEQP-VK.clipping.user_defined.clip_distance.vert_tess.8_fragmentshader_read
dEQP-VK.clipping.user_defined.clip_cull_distance.vert_tess.8_fragmentshader_read
```

@cdavis5e Please review for tess compatibility