### PR TITLE
[Spirv_msl] Fix normalize on half3/half2

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -9165,13 +9165,13 @@ void CompilerMSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop, 
 
 	case GLSLstd450Normalize:
 	{
-		auto& exp_type = expression_type(args[0]);
+		auto &exp_type = expression_type(args[0]);
 		// MSL does not support scalar versions here.
 		// MSL has no implementation for normalize in the fast:: namespace for half2 and half3
 		// Returns -1 or 1 for valid input, sign() does the job.
 		if (exp_type.vecsize == 1)
 			emit_unary_func_op(result_type, id, args[0], "sign");
-		else if (exp_type.vecsize <= 3 && exp_type.basetype == spirv_cross::SPIRType::Half)
+		else if (exp_type.vecsize <= 3 && exp_type.basetype == SPIRType::Half)
 			emit_unary_func_op(result_type, id, args[0], "normalize");
 		else
 			emit_unary_func_op(result_type, id, args[0], "fast::normalize");

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -9165,9 +9165,12 @@ void CompilerMSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop, 
 
 	case GLSLstd450Normalize:
 		// MSL does not support scalar versions here.
+		// MSL has no implementation for normalize in the fast:: namespace for half2 and half3
 		// Returns -1 or 1 for valid input, sign() does the job.
 		if (expression_type(args[0]).vecsize == 1)
 			emit_unary_func_op(result_type, id, args[0], "sign");
+		else if (expression_type(args[0]).vecsize <= 3 && (get<SPIRType>(args[0]).basetype == spirv_cross::SPIRType::Half) )
+			emit_unary_func_op(result_type, id, args[0], "normalize");
 		else
 			emit_unary_func_op(result_type, id, args[0], "fast::normalize");
 		break;

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -9164,17 +9164,19 @@ void CompilerMSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop, 
 		break;
 
 	case GLSLstd450Normalize:
+	{
+		auto& exp_type = expression_type(args[0]);
 		// MSL does not support scalar versions here.
 		// MSL has no implementation for normalize in the fast:: namespace for half2 and half3
 		// Returns -1 or 1 for valid input, sign() does the job.
-		if (expression_type(args[0]).vecsize == 1)
+		if (exp_type.vecsize == 1)
 			emit_unary_func_op(result_type, id, args[0], "sign");
-		else if (expression_type(args[0]).vecsize <= 3 && (get<SPIRType>(args[0]).basetype == spirv_cross::SPIRType::Half) )
+		else if (exp_type.vecsize <= 3 && exp_type.basetype == spirv_cross::SPIRType::Half)
 			emit_unary_func_op(result_type, id, args[0], "normalize");
 		else
 			emit_unary_func_op(result_type, id, args[0], "fast::normalize");
 		break;
-
+	}
 	case GLSLstd450Reflect:
 		if (get<SPIRType>(result_type).vecsize == 1)
 			emit_binary_func_op(result_type, id, args[0], args[1], "spvReflect");


### PR DESCRIPTION
Msl implementation of the fast and precise namespace is not guarenteed  for half by the specification and will break in some cases.

Calling fast::normalize with a half3 or a half2 as parameters will not compile, because thoses are not implemented (reproducible when targeting mac or ios, last version tested with Xcode-12.5.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/metal) .

Peaking at the msl documentation: https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf, support is only explicitly stated for single precision floating point

```
For single precision floating-point, Metal supports two variants of the math functions listed in
Table 6.4: the precise and the fast variants. The ffast-math compiler option (refer to section
1.5.3) selects the appropriate variant when compiling the Metal source. In addition, the
metal::precise and metal::fast nested namespaces provide an explicit way to select the
fast or precise variant of these math functions for single precision floating-point.
```

This pull request use a regular normalize instead of fast normalize for half3 and half2. fast normalize is implemented for half4 and scalar values are a special case already.