### PR TITLE
MSL: Don't output depth and stencil values with explicit early fragment tests.

### DIFF
--- a/reference/opt/shaders-msl/frag/depth-out-early-frag-tests.frag
+++ b/reference/opt/shaders-msl/frag/depth-out-early-frag-tests.frag
@@ -1,0 +1,19 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 color_out [[color(0)]];
+};
+
+[[ early_fragment_tests ]] fragment main0_out main0()
+{
+    float gl_FragDepth;
+    main0_out out = {};
+    out.color_out = float4(1.0, 0.0, 0.0, 1.0);
+    gl_FragDepth = 0.699999988079071044921875;
+    return out;
+}
+

--- a/reference/opt/shaders-msl/frag/depth-out-no-early-frag-tests.frag
+++ b/reference/opt/shaders-msl/frag/depth-out-no-early-frag-tests.frag
@@ -1,0 +1,19 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 color_out [[color(0)]];
+    float gl_FragDepth [[depth(less)]];
+};
+
+fragment main0_out main0()
+{
+    main0_out out = {};
+    out.color_out = float4(1.0, 0.0, 0.0, 1.0);
+    out.gl_FragDepth = 0.699999988079071044921875;
+    return out;
+}
+

--- a/reference/shaders-msl/frag/depth-out-early-frag-tests.frag
+++ b/reference/shaders-msl/frag/depth-out-early-frag-tests.frag
@@ -1,0 +1,19 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 color_out [[color(0)]];
+};
+
+[[ early_fragment_tests ]] fragment main0_out main0()
+{
+    float gl_FragDepth;
+    main0_out out = {};
+    out.color_out = float4(1.0, 0.0, 0.0, 1.0);
+    gl_FragDepth = 0.699999988079071044921875;
+    return out;
+}
+

--- a/reference/shaders-msl/frag/depth-out-no-early-frag-tests.frag
+++ b/reference/shaders-msl/frag/depth-out-no-early-frag-tests.frag
@@ -1,0 +1,19 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 color_out [[color(0)]];
+    float gl_FragDepth [[depth(less)]];
+};
+
+fragment main0_out main0()
+{
+    main0_out out = {};
+    out.color_out = float4(1.0, 0.0, 0.0, 1.0);
+    out.gl_FragDepth = 0.699999988079071044921875;
+    return out;
+}
+

--- a/shaders-msl/frag/depth-out-early-frag-tests.frag
+++ b/shaders-msl/frag/depth-out-early-frag-tests.frag
@@ -1,0 +1,11 @@
+#version 430
+layout(depth_less) out float gl_FragDepth;
+layout(early_fragment_tests) in;
+
+layout(location = 0) out vec4 color_out;
+
+void main()
+{
+    color_out = vec4(1.0, 0.0, 0.0, 1.0);
+    gl_FragDepth = 0.699999988079071044921875;
+}

--- a/shaders-msl/frag/depth-out-no-early-frag-tests.frag
+++ b/shaders-msl/frag/depth-out-no-early-frag-tests.frag
@@ -1,0 +1,10 @@
+#version 430
+layout(depth_less) out float gl_FragDepth;
+
+layout(location = 0) out vec4 color_out;
+
+void main()
+{
+    color_out = vec4(1.0, 0.0, 0.0, 1.0);
+    gl_FragDepth = 0.699999988079071044921875;
+}

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -932,6 +932,8 @@ protected:
 	void build_implicit_builtins();
 	uint32_t build_constant_uint_array_pointer();
 	void emit_entry_point_declarations() override;
+	bool uses_explicit_early_fragment_test();
+
 	uint32_t builtin_frag_coord_id = 0;
 	uint32_t builtin_sample_id_id = 0;
 	uint32_t builtin_sample_mask_id = 0;


### PR DESCRIPTION
Fragment shaders that require explicit early fragment tests are incompatible with specifying depth and stencil values within the shader. If explicit early fragment tests is specified, remove the depth and stencil outputs from the output structure, and replace them with dummy local variables.

Add `CompilerMSL:uses_explicit_early_fragment_test()` function to consolidate testing for whether early fragment tests are required.

Add two unit tests for depth-out with, and without, early fragment tests.

Fixes #1764.