### PR TITLE
ESSL: Throw if array input var is found in vs.

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -3565,6 +3565,11 @@ void CompilerGLSL::emit_resources()
 		    (var.storage == StorageClassInput || var.storage == StorageClassOutput) &&
 		    interface_variable_exists_in_entry_point(var.self) && !is_hidden)
 		{
+			if (options.es && get_execution_model() == ExecutionModelVertex && var.storage == StorageClassInput &&
+			    type.array.size() == 1)
+			{
+				SPIRV_CROSS_THROW("OpenGL ES doesn't support array input variables in vertex shader.");
+			}
 			emit_interface_block(var);
 			emitted = true;
 		}


### PR DESCRIPTION
Hi, in [OpenGL-ES spec](https://www.khronos.org/registry/OpenGL/specs/es/3.1/GLSL_ES_Specification_3.10.withchanges.pdf), there's a restriction for vertex shader input: 
> It is a compile-time error to declare a vertex shader input with, or that contains, any of the following types:
• A boolean type
• An opaque type
• An array
• A structure

I noticed this because our shader failed to compile both for mali and adreno gpu:

```glsl
// vertex shader
#version 310 es
layout(location = 1) in vec2 in_var_ATTRIBUTE1[3];
```

```bash
// adreno
'attribute 2-component vector of float' : cannot declare arrays of this qualifier
// mali
S0049: Illegal type for input variable 'in_var_ATTRIBUTE1'
```

So i added a check for glsl backend, to report this issue when cross compiling rather than in real devices.