### PR TITLE
MSL: Handle partial access chains with array-of-UBO/SSBO.

### DIFF
--- a/reference/shaders-msl-no-opt/asm/frag/access-chain-array-ubo-partial.argument.msl2.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/access-chain-array-ubo-partial.argument.msl2.asm.frag
@@ -1,0 +1,27 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBOs
+{
+    float4 v;
+};
+
+struct spvDescriptorSetBuffer0
+{
+    constant UBOs* ubos [[id(0)]][2];
+};
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.FragColor = spvDescriptorSet0.ubos[0]->v + spvDescriptorSet0.ubos[1]->v;
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/asm/frag/access-chain-array-ubo-partial.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/access-chain-array-ubo-partial.asm.frag
@@ -1,0 +1,28 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct UBOs
+{
+    float4 v;
+};
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(constant UBOs* ubos_0 [[buffer(0)]], constant UBOs* ubos_1 [[buffer(1)]])
+{
+    constant UBOs* ubos[] =
+    {
+        ubos_0,
+        ubos_1,
+    };
+
+    main0_out out = {};
+    out.FragColor = ubos[0]->v + ubos[1]->v;
+    return out;
+}
+

--- a/shaders-msl-no-opt/asm/frag/access-chain-array-ubo-partial.argument.msl2.asm.frag
+++ b/shaders-msl-no-opt/asm/frag/access-chain-array-ubo-partial.argument.msl2.asm.frag
@@ -1,0 +1,50 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 25
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %FragColor "FragColor"
+               OpName %UBOs "UBOs"
+               OpMemberName %UBOs 0 "v"
+               OpName %ubos "ubos"
+               OpDecorate %FragColor Location 0
+               OpMemberDecorate %UBOs 0 Offset 0
+               OpDecorate %UBOs Block
+               OpDecorate %ubos DescriptorSet 0
+               OpDecorate %ubos Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+       %UBOs = OpTypeStruct %v4float
+       %uint = OpTypeInt 32 0
+     %uint_2 = OpConstant %uint 2
+%_arr_UBOs_uint_2 = OpTypeArray %UBOs %uint_2
+%_ptr_Uniform__arr_UBOs_uint_2 = OpTypePointer Uniform %_arr_UBOs_uint_2
+%_ptr_Uniform_UBOs = OpTypePointer Uniform %UBOs
+       %ubos = OpVariable %_ptr_Uniform__arr_UBOs_uint_2 Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
+      %int_1 = OpConstant %int 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %ptr0_partial = OpAccessChain %_ptr_Uniform_UBOs %ubos %int_0
+		 %ptr0 = OpAccessChain %_ptr_Uniform_v4float %ptr0_partial %int_0
+         %ptr1_partial = OpAccessChain %_ptr_Uniform_UBOs %ubos %int_1
+		 %ptr1 = OpAccessChain %_ptr_Uniform_v4float %ptr1_partial %int_0
+         %20 = OpLoad %v4float %ptr0
+         %23 = OpLoad %v4float %ptr1
+         %24 = OpFAdd %v4float %20 %23
+               OpStore %FragColor %24
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/frag/access-chain-array-ubo-partial.asm.frag
+++ b/shaders-msl-no-opt/asm/frag/access-chain-array-ubo-partial.asm.frag
@@ -1,0 +1,50 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 25
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %FragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %FragColor "FragColor"
+               OpName %UBOs "UBOs"
+               OpMemberName %UBOs 0 "v"
+               OpName %ubos "ubos"
+               OpDecorate %FragColor Location 0
+               OpMemberDecorate %UBOs 0 Offset 0
+               OpDecorate %UBOs Block
+               OpDecorate %ubos DescriptorSet 0
+               OpDecorate %ubos Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %FragColor = OpVariable %_ptr_Output_v4float Output
+       %UBOs = OpTypeStruct %v4float
+       %uint = OpTypeInt 32 0
+     %uint_2 = OpConstant %uint 2
+%_arr_UBOs_uint_2 = OpTypeArray %UBOs %uint_2
+%_ptr_Uniform__arr_UBOs_uint_2 = OpTypePointer Uniform %_arr_UBOs_uint_2
+%_ptr_Uniform_UBOs = OpTypePointer Uniform %UBOs
+       %ubos = OpVariable %_ptr_Uniform__arr_UBOs_uint_2 Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
+      %int_1 = OpConstant %int 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %ptr0_partial = OpAccessChain %_ptr_Uniform_UBOs %ubos %int_0
+		 %ptr0 = OpAccessChain %_ptr_Uniform_v4float %ptr0_partial %int_0
+         %ptr1_partial = OpAccessChain %_ptr_Uniform_UBOs %ubos %int_1
+		 %ptr1 = OpAccessChain %_ptr_Uniform_v4float %ptr1_partial %int_0
+         %20 = OpLoad %v4float %ptr0
+         %23 = OpLoad %v4float %ptr1
+         %24 = OpFAdd %v4float %20 %23
+               OpStore %FragColor %24
+               OpReturn
+               OpFunctionEnd

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -14196,7 +14196,7 @@ void CompilerMSL::sync_entry_point_aliases_and_names()
 
 string CompilerMSL::to_member_reference(uint32_t base, const SPIRType &type, uint32_t index, bool ptr_chain)
 {
-	auto *var = maybe_get<SPIRVariable>(base);
+	auto *var = maybe_get_backing_variable(base);
 	// If this is a buffer array, we have to dereference the buffer pointers.
 	// Otherwise, if this is a pointer expression, dereference it.
 


### PR DESCRIPTION
Need to consider the backing variable, not just plain SPIRVariable.

Fix #2040.