### PR TITLE
MSL: Potentially cast loaded Input variables.

### DIFF
--- a/reference/opt/shaders-msl/frag/vecsize-mismatch.shader-inputs.frag
+++ b/reference/opt/shaders-msl/frag/vecsize-mismatch.shader-inputs.frag
@@ -69,7 +69,7 @@ fragment main0_out main0(main0_in in [[stage_in]])
     c[1] = in.c_1;
     e[0] = in.e_0;
     e[1] = in.e_1;
-    out.FragColor = float4(float(int(in.a.x)), float(in.b.x), float2(float(uint(c[1])), float(e[0].w)) + in.d.xy);
+    out.FragColor = float4(float(int(short(in.a.x))), float(int(in.b.x)), float2(float(uint(c[1])), float(e[0].w)) + in.d.xy);
     return out;
 }
 

--- a/reference/opt/shaders-msl/vert/signedness-mismatch.shader-inputs.vert
+++ b/reference/opt/shaders-msl/vert/signedness-mismatch.shader-inputs.vert
@@ -68,7 +68,7 @@ vertex main0_out main0(main0_in in [[stage_in]])
     c[1] = in.c_1;
     d[0] = in.d_0;
     d[1] = in.d_1;
-    out.gl_Position = float4(float(int(in.a.x)), float(in.b.x), float(uint(c[1])), float(d[0].w));
+    out.gl_Position = float4(float(int(short(in.a.x))), float(int(in.b.x)), float(uint(c[1])), float(d[0].w));
     return out;
 }
 

--- a/reference/shaders-msl/frag/vecsize-mismatch.shader-inputs.frag
+++ b/reference/shaders-msl/frag/vecsize-mismatch.shader-inputs.frag
@@ -69,7 +69,7 @@ fragment main0_out main0(main0_in in [[stage_in]])
     c[1] = in.c_1;
     e[0] = in.e_0;
     e[1] = in.e_1;
-    out.FragColor = float4(float(int(in.a.x)), float(in.b.x), float2(float(uint(c[1])), float(e[0].w)) + in.d.xy);
+    out.FragColor = float4(float(int(short(in.a.x))), float(int(in.b.x)), float2(float(uint(c[1])), float(e[0].w)) + in.d.xy);
     return out;
 }
 

--- a/reference/shaders-msl/vert/signedness-mismatch.shader-inputs.vert
+++ b/reference/shaders-msl/vert/signedness-mismatch.shader-inputs.vert
@@ -68,7 +68,7 @@ vertex main0_out main0(main0_in in [[stage_in]])
     c[1] = in.c_1;
     d[0] = in.d_0;
     d[1] = in.d_1;
-    out.gl_Position = float4(float(int(in.a.x)), float(in.b.x), float(uint(c[1])), float(d[0].w));
+    out.gl_Position = float4(float(int(short(in.a.x))), float(int(in.b.x)), float(uint(c[1])), float(d[0].w));
     return out;
 }
 


### PR DESCRIPTION
If the sign is rewritten for an input, we might have to fixup the sign
in OpLoad, similar to builtins.

Fix #1934.