### PR TITLE
GLSL: Do not analyze precision for Undef variables.

### DIFF
--- a/reference/opt/shaders/asm/vert/spec-constant-op-composite.asm.vk.vert.vk
+++ b/reference/opt/shaders/asm/vert/spec-constant-op-composite.asm.vk.vert.vk
@@ -13,13 +13,16 @@ layout(location = 0) flat out int _4;
 
 void main()
 {
+    float _42 = float(_20);
     vec4 _65 = vec4(0.0);
-    _65.y = float(_20);
+    _65.y = _42;
+    float _47 = float(_25);
     vec4 _68 = _65;
-    _68.z = float(_25);
+    _68.z = _47;
     vec4 _52 = vec4(_32);
     vec4 _54 = _68 + _52;
-    vec2 _58 = _54.xy + vec2(_34);
+    vec2 _55 = vec2(_34);
+    vec2 _58 = _54.xy + _55;
     gl_Position = vec4(_58.x, _58.y, _54.z, _54.w);
     _4 = _35;
 }

--- a/reference/opt/shaders/vulkan/frag/spec-constant-ternary.vk.frag.vk
+++ b/reference/opt/shaders/vulkan/frag/spec-constant-ternary.vk.frag.vk
@@ -8,6 +8,7 @@ layout(location = 0) out float FragColor;
 
 void main()
 {
-    FragColor = float(f);
+    float _17 = float(f);
+    FragColor = _17;
 }
 

--- a/reference/shaders/asm/vert/spec-constant-op-composite.asm.vk.vert.vk
+++ b/reference/shaders/asm/vert/spec-constant-op-composite.asm.vk.vert.vk
@@ -15,11 +15,14 @@ layout(location = 0) flat out int _4;
 void main()
 {
     vec4 pos = vec4(0.0);
-    pos.y += float(_20);
-    pos.z += float(_25);
+    float _42 = float(_20);
+    pos.y += _42;
+    float _47 = float(_25);
+    pos.z += _47;
     vec4 _52 = vec4(_32);
     pos += _52;
-    vec2 _58 = pos.xy + vec2(_34);
+    vec2 _55 = vec2(_34);
+    vec2 _58 = pos.xy + _55;
     pos = vec4(_58.x, _58.y, pos.z, pos.w);
     gl_Position = pos;
     _4 = _35;

--- a/reference/shaders/vulkan/frag/spec-constant-ternary.vk.frag.vk
+++ b/reference/shaders/vulkan/frag/spec-constant-ternary.vk.frag.vk
@@ -8,6 +8,7 @@ layout(location = 0) out float FragColor;
 
 void main()
 {
-    FragColor = float(f);
+    float _17 = float(f);
+    FragColor = _17;
 }
 

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -4311,7 +4311,8 @@ void CompilerGLSL::force_temporary_and_recompile(uint32_t id)
 uint32_t CompilerGLSL::consume_temporary_in_precision_context(uint32_t type_id, uint32_t id, Options::Precision precision)
 {
 	// Constants do not have innate precision.
-	if (ir.ids[id].get_type() == TypeConstant || ir.ids[id].get_type() == TypeConstantOp)
+	auto handle_type = ir.ids[id].get_type();
+	if (handle_type == TypeConstant || handle_type == TypeConstantOp || handle_type == TypeUndef)
 		return id;
 
 	// Ignore anything that isn't 32-bit values.
@@ -10309,7 +10310,9 @@ CompilerGLSL::Options::Precision CompilerGLSL::analyze_expression_precision(cons
 	for (uint32_t i = 0; i < length; i++)
 	{
 		uint32_t arg = args[i];
-		if (ir.ids[arg].get_type() == TypeConstant)
+
+		auto handle_type = ir.ids[arg].get_type();
+		if (handle_type == TypeConstant || handle_type == TypeConstantOp || handle_type == TypeUndef)
 			continue;
 
 		if (has_decoration(arg, DecorationRelaxedPrecision))


### PR DESCRIPTION
Undefs won't have a chance to emit aliases, and any expression depending
on Undef will be garbage either way.

Fix #1935.