### PR TITLE
Qualify move as std::move

### DIFF
--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -690,7 +690,7 @@ struct SPIRExpression : IVariant
 
 	// Only created by the backend target to avoid creating tons of temporaries.
 	SPIRExpression(std::string expr, TypeID expression_type_, bool immutable_)
-	    : expression(move(expr))
+	    : expression(std::move(expr))
 	    , expression_type(expression_type_)
 	    , immutable(immutable_)
 	{


### PR DESCRIPTION
Seeing downstream errors:
"spirv_common.hpp:692:19: error: unqualified call to std::move"