### PR TITLE
MSL: append entry point args to local variable names to avoid conflicts

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -9335,6 +9335,9 @@ void CompilerMSL::emit_function_prototype(SPIRFunction &func, const Bitset &)
 		else
 			decl += entry_point_args_classic(!func.arguments.empty());
 
+		// append entry point args to avoid conflicts in local variable names.
+		local_variable_names.insert(resource_names.begin(), resource_names.end());
+
 		// If entry point function has variables that require early declaration,
 		// ensure they each have an empty initializer, creating one if needed.
 		// This is done at this late stage because the initialization expression


### PR DESCRIPTION
example:
```
#version 310 es
precision highp float;

layout(location = 0) out vec4 FragColor;
layout(binding = 0) uniform sampler2D texSampler2D;
layout(binding = 1) uniform ALPHA {
        float alpha;
} alpha;

void main()
{
        vec4 alpha = vec4(alpha.alpha);
        vec4 texColor = texture(texSampler2D, vec2(0.0, 0.0));
        texColor.xyz += alpha.xyz;
        FragColor = texColor;
}
```

before:
```
#include <metal_stdlib>
#include <simd/simd.h>

using namespace metal;

struct ALPHA
{
    float alpha;
};

struct main0_out
{
    float4 FragColor [[color(0)]];
};

fragment main0_out main0(constant ALPHA& alpha [[buffer(0)]], texture2d<float> texSampler2D [[texture(0)]], sampler texSampler2DSmplr [[sampler(0)]])
{
    main0_out out = {};
    float4 alpha = float4(alpha.alpha);
    float4 texColor = texSampler2D.sample(texSampler2DSmplr, float2(0.0));
    float4 _32 = texColor;
    float3 _34 = _32.xyz + alpha.xyz;
    texColor.x = _34.x;
    texColor.y = _34.y;
    texColor.z = _34.z;
    out.FragColor = texColor;
    return out;
}
```

the local variable `float4 alpha` is conflicted by `alpha` argument in main0