### PR TITLE
HLSL: added support for tesselation shaders (WIP)

### DIFF
--- a/reference/shaders-hlsl/tese/input-array.tese
+++ b/reference/shaders-hlsl/tese/input-array.tese
@@ -1,0 +1,47 @@
+static float4 gl_Position;
+static float gl_TessLevelOuter[4];
+static float gl_TessLevelInner[2];
+static float3 gl_TessCoord;
+struct SPIRV_Cross_DS_Point_Input
+{
+    float4 Floats : TEXCOORD0;
+    float4 Floats2 : TEXCOORD2;
+};
+
+struct SPIRV_Cross_Input
+{
+    float gl_TessLevelOuter[4] : SV_TessFactor;
+    float gl_TessLevelInner[2] : SV_InsideTessFactor;
+    float2 gl_TessCoord : SV_DomainLocation;
+};
+
+struct SPIRV_Cross_Output
+{
+};
+
+struct SPIRV_Cross_DS_Point_Output
+{
+    float4 gl_Position : SV_Position;
+};
+
+void set_position(OutputPatch<SPIRV_Cross_DS_Point_Input,3> gl_in)
+{
+    gl_Position = (gl_in[0].Floats * gl_TessCoord.x) + (gl_in[1].Floats2 * gl_TessCoord.y);
+}
+
+void tese_main(OutputPatch<SPIRV_Cross_DS_Point_Input,3> gl_in)
+{
+    set_position(gl_in);
+}
+
+[domain("quad")]
+SPIRV_Cross_DS_Point_Output main(SPIRV_Cross_Input stage_input, OutputPatch<SPIRV_Cross_DS_Point_Input, 3> gl_in)
+{
+    gl_TessLevelOuter = stage_input.gl_TessLevelOuter;
+    gl_TessLevelInner = stage_input.gl_TessLevelInner;
+    gl_TessCoord = float3(stage_input.gl_TessCoord, 0.0);
+    tese_main(gl_in);
+    SPIRV_Cross_DS_Point_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/tese/input-types.tese
+++ b/reference/shaders-hlsl/tese/input-types.tese
@@ -1,0 +1,74 @@
+struct Foo
+{
+    float4 a;
+    float4 b;
+};
+
+static float4 gl_Position;
+static float gl_TessLevelOuter[4];
+static float gl_TessLevelInner[2];
+static float3 gl_TessCoord;
+static float4 vColors;
+static Foo vFoo;
+static float4 vColorsArray[2];
+
+struct SPIRV_Cross_DS_Point_Input
+{
+    float4 vColor : TEXCOORD0;
+    Foo vFoos : TEXCOORD14;
+};
+
+struct SPIRV_Cross_Input
+{
+    float gl_TessLevelOuter[4] : SV_TessFactor;
+    float gl_TessLevelInner[2] : SV_InsideTessFactor;
+    float2 gl_TessCoord : SV_DomainLocation;
+    float4 vColors : TEXCOORD1;
+    float4 vColorsArray[2] : TEXCOORD2;
+    Foo vFoo : TEXCOORD8;
+};
+
+struct SPIRV_Cross_Output
+{
+};
+
+struct SPIRV_Cross_DS_Point_Output
+{
+    float4 gl_Position : SV_Position;
+};
+
+void set_from_function(OutputPatch<SPIRV_Cross_DS_Point_Input,3> gl_in)
+{
+    gl_Position += gl_in[0].vColor;
+    gl_Position += gl_in[1].vColor;
+    gl_Position += vColors;
+    Foo foo = vFoo;
+    gl_Position += foo.a;
+    gl_Position += foo.b;
+    foo = gl_in[0].vFoos;
+    gl_Position += foo.a;
+    gl_Position += foo.b;
+    foo = gl_in[1].vFoos;
+    gl_Position += foo.a;
+    gl_Position += foo.b;
+}
+
+void tese_main(OutputPatch<SPIRV_Cross_DS_Point_Input,3> gl_in)
+{
+    set_from_function(gl_in);
+}
+
+[domain("quad")]
+SPIRV_Cross_DS_Point_Output main(SPIRV_Cross_Input stage_input, OutputPatch<SPIRV_Cross_DS_Point_Input, 3> gl_in)
+{
+    gl_TessLevelOuter = stage_input.gl_TessLevelOuter;
+    gl_TessLevelInner = stage_input.gl_TessLevelInner;
+    gl_TessCoord = float3(stage_input.gl_TessCoord, 0.0);
+    vColors = stage_input.vColors;
+    vFoo = stage_input.vFoo;
+    vColorsArray = stage_input.vColorsArray;
+    tese_main(gl_in);
+    SPIRV_Cross_DS_Point_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/tese/triangle-tess-level.tese
+++ b/reference/shaders-hlsl/tese/triangle-tess-level.tese
@@ -1,0 +1,38 @@
+static float4 gl_Position;
+static float gl_TessLevelOuter[4];
+static float gl_TessLevelInner[2];
+static float3 gl_TessCoord;
+struct SPIRV_Cross_Input
+{
+    float gl_TessLevelOuter[3] : SV_TessFactor;
+    float gl_TessLevelInner : SV_InsideTessFactor;
+    float3 gl_TessCoord : SV_DomainLocation;
+};
+
+struct SPIRV_Cross_Output
+{
+};
+
+struct SPIRV_Cross_DS_Point_Output
+{
+    float4 gl_Position : SV_Position;
+};
+
+void tese_main()
+{
+    gl_Position = float4((gl_TessCoord.x * gl_TessLevelInner[0]) * gl_TessLevelOuter[0], (gl_TessCoord.y * gl_TessLevelInner[0]) * gl_TessLevelOuter[1], (gl_TessCoord.z * gl_TessLevelInner[0]) * gl_TessLevelOuter[2], 1.0f);
+}
+
+[domain("tri")]
+SPIRV_Cross_DS_Point_Output main(SPIRV_Cross_Input stage_input)
+{
+    gl_TessLevelOuter[0] = stage_input.gl_TessLevelOuter[0];
+    gl_TessLevelOuter[1] = stage_input.gl_TessLevelOuter[1];
+    gl_TessLevelOuter[2] = stage_input.gl_TessLevelOuter[2];
+    gl_TessLevelInner[0] = stage_input.gl_TessLevelInner;
+    gl_TessCoord = stage_input.gl_TessCoord;
+    tese_main();
+    SPIRV_Cross_DS_Point_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/tese/triangle.tese
+++ b/reference/shaders-hlsl/tese/triangle.tese
@@ -1,0 +1,38 @@
+static float4 gl_Position;
+static float gl_TessLevelOuter[4];
+static float gl_TessLevelInner[2];
+static float3 gl_TessCoord;
+struct SPIRV_Cross_Input
+{
+    float gl_TessLevelOuter[3] : SV_TessFactor;
+    float gl_TessLevelInner : SV_InsideTessFactor;
+    float3 gl_TessCoord : SV_DomainLocation;
+};
+
+struct SPIRV_Cross_Output
+{
+};
+
+struct SPIRV_Cross_DS_Point_Output
+{
+    float4 gl_Position : SV_Position;
+};
+
+void tese_main()
+{
+    gl_Position = 1.0f.xxxx;
+}
+
+[domain("tri")]
+SPIRV_Cross_DS_Point_Output main(SPIRV_Cross_Input stage_input)
+{
+    gl_TessLevelOuter[0] = stage_input.gl_TessLevelOuter[0];
+    gl_TessLevelOuter[1] = stage_input.gl_TessLevelOuter[1];
+    gl_TessLevelOuter[2] = stage_input.gl_TessLevelOuter[2];
+    gl_TessLevelInner[0] = stage_input.gl_TessLevelInner;
+    gl_TessCoord = stage_input.gl_TessCoord;
+    tese_main();
+    SPIRV_Cross_DS_Point_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    return stage_output;
+}

--- a/shaders-hlsl/tese/input-array.tese
+++ b/shaders-hlsl/tese/input-array.tese
@@ -1,0 +1,15 @@
+#version 450
+
+layout(ccw, quads, fractional_odd_spacing) in;
+layout(location = 0) in vec4 Floats[];
+layout(location = 2) in vec4 Floats2[gl_MaxPatchVertices];
+
+void set_position()
+{
+  gl_Position = Floats[0] * gl_TessCoord.x + Floats2[1] * gl_TessCoord.y;
+}
+
+void main()
+{
+  set_position();
+}

--- a/shaders-hlsl/tese/input-types.tese
+++ b/shaders-hlsl/tese/input-types.tese
@@ -1,0 +1,77 @@
+#version 450
+
+layout(ccw, quads, fractional_even_spacing) in;
+
+// Try to use the whole taxonomy of input methods.
+
+// Per-vertex vector.
+layout(location = 0) in vec4 vColor[];
+// Per-patch vector.
+layout(location = 1) patch in vec4 vColors;
+// Per-patch vector array.
+layout(location = 2) patch in vec4 vColorsArray[2];
+
+// I/O blocks, per patch and per control point.
+/*
+layout(location = 4) in Block
+{
+        vec4 a;
+        vec4 b;
+} blocks[];
+
+layout(location = 6) patch in PatchBlock
+{
+        vec4 a;
+        vec4 b;
+} patch_block;
+*/
+// Composites.
+struct Foo
+{
+        vec4 a;
+        vec4 b;
+};
+layout(location = 8) patch in Foo vFoo;
+//layout(location = 10) patch in Foo vFooArray[2];  // FIXME: Handling of array-of-struct input is broken!
+
+// Per-control point struct.
+layout(location = 14) in Foo vFoos[];
+
+void set_from_function()
+{
+        /*
+        gl_Position = blocks[0].a;
+        gl_Position += blocks[0].b;
+        gl_Position += blocks[1].a;
+        gl_Position += blocks[1].b;
+        gl_Position += patch_block.a;
+        gl_Position += patch_block.b;
+        */
+        gl_Position += vColor[0];
+        gl_Position += vColor[1];
+        gl_Position += vColors;
+
+        Foo foo = vFoo;
+        gl_Position += foo.a;
+        gl_Position += foo.b;
+
+        /*foo = vFooArray[0];
+        gl_Position += foo.a;
+        gl_Position += foo.b;
+        foo = vFooArray[1];
+        gl_Position += foo.a;
+        gl_Position += foo.b;*/
+
+        foo = vFoos[0];
+        gl_Position += foo.a;
+        gl_Position += foo.b;
+
+        foo = vFoos[1];
+        gl_Position += foo.a;
+        gl_Position += foo.b;
+}
+
+void main()
+{
+        set_from_function();
+}

--- a/shaders-hlsl/tese/triangle-tess-level.tese
+++ b/shaders-hlsl/tese/triangle-tess-level.tese
@@ -1,0 +1,12 @@
+#version 310 es
+#extension GL_EXT_tessellation_shader : require
+
+layout(cw, triangles, fractional_even_spacing) in;
+
+void main()
+{
+  gl_Position = vec4(gl_TessCoord.x * gl_TessLevelInner[0] * gl_TessLevelOuter[0],
+                     gl_TessCoord.y * gl_TessLevelInner[0] * gl_TessLevelOuter[1],
+                     gl_TessCoord.z * gl_TessLevelInner[0] * gl_TessLevelOuter[2],
+                     1);
+}

--- a/shaders-hlsl/tese/triangle.tese
+++ b/shaders-hlsl/tese/triangle.tese
@@ -1,0 +1,9 @@
+#version 310 es
+#extension GL_EXT_tessellation_shader : require
+
+layout(cw, triangles, fractional_even_spacing) in;
+
+void main()
+{
+   gl_Position = vec4(1.0);
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -8879,6 +8879,11 @@ string CompilerGLSL::access_chain_internal(uint32_t base, const uint32_t *indice
 					break;
 				}
 			}
+			else if (backend.force_gl_in_block_hlsl && i == 0 && var && !is_builtin_variable(*var) &&
+			         var->storage == StorageClassInput && !has_decoration(var->self, DecorationPatch))
+			{
+				expr = join("gl_in[", to_expression(index, register_expression_read), "].", expr);
+			}
 			else if (options.flatten_multidimensional_arrays && dimension_flatten)
 			{
 				// If we are flattening multidimensional arrays, do manual stride computation.

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -589,6 +589,7 @@ protected:
 		bool allow_precision_qualifiers = false;
 		bool can_swizzle_scalar = false;
 		bool force_gl_in_out_block = false;
+		bool force_gl_in_block_hlsl = false;
 		bool can_return_array = true;
 		bool allow_truncated_access_chain = false;
 		bool supports_extensions = false;
@@ -706,8 +707,9 @@ protected:
 	virtual void prepare_access_chain_for_scalar_access(std::string &expr, const SPIRType &type,
 	                                                    spv::StorageClass storage, bool &is_packed);
 
-	std::string access_chain(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type,
-	                         AccessChainMeta *meta = nullptr, bool ptr_chain = false);
+	virtual std::string access_chain(uint32_t base, const uint32_t *indices, uint32_t count,
+	                                 const SPIRType &target_type, AccessChainMeta *meta = nullptr,
+	                                 bool ptr_chain = false);
 
 	std::string flattened_access_chain(uint32_t base, const uint32_t *indices, uint32_t count,
 	                                   const SPIRType &target_type, uint32_t offset, uint32_t matrix_stride,

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1631,8 +1631,14 @@ void CompilerHLSL::emit_resources()
 
 			if (var.block)
 			{
-				if (var.block_member_index == 0)
-					emit_interface_block_in_struct(*var.var, active_inputs);
+				if (is_tessellation_shader())
+				{
+					if (var.block_member_index == 0)
+						emit_interface_block_in_struct(*var.var, active_inputs);
+				}
+				else
+					emit_interface_block_member_in_struct(*var.var, var.block_member_index, var.location,
+					                                      active_inputs);
 			}
 			else
 				emit_interface_block_in_struct(*var.var, active_inputs);

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -2776,7 +2776,7 @@ void CompilerHLSL::emit_hlsl_patch_constant_func()
 {
 	SmallVector<string> arguments;
 	if (require_input)
-		arguments.push_back("InputPatch<SPIRV_Cross_HS_Point_Input, 32> gl_in");
+    arguments.push_back("InputPatch<SPIRV_Cross_HS_Point_Input,32> gl_in");
 
 	statement("SPIRV_Cross_Output", " tesc_patch_constant(", merge(arguments), ")");
 	begin_scope();
@@ -2875,13 +2875,13 @@ void CompilerHLSL::emit_hlsl_entry_point()
 	{
 	case ExecutionModelTessellationControl:
 		arguments.push_back("SPIRV_Cross_Input stage_input");
-		arguments.push_back("InputPatch<SPIRV_Cross_HS_Point_Input, 32> gl_in");
+    arguments.push_back("InputPatch<SPIRV_Cross_HS_Point_Input,32> gl_in");
 		break;
 
 	case ExecutionModelTessellationEvaluation:
 		arguments.push_back("SPIRV_Cross_Input stage_input");
 		if (require_input)
-			arguments.push_back("OutputPatch<SPIRV_Cross_DS_Point_Input, 3> gl_in");
+      arguments.push_back("OutputPatch<SPIRV_Cross_DS_Point_Input,3> gl_in");
 		break;
 
 	default:

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -284,6 +284,8 @@ private:
 	bool emitted_per_vertex_inputs = false;
 	void emit_per_vertex_inputs();
 
+	bool is_per_patch_variable(const SPIRVariable &var) const;
+
 	Options hlsl_options;
 
 	// TODO: Refactor this to be more similar to MSL, maybe have some common system in place?

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -280,6 +280,8 @@ private:
 	void append_gl_inout_to_functions(VariableID gl_in);
 	void append_gl_inout_to_function(VariableID gl_in, uint32_t func_id,
 	                                 std::unordered_set<uint32_t> &processed_func_ids);
+
+	bool emitted_per_vertex_inputs = false;
 	void emit_per_vertex_inputs();
 
 	Options hlsl_options;

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -215,6 +215,7 @@ private:
 	std::string image_type_hlsl_legacy(const SPIRType &type, uint32_t id);
 	void emit_function_prototype(SPIRFunction &func, const Bitset &return_flags) override;
 	void emit_hlsl_entry_point();
+	void emit_hlsl_patch_constant_func();
 	void emit_header() override;
 	void emit_resources();
 	void declare_undefined_values() override;
@@ -225,6 +226,7 @@ private:
 	                                           std::unordered_set<uint32_t> &active_locations);
 	void emit_builtin_inputs_in_struct();
 	void emit_builtin_outputs_in_struct();
+	void emit_tess_builtin_inputs_in_struct();
 	void emit_texture_op(const Instruction &i, bool sparse) override;
 	void emit_instruction(const Instruction &instruction) override;
 	void emit_glsl_op(uint32_t result_type, uint32_t result_id, uint32_t op, const uint32_t *args,
@@ -260,6 +262,8 @@ private:
 	void write_access_chain_array(const SPIRAccessChain &chain, uint32_t value,
 	                              const SmallVector<uint32_t> &composite_chain);
 	std::string write_access_chain_value(uint32_t value, const SmallVector<uint32_t> &composite_chain, bool enclose);
+	std::string access_chain(uint32_t base, const uint32_t *indices, uint32_t count, const SPIRType &target_type,
+	                         AccessChainMeta *meta = nullptr, bool ptr_chain = false) override;
 	void emit_store(const Instruction &instruction);
 	void emit_atomic(const uint32_t *ops, uint32_t length, spv::Op op);
 	void emit_subgroup_op(const Instruction &i) override;
@@ -273,6 +277,10 @@ private:
 	void replace_illegal_names() override;
 
 	bool is_hlsl_force_storage_buffer_as_uav(ID id) const;
+	void append_gl_inout_to_functions(VariableID gl_in);
+	void append_gl_inout_to_function(VariableID gl_in, uint32_t func_id,
+	                                 std::unordered_set<uint32_t> &processed_func_ids);
+	void emit_per_vertex_inputs();
 
 	Options hlsl_options;
 

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -382,6 +382,10 @@ def shader_model_hlsl(shader):
             return '-Tps_5_1'
     elif '.comp' in shader:
         return '-Tcs_5_1'
+    elif '.tese' in shader:
+        return '-Tds_5_0'
+    elif '.tesc' in shader:
+        return '-Ths_5_0'
     else:
         return None
 


### PR DESCRIPTION
Followup to #1739 - decided to start a new pr, since original is supper outdated now.
This is still more of a prototype at this point, and the goal of PR to collect opinions about approach.

Limitations:
 * No support for `barrier()` - HLSL has no support for that in geometry pipeline at all. A exception will be thrown, if `OpControlBarrier` reached.
 * Only `gl_out[gl_InvocationID]` is supported. This is actually inline with OpenGL, but limitation in comparation with Vulkan
 * `vertex.flip_vert_y` is an issue. Flipping logically suppose to be done at the end of geometry pipeline.
 * For HULL shader: `patchconstantfunc` will call `tesc_main` multiple times, only to determinate `gl_TessLevel*` values.
 This makes for ugly code, yet DX12 compiler is smart enough to remove this code.
 NOTE: there seems to be no way to pass extra data from `main` to `patchconstantfunc` - so we basically have to calculate  `gl_TessLevel*` twice.
 * No unit tests regarding HULL shaders - glslangValidator [crashes](https://github.com/KhronosGroup/glslang/issues/2914) on compiling. (DXC obviously works fine) 

TODO:
 * `InputPath<>` and `OutputPatch<>` sizes are hard-coded
 * HULL shader, in DirectX, requires multiple extra annotations: `outputcontrolpoints`, `domain`, `partitioning`, `outputtopology` - those are absent from Tess-control shader in spirv. Hard-coded for now, long term idea is to fetch them from Tess-eval shader

Practical point of view:
* Hull shader is a performance concern
* Game engine that uses this cross-compilation has to do extra work to take care of `vertex.flip_vert_y` and to pass hints, like `partitioning` from TessEvaluation to Hull shader. What means - to delay cross compilation, until all shaders in pipeline are known.
* It works for my game: tested on water shader :)
 