### PR TITLE
Promote Unreachable cases into break to avoid fallthrough.

### DIFF
--- a/reference/opt/shaders-hlsl/frag/switch-unreachable-break.frag
+++ b/reference/opt/shaders-hlsl/frag/switch-unreachable-break.frag
@@ -1,0 +1,49 @@
+cbuffer UBO : register(b0)
+{
+    int _13_cond : packoffset(c0);
+    int _13_cond2 : packoffset(c0.y);
+};
+
+
+static float4 FragColor;
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    bool _49;
+    switch (_13_cond)
+    {
+        case 1:
+        {
+            if (_13_cond2 < 50)
+            {
+                _49 = false;
+                break;
+            }
+            else
+            {
+                discard;
+            }
+            break; // unreachable workaround
+        }
+        default:
+        {
+            _49 = true;
+            break;
+        }
+    }
+    bool4 _45 = _49.xxxx;
+    FragColor = float4(_45.x ? 10.0f.xxxx.x : 20.0f.xxxx.x, _45.y ? 10.0f.xxxx.y : 20.0f.xxxx.y, _45.z ? 10.0f.xxxx.z : 20.0f.xxxx.z, _45.w ? 10.0f.xxxx.w : 20.0f.xxxx.w);
+}
+
+SPIRV_Cross_Output main()
+{
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/opt/shaders-msl/frag/switch-unreachable-break.frag
+++ b/reference/opt/shaders-msl/frag/switch-unreachable-break.frag
@@ -1,0 +1,43 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBO
+{
+    int cond;
+    int cond2;
+};
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(constant UBO& _15 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.FragColor = float4(10.0);
+    switch (_15.cond)
+    {
+        case 1:
+        {
+            if (_15.cond2 < 50)
+            {
+                break;
+            }
+            else
+            {
+                discard_fragment();
+            }
+            break; // unreachable workaround
+        }
+        default:
+        {
+            out.FragColor = float4(20.0);
+            break;
+        }
+    }
+    return out;
+}
+

--- a/reference/opt/shaders/frag/switch-unreachable-break.frag
+++ b/reference/opt/shaders/frag/switch-unreachable-break.frag
@@ -1,0 +1,37 @@
+#version 450
+
+layout(binding = 0, std140) uniform UBO
+{
+    int cond;
+    int cond2;
+} _13;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    bool _49;
+    switch (_13.cond)
+    {
+        case 1:
+        {
+            if (_13.cond2 < 50)
+            {
+                _49 = false;
+                break;
+            }
+            else
+            {
+                discard;
+            }
+            break; // unreachable workaround
+        }
+        default:
+        {
+            _49 = true;
+            break;
+        }
+    }
+    FragColor = mix(vec4(20.0), vec4(10.0), bvec4(_49));
+}
+

--- a/reference/opt/shaders/legacy/vert/switch-nested.legacy.vert
+++ b/reference/opt/shaders/legacy/vert/switch-nested.legacy.vert
@@ -28,6 +28,7 @@ void main()
                     _101 = vec4(0.0);
                     break;
                 }
+                break; // unreachable workaround
             }
             _102 = _101;
             break;
@@ -37,6 +38,7 @@ void main()
             _102 = vec4(0.0);
             break;
         }
+        break; // unreachable workaround
     }
     gl_Position = _102;
 }

--- a/reference/shaders-hlsl/frag/switch-unreachable-break.frag
+++ b/reference/shaders-hlsl/frag/switch-unreachable-break.frag
@@ -1,0 +1,55 @@
+cbuffer UBO : register(b0)
+{
+    int _13_cond : packoffset(c0);
+    int _13_cond2 : packoffset(c0.y);
+};
+
+
+static float4 FragColor;
+static float4 vInput;
+
+struct SPIRV_Cross_Input
+{
+    float4 vInput : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 FragColor : SV_Target0;
+};
+
+void frag_main()
+{
+    bool frog = false;
+    switch (_13_cond)
+    {
+        case 1:
+        {
+            if (_13_cond2 < 50)
+            {
+                break;
+            }
+            else
+            {
+                discard;
+            }
+            break; // unreachable workaround
+        }
+        default:
+        {
+            frog = true;
+            break;
+        }
+    }
+    bool4 _45 = frog.xxxx;
+    FragColor = float4(_45.x ? 10.0f.xxxx.x : 20.0f.xxxx.x, _45.y ? 10.0f.xxxx.y : 20.0f.xxxx.y, _45.z ? 10.0f.xxxx.z : 20.0f.xxxx.z, _45.w ? 10.0f.xxxx.w : 20.0f.xxxx.w);
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    vInput = stage_input.vInput;
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.FragColor = FragColor;
+    return stage_output;
+}

--- a/reference/shaders-msl/frag/switch-unreachable-break.frag
+++ b/reference/shaders-msl/frag/switch-unreachable-break.frag
@@ -1,0 +1,43 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBO
+{
+    int cond;
+    int cond2;
+};
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(constant UBO& _15 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.FragColor = float4(10.0);
+    switch (_15.cond)
+    {
+        case 1:
+        {
+            if (_15.cond2 < 50)
+            {
+                break;
+            }
+            else
+            {
+                discard_fragment();
+            }
+            break; // unreachable workaround
+        }
+        default:
+        {
+            out.FragColor = float4(20.0);
+            break;
+        }
+    }
+    return out;
+}
+

--- a/reference/shaders/frag/switch-unreachable-break.frag
+++ b/reference/shaders/frag/switch-unreachable-break.frag
@@ -1,0 +1,36 @@
+#version 450
+
+layout(binding = 0, std140) uniform UBO
+{
+    int cond;
+    int cond2;
+} _13;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+    bool frog = false;
+    switch (_13.cond)
+    {
+        case 1:
+        {
+            if (_13.cond2 < 50)
+            {
+                break;
+            }
+            else
+            {
+                discard;
+            }
+            break; // unreachable workaround
+        }
+        default:
+        {
+            frog = true;
+            break;
+        }
+    }
+    FragColor = mix(vec4(20.0), vec4(10.0), bvec4(frog));
+}
+

--- a/shaders-hlsl/frag/switch-unreachable-break.frag
+++ b/shaders-hlsl/frag/switch-unreachable-break.frag
@@ -1,0 +1,32 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) in vec4 vInput;
+
+layout(set = 0, binding = 0) uniform UBO
+{
+	int cond;
+	int cond2;
+};
+
+void main()
+{
+	bool frog = false;
+	switch (cond)
+	{
+	case 1:
+		if (cond2 < 50)
+			break;
+		else
+			discard;
+
+		break;
+
+	default:
+		frog = true;
+		break;
+	}
+
+	FragColor = frog ? vec4(10.0) : vec4(20.0);
+}
+

--- a/shaders-msl/frag/switch-unreachable-break.frag
+++ b/shaders-msl/frag/switch-unreachable-break.frag
@@ -1,0 +1,30 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) in vec4 vInput;
+
+layout(set = 0, binding = 0) uniform UBO
+{
+	int cond;
+	int cond2;
+};
+
+void main()
+{
+	FragColor = vec4(10.0);
+	switch (cond)
+	{
+	case 1:
+		if (cond2 < 50)
+			break;
+		else
+			discard;
+
+		break;
+
+	default:
+		FragColor = vec4(20.0);
+		break;
+	}
+}
+

--- a/shaders/frag/switch-unreachable-break.frag
+++ b/shaders/frag/switch-unreachable-break.frag
@@ -1,0 +1,32 @@
+#version 450
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) in vec4 vInput;
+
+layout(set = 0, binding = 0) uniform UBO
+{
+	int cond;
+	int cond2;
+};
+
+void main()
+{
+	bool frog = false;
+	switch (cond)
+	{
+	case 1:
+		if (cond2 < 50)
+			break;
+		else
+			discard;
+
+		break;
+
+	default:
+		frog = true;
+		break;
+	}
+
+	FragColor = frog ? vec4(10.0) : vec4(20.0);
+}
+

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -15707,8 +15707,43 @@ void CompilerGLSL::emit_block_chain(SPIRBlock &block)
 		break;
 
 	case SPIRBlock::Unreachable:
+	{
+		// Avoid emitting false fallthrough, which can happen for
+		// if (cond) break; else discard; inside a case label.
+		// Discard is not always implementable as a terminator.
+
+		auto &cfg = get_cfg_for_current_function();
+		bool inner_dominator_is_switch = false;
+		ID id = block.self;
+
+		while (id)
+		{
+			auto &iter_block = get<SPIRBlock>(id);
+			if (iter_block.terminator == SPIRBlock::MultiSelect ||
+			    iter_block.merge == SPIRBlock::MergeLoop)
+			{
+				ID next_block = iter_block.merge == SPIRBlock::MergeLoop ?
+				                iter_block.merge_block : iter_block.next_block;
+				bool outside_construct = next_block && cfg.find_common_dominator(next_block, block.self) == next_block;
+				if (!outside_construct)
+				{
+					inner_dominator_is_switch = iter_block.terminator == SPIRBlock::MultiSelect;
+					break;
+				}
+			}
+
+			if (cfg.get_preceding_edges(id).empty())
+				break;
+
+			id = cfg.get_immediate_dominator(id);
+		}
+
+		if (inner_dominator_is_switch)
+			statement("break; // unreachable workaround");
+
 		emit_next_block = false;
 		break;
+	}
 
 	case SPIRBlock::IgnoreIntersection:
 		statement("ignoreIntersectionEXT;");


### PR DESCRIPTION
HLSL is very fussy about fallthrough in switch blocks, so promote
Unreachable blocks to breaks if they are inside a switch construct.

Some false positives are possible in weird multi-break scenarios, but
this is benign.

Fix #1943.