### PR TITLE
Add corner case for structs containing templated arrays

### DIFF
--- a/reference/opt/shaders-msl/asm/frag/offset-decorator-can-be-ignored.asm.frag
+++ b/reference/opt/shaders-msl/asm/frag/offset-decorator-can-be-ignored.asm.frag
@@ -1,0 +1,9 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+fragment void main0()
+{
+}
+

--- a/reference/opt/shaders/asm/frag/offset-decorator-can-be-ignored.asm.frag
+++ b/reference/opt/shaders/asm/frag/offset-decorator-can-be-ignored.asm.frag
@@ -1,0 +1,8 @@
+#version 320 es
+precision mediump float;
+precision highp int;
+
+void main()
+{
+}
+

--- a/reference/shaders-msl/asm/frag/offset-decorator-can-be-ignored.asm.frag
+++ b/reference/shaders-msl/asm/frag/offset-decorator-can-be-ignored.asm.frag
@@ -1,0 +1,60 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wmissing-braces"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+template<typename T, size_t Num>
+struct spvUnsafeArray
+{
+    T elements[Num ? Num : 1];
+    
+    thread T& operator [] (size_t pos) thread
+    {
+        return elements[pos];
+    }
+    constexpr const thread T& operator [] (size_t pos) const thread
+    {
+        return elements[pos];
+    }
+    
+    device T& operator [] (size_t pos) device
+    {
+        return elements[pos];
+    }
+    constexpr const device T& operator [] (size_t pos) const device
+    {
+        return elements[pos];
+    }
+    
+    constexpr const constant T& operator [] (size_t pos) const constant
+    {
+        return elements[pos];
+    }
+    
+    threadgroup T& operator [] (size_t pos) threadgroup
+    {
+        return elements[pos];
+    }
+    constexpr const threadgroup T& operator [] (size_t pos) const threadgroup
+    {
+        return elements[pos];
+    }
+};
+
+struct foo
+{
+    spvUnsafeArray<float, 3> a;
+};
+
+constant spvUnsafeArray<float, 3> _17 = spvUnsafeArray<float, 3>({ 1.0, 2.0, 3.0 });
+
+fragment void main0()
+{
+    foo a = foo{ spvUnsafeArray<float, 3>({ 1.0, 2.0, 3.0 }) };
+    spvUnsafeArray<float, 3> b;
+    b = a.a;
+}
+

--- a/reference/shaders/asm/frag/offset-decorator-can-be-ignored.asm.frag
+++ b/reference/shaders/asm/frag/offset-decorator-can-be-ignored.asm.frag
@@ -1,0 +1,15 @@
+#version 320 es
+precision mediump float;
+precision highp int;
+
+struct foo
+{
+    float a[3];
+};
+
+void main()
+{
+    foo a = foo(float[](1.0, 2.0, 3.0));
+    float b[3] = a.a;
+}
+

--- a/shaders-msl/asm/frag/offset-decorator-can-be-ignored.asm.frag
+++ b/shaders-msl/asm/frag/offset-decorator-can-be-ignored.asm.frag
@@ -1,0 +1,48 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google Shaderc over Glslang; 10
+; Bound: 24
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginUpperLeft
+               OpSource ESSL 320
+               OpSourceExtension "GL_GOOGLE_cpp_style_line_directive"
+               OpSourceExtension "GL_GOOGLE_include_directive"
+               OpName %main "main"
+               OpName %foo "foo"
+               OpMemberName %foo 0 "a"
+               OpName %a "a"
+               OpName %b "b"
+               OpMemberDecorate %foo 0 RelaxedPrecision
+               OpMemberDecorate %foo 0 Offset 0
+               OpDecorate %b RelaxedPrecision
+               OpDecorate %23 RelaxedPrecision
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+       %uint = OpTypeInt 32 0
+     %uint_3 = OpConstant %uint 3
+%_arr_float_uint_3 = OpTypeArray %float %uint_3
+        %foo = OpTypeStruct %_arr_float_uint_3
+%_ptr_Function_foo = OpTypePointer Function %foo
+    %float_1 = OpConstant %float 1
+    %float_2 = OpConstant %float 2
+    %float_3 = OpConstant %float 3
+         %16 = OpConstantComposite %_arr_float_uint_3 %float_1 %float_2 %float_3
+         %17 = OpConstantComposite %foo %16
+%_ptr_Function__arr_float_uint_3 = OpTypePointer Function %_arr_float_uint_3
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %a = OpVariable %_ptr_Function_foo Function
+          %b = OpVariable %_ptr_Function__arr_float_uint_3 Function
+               OpStore %a %17
+         %22 = OpAccessChain %_ptr_Function__arr_float_uint_3 %a %int_0
+         %23 = OpLoad %_arr_float_uint_3 %22
+               OpStore %b %23
+               OpReturn
+               OpFunctionEnd

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -1267,6 +1267,25 @@ const Bitset &Compiler::get_member_decoration_bitset(TypeID id, uint32_t index) 
 	return ir.get_member_decoration_bitset(id, index);
 }
 
+bool Compiler::can_ignore_decoration_offset(const SPIRType &ty, uint32_t index) const
+{
+	bool has_decoration = ir.has_member_decoration(ty.self, index, DecorationOffset);
+	if (!has_decoration || index != 0)
+		return false;
+
+	auto offset = type_struct_member_offset(ty, 0);
+	auto struct_size = ty.member_types.size();
+	if (struct_size != 1)
+		return false;
+
+	bool check_is_scalar = Compiler::is_scalar(get<SPIRType>(ty.member_types[0]));
+	// In this case where the offset for the first struct member is 0, scaar
+	// and the struct total size is 1, we can safely ignore the
+	// DecorationOffset since it doesn't change the behavior from a normal
+	// struct.
+	return check_is_scalar && offset == 0;
+}
+
 bool Compiler::has_member_decoration(TypeID id, uint32_t index, Decoration decoration) const
 {
 	return ir.has_member_decoration(id, index, decoration);

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -241,6 +241,12 @@ public:
 	// Returns whether the decoration has been applied to a member of a struct.
 	bool has_member_decoration(TypeID id, uint32_t index, spv::Decoration decoration) const;
 
+	// Check if we can ignore the offset decoration. There are cases where the
+	// struct is only of one member and contains the Offset decorator, when the
+	// offset is 0 and the member is scalar, the decorator can be simply
+	// ignored since it won't affect in the final struct.
+	bool can_ignore_decoration_offset(const SPIRType &ty, uint32_t index) const;
+
 	// Similar to set_decoration, but for struct members.
 	void set_member_decoration(TypeID id, uint32_t index, spv::Decoration decoration, uint32_t argument = 0);
 	void set_member_decoration_string(TypeID id, uint32_t index, spv::Decoration decoration,
@@ -464,8 +470,8 @@ public:
 	// get_type(resource.base_type_id)
 	// as decorations are set in the basic Block type.
 	// The type passed in here must have these decorations set, or an exception is raised.
-	// Only UBOs and SSBOs or sub-structs which are part of these buffer types will have these decorations set.
 	uint32_t type_struct_member_offset(const SPIRType &type, uint32_t index) const;
+	// Only UBOs and SSBOs or sub-structs which are part of these buffer types will have these decorations set.
 	uint32_t type_struct_member_array_stride(const SPIRType &type, uint32_t index) const;
 	uint32_t type_struct_member_matrix_stride(const SPIRType &type, uint32_t index) const;
 


### PR DESCRIPTION
This adds a special corner case when there's a struct with only one member that contains
the offset decorator set to 0, we can ignore said decorator so we can emit
the templated array.

I'm not completely sure about this approach but any feedback is welcomed.

**NOTE:** This needs to run `./test_shaders.sh --update` but I've not pushed them to make it easier to review.

This fixes https://github.com/KhronosGroup/SPIRV-Cross/issues/1763

```
Test case 'dEQP-VK.spirv_assembly.instruction.graphics.decoration_group.same_decoration_group_on_multiple_types_vert'..
  Pass (Rendered output matches input)

Test case 'dEQP-VK.spirv_assembly.instruction.graphics.decoration_group.same_decoration_group_on_multiple_types_tessc'..
  Pass (Rendered output matches input)

Test case 'dEQP-VK.spirv_assembly.instruction.graphics.decoration_group.same_decoration_group_on_multiple_types_tesse'..
  Pass (Rendered output matches input)

Test case 'dEQP-VK.spirv_assembly.instruction.graphics.decoration_group.same_decoration_group_on_multiple_types_frag'..
  Pass (Rendered output matches input)
```