### PR TITLE
HLSL: Do not emit VPOS fixup unless position is active.

### DIFF
--- a/reference/shaders-hlsl-no-opt/vert/empty-shader.sm30.vert
+++ b/reference/shaders-hlsl-no-opt/vert/empty-shader.sm30.vert
@@ -1,0 +1,8 @@
+void vert_main()
+{
+}
+
+void main()
+{
+    vert_main();
+}

--- a/shaders-hlsl-no-opt/vert/empty-shader.sm30.vert
+++ b/shaders-hlsl-no-opt/vert/empty-shader.sm30.vert
@@ -1,0 +1,5 @@
+#version 450
+
+void main()
+{
+}

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1335,7 +1335,8 @@ void CompilerHLSL::emit_resources()
 		}
 	});
 
-	if (execution.model == ExecutionModelVertex && hlsl_options.shader_model <= 30)
+	if (execution.model == ExecutionModelVertex && hlsl_options.shader_model <= 30 &&
+	    active_output_builtins.get(BuiltInPosition))
 	{
 		statement("uniform float4 gl_HalfPixel;");
 		emitted = true;
@@ -2739,7 +2740,7 @@ void CompilerHLSL::emit_hlsl_entry_point()
 
 void CompilerHLSL::emit_fixup()
 {
-	if (is_vertex_like_shader())
+	if (is_vertex_like_shader() && active_output_builtins.get(BuiltInPosition))
 	{
 		// Do various mangling on the gl_Position.
 		if (hlsl_options.shader_model <= 30)


### PR DESCRIPTION
Fix #1861.