### PR TITLE
HLSL: fix BuiltInLayer to emit semantic 'SV_RenderTargetArrayIndex'

### DIFF
--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -645,9 +645,9 @@ void CompilerHLSL::emit_builtin_outputs_in_struct()
 
 		case BuiltInLayer:
 			if (hlsl_options.shader_model < 50 || get_entry_point().model != ExecutionModelGeometry)
-				SPIRV_CROSS_THROW("Render target index output is only supported in GS 5.0 or higher.");
+				SPIRV_CROSS_THROW("Render target array index output is only supported in GS 5.0 or higher.");
 			type = "uint";
-			semantic = "SV_RenderTargetIndex";
+			semantic = "SV_RenderTargetArrayIndex";
 			break;
 
 		default:
@@ -797,9 +797,9 @@ void CompilerHLSL::emit_builtin_inputs_in_struct()
 
 		case BuiltInLayer:
 			if (hlsl_options.shader_model < 50 || get_entry_point().model != ExecutionModelFragment)
-				SPIRV_CROSS_THROW("Render target index input is only supported in PS 5.0 or higher.");
+				SPIRV_CROSS_THROW("Render target array index input is only supported in PS 5.0 or higher.");
 			type = "uint";
-			semantic = "SV_RenderTargetIndex";
+			semantic = "SV_RenderTargetArrayIndex";
 			break;
 
 		default:


### PR DESCRIPTION
When trying to use `gl_Layer` and converting to HLSL, I ran into some difficulty.  I think the previous PR had a mistake, as from what I can tell `gl_Layer`'s substitute is `SV_RenderTargetArrayIndex`.