### PR TITLE
Implement more proper semantics for RelaxedPrecision vs mediump

### DIFF
--- a/reference/opt/shaders/asm/vert/spec-constant-op-composite.asm.vk.vert.vk
+++ b/reference/opt/shaders/asm/vert/spec-constant-op-composite.asm.vk.vert.vk
@@ -17,7 +17,8 @@ void main()
     _65.y = float(_20);
     vec4 _68 = _65;
     _68.z = float(_25);
-    vec4 _54 = _68 + vec4(_32);
+    vec4 _52 = vec4(_32);
+    vec4 _54 = _68 + _52;
     vec2 _58 = _54.xy + vec2(_34);
     gl_Position = vec4(_58.x, _58.y, _54.z, _54.w);
     _4 = _35;

--- a/reference/opt/shaders/comp/bake_gradient.comp
+++ b/reference/opt/shaders/comp/bake_gradient.comp
@@ -16,11 +16,19 @@ void main()
 {
     vec4 _59 = (vec2(gl_GlobalInvocationID.xy) * _46.uInvSize.xy).xyxy + (_46.uInvSize * 0.5);
     vec2 _67 = _59.xy;
+    mediump float _79 = textureLodOffset(uHeight, _67, 0.0, ivec2(-1, 0)).x;
+    float hp_copy_79 = _79;
+    mediump float _87 = textureLodOffset(uHeight, _67, 0.0, ivec2(1, 0)).x;
+    float hp_copy_87 = _87;
+    mediump float _94 = textureLodOffset(uHeight, _67, 0.0, ivec2(0, -1)).x;
+    float hp_copy_94 = _94;
+    mediump float _101 = textureLodOffset(uHeight, _67, 0.0, ivec2(0, 1)).x;
+    float hp_copy_101 = _101;
     vec2 _128 = _59.zw;
     vec2 _157 = ((textureLodOffset(uDisplacement, _128, 0.0, ivec2(1, 0)).xy - textureLodOffset(uDisplacement, _128, 0.0, ivec2(-1, 0)).xy) * 0.60000002384185791015625) * _46.uScale.z;
     vec2 _161 = ((textureLodOffset(uDisplacement, _128, 0.0, ivec2(0, 1)).xy - textureLodOffset(uDisplacement, _128, 0.0, ivec2(0, -1)).xy) * 0.60000002384185791015625) * _46.uScale.z;
     ivec2 _172 = ivec2(gl_GlobalInvocationID.xy);
     imageStore(iHeightDisplacement, _172, vec4(textureLod(uHeight, _67, 0.0).x, 0.0, 0.0, 0.0));
-    imageStore(iGradJacobian, _172, vec4((_46.uScale.xy * 0.5) * vec2(textureLodOffset(uHeight, _67, 0.0, ivec2(1, 0)).x - textureLodOffset(uHeight, _67, 0.0, ivec2(-1, 0)).x, textureLodOffset(uHeight, _67, 0.0, ivec2(0, 1)).x - textureLodOffset(uHeight, _67, 0.0, ivec2(0, -1)).x), ((1.0 + _157.x) * (1.0 + _161.y)) - (_157.y * _161.x), 0.0));
+    imageStore(iGradJacobian, _172, vec4((_46.uScale.xy * 0.5) * vec2(hp_copy_87 - hp_copy_79, hp_copy_101 - hp_copy_94), ((1.0 + _157.x) * (1.0 + _161.y)) - (_157.y * _161.x), 0.0));
 }
 

--- a/reference/opt/shaders/frag/constant-array.frag
+++ b/reference/opt/shaders/frag/constant-array.frag
@@ -17,6 +17,10 @@ layout(location = 0) flat in mediump int index;
 
 void main()
 {
-    FragColor = ((_37[index] + _55[index][index + 1]) + vec4(30.0)) + vec4(_75[index].a + _75[index].b);
+    highp float _106 = _75[index].a;
+    float mp_copy_106 = _106;
+    highp float _107 = _75[index].b;
+    float mp_copy_107 = _107;
+    FragColor = ((_37[index] + _55[index][index + 1]) + vec4(30.0)) + vec4(mp_copy_106 + mp_copy_107);
 }
 

--- a/reference/opt/shaders/frag/frexp-modf.frag
+++ b/reference/opt/shaders/frag/frexp-modf.frag
@@ -22,12 +22,14 @@ void main()
 {
     ResType _22;
     _22._m0 = frexp(v0 + 1.0, _22._m1);
+    highp float _24 = _22._m0;
+    float mp_copy_24 = _24;
     ResType_1 _35;
     _35._m0 = frexp(v1, _35._m1);
     float r0;
     float _41 = modf(v0, r0);
     vec2 r1;
     vec2 _45 = modf(v1, r1);
-    FragColor = ((((_22._m0 + _35._m0.x) + _35._m0.y) + _41) + _45.x) + _45.y;
+    FragColor = ((((mp_copy_24 + _35._m0.x) + _35._m0.y) + _41) + _45.x) + _45.y;
 }
 

--- a/reference/opt/shaders/tese/water_tess.tese
+++ b/reference/opt/shaders/tese/water_tess.tese
@@ -24,11 +24,12 @@ void main()
     vec2 _202 = vOutPatchPosBase + (gl_TessCoord.xy * _31.uPatchSize);
     vec2 _216 = mix(vPatchLods.yx, vPatchLods.zw, vec2(gl_TessCoord.x));
     float _223 = mix(_216.x, _216.y, gl_TessCoord.y);
-    mediump float _225 = floor(_223);
+    mediump float mp_copy_223 = _223;
+    mediump float _225 = floor(mp_copy_223);
     vec2 _125 = _202 * _31.uInvHeightmapSize;
     vec2 _141 = _31.uInvHeightmapSize * exp2(_225);
     vGradNormalTex = vec4(_125 + (_31.uInvHeightmapSize * 0.5), _125 * _31.uScale.zw);
-    mediump vec3 _256 = mix(textureLod(uHeightmapDisplacement, _125 + (_141 * 0.5), _225).xyz, textureLod(uHeightmapDisplacement, _125 + (_141 * 1.0), _225 + 1.0).xyz, vec3(_223 - _225));
+    mediump vec3 _256 = mix(textureLod(uHeightmapDisplacement, _125 + (_141 * 0.5), _225).xyz, textureLod(uHeightmapDisplacement, _125 + (_141 * 1.0), _225 + 1.0).xyz, vec3(mp_copy_223 - _225));
     vec2 _171 = (_202 * _31.uScale.xy) + _256.yz;
     vWorld = vec3(_171.x, _256.x, _171.y);
     gl_Position = _31.uMVP * vec4(vWorld, 1.0);

--- a/reference/opt/shaders/vert/ground.vert
+++ b/reference/opt/shaders/vert/ground.vert
@@ -84,7 +84,8 @@ void main()
     vec4 _345 = vec4((_310 + uvec2(_384, _385)).xyxy & (~_317).xxyy);
     vec2 _173 = ((_53.Patches[(gl_InstanceID + SPIRV_Cross_BaseInstance)].Position.xz * _156.InvGroundSize_PatchScale.zw) + mix(_345.xy, _345.zw, vec2(_301 - _303))) * _156.InvGroundSize_PatchScale.xy;
     mediump float _362 = textureLod(TexLOD, _173, 0.0).x * 7.96875;
-    float _364 = floor(_362);
+    float hp_copy_362 = _362;
+    float _364 = floor(hp_copy_362);
     vec2 _185 = _156.InvGroundSize_PatchScale.xy * exp2(_364);
     vec3 _230 = (vec3(_173.x, mix(textureLod(TexHeightmap, _173 + (_185 * 0.5), _364).x, textureLod(TexHeightmap, _173 + (_185 * 1.0), _364 + 1.0).x, _362 - _364), _173.y) * _156.GroundScale.xyz) + _156.GroundPosition.xyz;
     EyeVec = _230 - _236.g_CamPos.xyz;

--- a/reference/opt/shaders/vert/ocean.vert
+++ b/reference/opt/shaders/vert/ocean.vert
@@ -116,7 +116,8 @@ void main()
     vec2 _197 = ((_53.Patches[(gl_InstanceID + SPIRV_Cross_BaseInstance)].Position.xz * _180.InvOceanSize_PatchScale.zw) + mix(_416.xy, _416.zw, vec2(_351 - _353))) * _180.InvOceanSize_PatchScale.xy;
     vec2 _204 = _197 * _180.NormalTexCoordScale.zw;
     mediump float _433 = textureLod(TexLOD, _197, 0.0).x * 7.96875;
-    float _435 = floor(_433);
+    float hp_copy_433 = _433;
+    float _435 = floor(hp_copy_433);
     vec2 _220 = (_180.InvOceanSize_PatchScale.xy * exp2(_435)) * _180.NormalTexCoordScale.zw;
     vec3 _267 = ((vec3(_197.x, 0.0, _197.y) + mix(textureLod(TexDisplacement, _204 + (_220 * 0.5), _435).yxz, textureLod(TexDisplacement, _204 + (_220 * 1.0), _435 + 1.0).yxz, vec3(_433 - _435))) * _180.OceanScale.xyz) + _180.OceanPosition.xyz;
     EyeVec = _267 - _273.g_CamPos.xyz;

--- a/reference/opt/shaders/vert/read-from-row-major-array.vert
+++ b/reference/opt/shaders/vert/read-from-row-major-array.vert
@@ -13,6 +13,18 @@ mat2x3 spvWorkaroundRowMajor(mat2x3 wrap) { return wrap; }
 void main()
 {
     gl_Position = a_position;
-    v_vtxResult = ((float(abs(spvWorkaroundRowMajor(_104.var[0][0])[0].x - 2.0) < 0.0500000007450580596923828125) * float(abs(spvWorkaroundRowMajor(_104.var[0][0])[0].y - 6.0) < 0.0500000007450580596923828125)) * float(abs(spvWorkaroundRowMajor(_104.var[0][0])[0].z - (-6.0)) < 0.0500000007450580596923828125)) * ((float(abs(spvWorkaroundRowMajor(_104.var[0][0])[1].x) < 0.0500000007450580596923828125) * float(abs(spvWorkaroundRowMajor(_104.var[0][0])[1].y - 5.0) < 0.0500000007450580596923828125)) * float(abs(spvWorkaroundRowMajor(_104.var[0][0])[1].z - 5.0) < 0.0500000007450580596923828125));
+    float _172 = float(abs(spvWorkaroundRowMajor(_104.var[0][0])[0].x - 2.0) < 0.0500000007450580596923828125);
+    mediump float mp_copy_172 = _172;
+    float _180 = float(abs(spvWorkaroundRowMajor(_104.var[0][0])[0].y - 6.0) < 0.0500000007450580596923828125);
+    mediump float mp_copy_180 = _180;
+    float _188 = float(abs(spvWorkaroundRowMajor(_104.var[0][0])[0].z - (-6.0)) < 0.0500000007450580596923828125);
+    mediump float mp_copy_188 = _188;
+    float _221 = float(abs(spvWorkaroundRowMajor(_104.var[0][0])[1].x) < 0.0500000007450580596923828125);
+    mediump float mp_copy_221 = _221;
+    float _229 = float(abs(spvWorkaroundRowMajor(_104.var[0][0])[1].y - 5.0) < 0.0500000007450580596923828125);
+    mediump float mp_copy_229 = _229;
+    float _237 = float(abs(spvWorkaroundRowMajor(_104.var[0][0])[1].z - 5.0) < 0.0500000007450580596923828125);
+    mediump float mp_copy_237 = _237;
+    v_vtxResult = ((mp_copy_172 * mp_copy_180) * mp_copy_188) * ((mp_copy_221 * mp_copy_229) * mp_copy_237);
 }
 

--- a/reference/opt/shaders/vulkan/frag/separate-sampler-texture-array.vk.frag
+++ b/reference/opt/shaders/vulkan/frag/separate-sampler-texture-array.vk.frag
@@ -13,7 +13,11 @@ layout(location = 0) out vec4 FragColor;
 
 void main()
 {
-    vec2 _95 = (vTex + (vec2(1.0) / vec2(textureSize(SPIRV_Cross_CombineduTextureuSampler[1], 0)))) + (vec2(1.0) / vec2(textureSize(SPIRV_Cross_CombineduTextureuSampler[2], 1)));
+    highp vec2 _76 = vec2(1.0) / vec2(textureSize(SPIRV_Cross_CombineduTextureuSampler[1], 0));
+    vec2 mp_copy_76 = _76;
+    highp vec2 _86 = vec2(1.0) / vec2(textureSize(SPIRV_Cross_CombineduTextureuSampler[2], 1));
+    vec2 mp_copy_86 = _86;
+    vec2 _95 = (vTex + mp_copy_76) + mp_copy_86;
     FragColor = ((((texture(SPIRV_Cross_CombineduTextureuSampler[2], _95) + texture(SPIRV_Cross_CombineduTextureuSampler[1], _95)) + texture(SPIRV_Cross_CombineduTextureuSampler[1], _95)) + texture(SPIRV_Cross_CombineduTextureArrayuSampler[3], vTex3)) + texture(SPIRV_Cross_CombineduTextureCubeuSampler[1], vTex3)) + texture(SPIRV_Cross_CombineduTexture3DuSampler[2], vTex3);
 }
 

--- a/reference/opt/shaders/vulkan/frag/separate-sampler-texture-array.vk.frag.vk
+++ b/reference/opt/shaders/vulkan/frag/separate-sampler-texture-array.vk.frag.vk
@@ -14,7 +14,11 @@ layout(location = 0) out vec4 FragColor;
 
 void main()
 {
-    vec2 _95 = (vTex + (vec2(1.0) / vec2(textureSize(sampler2D(uTexture[1], uSampler), 0)))) + (vec2(1.0) / vec2(textureSize(sampler2D(uTexture[2], uSampler), 1)));
+    highp vec2 _76 = vec2(1.0) / vec2(textureSize(sampler2D(uTexture[1], uSampler), 0));
+    vec2 mp_copy_76 = _76;
+    highp vec2 _86 = vec2(1.0) / vec2(textureSize(sampler2D(uTexture[2], uSampler), 1));
+    vec2 mp_copy_86 = _86;
+    vec2 _95 = (vTex + mp_copy_76) + mp_copy_86;
     FragColor = ((((texture(sampler2D(uTexture[2], uSampler), _95) + texture(sampler2D(uTexture[1], uSampler), _95)) + texture(sampler2D(uTexture[1], uSampler), _95)) + texture(sampler2DArray(uTextureArray[3], uSampler), vTex3)) + texture(samplerCube(uTextureCube[1], uSampler), vTex3)) + texture(sampler3D(uTexture3D[2], uSampler), vTex3);
 }
 

--- a/reference/opt/shaders/vulkan/frag/separate-sampler-texture.vk.frag
+++ b/reference/opt/shaders/vulkan/frag/separate-sampler-texture.vk.frag
@@ -13,7 +13,11 @@ layout(location = 0) out vec4 FragColor;
 
 void main()
 {
-    vec2 _73 = (vTex + (vec2(1.0) / vec2(textureSize(SPIRV_Cross_CombineduTextureuSampler, 0)))) + (vec2(1.0) / vec2(textureSize(SPIRV_Cross_CombineduTextureuSampler, 1)));
+    highp vec2 _54 = vec2(1.0) / vec2(textureSize(SPIRV_Cross_CombineduTextureuSampler, 0));
+    vec2 mp_copy_54 = _54;
+    highp vec2 _64 = vec2(1.0) / vec2(textureSize(SPIRV_Cross_CombineduTextureuSampler, 1));
+    vec2 mp_copy_64 = _64;
+    vec2 _73 = (vTex + mp_copy_54) + mp_copy_64;
     FragColor = (((texture(SPIRV_Cross_CombineduTextureuSampler, _73) + texture(SPIRV_Cross_CombineduTextureuSampler, _73)) + texture(SPIRV_Cross_CombineduTextureArrayuSampler, vTex3)) + texture(SPIRV_Cross_CombineduTextureCubeuSampler, vTex3)) + texture(SPIRV_Cross_CombineduTexture3DuSampler, vTex3);
 }
 

--- a/reference/opt/shaders/vulkan/frag/separate-sampler-texture.vk.frag.vk
+++ b/reference/opt/shaders/vulkan/frag/separate-sampler-texture.vk.frag.vk
@@ -14,7 +14,11 @@ layout(location = 0) out vec4 FragColor;
 
 void main()
 {
-    vec2 _73 = (vTex + (vec2(1.0) / vec2(textureSize(sampler2D(uTexture, uSampler), 0)))) + (vec2(1.0) / vec2(textureSize(sampler2D(uTexture, uSampler), 1)));
+    highp vec2 _54 = vec2(1.0) / vec2(textureSize(sampler2D(uTexture, uSampler), 0));
+    vec2 mp_copy_54 = _54;
+    highp vec2 _64 = vec2(1.0) / vec2(textureSize(sampler2D(uTexture, uSampler), 1));
+    vec2 mp_copy_64 = _64;
+    vec2 _73 = (vTex + mp_copy_54) + mp_copy_64;
     FragColor = (((texture(sampler2D(uTexture, uSampler), _73) + texture(sampler2D(uTexture, uSampler), _73)) + texture(sampler2DArray(uTextureArray, uSampler), vTex3)) + texture(samplerCube(uTextureCube, uSampler), vTex3)) + texture(sampler3D(uTexture3D, uSampler), vTex3);
 }
 

--- a/reference/shaders-no-opt/asm/comp/local-size-id.vk.asm.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/local-size-id.vk.asm.comp.vk
@@ -13,6 +13,10 @@ layout(set = 0, binding = 0, std430) buffer SSBO
 
 void main()
 {
-    _8.values[gl_GlobalInvocationID.x] = ((((_8.values[gl_GlobalInvocationID.x] + vec4(2.0)) + vec3(_30).xyzz) * float(int(gl_WorkGroupSize.x))) * float(int(gl_WorkGroupSize.y))) * float(int(2u));
+    vec3 _38 = vec3(_30);
+    float _41 = float(int(gl_WorkGroupSize.x));
+    float _42 = float(int(gl_WorkGroupSize.y));
+    float _43 = float(int(2u));
+    _8.values[gl_GlobalInvocationID.x] = ((((_8.values[gl_GlobalInvocationID.x] + vec4(2.0)) + _38.xyzz) * _41) * _42) * _43;
 }
 

--- a/reference/shaders-no-opt/asm/frag/late-expression-invalidation-2.asm.frag
+++ b/reference/shaders-no-opt/asm/frag/late-expression-invalidation-2.asm.frag
@@ -25,7 +25,8 @@ highp mat2x4 _60 = mat2x4(vec4(0.0), vec4(0.0));
 
 void main()
 {
-    int _68 = -(256 - 14);
+    int _65 = 256 - 14;
+    int _68 = -_65;
     highp vec2 pos = gl_FragCoord.xy / _7.resolution;
     ivec2 ipos = ivec2(int(pos.x * 16.0), int(pos.y * 16.0));
     int i = 0;

--- a/reference/shaders-no-opt/asm/frag/ldexp-uint-exponent.asm.frag
+++ b/reference/shaders-no-opt/asm/frag/ldexp-uint-exponent.asm.frag
@@ -6,6 +6,8 @@ layout(location = 0) out highp vec4 _GLF_color;
 
 void main()
 {
-    _GLF_color = ldexp(vec4(1.0), ivec4(uvec4(bitCount(uvec4(1u)))));
+    mediump uvec4 _4 = uvec4(bitCount(uvec4(1u)));
+    uvec4 hp_copy_4 = _4;
+    _GLF_color = ldexp(vec4(1.0), ivec4(hp_copy_4));
 }
 

--- a/reference/shaders-no-opt/asm/frag/relaxed-precision-inheritance-rules-hoisted-temporaries.asm.frag
+++ b/reference/shaders-no-opt/asm/frag/relaxed-precision-inheritance-rules-hoisted-temporaries.asm.frag
@@ -1,0 +1,23 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+layout(location = 0) in vec4 vColor;
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    float a = vColor.x;
+    highp float b = vColor.y;
+    int i = 0;
+    float _14;
+    highp float hp_copy_14;
+    float _15;
+    highp float hp_copy_15;
+    for (; i < 4; i++, _14 = a, hp_copy_14 = _14, _15 = a * _14, hp_copy_15 = _15, b += (hp_copy_15 * hp_copy_14))
+    {
+        FragColor += vec4(1.0);
+    }
+    FragColor += vec4(b);
+}
+

--- a/reference/shaders-no-opt/asm/frag/relaxed-precision-inheritance-rules-hoisted-temporary.asm.frag
+++ b/reference/shaders-no-opt/asm/frag/relaxed-precision-inheritance-rules-hoisted-temporary.asm.frag
@@ -1,0 +1,19 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+layout(location = 0) in float vColor;
+layout(location = 0) out float FragColor;
+
+void main()
+{
+    float b;
+    highp float hp_copy_b;
+    do
+    {
+        b = vColor * vColor;
+        hp_copy_b = b;
+    } while (false);
+    FragColor = hp_copy_b * hp_copy_b;
+}
+

--- a/reference/shaders-no-opt/asm/frag/relaxed-precision-inheritance-rules.asm.frag
+++ b/reference/shaders-no-opt/asm/frag/relaxed-precision-inheritance-rules.asm.frag
@@ -1,0 +1,53 @@
+#version 320 es
+precision mediump float;
+precision highp int;
+
+layout(binding = 0, std140) uniform UBO
+{
+    float mediump_float;
+    highp float highp_float;
+} ubo;
+
+layout(location = 0) out vec4 FragColor0;
+layout(location = 1) out vec4 FragColor1;
+layout(location = 2) out vec4 FragColor2;
+layout(location = 3) out vec4 FragColor3;
+layout(location = 0) in vec4 V4;
+
+void main()
+{
+    vec4 V4_value0 = V4;
+    highp vec4 hp_copy_V4_value0 = V4_value0;
+    float V1_value0 = V4.x;
+    highp float hp_copy_V1_value0 = V1_value0;
+    float V1_value2 = V4_value0.z;
+    highp float hp_copy_V1_value2 = V1_value2;
+    float ubo_mp0 = ubo.mediump_float;
+    highp float hp_copy_ubo_mp0 = ubo_mp0;
+    highp float ubo_hp0 = ubo.highp_float;
+    float mp_copy_ubo_hp0 = ubo_hp0;
+    highp vec4 _48 = hp_copy_V4_value0 - vec4(3.0);
+    vec4 mp_copy_48 = _48;
+    FragColor0 = V4_value0 + vec4(3.0);
+    FragColor1 = _48;
+    FragColor2 = mp_copy_48 * vec4(3.0);
+    float _21 = V1_value0 + 3.0;
+    float float_0_weird = 3.0 - mp_copy_ubo_hp0;
+    highp float hp_copy_float_0_weird = float_0_weird;
+    highp float _49 = hp_copy_V1_value0 - hp_copy_float_0_weird;
+    float mp_copy_49 = _49;
+    FragColor3 = vec4(_21, _49, mp_copy_49 * mp_copy_ubo_hp0, 3.0);
+    highp float _51 = hp_copy_V1_value2 - hp_copy_ubo_mp0;
+    float mp_copy_51 = _51;
+    FragColor3 = vec4(V4_value0.z + ubo_mp0, _51, mp_copy_51 * mp_copy_ubo_hp0, 3.0);
+    FragColor0 = sin(hp_copy_V4_value0);
+    FragColor1 = sin(V4_value0);
+    float phi_mp;
+    highp float phi_hp;
+    phi_mp = _21;
+    phi_hp = _49;
+    highp float hp_copy_phi_mp = phi_mp;
+    float mp_copy_phi_hp = phi_hp;
+    FragColor2 = vec4(phi_mp + phi_mp, hp_copy_phi_mp + hp_copy_phi_mp, mp_copy_phi_hp + mp_copy_phi_hp, phi_hp + phi_hp);
+}
+

--- a/reference/shaders/asm/vert/spec-constant-op-composite.asm.vk.vert.vk
+++ b/reference/shaders/asm/vert/spec-constant-op-composite.asm.vk.vert.vk
@@ -17,7 +17,8 @@ void main()
     vec4 pos = vec4(0.0);
     pos.y += float(_20);
     pos.z += float(_25);
-    pos += vec4(_32);
+    vec4 _52 = vec4(_32);
+    pos += _52;
     vec2 _58 = pos.xy + vec2(_34);
     pos = vec4(_58.x, _58.y, pos.z, pos.w);
     gl_Position = pos;

--- a/shaders-no-opt/asm/frag/relaxed-precision-inheritance-rules-hoisted-temporaries.asm.frag
+++ b/shaders-no-opt/asm/frag/relaxed-precision-inheritance-rules-hoisted-temporaries.asm.frag
@@ -1,0 +1,97 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 52
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %vColor %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource ESSL 310
+               OpName %main "main"
+               OpName %a "a"
+               OpName %vColor "vColor"
+               OpName %b "b"
+               OpName %i "i"
+               OpName %FragColor "FragColor"
+               OpDecorate %a RelaxedPrecision
+               OpDecorate %vColor RelaxedPrecision
+               OpDecorate %vColor Location 0
+               OpDecorate %16 RelaxedPrecision
+               OpDecorate %20 RelaxedPrecision
+               OpDecorate %FragColor RelaxedPrecision
+               OpDecorate %FragColor Location 0
+               OpDecorate %37 RelaxedPrecision
+               OpDecorate %38 RelaxedPrecision
+               OpDecorate %39 RelaxedPrecision
+               OpDecorate %43 RelaxedPrecision
+               OpDecorate %44 RelaxedPrecision
+               OpDecorate %45 RelaxedPrecision
+               OpDecorate %49 RelaxedPrecision
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_ptr_Function_float = OpTypePointer Function %float
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+     %vColor = OpVariable %_ptr_Input_v4float Input
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+%_ptr_Input_float = OpTypePointer Input %float
+     %uint_1 = OpConstant %uint 1
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+      %int_0 = OpConstant %int 0
+      %int_4 = OpConstant %int 4
+       %bool = OpTypeBool
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+    %float_1 = OpConstant %float 1
+      %int_1 = OpConstant %int 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %a = OpVariable %_ptr_Function_float Function
+          %b = OpVariable %_ptr_Function_float Function
+          %i = OpVariable %_ptr_Function_int Function
+         %15 = OpAccessChain %_ptr_Input_float %vColor %uint_0
+         %16 = OpLoad %float %15
+               OpStore %a %16
+         %19 = OpAccessChain %_ptr_Input_float %vColor %uint_1
+         %20 = OpLoad %float %19
+               OpStore %b %20
+               OpStore %i %int_0
+               OpBranch %25
+         %25 = OpLabel
+               OpLoopMerge %27 %28 None
+               OpBranch %29
+         %29 = OpLabel
+         %30 = OpLoad %int %i
+         %33 = OpSLessThan %bool %30 %int_4
+               OpBranchConditional %33 %26 %27
+         %26 = OpLabel
+         %37 = OpLoad %v4float %FragColor
+         %38 = OpCompositeConstruct %v4float %float_1 %float_1 %float_1 %float_1
+         %39 = OpFAdd %v4float %37 %38
+               OpStore %FragColor %39
+               OpBranch %28
+         %28 = OpLabel
+         %40 = OpLoad %int %i
+         %42 = OpIAdd %int %40 %int_1
+               OpStore %i %42
+         %43 = OpLoad %float %a
+         %44 = OpLoad %float %a
+         %45 = OpFMul %float %43 %44
+         %force_tmp = OpFMul %float %45 %44
+         %46 = OpLoad %float %b
+         %47 = OpFAdd %float %46 %force_tmp
+               OpStore %b %47
+               OpBranch %25
+         %27 = OpLabel
+         %48 = OpLoad %float %b
+         %49 = OpLoad %v4float %FragColor
+         %50 = OpCompositeConstruct %v4float %48 %48 %48 %48
+         %51 = OpFAdd %v4float %49 %50
+               OpStore %FragColor %51
+               OpReturn
+               OpFunctionEnd

--- a/shaders-no-opt/asm/frag/relaxed-precision-inheritance-rules-hoisted-temporary.asm.frag
+++ b/shaders-no-opt/asm/frag/relaxed-precision-inheritance-rules-hoisted-temporary.asm.frag
@@ -1,0 +1,47 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 27
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %vColor %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource ESSL 310
+               OpName %main "main"
+               OpName %b "b"
+               OpName %vColor "vColor"
+               OpName %FragColor "FragColor"
+               OpDecorate %b RelaxedPrecision
+               OpDecorate %vColor RelaxedPrecision
+               OpDecorate %vColor Location 0
+               OpDecorate %FragColor RelaxedPrecision
+               OpDecorate %FragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_ptr_Function_float = OpTypePointer Function %float
+%_ptr_Input_float = OpTypePointer Input %float
+     %vColor = OpVariable %_ptr_Input_float Input
+       %bool = OpTypeBool
+      %false = OpConstantFalse %bool
+%_ptr_Output_float = OpTypePointer Output %float
+  %FragColor = OpVariable %_ptr_Output_float Output
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpBranch %6
+          %6 = OpLabel
+               OpLoopMerge %8 %9 None
+               OpBranch %7
+          %7 = OpLabel
+		  	%15 = OpLoad %float %vColor
+          %b = OpFMul %float %15 %15
+               OpBranch %9
+          %9 = OpLabel
+               OpBranchConditional %false %6 %8
+          %8 = OpLabel
+         %bb = OpFMul %float %b %b
+               OpStore %FragColor %bb
+               OpReturn
+               OpFunctionEnd

--- a/shaders-no-opt/asm/frag/relaxed-precision-inheritance-rules.asm.frag
+++ b/shaders-no-opt/asm/frag/relaxed-precision-inheritance-rules.asm.frag
@@ -1,0 +1,146 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 15
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor0 %FragColor1 %FragColor2 %FragColor3 %V4
+               OpExecutionMode %main OriginUpperLeft
+               OpSource ESSL 320
+               OpName %main "main"
+               OpName %FragColor0 "FragColor0"
+               OpName %FragColor1 "FragColor1"
+               OpName %FragColor2 "FragColor2"
+               OpName %FragColor3 "FragColor3"
+               OpName %V4 "V4"
+			   OpName %V4_value0 "V4_value0"
+			   OpName %V1_value0 "V1_value0"
+			   OpName %V1_value1 "V1_value1"
+			   OpName %V1_value2 "V1_value2"
+			   OpName %float_0_weird "float_0_weird"
+			   OpName %ubo "ubo"
+			   OpName %ubo_mp0 "ubo_mp0"
+			   OpName %ubo_hp0 "ubo_hp0"
+			   OpName %block "UBO"
+			   OpName %phi_mp "phi_mp"
+			   OpName %phi_hp "phi_hp"
+			   OpMemberName %block 0 "mediump_float"
+			   OpMemberName %block 1 "highp_float"
+               OpDecorate %FragColor0 RelaxedPrecision
+               OpDecorate %FragColor0 Location 0
+               OpDecorate %FragColor1 RelaxedPrecision
+               OpDecorate %FragColor1 Location 1
+               OpDecorate %FragColor2 RelaxedPrecision
+               OpDecorate %FragColor2 Location 2
+               OpDecorate %FragColor3 RelaxedPrecision
+               OpDecorate %FragColor3 Location 3
+               OpDecorate %V4 RelaxedPrecision
+               OpDecorate %V4 Location 0
+			   OpDecorate %V4_add RelaxedPrecision
+			   OpDecorate %V4_mul RelaxedPrecision
+			   OpDecorate %V1_add RelaxedPrecision
+			   OpDecorate %V1_mul RelaxedPrecision
+			   OpDecorate %phi_mp RelaxedPrecision
+			   OpDecorate %mp_to_mp RelaxedPrecision
+			   OpDecorate %hp_to_mp RelaxedPrecision
+			   OpDecorate %V1_add_composite RelaxedPrecision
+			   OpDecorate %V1_mul_composite RelaxedPrecision
+			   OpDecorate %V4_sin1 RelaxedPrecision
+			   OpDecorate %float_0_weird RelaxedPrecision
+			   OpDecorate %ubo Binding 0
+			   OpDecorate %ubo DescriptorSet 0
+			   OpDecorate %block Block
+			   OpMemberDecorate %block 0 Offset 0
+			   OpMemberDecorate %block 1 Offset 4
+			   OpMemberDecorate %block 0 RelaxedPrecision
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+	  %block = OpTypeStruct %float %float
+	  %block_ptr = OpTypePointer Uniform %block
+	  %ubo_float_ptr = OpTypePointer Uniform %float
+	  %ubo = OpVariable %block_ptr Uniform
+      %uint = OpTypeInt 32 0
+	  %uint_0 = OpConstant %uint 0
+	  %uint_1 = OpConstant %uint 1
+	  %uint_2 = OpConstant %uint 2
+	  %uint_3 = OpConstant %uint 3
+	  %float_3 = OpConstant %float 3.0
+    %v4float = OpTypeVector %float 4
+	  %float_3_splat = OpConstantComposite %v4float %float_3 %float_3 %float_3 %float_3
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor0 = OpVariable %_ptr_Output_v4float Output
+  %FragColor1 = OpVariable %_ptr_Output_v4float Output
+  %FragColor2 = OpVariable %_ptr_Output_v4float Output
+  %FragColor3 = OpVariable %_ptr_Output_v4float Output
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%_ptr_Input_float = OpTypePointer Input %float
+         %V4 = OpVariable %_ptr_Input_v4float Input
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+
+		; Inherits precision in GLSL
+         %V4_value0 = OpLoad %v4float %V4
+
+		; Inherits precision in GLSL
+		 %ptr_V4x = OpAccessChain %_ptr_Input_float %V4 %uint_0
+
+		; Inherits precision in GLSL
+         %V1_value0 = OpLoad %float %ptr_V4x
+         %V1_value1 = OpCompositeExtract %float %V4_value0 2
+         %V1_value2 = OpCopyObject %float %V1_value1
+
+		 %mp_ptr = OpAccessChain %ubo_float_ptr %ubo %uint_0
+		 %hp_ptr = OpAccessChain %ubo_float_ptr %ubo %uint_1
+		 %ubo_mp0 = OpLoad %float %mp_ptr
+		 %ubo_hp0 = OpLoad %float %hp_ptr
+
+		; Stays mediump
+         %V4_add = OpFAdd %v4float %V4_value0 %float_3_splat
+		; Must promote to highp
+         %V4_sub = OpFSub %v4float %V4_value0 %float_3_splat
+		; Relaxed, truncate inputs.
+         %V4_mul = OpFMul %v4float %V4_sub %float_3_splat
+		 OpStore %FragColor0 %V4_add
+		 OpStore %FragColor1 %V4_sub
+		 OpStore %FragColor2 %V4_mul
+
+		; Same as V4 tests.
+         %V1_add = OpFAdd %float %V1_value0 %float_3
+		 %float_0_weird = OpFSub %float %float_3 %ubo_hp0
+         %V1_sub = OpFSub %float %V1_value0 %float_0_weird
+         %V1_mul = OpFMul %float %V1_sub %ubo_hp0
+		 %V1_result = OpCompositeConstruct %v4float %V1_add %V1_sub %V1_mul %float_3
+		 OpStore %FragColor3 %V1_result
+
+		; Same as V4 tests, but composite forwarding.
+         %V1_add_composite = OpFAdd %float %V1_value1 %ubo_mp0
+         %V1_sub_composite = OpFSub %float %V1_value2 %ubo_mp0
+         %V1_mul_composite = OpFMul %float %V1_sub_composite %ubo_hp0
+		 %V1_result_composite = OpCompositeConstruct %v4float %V1_add_composite %V1_sub_composite %V1_mul_composite %float_3
+		 OpStore %FragColor3 %V1_result_composite
+
+		 ; Must promote input to highp.
+		 %V4_sin0 = OpExtInst %v4float %1 Sin %V4_value0
+		 OpStore %FragColor0 %V4_sin0
+		 ; Can keep mediump input.
+		 %V4_sin1 = OpExtInst %v4float %1 Sin %V4_value0
+		 OpStore %FragColor1 %V4_sin1
+
+		OpBranch %next
+		%next = OpLabel
+			%phi_mp = OpPhi %float %V1_add %5
+			%phi_hp = OpPhi %float %V1_sub %5
+
+			; Consume PHIs in different precision contexts
+			%mp_to_mp = OpFAdd %float %phi_mp %phi_mp
+			%mp_to_hp = OpFAdd %float %phi_mp %phi_mp
+			%hp_to_mp = OpFAdd %float %phi_hp %phi_hp
+			%hp_to_hp = OpFAdd %float %phi_hp %phi_hp
+			%complete = OpCompositeConstruct %v4float %mp_to_mp %mp_to_hp %hp_to_mp %hp_to_hp
+			OpStore %FragColor2 %complete
+
+               OpReturn
+               OpFunctionEnd

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -24,7 +24,11 @@
 #ifndef SPIRV_CROSS_COMMON_HPP
 #define SPIRV_CROSS_COMMON_HPP
 
+#ifndef SPV_ENABLE_UTILITY_CODE
+#define SPV_ENABLE_UTILITY_CODE
+#endif
 #include "spirv.hpp"
+
 #include "spirv_cross_containers.hpp"
 #include "spirv_cross_error_handling.hpp"
 #include <functional>

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -1564,6 +1564,7 @@ struct AccessChainMeta
 	bool storage_is_packed = false;
 	bool storage_is_invariant = false;
 	bool flattened_struct = false;
+	bool relaxed_precision = false;
 };
 
 enum ExtendedDecorations

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -4710,46 +4710,22 @@ bool Compiler::reflection_ssbo_instance_name_is_significant() const
 	return aliased_ssbo_types;
 }
 
-bool Compiler::instruction_to_result_type(uint32_t &result_type, uint32_t &result_id, spv::Op op, const uint32_t *args,
-                                          uint32_t length)
+bool Compiler::instruction_to_result_type(uint32_t &result_type, uint32_t &result_id, spv::Op op,
+                                          const uint32_t *args, uint32_t length)
 {
-	// Most instructions follow the pattern of <result-type> <result-id> <arguments>.
-	// There are some exceptions.
-	switch (op)
-	{
-	case OpStore:
-	case OpCopyMemory:
-	case OpCopyMemorySized:
-	case OpImageWrite:
-	case OpAtomicStore:
-	case OpAtomicFlagClear:
-	case OpEmitStreamVertex:
-	case OpEndStreamPrimitive:
-	case OpControlBarrier:
-	case OpMemoryBarrier:
-	case OpGroupWaitEvents:
-	case OpRetainEvent:
-	case OpReleaseEvent:
-	case OpSetUserEventStatus:
-	case OpCaptureEventProfilingInfo:
-	case OpCommitReadPipe:
-	case OpCommitWritePipe:
-	case OpGroupCommitReadPipe:
-	case OpGroupCommitWritePipe:
-	case OpLine:
-	case OpNoLine:
+	if (length < 2)
 		return false;
 
-	default:
-		if (length > 1 && maybe_get<SPIRType>(args[0]) != nullptr)
-		{
-			result_type = args[0];
-			result_id = args[1];
-			return true;
-		}
-		else
-			return false;
+	bool has_result_id = false, has_result_type = false;
+	HasResultAndType(op, &has_result_id, &has_result_type);
+	if (has_result_id && has_result_type)
+	{
+		result_type = args[0];
+		result_id = args[1];
+		return true;
 	}
+	else
+		return false;
 }
 
 Bitset Compiler::combined_decoration_for_member(const SPIRType &type, uint32_t index) const

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -556,6 +556,11 @@ protected:
 		}
 	}
 
+	uint32_t *stream_mutable(const Instruction &instr) const
+	{
+		return const_cast<uint32_t *>(stream(instr));
+	}
+
 	ParsedIR ir;
 	// Marks variables which have global scope and variables which can alias with other variables
 	// (SSBO, image load store, etc)

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -24,6 +24,9 @@
 #ifndef SPIRV_CROSS_HPP
 #define SPIRV_CROSS_HPP
 
+#ifndef SPV_ENABLE_UTILITY_CODE
+#define SPV_ENABLE_UTILITY_CODE
+#endif
 #include "spirv.hpp"
 #include "spirv_cfg.hpp"
 #include "spirv_cross_parsed_ir.hpp"

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -21,7 +21,6 @@
  *  2. The MIT License, found at <http://opensource.org/licenses/MIT>.
  */
 
-#define SPV_ENABLE_UTILITY_CODE
 #include "spirv_glsl.hpp"
 #include "GLSL.std.450.h"
 #include "spirv_common.hpp"
@@ -10495,10 +10494,8 @@ CompilerGLSL::TemporaryCopy CompilerGLSL::handle_instruction_precision(const Ins
 				forward_relaxed_precision(ops[1], &ops[2], forwarding_length);
 		}
 
-		bool has_type_id = false;
-		bool has_result_id = false;
-		HasResultAndType(opcode, &has_result_id, &has_type_id);
-		if (has_result_id && has_type_id)
+		uint32_t result_type = 0, result_id = 0;
+		if (instruction_to_result_type(result_type, result_id, opcode, ops, length))
 		{
 			auto itr = temporary_to_mirror_precision_alias.find(ops[1]);
 			if (itr != temporary_to_mirror_precision_alias.end())


### PR DESCRIPTION
GLSL and SPIR-V work completely differently here.

GLSL inherits precision from its arguments, not its destination. SPIR-V on the other hand declares this on the instruction, where inputs may be truncated. Without RelaxedPrecision on a SPIR-V instruction, we might find that all inputs are mediump and will therefore execute in mediump. To counteract this, force temporaries and bind them to highp variables. We cannot mess with the RelaxedPrecision decoration since that will cascade down to sub-dependencies which we don't want.

GLSL will forward the relaxedprecision decorations from chained expressions, so do that as well by just inheriting RelaxedPrecision as necessary.

Fix #1868.