### PR TITLE
GLSL: Use trinary to prevent percision issues.

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -6396,6 +6396,11 @@ void CompilerGLSL::emit_mix_op(uint32_t result_type, uint32_t id, uint32_t left,
 	// fall back to regular trinary statements.
 	if (lerptype.vecsize == 1)
 		has_boolean_mix = false;
+	
+	// Multiple sequencial OpSelect might introduce percision issues, 
+	// fall back to trinary for safety.
+	if (expression_type(left).basetype == SPIRType::Float || expression_type(left).basetype == SPIRType::Half)
+		has_boolean_mix = false;
 
 	// If we can reduce the mix to a simple cast, do so.
 	// This helps for cases like int(bool), uint(bool) which is implemented with


### PR DESCRIPTION
Hi, i'm using dxc to cross compile our shaders. 
And i found a bug when rendering terrain (lower image):
![image](https://user-images.githubusercontent.com/1331120/147658834-4b0ce481-bd13-4bc4-bcfb-2da7770966f5.png)

We use branch in hlsl to perform swap op:
```hlsl
void CompareAndSwap(inout MaterialFloat2 LHS, inout MaterialFloat2 RHS) {
    if (RHS.x > LHS.x) {
        MaterialFloat2 Temp = LHS;
        LHS = RHS;
        RHS = Temp;
    }
}
```

And it's optimized to mix/select in glsl/msl, which introduces render artifacts show above.
After some investigation, i found that it 's related to using multiple mix ops.
Change to trinary statements fixes the bug, i think using many mix ops together might introduce precision issues.
We might need to use trinary when OpSelecting float data types? 

```glsl
// mix approach
    bvec2 _253 = bvec2(2.0 > _247);
    highp vec2 _254 = mix(_251, vec2(2.0), _253);
    highp vec2 _255 = mix(vec2(2.0), _251, _253);
    bvec2 _258 = bvec2(1.0 > _255.x);
    highp vec2 _259 = mix(_255, vec2(1.0), _258);
    highp vec2 _260 = mix(vec2(1.0), _255, _258);
    highp vec2 _265 = mix(_260, vec2(_250, 3.0), bvec2(_250 > _260.x));
    bvec2 _269 = bvec2(_265.x > _259.x);
    highp vec2 _270 = mix(_265, _259, _269);
    highp vec2 _271 = mix(_259, _265, _269);
    bvec2 _275 = bvec2(_271.x > _254.x);
    highp vec2 _276 = mix(_254, _271, _275);
    highp vec2 _277 = mix(_271, _254, _275);
    bvec2 _281 = bvec2(_270.x > _277.x);
    highp vec2 _282 = mix(_277, _270, _281);
    highp vec2 _283 = mix(_270, _277, _281);
    bvec2 _287 = bvec2(_283.y < _282.y);
    highp vec2 _288 = mix(_283, _282, _287);
    highp vec2 _289 = mix(_282, _283, _287);
    bvec2 _293 = bvec2(_289.y < _276.y);
    highp vec2 _294 = mix(_276, _289, _293);
    highp vec2 _295 = mix(_289, _276, _293);
    bvec2 _299 = bvec2(_288.y < _295.y);
    highp vec2 _300 = mix(_295, _288, _299);
    highp vec2 _301 = mix(_288, _295, _299);
// trinary 
    bvec2 _278 = bvec2(2.0 > _272);
    highp vec2 _279 = vec2(_278.x ? vec2(2.0).x : _276.x, _278.y ? vec2(2.0).y : _276.y);
    highp vec2 _280 = vec2(_278.x ? _276.x : vec2(2.0).x, _278.y ? _276.y : vec2(2.0).y);
    bvec2 _283 = bvec2(1.0 > _280.x);
    highp vec2 _284 = vec2(_283.x ? vec2(1.0).x : _280.x, _283.y ? vec2(1.0).y : _280.y);
    highp vec2 _285 = vec2(_283.x ? _280.x : vec2(1.0).x, _283.y ? _280.y : vec2(1.0).y);
    highp vec2 _286 = vec2(_275, 3.0);
    bvec2 _289 = bvec2(_275 > _285.x);
    highp vec2 _290 = vec2(_289.x ? _286.x : _285.x, _289.y ? _286.y : _285.y);
    bvec2 _294 = bvec2(_290.x > _284.x);
    highp vec2 _295 = vec2(_294.x ? _284.x : _290.x, _294.y ? _284.y : _290.y);
    highp vec2 _296 = vec2(_294.x ? _290.x : _284.x, _294.y ? _290.y : _284.y);
    bvec2 _300 = bvec2(_296.x > _279.x);
    highp vec2 _301 = vec2(_300.x ? _296.x : _279.x, _300.y ? _296.y : _279.y);
    highp vec2 _302 = vec2(_300.x ? _279.x : _296.x, _300.y ? _279.y : _296.y);
    bvec2 _306 = bvec2(_295.x > _302.x);
    highp vec2 _307 = vec2(_306.x ? _295.x : _302.x, _306.y ? _295.y : _302.y);
    highp vec2 _308 = vec2(_306.x ? _302.x : _295.x, _306.y ? _302.y : _295.y);
    bvec2 _312 = bvec2(_308.y < _307.y);
    highp vec2 _313 = vec2(_312.x ? _307.x : _308.x, _312.y ? _307.y : _308.y);
    highp vec2 _314 = vec2(_312.x ? _308.x : _307.x, _312.y ? _308.y : _307.y);
    bvec2 _318 = bvec2(_314.y < _301.y);
    highp vec2 _319 = vec2(_318.x ? _314.x : _301.x, _318.y ? _314.y : _301.y);
    highp vec2 _320 = vec2(_318.x ? _301.x : _314.x, _318.y ? _301.y : _314.y);
    bvec2 _324 = bvec2(_313.y < _320.y);
    highp vec2 _325 = vec2(_324.x ? _313.x : _320.x, _324.y ? _313.y : _320.y);
    highp vec2 _326 = vec2(_324.x ? _320.x : _313.x, _324.y ? _320.y : _313.y);
```