### PR TITLE
HLSL: add support for user-defined register/space id for push_constant(root constants)

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -715,6 +715,8 @@ struct CLIArguments
 	bool hlsl_base_vertex_index_explicit_binding = false;
 	uint32_t hlsl_base_vertex_index_register_index = 0;
 	uint32_t hlsl_base_vertex_index_register_space = 0;
+	uint32_t hlsl_push_constant_register_index = ResourceBindingPushConstantBinding;
+	uint32_t hlsl_push_constant_register_space = ResourceBindingPushConstantDescriptorSet;
 
 	bool hlsl_force_storage_buffer_as_uav = false;
 	bool hlsl_nonwritable_uav_texture_as_srv = false;
@@ -1377,6 +1379,7 @@ static string compile_iteration(const CLIArguments &args, std::vector<uint32_t> 
 		hlsl_opts.flatten_matrix_vertex_input_semantics = args.hlsl_flatten_matrix_vertex_input_semantics;
 		hlsl->set_hlsl_options(hlsl_opts);
 		hlsl->set_resource_binding_flags(args.hlsl_binding_flags);
+		hlsl->set_hlsl_push_constant_binding(args.hlsl_push_constant_register_index, args.hlsl_push_constant_register_space);
 		if (args.hlsl_base_vertex_index_explicit_binding)
 		{
 			hlsl->set_hlsl_aux_buffer_binding(HLSL_AUX_BINDING_BASE_VERTEX_INSTANCE,
@@ -1549,6 +1552,10 @@ static int main_inner(int argc, char *argv[])
 		args.hlsl_base_vertex_index_explicit_binding = true;
 		args.hlsl_base_vertex_index_register_index = parser.next_uint();
 		args.hlsl_base_vertex_index_register_space = parser.next_uint();
+	});
+	cbs.add("--hlsl-push-constant-binding", [&args](CLIParser &parser) {
+		args.hlsl_push_constant_register_index = parser.next_uint();
+		args.hlsl_push_constant_register_space = parser.next_uint();
 	});
 	cbs.add("--hlsl-auto-binding", [&args](CLIParser &parser) {
 		args.hlsl_binding_flags |= hlsl_resource_type_to_flag(parser.next_string());

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1236,6 +1236,12 @@ bool CompilerHLSL::is_hlsl_aux_buffer_binding_used(HLSLAuxBinding binding) const
 		return false;
 }
 
+void CompilerHLSL::set_hlsl_push_constant_binding(uint32_t register_index, uint32_t register_space)
+{
+	push_constant_info.register_index = register_index;
+	push_constant_info.register_space = register_space;
+}
+
 void CompilerHLSL::emit_composite_constants()
 {
 	// HLSL cannot declare structs or arrays inline, so we must move them out to
@@ -3470,8 +3476,8 @@ string CompilerHLSL::to_resource_binding(const SPIRVariable &var)
 		return "";
 
 	uint32_t desc_set =
-	    resource_flags == HLSL_BINDING_AUTO_PUSH_CONSTANT_BIT ? ResourceBindingPushConstantDescriptorSet : 0u;
-	uint32_t binding = resource_flags == HLSL_BINDING_AUTO_PUSH_CONSTANT_BIT ? ResourceBindingPushConstantBinding : 0u;
+		resource_flags == HLSL_BINDING_AUTO_PUSH_CONSTANT_BIT ? push_constant_info.register_space : 0u;
+	uint32_t binding = resource_flags == HLSL_BINDING_AUTO_PUSH_CONSTANT_BIT ? push_constant_info.register_index : 0u;
 
 	if (has_decoration(var.self, DecorationBinding))
 		binding = get_decoration(var.self, DecorationBinding);

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -54,8 +54,6 @@ enum HLSLBindingFlagBits
 	HLSL_BINDING_AUTO_NONE_BIT = 0,
 
 	// Push constant (root constant) resources will be declared as CBVs (b-space) without a register() declaration.
-	// A register will be automatically assigned by the D3D compiler, but must therefore be reflected in D3D-land.
-	// Push constants do not normally have a DecorationBinding set, but if they do, this can be used to ignore it.
 	HLSL_BINDING_AUTO_PUSH_CONSTANT_BIT = 1 << 0,
 
 	// cbuffer resources will be declared as CBVs (b-space) without a register() declaration.
@@ -220,6 +218,8 @@ public:
 	void set_hlsl_aux_buffer_binding(HLSLAuxBinding binding, uint32_t register_index, uint32_t register_space);
 	void unset_hlsl_aux_buffer_binding(HLSLAuxBinding binding);
 	bool is_hlsl_aux_buffer_binding_used(HLSLAuxBinding binding) const;
+
+	void set_hlsl_push_constant_binding(uint32_t register_index, uint32_t register_space);
 
 private:
 	std::string type_to_glsl(const SPIRType &type, uint32_t id = 0) override;
@@ -390,6 +390,12 @@ private:
 		bool explicit_binding = false;
 		bool used = false;
 	} base_vertex_info;
+
+	struct
+	{
+		uint32_t register_index = 0;
+		uint32_t register_space = 0;
+	} push_constant_info;
 
 	// Returns true for BuiltInSampleMask because gl_SampleMask[] is an array in SPIR-V, but SV_Coverage is a scalar in HLSL.
 	bool builtin_translates_to_nonarray(spv::BuiltIn builtin) const override;


### PR DESCRIPTION
Followup to #2032

Explicit binding for `push_constant`, helps engine to avoid link/runtime errors in generated hlsl shader-pipeline.
Note: not using AUX-buffer concept intentionally, since push_constant is not auxiliary item.

syntax:
`--hlsl-push-constant-binding <register> <space>`