### PR TITLE
Correctly reflect declared buffer size for out of order members.

### DIFF
--- a/reference/shaders-reflection/comp/out-of-order-block-offsets.comp.json
+++ b/reference/shaders-reflection/comp/out-of-order-block-offsets.comp.json
@@ -1,0 +1,44 @@
+{
+    "entryPoints" : [
+        {
+            "name" : "main",
+            "mode" : "comp",
+            "workgroup_size" : [
+                1,
+                1,
+                1
+            ],
+            "workgroup_size_is_spec_constant_id" : [
+                false,
+                false,
+                false
+            ]
+        }
+    ],
+    "types" : {
+        "_7" : {
+            "name" : "SSBO",
+            "members" : [
+                {
+                    "name" : "foo",
+                    "type" : "uint",
+                    "offset" : 8
+                },
+                {
+                    "name" : "bar",
+                    "type" : "uint",
+                    "offset" : 4
+                }
+            ]
+        }
+    },
+    "ssbos" : [
+        {
+            "type" : "_7",
+            "name" : "SSBO",
+            "block_size" : 12,
+            "set" : 0,
+            "binding" : 0
+        }
+    ]
+}

--- a/shaders-reflection/comp/out-of-order-block-offsets.comp
+++ b/shaders-reflection/comp/out-of-order-block-offsets.comp
@@ -1,0 +1,12 @@
+#version 450
+
+layout(set = 0, binding = 0) buffer SSBO
+{
+	layout(offset = 8) uint foo;
+	layout(offset = 4) uint bar;
+};
+
+void main()
+{
+	bar = foo;
+}


### PR DESCRIPTION
Need to deduce size based on member with highest offset, not highest
index.

Fix #1802.