### PR TITLE
Allow volatile vars that are not builtins to be forwarded.

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -9600,8 +9600,8 @@ bool CompilerGLSL::should_forward(uint32_t id) const
 	auto *var = maybe_get<SPIRVariable>(id);
 	if (var)
 	{
-		// Never forward volatile variables, e.g. SPIR-V 1.6 IsHelperInvocation.
-		return !has_decoration(id, DecorationVolatile);
+		// Never forward volatile builtin variables, e.g. SPIR-V 1.6 HelperInvocation.
+		return !(has_decoration(id, DecorationBuiltIn) && has_decoration(id, DecorationVolatile));
 	}
 
 	// For debugging emit temporary variables for all expressions
@@ -9615,9 +9615,11 @@ bool CompilerGLSL::should_forward(uint32_t id) const
 	if (expr && expr->expression_dependencies.size() >= max_expression_dependencies)
 		return false;
 
-	if (expr && expr->loaded_from && has_decoration(expr->loaded_from, DecorationVolatile))
+	if (expr && expr->loaded_from
+		&& has_decoration(expr->loaded_from, DecorationBuiltIn)
+		&& has_decoration(expr->loaded_from, DecorationVolatile))
 	{
-		// Never forward volatile variables.
+		// Never forward volatile builtin variables, e.g. SPIR-V 1.6 HelperInvocation.
 		return false;
 	}
 


### PR DESCRIPTION
This fixes a regression introduced by 93b0dc7, where all volatile variables were not allowed to be forwarded. This doesn't work well for volatile memory object variables like images or buffer blocks, because it forces local variables
to be defined, which is unnecessary, and sometimes results in wrong types.

This patch restricts volatile builtin variables (eg. `HelperInvocation`) from being forwarded, but allows other volatile variables to be forwarded, as before.