### PR TITLE
Fix incorrect MSL gl_TessCoord variable type

### DIFF
--- a/reference/opt/shaders-msl/asm/tese/unnamed-builtin-array.asm.tese
+++ b/reference/opt/shaders-msl/asm/tese/unnamed-builtin-array.asm.tese
@@ -55,8 +55,9 @@ struct main0_patchIn
     float2 gl_TessLevelInner [[attribute(1)]];
 };
 
-[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoord [[position_in_patch]])
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoordIn [[position_in_patch]])
 {
+    float3 gl_TessCoord = float3(gl_TessCoordIn.x, gl_TessCoordIn.y, 0.0);
     main0_out out = {};
     spvUnsafeArray<float, 2> gl_TessLevelInner = {};
     spvUnsafeArray<float, 4> gl_TessLevelOuter = {};

--- a/reference/opt/shaders-msl/tese/input-array.tese
+++ b/reference/opt/shaders-msl/tese/input-array.tese
@@ -19,8 +19,9 @@ struct main0_patchIn
     patch_control_point<main0_in> gl_in;
 };
 
-[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoord [[position_in_patch]])
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoordIn [[position_in_patch]])
 {
+    float3 gl_TessCoord = float3(gl_TessCoordIn.x, gl_TessCoordIn.y, 0.0);
     main0_out out = {};
     out.gl_Position = (patchIn.gl_in[0].Floats * gl_TessCoord.x) + (patchIn.gl_in[1].Floats2 * gl_TessCoord.y);
     return out;

--- a/reference/opt/shaders-msl/tese/quad.domain.tese
+++ b/reference/opt/shaders-msl/tese/quad.domain.tese
@@ -55,8 +55,9 @@ struct main0_patchIn
     float2 gl_TessLevelInner [[attribute(1)]];
 };
 
-[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoord [[position_in_patch]])
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoordIn [[position_in_patch]])
 {
+    float3 gl_TessCoord = float3(gl_TessCoordIn.x, gl_TessCoordIn.y, 0.0);
     main0_out out = {};
     spvUnsafeArray<float, 2> gl_TessLevelInner = {};
     spvUnsafeArray<float, 4> gl_TessLevelOuter = {};

--- a/reference/opt/shaders-msl/tese/quad.tese
+++ b/reference/opt/shaders-msl/tese/quad.tese
@@ -55,8 +55,9 @@ struct main0_patchIn
     float2 gl_TessLevelInner [[attribute(1)]];
 };
 
-[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoord [[position_in_patch]])
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoordIn [[position_in_patch]])
 {
+    float3 gl_TessCoord = float3(gl_TessCoordIn.x, gl_TessCoordIn.y, 0.0);
     main0_out out = {};
     spvUnsafeArray<float, 2> gl_TessLevelInner = {};
     spvUnsafeArray<float, 4> gl_TessLevelOuter = {};

--- a/reference/opt/shaders-msl/tese/water_tess.tese
+++ b/reference/opt/shaders-msl/tese/water_tess.tese
@@ -26,12 +26,13 @@ struct main0_patchIn
     float4 vPatchLods [[attribute(1)]];
 };
 
-[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], constant UBO& _31 [[buffer(0)]], texture2d<float> uHeightmapDisplacement [[texture(0)]], sampler uHeightmapDisplacementSmplr [[sampler(0)]], float2 gl_TessCoord [[position_in_patch]])
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], constant UBO& _31 [[buffer(0)]], texture2d<float> uHeightmapDisplacement [[texture(0)]], sampler uHeightmapDisplacementSmplr [[sampler(0)]], float2 gl_TessCoordIn [[position_in_patch]])
 {
+    float3 gl_TessCoord = float3(gl_TessCoordIn.x, gl_TessCoordIn.y, 0.0);
     main0_out out = {};
-    float2 _202 = patchIn.vOutPatchPosBase + (float3(gl_TessCoord, 0).xy * _31.uPatchSize);
-    float2 _216 = mix(patchIn.vPatchLods.yx, patchIn.vPatchLods.zw, float2(float3(gl_TessCoord, 0).x));
-    float _223 = mix(_216.x, _216.y, float3(gl_TessCoord, 0).y);
+    float2 _202 = patchIn.vOutPatchPosBase + (gl_TessCoord.xy * _31.uPatchSize);
+    float2 _216 = mix(patchIn.vPatchLods.yx, patchIn.vPatchLods.zw, float2(gl_TessCoord.x));
+    float _223 = mix(_216.x, _216.y, gl_TessCoord.y);
     float _225 = floor(_223);
     float2 _125 = _202 * _31.uInvHeightmapSize;
     float2 _141 = _31.uInvHeightmapSize * exp2(_225);

--- a/reference/shaders-msl/asm/tese/unnamed-builtin-array.asm.tese
+++ b/reference/shaders-msl/asm/tese/unnamed-builtin-array.asm.tese
@@ -55,8 +55,9 @@ struct main0_patchIn
     float2 gl_TessLevelInner [[attribute(1)]];
 };
 
-[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoord [[position_in_patch]])
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoordIn [[position_in_patch]])
 {
+    float3 gl_TessCoord = float3(gl_TessCoordIn.x, gl_TessCoordIn.y, 0.0);
     main0_out out = {};
     spvUnsafeArray<float, 2> gl_TessLevelInner = {};
     spvUnsafeArray<float, 4> gl_TessLevelOuter = {};

--- a/reference/shaders-msl/tese/input-array.tese
+++ b/reference/shaders-msl/tese/input-array.tese
@@ -22,13 +22,14 @@ struct main0_patchIn
 };
 
 static inline __attribute__((always_inline))
-void set_position(thread float4& gl_Position, thread patch_control_point<main0_in>& gl_in, thread float2& gl_TessCoord)
+void set_position(thread float4& gl_Position, thread patch_control_point<main0_in>& gl_in, thread float3& gl_TessCoord)
 {
     gl_Position = (gl_in[0].Floats * gl_TessCoord.x) + (gl_in[1].Floats2 * gl_TessCoord.y);
 }
 
-[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoord [[position_in_patch]])
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoordIn [[position_in_patch]])
 {
+    float3 gl_TessCoord = float3(gl_TessCoordIn.x, gl_TessCoordIn.y, 0.0);
     main0_out out = {};
     set_position(out.gl_Position, patchIn.gl_in, gl_TessCoord);
     return out;

--- a/reference/shaders-msl/tese/quad.domain.tese
+++ b/reference/shaders-msl/tese/quad.domain.tese
@@ -55,8 +55,9 @@ struct main0_patchIn
     float2 gl_TessLevelInner [[attribute(1)]];
 };
 
-[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoord [[position_in_patch]])
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoordIn [[position_in_patch]])
 {
+    float3 gl_TessCoord = float3(gl_TessCoordIn.x, gl_TessCoordIn.y, 0.0);
     main0_out out = {};
     spvUnsafeArray<float, 2> gl_TessLevelInner = {};
     spvUnsafeArray<float, 4> gl_TessLevelOuter = {};

--- a/reference/shaders-msl/tese/quad.tese
+++ b/reference/shaders-msl/tese/quad.tese
@@ -56,13 +56,14 @@ struct main0_patchIn
 };
 
 static inline __attribute__((always_inline))
-void set_position(thread float4& gl_Position, thread float2& gl_TessCoord, thread spvUnsafeArray<float, 2>& gl_TessLevelInner, thread spvUnsafeArray<float, 4>& gl_TessLevelOuter)
+void set_position(thread float4& gl_Position, thread float3& gl_TessCoord, thread spvUnsafeArray<float, 2>& gl_TessLevelInner, thread spvUnsafeArray<float, 4>& gl_TessLevelOuter)
 {
     gl_Position = float4(((gl_TessCoord.x * gl_TessLevelInner[0]) * gl_TessLevelOuter[0]) + (((1.0 - gl_TessCoord.x) * gl_TessLevelInner[0]) * gl_TessLevelOuter[2]), ((gl_TessCoord.y * gl_TessLevelInner[1]) * gl_TessLevelOuter[1]) + (((1.0 - gl_TessCoord.y) * gl_TessLevelInner[1]) * gl_TessLevelOuter[3]), 0.0, 1.0);
 }
 
-[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoord [[position_in_patch]])
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], float2 gl_TessCoordIn [[position_in_patch]])
 {
+    float3 gl_TessCoord = float3(gl_TessCoordIn.x, gl_TessCoordIn.y, 0.0);
     main0_out out = {};
     spvUnsafeArray<float, 2> gl_TessLevelInner = {};
     spvUnsafeArray<float, 4> gl_TessLevelOuter = {};

--- a/reference/shaders-msl/tese/water_tess.tese
+++ b/reference/shaders-msl/tese/water_tess.tese
@@ -50,10 +50,11 @@ float3 sample_height_displacement(thread const float2& uv, thread const float2& 
     return mix(uHeightmapDisplacement.sample(uHeightmapDisplacementSmplr, (uv + (off * 0.5)), level(lod.x)).xyz, uHeightmapDisplacement.sample(uHeightmapDisplacementSmplr, (uv + (off * 1.0)), level(lod.x + 1.0)).xyz, float3(lod.y));
 }
 
-[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], constant UBO& v_31 [[buffer(0)]], texture2d<float> uHeightmapDisplacement [[texture(0)]], sampler uHeightmapDisplacementSmplr [[sampler(0)]], float2 gl_TessCoord [[position_in_patch]])
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], constant UBO& v_31 [[buffer(0)]], texture2d<float> uHeightmapDisplacement [[texture(0)]], sampler uHeightmapDisplacementSmplr [[sampler(0)]], float2 gl_TessCoordIn [[position_in_patch]])
 {
+    float3 gl_TessCoord = float3(gl_TessCoordIn.x, gl_TessCoordIn.y, 0.0);
     main0_out out = {};
-    float2 tess_coord = float3(gl_TessCoord, 0).xy;
+    float2 tess_coord = gl_TessCoord.xy;
     float2 param = tess_coord;
     float2 pos = lerp_vertex(param, patchIn.vOutPatchPosBase, v_31);
     float2 param_1 = tess_coord;

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1322,8 +1322,33 @@ void CompilerMSL::emit_entry_point_declarations()
 	if (get_entry_point().model == ExecutionModelTessellationEvaluation &&
 	    get_entry_point().flags.get(ExecutionModeQuads))
 	{
-		auto name = builtin_to_glsl(BuiltInTessCoord, StorageClassFunction);
-		statement("const float3 " + name + " = float3(" + name + "In.x, " + name + "In.y, 0.0);");
+		ir.for_each_typed_id<SPIRVariable>([&](uint32_t var_id, SPIRVariable &var)
+		{
+			if (var.storage != StorageClassInput)
+				return;
+
+			auto bi_type = BuiltIn(get_decoration(var_id, DecorationBuiltIn));
+
+			// Don't emit SamplePosition as a separate parameter. In the entry
+			// point, we get that by calling get_sample_position() on the sample ID.
+			if (is_builtin_variable(var) &&
+			    get_variable_data_type(var).basetype != SPIRType::Struct &&
+			    get_variable_data_type(var).basetype != SPIRType::ControlPointArray)
+			{
+				// If the builtin is not part of the active input builtin set, don't emit it.
+				// Relevant for multiple entry-point modules which might declare unused builtins.
+				if (!active_input_builtins.get(bi_type) || !interface_variable_exists_in_entry_point(var_id))
+					return;
+
+				if (is_direct_input_builtin(bi_type) && bi_type == BuiltInTessCoord)
+				{
+					builtin_declaration = true;
+					auto name = builtin_to_glsl(BuiltInTessCoord, StorageClassInput);
+					statement("float3 " + name + " = float3(" + name + "In.x, " + name + "In.y, 0.0);");
+					builtin_declaration = false;
+				}
+			}
+		});
 	}
 }
 
@@ -11457,11 +11482,12 @@ void CompilerMSL::entry_point_args_builtin(string &ep_args)
 
 				// Handle HLSL-style 0-based vertex/instance index.
 				builtin_declaration = true;
-				ep_args += builtin_type_decl(bi_type, var_id) + " " + to_expression(var_id);
 
 				// Handle different MSL gl_TessCoord types. (float2, float3)
 				if (bi_type == BuiltInTessCoord && get_entry_point().flags.get(ExecutionModeQuads))
-					ep_args += "In";
+					ep_args += "float2 " + to_expression(var_id) + "In";
+				else
+					ep_args += builtin_type_decl(bi_type, var_id) + " " + to_expression(var_id);
 
 				ep_args += " [[" + builtin_qualifier(bi_type);
 				if (bi_type == BuiltInSampleMask && get_entry_point().flags.get(ExecutionModePostDepthCoverage))
@@ -14594,7 +14620,7 @@ string CompilerMSL::builtin_type_decl(BuiltIn builtin, uint32_t id)
 
 	// Tess. evaluation function in
 	case BuiltInTessCoord:
-		return execution.flags.get(ExecutionModeQuads) ? "float2" : "float3";
+		return "float3";
 
 	// Fragment function in
 	case BuiltInFrontFacing:
@@ -15545,13 +15571,6 @@ void CompilerMSL::cast_from_variable_load(uint32_t source_id, std::string &expr,
 			else
 				expr = bitcast_expression(expr_type, expected_type, expr);
 		}
-	}
-
-	if (builtin == BuiltInTessCoord && get_entry_point().flags.get(ExecutionModeQuads) && expr_type.vecsize == 3)
-	{
-		// In SPIR-V, this is always a vec3, even for quads. In Metal, though, it's a float2 for quads.
-		// The code is expecting a float3, so we need to widen this.
-		expr = join("float3(", expr, ", 0)");
 	}
 }
 


### PR DESCRIPTION
Fix for this issue #1762.

Adds "In" postfix to the "gl_TessCoord" on entry point arguments decompilation stage if built in type is "BuiltInTessCoord" and execution mode is "ExecutionModeQuads". And declares shadow  variable "gl_TessCoord" on entry point declarations.

I have compiled and tested it with VK-GL-CTS, looks like it now works as expected.