### PR TITLE
Fix compilation errors with deprecated sprintf function

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -5275,7 +5275,7 @@ string CompilerGLSL::convert_float_to_string(const SPIRConstant &c, uint32_t col
 			in_type.width = 32;
 
 			char print_buffer[32];
-			sprintf(print_buffer, "0x%xu", c.scalar(col, row));
+			snprintf(print_buffer, sizeof(print_buffer), "0x%xu", c.scalar(col, row));
 
 			const char *comment = "inf";
 			if (float_value == -numeric_limits<float>::infinity())
@@ -5347,8 +5347,8 @@ std::string CompilerGLSL::convert_double_to_string(const SPIRConstant &c, uint32
 			require_extension_internal("GL_ARB_gpu_shader_int64");
 
 			char print_buffer[64];
-			sprintf(print_buffer, "0x%llx%s", static_cast<unsigned long long>(u64_value),
-			        backend.long_long_literal_suffix ? "ull" : "ul");
+			snprintf(print_buffer, sizeof(print_buffer), "0x%llx%s", static_cast<unsigned long long>(u64_value),
+			         backend.long_long_literal_suffix ? "ull" : "ul");
 
 			const char *comment = "inf";
 			if (double_value == -numeric_limits<double>::infinity())

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -16405,6 +16405,6 @@ void CompilerMSL::emit_block_hints(const SPIRBlock &)
 string CompilerMSL::additional_fixed_sample_mask_str() const
 {
 	char print_buffer[32];
-	sprintf(print_buffer, "0x%x", msl_options.additional_fixed_sample_mask);
+	snprintf(print_buffer, sizeof(print_buffer), "0x%x", msl_options.additional_fixed_sample_mask);
 	return print_buffer;
 }


### PR DESCRIPTION
This commit modifies sprintf calls to fix the following compilation
errors using XCode 14.0 beta on MacOS:

> 'sprintf' is deprecated: This function is provided for compatibility
> reasons only.  Due to security concerns inherent in the design of
> sprintf(3), it is highly recommended that you use snprintf(3) instead.