### PR TITLE
Don't rename remapped variables like 'gl_LastFragDepthARM'

### DIFF
--- a/spirv_cross_parsed_ir.cpp
+++ b/spirv_cross_parsed_ir.cpp
@@ -330,6 +330,10 @@ void ParsedIR::fixup_reserved_names()
 {
 	for (uint32_t id : meta_needing_name_fixup)
 	{
+		// Don't rename remapped variables like 'gl_LastFragDepthARM'.
+		if (ids[id].get_type() == TypeVariable && get<SPIRVariable>(id).remapped_variable)
+			continue;
+
 		auto &m = meta[id];
 		sanitize_identifier(m.decoration.alias, false, false);
 		for (auto &memb : m.members)
@@ -342,8 +346,6 @@ void ParsedIR::set_name(ID id, const string &name)
 {
 	auto &m = meta[id];
 	m.decoration.alias = name;
-	if (ids[id].get_type() == TypeVariable && get<SPIRVariable>(id).remapped_variable)
-		return;
 	if (!is_valid_identifier(name) || is_reserved_identifier(name, false, false))
 		meta_needing_name_fixup.insert(id);
 }

--- a/spirv_cross_parsed_ir.cpp
+++ b/spirv_cross_parsed_ir.cpp
@@ -342,6 +342,8 @@ void ParsedIR::set_name(ID id, const string &name)
 {
 	auto &m = meta[id];
 	m.decoration.alias = name;
+	if (ids[id].get_type() == TypeVariable && get<SPIRVariable>(id).remapped_variable)
+		return;
 	if (!is_valid_identifier(name) || is_reserved_identifier(name, false, false))
 		meta_needing_name_fixup.insert(id);
 }

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -649,7 +649,7 @@ string CompilerGLSL::compile()
 	{
 		// only NV_gpu_shader5 supports divergent indexing on OpenGL, and it does so without extra qualifiers
 		backend.nonuniform_qualifier = "";
-		backend.needs_row_major_load_workaround = true;
+		backend.needs_row_major_load_workaround = !options.es;
 	}
 	backend.allow_precision_qualifiers = options.vulkan_semantics || options.es;
 	backend.force_gl_in_out_block = true;

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -649,7 +649,7 @@ string CompilerGLSL::compile()
 	{
 		// only NV_gpu_shader5 supports divergent indexing on OpenGL, and it does so without extra qualifiers
 		backend.nonuniform_qualifier = "";
-		backend.needs_row_major_load_workaround = !options.es;
+		backend.needs_row_major_load_workaround = options.enable_row_major_load_workaround;
 	}
 	backend.allow_precision_qualifiers = options.vulkan_semantics || options.es;
 	backend.force_gl_in_out_block = true;

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -145,6 +145,12 @@ public:
 		// compares.
 		bool relax_nan_checks = false;
 
+		// Loading row-major matrices from UBOs on older AMD Windows OpenGL drivers is problematic.
+		// To load these types correctly, we must generate a wrapper. them in a dummy function which only purpose is to
+		// ensure row_major decoration is actually respected.
+		// This workaround may cause significant performance degeneration on some Android devices.
+		bool enable_row_major_load_workaround = true;
+
 		// If non-zero, controls layout(num_views = N) in; in GL_OVR_multiview2.
 		uint32_t ovr_multiview_view_count = 0;
 


### PR DESCRIPTION
The name fixing logic makes shaders with depth fetch broken (`gl_LastFragDepthARM` is renamed to `_RESERVED_IDENTIFIER_FIXUP_gl_LastFragDepthARM`). We should prevent remapped vars from being renamed.