### PR TITLE
HLSL: Add missing `BuiltInLayer` to HLSL backend.

### DIFF
--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -643,6 +643,13 @@ void CompilerHLSL::emit_builtin_outputs_in_struct()
 			else
 				SPIRV_CROSS_THROW("Unsupported builtin in HLSL.");
 
+		case BuiltInLayer:
+			if (hlsl_options.shader_model < 50 || get_entry_point().model != ExecutionModelGeometry)
+				SPIRV_CROSS_THROW("Render target index output is only supported in GS 5.0 or higher.");
+			type = "uint";
+			semantic = "SV_RenderTargetIndex";
+			break;
+
 		default:
 			SPIRV_CROSS_THROW("Unsupported builtin in HLSL.");
 		}
@@ -787,6 +794,13 @@ void CompilerHLSL::emit_builtin_inputs_in_struct()
 				break;
 			else
 				SPIRV_CROSS_THROW("Unsupported builtin in HLSL.");
+
+		case BuiltInLayer:
+			if (hlsl_options.shader_model < 50 || get_entry_point().model != ExecutionModelFragment)
+				SPIRV_CROSS_THROW("Render target index input is only supported in PS 5.0 or higher.");
+			type = "uint";
+			semantic = "SV_RenderTargetIndex";
+			break;
 
 		default:
 			SPIRV_CROSS_THROW("Unsupported builtin in HLSL.");
@@ -1147,6 +1161,7 @@ void CompilerHLSL::emit_builtin_variables()
 
 		case BuiltInPrimitiveId:
 		case BuiltInViewIndex:
+		case BuiltInLayer:
 			type = "uint";
 			break;
 


### PR DESCRIPTION
This adds a translation of `BuiltInLayer` (aka. `gl_Layer`) into `SV_RenderTargetIndex` to the output in the HLSL backend.