### PR TITLE
Support OpTerminateInvocation as synonym of the deprecated OpKill.

### DIFF
--- a/spirv_parser.cpp
+++ b/spirv_parser.cpp
@@ -1067,6 +1067,7 @@ void Parser::parse(const Instruction &instruction)
 	}
 
 	case OpKill:
+	case OpTerminateInvocation:
 	{
 		if (!current_block)
 			SPIRV_CROSS_THROW("Trying to end a non-existing block.");


### PR DESCRIPTION
Reference: https://www.khronos.org/registry/SPIR-V/specs/unified1/SPIRV.html#OpKill