### PR TITLE
ESSL: Generate correct precision qualifiers & type literal suffix.

### DIFF
--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -894,6 +894,7 @@ protected:
 	const Instruction *get_next_instruction_in_block(const Instruction &instr);
 	static uint32_t mask_relevant_memory_semantics(uint32_t semantics);
 
+	std::string float_to_string_shared(const SPIRConstant &c, uint32_t col, uint32_t row);
 	std::string convert_half_to_string(const SPIRConstant &value, uint32_t col, uint32_t row);
 	std::string convert_float_to_string(const SPIRConstant &value, uint32_t col, uint32_t row);
 	std::string convert_double_to_string(const SPIRConstant &value, uint32_t col, uint32_t row);


### PR DESCRIPTION
When enabling 16 bit types, current implementation uses for example 
'GL_EXT_shader_explicit_arithmetic_types_float16' to support different types. 

It requires an extension('EXT_shader_explicit_arithmetic_types') to be supported.

But for mobile platforms, it's [sufficient](https://developer.arm.com/documentation/101897/0200/shader-code/minimize-precision) to use precision qualifiers to mark the width of float types.
We only need 16bit float & vectors.

So for practical reasons, i made some ESSL related changes to support this behavior: 
```glsl
precision mediump float;
precision highp int;

layout(location = 0) in highp vec4 in_var_TEXCOORD10_centroid;
layout(location = 1) in highp vec4 in_var_TEXCOORD11_centroid;
layout(location = 2) in vec4 in_var_COLOR0;
layout(location = 3) in highp vec4 in_var_TEXCOORD0[2];
layout(location = 5) in vec4 in_var_TEXCOORD7;
layout(location = 6) in highp vec4 in_var_TEXCOORD8;
layout(location = 0) out vec4 out_var_SV_Target0;
layout(location = 1) out vec4 out_var_SV_Target1;
layout(location = 2) out vec4 out_var_SV_Target2;

void main()
{
    highp vec4 _309 = gl_FragCoord;
    _309.w = 0.0 / gl_FragCoord.w;
    highp vec4 param_var_SvPosition = _309;
    vec3 _329 = vec3(in_var_TEXCOORD10_centroid.xyz);
    vec4 _330 = vec4(in_var_TEXCOORD11_centroid);
    vec4 _296 = _330;
    vec3 _333 = _330.xyz;
    mat3 _338 = mat3(_329, cross(_333, _329) * _296.w, _333);
    highp vec2 _228 = vec2(in_var_TEXCOORD0[1u].x, in_var_TEXCOORD0[1u].y);
```