### PR TITLE
Fix control flow bug where we missed continue;

### DIFF
--- a/reference/shaders-no-opt/comp/loop-break-merge-after-inner-continue.comp
+++ b/reference/shaders-no-opt/comp/loop-break-merge-after-inner-continue.comp
@@ -1,0 +1,22 @@
+#version 450
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0, std430) buffer STO
+{
+    uint data[];
+} ssbo;
+
+void main()
+{
+    while (true)
+    {
+        ssbo.data[0]++;
+        if (ssbo.data[2] != 0u)
+        {
+            ssbo.data[5]++;
+            continue;
+        }
+        break;
+    }
+}
+

--- a/shaders-no-opt/comp/loop-break-merge-after-inner-continue.comp
+++ b/shaders-no-opt/comp/loop-break-merge-after-inner-continue.comp
@@ -1,0 +1,21 @@
+#version 450
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout (binding = 0) buffer STO
+{
+  uint data[];
+} ssbo;
+
+void main()
+{
+  while(true)
+  {
+    ssbo.data[0] += 1;
+    if (bool(ssbo.data[2]))
+    {
+      ssbo.data[5] += 1;
+      continue;
+    }
+    break;
+  }
+}


### PR DESCRIPTION
Case which caused failure:

if (cond)
{
    continue;
}
break;

Only allow tracing from inner selections if the outer header never
merges execution.

Fix #1957.