### PR TITLE
GLSL: Deal with buffer_reference_align.

### DIFF
--- a/reference/opt/shaders/vulkan/comp/array-of-buffer-reference.nocompat.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/array-of-buffer-reference.nocompat.vk.comp.vk
@@ -3,7 +3,7 @@
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer Block;
-layout(buffer_reference, std430) buffer Block
+layout(buffer_reference, buffer_reference_align = 4, std430) buffer Block
 {
     float v;
 };

--- a/reference/opt/shaders/vulkan/comp/buffer-reference-atomic.nocompat.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/buffer-reference-atomic.nocompat.vk.comp.vk
@@ -1,0 +1,28 @@
+#version 450
+#extension GL_EXT_buffer_reference : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(buffer_reference) buffer Bar;
+layout(buffer_reference) buffer Foo;
+layout(buffer_reference, buffer_reference_align = 8, std430) buffer Bar
+{
+    uint a;
+    uint b;
+    Foo foo;
+};
+
+layout(buffer_reference, std430) buffer Foo
+{
+    uint v;
+};
+
+layout(push_constant, std430) uniform Push
+{
+    Bar bar;
+} _13;
+
+void main()
+{
+    uint _24 = atomicAdd(_13.bar.b, 1u);
+}
+

--- a/reference/opt/shaders/vulkan/comp/buffer-reference-base-alignment-promote.nocompat.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/buffer-reference-base-alignment-promote.nocompat.vk.comp.vk
@@ -1,0 +1,28 @@
+#version 450
+#extension GL_EXT_buffer_reference : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(buffer_reference) buffer Bar;
+layout(buffer_reference) buffer Foo;
+layout(buffer_reference, buffer_reference_align = 8, std430) buffer Bar
+{
+    uint a;
+    uint b;
+    Foo foo;
+};
+
+layout(buffer_reference, std430) buffer Foo
+{
+    uint v;
+};
+
+layout(push_constant, std430) uniform Push
+{
+    Bar bar;
+} _15;
+
+void main()
+{
+    uint _31 = atomicAdd(_15.bar.a, _15.bar.b);
+}
+

--- a/reference/opt/shaders/vulkan/comp/buffer-reference-bitcast-uvec2-2.nocompat.invalid.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/buffer-reference-bitcast-uvec2-2.nocompat.invalid.vk.comp.vk
@@ -4,7 +4,7 @@
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer PtrInt;
-layout(buffer_reference, std430) buffer PtrInt
+layout(buffer_reference, buffer_reference_align = 4, std430) buffer PtrInt
 {
     int value;
 };

--- a/reference/opt/shaders/vulkan/comp/buffer-reference-bitcast-uvec2.nocompat.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/buffer-reference-bitcast-uvec2.nocompat.vk.comp.vk
@@ -4,7 +4,7 @@
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer PtrInt;
-layout(buffer_reference, std430) buffer PtrInt
+layout(buffer_reference, buffer_reference_align = 16, std430) buffer PtrInt
 {
     int value;
 };

--- a/reference/opt/shaders/vulkan/comp/buffer-reference-bitcast.nocompat.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/buffer-reference-bitcast.nocompat.vk.comp.vk
@@ -4,12 +4,12 @@ layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer PtrUint;
 layout(buffer_reference) buffer PtrInt;
-layout(buffer_reference, std430) buffer PtrUint
+layout(buffer_reference, buffer_reference_align = 4, std430) buffer PtrUint
 {
     uint value;
 };
 
-layout(buffer_reference, std430) buffer PtrInt
+layout(buffer_reference, buffer_reference_align = 16, std430) buffer PtrInt
 {
     int value;
 };

--- a/reference/opt/shaders/vulkan/comp/buffer-reference-decorations.nocompat.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/buffer-reference-decorations.nocompat.vk.comp.vk
@@ -5,17 +5,17 @@ layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 layout(buffer_reference) buffer RO;
 layout(buffer_reference) buffer RW;
 layout(buffer_reference) buffer WO;
-layout(buffer_reference, std430) readonly buffer RO
+layout(buffer_reference, buffer_reference_align = 16, std430) readonly buffer RO
 {
     vec4 v[];
 };
 
-layout(buffer_reference, std430) restrict buffer RW
+layout(buffer_reference, buffer_reference_align = 16, std430) restrict buffer RW
 {
     vec4 v[];
 };
 
-layout(buffer_reference, std430) coherent writeonly buffer WO
+layout(buffer_reference, buffer_reference_align = 16, std430) coherent writeonly buffer WO
 {
     vec4 v[];
 };

--- a/reference/opt/shaders/vulkan/comp/buffer-reference.nocompat.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/buffer-reference.nocompat.vk.comp.vk
@@ -4,7 +4,7 @@
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer Node;
-layout(buffer_reference, std430) buffer Node
+layout(buffer_reference, buffer_reference_align = 16, std430) buffer Node
 {
     layout(offset = 0) int value;
     layout(offset = 16) Node next;

--- a/reference/shaders-no-opt/asm/comp/buffer-reference-aliased-block-name.nocompat.vk.asm.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/buffer-reference-aliased-block-name.nocompat.vk.asm.comp.vk
@@ -5,17 +5,17 @@ layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 layout(buffer_reference) buffer Alias;
 layout(buffer_reference) buffer _6;
 layout(buffer_reference) buffer _7;
-layout(buffer_reference, std430) readonly buffer Alias
+layout(buffer_reference, buffer_reference_align = 16, std430) readonly buffer Alias
 {
     vec4 v[];
 };
 
-layout(buffer_reference, std430) restrict buffer _6
+layout(buffer_reference, buffer_reference_align = 16, std430) restrict buffer _6
 {
     vec4 v[];
 };
 
-layout(buffer_reference, std430) coherent writeonly buffer _7
+layout(buffer_reference, buffer_reference_align = 16, std430) coherent writeonly buffer _7
 {
     vec4 v[];
 };

--- a/reference/shaders-no-opt/asm/comp/buffer-reference-pointer-to-pod-in-buffer.asm.nocompat.vk.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/buffer-reference-pointer-to-pod-in-buffer.asm.nocompat.vk.comp.vk
@@ -1,0 +1,19 @@
+#version 450
+#extension GL_EXT_buffer_reference : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(buffer_reference, buffer_reference_align = 8) buffer uvec4Pointer
+{
+    uvec4 value;
+};
+
+layout(push_constant, std430) uniform Push
+{
+    uvec4Pointer ptr;
+} _4;
+
+void main()
+{
+    _4.ptr.value = uvec4(1u, 2u, 3u, 4u);
+}
+

--- a/reference/shaders-no-opt/asm/comp/buffer-reference-pointer-to-unused-pod-in-buffer.asm.nocompat.vk.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/buffer-reference-pointer-to-unused-pod-in-buffer.asm.nocompat.vk.comp.vk
@@ -1,0 +1,13 @@
+#version 450
+#extension GL_EXT_buffer_reference : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(buffer_reference) buffer uvec4Pointer
+{
+    uvec4 value;
+};
+
+void main()
+{
+}
+

--- a/reference/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer-2.asm.nocompat.vk.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer-2.asm.nocompat.vk.comp.vk
@@ -3,7 +3,7 @@
 #extension GL_EXT_buffer_reference : require
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
-layout(buffer_reference) buffer uintPointer
+layout(buffer_reference, buffer_reference_align = 4) buffer uintPointer
 {
     uint value;
 };

--- a/reference/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer.asm.nocompat.vk.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer.asm.nocompat.vk.comp.vk
@@ -3,7 +3,7 @@
 #extension GL_EXT_buffer_reference : require
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
-layout(buffer_reference) buffer uint0_Pointer
+layout(buffer_reference, buffer_reference_align = 4) buffer uint0_Pointer
 {
     uint value[];
 };

--- a/reference/shaders/vulkan/comp/array-of-buffer-reference.nocompat.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/array-of-buffer-reference.nocompat.vk.comp.vk
@@ -3,7 +3,7 @@
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer Block;
-layout(buffer_reference, std430) buffer Block
+layout(buffer_reference, buffer_reference_align = 4, std430) buffer Block
 {
     float v;
 };

--- a/reference/shaders/vulkan/comp/buffer-reference-atomic.nocompat.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/buffer-reference-atomic.nocompat.vk.comp.vk
@@ -1,0 +1,28 @@
+#version 450
+#extension GL_EXT_buffer_reference : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(buffer_reference) buffer Bar;
+layout(buffer_reference) buffer Foo;
+layout(buffer_reference, buffer_reference_align = 8, std430) buffer Bar
+{
+    uint a;
+    uint b;
+    Foo foo;
+};
+
+layout(buffer_reference, std430) buffer Foo
+{
+    uint v;
+};
+
+layout(push_constant, std430) uniform Push
+{
+    Bar bar;
+} _13;
+
+void main()
+{
+    uint _24 = atomicAdd(_13.bar.b, 1u);
+}
+

--- a/reference/shaders/vulkan/comp/buffer-reference-base-alignment-promote.nocompat.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/buffer-reference-base-alignment-promote.nocompat.vk.comp.vk
@@ -1,0 +1,29 @@
+#version 450
+#extension GL_EXT_buffer_reference : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(buffer_reference) buffer Bar;
+layout(buffer_reference) buffer Foo;
+layout(buffer_reference, buffer_reference_align = 8, std430) buffer Bar
+{
+    uint a;
+    uint b;
+    Foo foo;
+};
+
+layout(buffer_reference, std430) buffer Foo
+{
+    uint v;
+};
+
+layout(push_constant, std430) uniform Push
+{
+    Bar bar;
+} _15;
+
+void main()
+{
+    uint v = _15.bar.b;
+    uint _31 = atomicAdd(_15.bar.a, v);
+}
+

--- a/reference/shaders/vulkan/comp/buffer-reference-bitcast-uvec2-2.nocompat.invalid.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/buffer-reference-bitcast-uvec2-2.nocompat.invalid.vk.comp.vk
@@ -4,7 +4,7 @@
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer PtrInt;
-layout(buffer_reference, std430) buffer PtrInt
+layout(buffer_reference, buffer_reference_align = 4, std430) buffer PtrInt
 {
     int value;
 };

--- a/reference/shaders/vulkan/comp/buffer-reference-bitcast-uvec2.nocompat.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/buffer-reference-bitcast-uvec2.nocompat.vk.comp.vk
@@ -4,7 +4,7 @@
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer PtrInt;
-layout(buffer_reference, std430) buffer PtrInt
+layout(buffer_reference, buffer_reference_align = 16, std430) buffer PtrInt
 {
     int value;
 };

--- a/reference/shaders/vulkan/comp/buffer-reference-bitcast.nocompat.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/buffer-reference-bitcast.nocompat.vk.comp.vk
@@ -4,12 +4,12 @@ layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer PtrUint;
 layout(buffer_reference) buffer PtrInt;
-layout(buffer_reference, std430) buffer PtrUint
+layout(buffer_reference, buffer_reference_align = 4, std430) buffer PtrUint
 {
     uint value;
 };
 
-layout(buffer_reference, std430) buffer PtrInt
+layout(buffer_reference, buffer_reference_align = 16, std430) buffer PtrInt
 {
     int value;
 };

--- a/reference/shaders/vulkan/comp/buffer-reference-decorations.nocompat.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/buffer-reference-decorations.nocompat.vk.comp.vk
@@ -5,17 +5,17 @@ layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 layout(buffer_reference) buffer RO;
 layout(buffer_reference) buffer RW;
 layout(buffer_reference) buffer WO;
-layout(buffer_reference, std430) readonly buffer RO
+layout(buffer_reference, buffer_reference_align = 16, std430) readonly buffer RO
 {
     vec4 v[];
 };
 
-layout(buffer_reference, std430) restrict buffer RW
+layout(buffer_reference, buffer_reference_align = 16, std430) restrict buffer RW
 {
     vec4 v[];
 };
 
-layout(buffer_reference, std430) coherent writeonly buffer WO
+layout(buffer_reference, buffer_reference_align = 16, std430) coherent writeonly buffer WO
 {
     vec4 v[];
 };

--- a/reference/shaders/vulkan/comp/buffer-reference.nocompat.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/buffer-reference.nocompat.vk.comp.vk
@@ -4,7 +4,7 @@
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer Node;
-layout(buffer_reference, std430) buffer Node
+layout(buffer_reference, buffer_reference_align = 16, std430) buffer Node
 {
     layout(offset = 0) int value;
     layout(offset = 16) Node next;

--- a/shaders-no-opt/asm/comp/buffer-reference-pointer-to-pod-in-buffer.asm.nocompat.vk.comp
+++ b/shaders-no-opt/asm/comp/buffer-reference-pointer-to-pod-in-buffer.asm.nocompat.vk.comp
@@ -1,0 +1,44 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 25
+; Schema: 0
+               OpCapability Shader
+               OpCapability PhysicalStorageBufferAddresses
+               OpExtension "SPV_EXT_physical_storage_buffer"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel PhysicalStorageBuffer64 GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_buffer_reference"
+               OpName %main "main"
+               OpName %Push "Push"
+               OpMemberName %Push 0 "ptr"
+               OpName %_ ""
+               OpMemberDecorate %Push 0 Offset 0
+               OpDecorate %Push Block
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %v4uint = OpTypeVector %uint 4
+%_ptr_PhysicalStorageBuffer_uintPtr = OpTypePointer PhysicalStorageBuffer %v4uint
+       %Push = OpTypeStruct %_ptr_PhysicalStorageBuffer_uintPtr
+%_ptr_PushConstant_Push = OpTypePointer PushConstant %Push
+          %_ = OpVariable %_ptr_PushConstant_Push PushConstant
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_PushConstant__ptr_PhysicalStorageBuffer_uintPtr = OpTypePointer PushConstant %_ptr_PhysicalStorageBuffer_uintPtr
+     %uint_1 = OpConstant %uint 1
+     %uint_2 = OpConstant %uint 2
+     %uint_3 = OpConstant %uint 3
+     %uint_4 = OpConstant %uint 4
+         %22 = OpConstantComposite %v4uint %uint_1 %uint_2 %uint_3 %uint_4
+%_ptr_PhysicalStorageBuffer_v4uint = OpTypePointer PhysicalStorageBuffer %v4uint
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %16 = OpAccessChain %_ptr_PushConstant__ptr_PhysicalStorageBuffer_uintPtr %_ %int_0
+         %17 = OpLoad %_ptr_PhysicalStorageBuffer_uintPtr %16
+               OpStore %17 %22 Aligned 8
+               OpReturn
+               OpFunctionEnd

--- a/shaders-no-opt/asm/comp/buffer-reference-pointer-to-unused-pod-in-buffer.asm.nocompat.vk.comp
+++ b/shaders-no-opt/asm/comp/buffer-reference-pointer-to-unused-pod-in-buffer.asm.nocompat.vk.comp
@@ -1,0 +1,44 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 25
+; Schema: 0
+               OpCapability Shader
+               OpCapability PhysicalStorageBufferAddresses
+               OpExtension "SPV_EXT_physical_storage_buffer"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel PhysicalStorageBuffer64 GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_buffer_reference"
+               OpName %main "main"
+               OpName %Push "Push"
+               OpMemberName %Push 0 "ptr"
+               OpName %_ ""
+               OpMemberDecorate %Push 0 Offset 0
+               OpDecorate %Push Block
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %v4uint = OpTypeVector %uint 4
+%_ptr_PhysicalStorageBuffer_uintPtr = OpTypePointer PhysicalStorageBuffer %v4uint
+       %Push = OpTypeStruct %_ptr_PhysicalStorageBuffer_uintPtr
+%_ptr_PushConstant_Push = OpTypePointer PushConstant %Push
+          %_ = OpVariable %_ptr_PushConstant_Push PushConstant
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_PushConstant__ptr_PhysicalStorageBuffer_uintPtr = OpTypePointer PushConstant %_ptr_PhysicalStorageBuffer_uintPtr
+     %uint_1 = OpConstant %uint 1
+     %uint_2 = OpConstant %uint 2
+     %uint_3 = OpConstant %uint 3
+     %uint_4 = OpConstant %uint 4
+         %22 = OpConstantComposite %v4uint %uint_1 %uint_2 %uint_3 %uint_4
+%_ptr_PhysicalStorageBuffer_v4uint = OpTypePointer PhysicalStorageBuffer %v4uint
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         ;%16 = OpAccessChain %_ptr_PushConstant__ptr_PhysicalStorageBuffer_uintPtr %_ %int_0
+         ;%17 = OpLoad %_ptr_PhysicalStorageBuffer_uintPtr %16
+         ;      OpStore %17 %22 Aligned 8
+               OpReturn
+               OpFunctionEnd

--- a/shaders/vulkan/comp/array-of-buffer-reference.nocompat.vk.comp
+++ b/shaders/vulkan/comp/array-of-buffer-reference.nocompat.vk.comp
@@ -2,7 +2,7 @@
 #extension GL_EXT_buffer_reference : require
 layout(local_size_x = 1) in;
 
-layout(buffer_reference) buffer Block
+layout(buffer_reference, buffer_reference_align = 4) buffer Block
 {
 	float v;
 };

--- a/shaders/vulkan/comp/buffer-reference-atomic.nocompat.vk.comp
+++ b/shaders/vulkan/comp/buffer-reference-atomic.nocompat.vk.comp
@@ -1,0 +1,24 @@
+#version 450
+#extension GL_EXT_buffer_reference : require
+
+layout(buffer_reference) buffer Foo
+{
+	uint v;
+};
+
+layout(buffer_reference, buffer_reference_align = 8) buffer Bar
+{
+	uint a;
+	uint b;
+	Foo foo;
+};
+
+layout(push_constant) uniform Push
+{
+	Bar bar;
+};
+
+void main()
+{
+	atomicAdd(bar.b, 1u);
+}

--- a/shaders/vulkan/comp/buffer-reference-base-alignment-promote.nocompat.vk.comp
+++ b/shaders/vulkan/comp/buffer-reference-base-alignment-promote.nocompat.vk.comp
@@ -1,0 +1,25 @@
+#version 450
+#extension GL_EXT_buffer_reference : require
+
+layout(buffer_reference) buffer Foo
+{
+	uint v;
+};
+
+layout(buffer_reference, buffer_reference_align = 8) buffer Bar
+{
+	uint a;
+	uint b;
+	Foo foo;
+};
+
+layout(push_constant) uniform Push
+{
+	Bar bar;
+};
+
+void main()
+{
+	uint v = bar.b;
+	atomicAdd(bar.a, v);
+}

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -592,7 +592,7 @@ protected:
 	void emit_resources();
 	void emit_extension_workarounds(spv::ExecutionModel model);
 	void emit_buffer_block_native(const SPIRVariable &var);
-	void emit_buffer_reference_block(SPIRType &type, bool forward_declaration);
+	void emit_buffer_reference_block(uint32_t type_id, bool forward_declaration);
 	void emit_buffer_block_legacy(const SPIRVariable &var);
 	void emit_buffer_block_flattened(const SPIRVariable &type);
 	void fixup_implicit_builtin_block_names();


### PR DESCRIPTION
This is somewhat awkward to support, but the best effort we can do here
is to analyze various Load/Store opcodes and deduce the ideal overall
alignment based on this. This is not a 100% perfect solution, but should
be correct for any reasonable use case.

Also fix various nitpicks with BDA support while I'm at it.

Fix #1801.