### PR TITLE
HLSL: Add support for gl_HelperInvocation.

### DIFF
--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -728,6 +728,11 @@ void CompilerHLSL::emit_builtin_inputs_in_struct()
 			// Handled specially.
 			break;
 
+		case BuiltInHelperInvocation:
+			if (hlsl_options.shader_model < 50 || (get_entry_point().model != ExecutionModelFragment && get_entry_point().model != ExecutionModelGLCompute))
+				SPIRV_CROSS_THROW("Helper Invocation input is only supported in PS 5.0 or higher.");
+			break;
+
 		case BuiltInClipDistance:
 			// HLSL is a bit weird here, use SV_ClipDistance0, SV_ClipDistance1 and so on with vectors.
 			for (uint32_t clip = 0; clip < clip_distance_count; clip += 4)
@@ -984,6 +989,8 @@ std::string CompilerHLSL::builtin_to_glsl(spv::BuiltIn builtin, spv::StorageClas
 		return "WaveGetLaneIndex()";
 	case BuiltInSubgroupSize:
 		return "WaveGetLaneCount()";
+	case BuiltInHelperInvocation:
+		return "IsHelperLane()";
 
 	default:
 		return CompilerGLSL::builtin_to_glsl(builtin, storage);
@@ -1101,6 +1108,11 @@ void CompilerHLSL::emit_builtin_variables()
 			if (hlsl_options.shader_model < 60)
 				SPIRV_CROSS_THROW("Need SM 6.0 for Wave ops.");
 			type = "uint4";
+			break;
+
+		case BuiltInHelperInvocation:
+			if (hlsl_options.shader_model < 50)
+				SPIRV_CROSS_THROW("Need SM 5.0 for Helper Invocation.");
 			break;
 
 		case BuiltInClipDistance:
@@ -2521,6 +2533,7 @@ void CompilerHLSL::emit_hlsl_entry_point()
 		case BuiltInPointCoord:
 		case BuiltInSubgroupSize:
 		case BuiltInSubgroupLocalInvocationId:
+		case BuiltInHelperInvocation:
 			break;
 
 		case BuiltInSubgroupEqMask:


### PR DESCRIPTION
~If targeting SM >= 6.6, `IsHelperLane()` is used.~

~It targeting SM >= 5.0 and < 6.6, the same emulation that DXC does is done here; namely, casting `SV_Coverage` to `bool`.~

**UPDATE:**
`IsHelperLane()` will be used in any case, as long as the ninimum shader model is being targeted.
Kept the old info below the line for possible future reference.

---

NOTES:
- Since a DXC compiler recent enough version is able to understand `IsHelperLane()`, SPIRV-Cross could just emit that, but I believe it's better to do the emulation right here in case users are using an older version of the compiler.
- Curiously, DXC is able to emulate via `@dx.op.coverage` even in `ps_4_0`, despite `SV_Coverage` allegedly not being supported there. In this case DXC would do a better job of emulating it. Maybe it can even digest `SV_Coverage` in `ps_4_0`. I haven't tested. In any case, this PR as it is may be already good enough as an improvement over the current state of things.

References:
- https://microsoft.github.io/DirectX-Specs/d3d/HLSL_ShaderModel6_6.html, for the mention of `IsHelperLane()` being emulated for older SMs.
- https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-semantics, where it's stated that `SV_Coverage` requires `ps_5_0`.

Elaborating on DXC behavior, consider the following HLSL file:
```
float4 main() : SV_Target
{
	return IsHelperLane() ? float4(1, 1, 1, 1) :  float4(0, 0, 0, 0);
}
```

Check the output of it targeting PS 4.0 (which is exactly the same for 5.0 and 6.0) and 6.6: [dxc_experiment.zip](https://github.com/KhronosGroup/SPIRV-Cross/files/8180824/dxc_experiment.zip) 