### PR TITLE
GLSL: Add basic support for GL_EXT_shader_atomic_float.

### DIFF
--- a/reference/opt/shaders/vulkan/comp/fp-atomic.nocompat.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/fp-atomic.nocompat.vk.comp.vk
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_EXT_shader_atomic_float : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(set = 0, binding = 1, std430) buffer SSBO
+{
+    float v;
+} _18;
+
+layout(set = 0, binding = 0, r32f) uniform image2D uImage;
+
+shared float shared_v;
+
+void main()
+{
+    float _15 = atomicAdd(shared_v, 2.0);
+    float value = _15;
+    float _24 = atomicAdd(_18.v, _15);
+    float _39 = imageAtomicAdd(uImage, ivec2(gl_GlobalInvocationID.xy), _15);
+    float _45 = imageAtomicExchange(uImage, ivec2(gl_GlobalInvocationID.xy), _15);
+    value = _45;
+}
+

--- a/reference/shaders/vulkan/comp/fp-atomic.nocompat.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/fp-atomic.nocompat.vk.comp.vk
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_EXT_shader_atomic_float : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(set = 0, binding = 1, std430) buffer SSBO
+{
+    float v;
+} _18;
+
+layout(set = 0, binding = 0, r32f) uniform image2D uImage;
+
+shared float shared_v;
+
+void main()
+{
+    float _15 = atomicAdd(shared_v, 2.0);
+    float value = _15;
+    float _24 = atomicAdd(_18.v, value);
+    float _39 = imageAtomicAdd(uImage, ivec2(gl_GlobalInvocationID.xy), value);
+    float _45 = imageAtomicExchange(uImage, ivec2(gl_GlobalInvocationID.xy), value);
+    value = _45;
+}
+

--- a/shaders/vulkan/comp/fp-atomic.nocompat.vk.comp
+++ b/shaders/vulkan/comp/fp-atomic.nocompat.vk.comp
@@ -1,0 +1,18 @@
+#version 450
+#extension GL_EXT_shader_atomic_float : require
+
+shared float shared_v;
+layout(set = 0, binding = 0, r32f) uniform image2D uImage;
+
+layout(set = 0, binding = 1) buffer SSBO
+{
+	float v;
+};
+
+void main()
+{
+	float value = atomicAdd(shared_v, 2.0);
+	atomicAdd(v, value);
+	imageAtomicAdd(uImage, ivec2(gl_GlobalInvocationID.xy), value);
+	value = imageAtomicExchange(uImage, ivec2(gl_GlobalInvocationID.xy), value);
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -6066,6 +6066,16 @@ void CompilerGLSL::emit_binary_func_op(uint32_t result_type, uint32_t result_id,
 void CompilerGLSL::emit_atomic_func_op(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1,
                                        const char *op)
 {
+	auto &type = get<SPIRType>(result_type);
+	if (type_is_floating_point(type))
+	{
+		if (!options.vulkan_semantics)
+			SPIRV_CROSS_THROW("Floating point atomics requires Vulkan semantics.");
+		if (options.es)
+			SPIRV_CROSS_THROW("Floating point atomics requires desktop GLSL.");
+		require_extension_internal("GL_EXT_shader_atomic_float");
+	}
+
 	forced_temporaries.insert(result_id);
 	emit_op(result_type, result_id,
 	        join(op, "(", to_non_uniform_aware_expression(op0), ", ",
@@ -12132,6 +12142,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 	}
 
 	case OpAtomicIAdd:
+	case OpAtomicFAddEXT:
 	{
 		const char *op = check_atomic_image(ops[2]) ? "imageAtomicAdd" : "atomicAdd";
 		emit_atomic_func_op(ops[0], ops[1], ops[2], ops[5], op);


### PR DESCRIPTION
Fix #1944.

atomicLoad/Store is left out and should be handled when Vulkan memory model support is eventually added.