### PR TITLE
HLSL: Implement bit casts between Half and UShort.

### DIFF
--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -3598,6 +3598,18 @@ string CompilerHLSL::bitcast_glsl_op(const SPIRType &out_type, const SPIRType &i
 		}
 		return "spvPackFloat2x16";
 	}
+	else if (out_type.basetype == SPIRType::UShort && in_type.basetype == SPIRType::Half)
+	{
+		if (hlsl_options.shader_model < 40)
+			SPIRV_CROSS_THROW("Half to UShort requires Shader Model 4.");
+		return "(" + type_to_glsl(out_type) + ")f32tof16";
+	}
+	else if (out_type.basetype == SPIRType::Half && in_type.basetype == SPIRType::UShort)
+	{
+		if (hlsl_options.shader_model < 40)
+			SPIRV_CROSS_THROW("UShort to Half requires Shader Model 4.");
+		return "(" + type_to_glsl(out_type) + ")f16tof32";
+	}
 	else
 		return "";
 }


### PR DESCRIPTION
I'm trying to get AMD FidelityFX shader through SPIRV-Cross. For some reasons, I have to compile to SPIR-V first. (I know it'd be better to use the HLSL version directly, but for now this flow is more convenient for me.)

The matter is that this function in the generated HLSL gives compile errors:
```
half APrxLoRsqH1(half a)
{
    uint16_t param = 22947u;
    uint16_t param_1 = 1u;
    return (AW1_x(param) - ((a) >> AW1_x(param_1)));
}
```
> `error: int or unsigned int type required`
> `   return (AW1_x(param) - ((a) >> AW1_x(param_1)));`

For reference, this is the corresponding SPIR-V dissasembly of the function:
```
%APrxLoRsqH1_f161_ = OpFunction %half None %32 ; 0x000041a0
        %a_7 = OpFunctionParameter %_ptr_Function_half ; 0x000041b4
         %90 = OpLabel ; 0x000041c0
    %param_9 = OpVariable %_ptr_Function_ushort Function ; 0x000041c8
   %param_10 = OpVariable %_ptr_Function_ushort Function ; 0x000041d8
               OpStore %param_9 %ushort_22947 ; 0x000041e8
        %328 = OpFunctionCall %ushort %AW1_x_u161_ %param_9 ; 0x000041f4
        %329 = OpLoad %half %a_7 ; 0x00004208
        %330 = OpBitcast %ushort %329 ; 0x00004218
               OpStore %param_10 %ushort_1 ; 0x00004228
        %333 = OpFunctionCall %ushort %AW1_x_u161_ %param_10 ; 0x00004234
        %334 = OpShiftRightLogical %ushort %330 %333 ; 0x00004248
        %335 = OpISub %ushort %328 %334 ; 0x0000425c
        %336 = OpBitcast %half %335 ; 0x00004270
               OpReturnValue %336 ; 0x00004280
               OpFunctionEnd ; 0x00004288
```

This PR extends the support for bit casts so the function at hand is generated correctly for HLSL, like this:
```
half APrxLoRsqH1(half a)
{
    uint16_t param = 22947u;
    uint16_t param_1 = 1u;
    return f16tof32(AW1_x(param) - (f32tof16(a) >> AW1_x(param_1)));
}
```

The compiler will need to be passed the `-enable-16bit-types` switch, which will only work on SM 6.2+, but the intrinsics used were introduced in SM 5.0, so that's the one checked for.