### PR TITLE
MSL: Fix restrict vs __restrict incompatibility.

### DIFF
--- a/reference/opt/shaders-msl/asm/comp/bitcast_iadd.asm.comp
+++ b/reference/opt/shaders-msl/asm/comp/bitcast_iadd.asm.comp
@@ -15,7 +15,7 @@ struct _4
     int4 _m1;
 };
 
-kernel void main0(device _3& restrict _5 [[buffer(0)]], device _4& restrict _6 [[buffer(1)]])
+kernel void main0(device _3& __restrict _5 [[buffer(0)]], device _4& __restrict _6 [[buffer(1)]])
 {
     _6._m0 = _5._m1 + uint4(_5._m0);
     _6._m0 = uint4(_5._m0) + _5._m1;

--- a/reference/opt/shaders-msl/asm/comp/bitcast_icmp.asm.comp
+++ b/reference/opt/shaders-msl/asm/comp/bitcast_icmp.asm.comp
@@ -15,7 +15,7 @@ struct _4
     int4 _m1;
 };
 
-kernel void main0(device _3& restrict _5 [[buffer(0)]], device _4& restrict _6 [[buffer(1)]])
+kernel void main0(device _3& __restrict _5 [[buffer(0)]], device _4& __restrict _6 [[buffer(1)]])
 {
     _6._m0 = uint4(int4(_5._m1) < _5._m0);
     _6._m0 = uint4(int4(_5._m1) <= _5._m0);

--- a/reference/opt/shaders-msl/asm/comp/multiple-entry.asm.comp
+++ b/reference/opt/shaders-msl/asm/comp/multiple-entry.asm.comp
@@ -15,7 +15,7 @@ struct _7
     int4 _m1;
 };
 
-kernel void main0(device _6& restrict _8 [[buffer(0)]], device _7& restrict _9 [[buffer(1)]])
+kernel void main0(device _6& __restrict _8 [[buffer(0)]], device _7& __restrict _9 [[buffer(1)]])
 {
     _9._m0 = _8._m1 + uint4(_8._m0);
     _9._m0 = uint4(_8._m0) + _8._m1;

--- a/reference/opt/shaders-msl/comp/buffer_device_address.msl2.comp
+++ b/reference/opt/shaders-msl/comp/buffer_device_address.msl2.comp
@@ -32,7 +32,7 @@ kernel void main0(constant Registers& registers [[buffer(0)]], uint3 gl_GlobalIn
     uint _30 = ((_19 * 8u) * gl_NumWorkGroups.x) + _29;
     uint local_index = _30;
     uint slice = gl_WorkGroupID.z;
-    device Position* positions = registers.references->buffers[gl_WorkGroupID.z];
+    device Position* __restrict positions = registers.references->buffers[gl_WorkGroupID.z];
     float _66 = float(gl_WorkGroupID.z);
     float _70 = fract(fma(_66, 0.100000001490116119384765625, registers.fract_time));
     float _71 = 6.283125400543212890625 * _70;

--- a/reference/opt/shaders-msl/vert/buffer_device_address.msl2.vert
+++ b/reference/opt/shaders-msl/vert/buffer_device_address.msl2.vert
@@ -32,7 +32,7 @@ vertex main0_out main0(constant Registers& registers [[buffer(0)]], uint gl_Inst
 {
     main0_out out = {};
     int slice = int(gl_InstanceIndex);
-    const device Position* positions = registers.references->buffers[int(gl_InstanceIndex)];
+    const device Position* __restrict positions = registers.references->buffers[int(gl_InstanceIndex)];
     float2 _45 = registers.references->buffers[int(gl_InstanceIndex)]->positions[int(gl_VertexIndex)] * 2.5;
     float2 pos = _45;
     float2 _60 = _45 + ((float2(float(int(gl_InstanceIndex) % 8), float(int(gl_InstanceIndex) / 8)) - float2(3.5)) * 3.0);

--- a/reference/shaders-msl-no-opt/comp/bda-restrict-pointer-variable.msl2.comp
+++ b/reference/shaders-msl-no-opt/comp/bda-restrict-pointer-variable.msl2.comp
@@ -1,0 +1,23 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Ref;
+
+struct Ref
+{
+    float4 v;
+};
+
+struct Registers
+{
+    device Ref* foo;
+};
+
+kernel void main0(constant Registers& _14 [[buffer(0)]])
+{
+    device Ref* __restrict ref = _14.foo;
+    ref->v = float4(1.0);
+}
+

--- a/reference/shaders-msl/asm/comp/bitcast_iadd.asm.comp
+++ b/reference/shaders-msl/asm/comp/bitcast_iadd.asm.comp
@@ -15,7 +15,7 @@ struct _4
     int4 _m1;
 };
 
-kernel void main0(device _3& restrict _5 [[buffer(0)]], device _4& restrict _6 [[buffer(1)]])
+kernel void main0(device _3& __restrict _5 [[buffer(0)]], device _4& __restrict _6 [[buffer(1)]])
 {
     _6._m0 = _5._m1 + uint4(_5._m0);
     _6._m0 = uint4(_5._m0) + _5._m1;

--- a/reference/shaders-msl/asm/comp/bitcast_icmp.asm.comp
+++ b/reference/shaders-msl/asm/comp/bitcast_icmp.asm.comp
@@ -15,7 +15,7 @@ struct _4
     int4 _m1;
 };
 
-kernel void main0(device _3& restrict _5 [[buffer(0)]], device _4& restrict _6 [[buffer(1)]])
+kernel void main0(device _3& __restrict _5 [[buffer(0)]], device _4& __restrict _6 [[buffer(1)]])
 {
     _6._m0 = uint4(int4(_5._m1) < _5._m0);
     _6._m0 = uint4(int4(_5._m1) <= _5._m0);

--- a/reference/shaders-msl/asm/comp/multiple-entry.asm.comp
+++ b/reference/shaders-msl/asm/comp/multiple-entry.asm.comp
@@ -15,7 +15,7 @@ struct _7
     int4 _m1;
 };
 
-kernel void main0(device _6& restrict _8 [[buffer(0)]], device _7& restrict _9 [[buffer(1)]])
+kernel void main0(device _6& __restrict _8 [[buffer(0)]], device _7& __restrict _9 [[buffer(1)]])
 {
     _9._m0 = _8._m1 + uint4(_8._m0);
     _9._m0 = uint4(_8._m0) + _8._m1;

--- a/reference/shaders-msl/comp/buffer_device_address.msl2.comp
+++ b/reference/shaders-msl/comp/buffer_device_address.msl2.comp
@@ -29,7 +29,7 @@ kernel void main0(constant Registers& registers [[buffer(0)]], uint3 gl_GlobalIn
     uint2 local_offset = gl_GlobalInvocationID.xy;
     uint local_index = ((local_offset.y * 8u) * gl_NumWorkGroups.x) + local_offset.x;
     uint slice = gl_WorkGroupID.z;
-    device Position* positions = registers.references->buffers[slice];
+    device Position* __restrict positions = registers.references->buffers[slice];
     float offset = 6.283125400543212890625 * fract(registers.fract_time + (float(slice) * 0.100000001490116119384765625));
     float2 pos = float2(local_offset);
     pos.x += (0.20000000298023223876953125 * sin((2.2000000476837158203125 * pos.x) + offset));

--- a/reference/shaders-msl/vert/buffer_device_address.msl2.vert
+++ b/reference/shaders-msl/vert/buffer_device_address.msl2.vert
@@ -32,7 +32,7 @@ vertex main0_out main0(constant Registers& registers [[buffer(0)]], uint gl_Inst
 {
     main0_out out = {};
     int slice = int(gl_InstanceIndex);
-    const device Position* positions = registers.references->buffers[slice];
+    const device Position* __restrict positions = registers.references->buffers[slice];
     float2 pos = positions->positions[int(gl_VertexIndex)] * 2.5;
     pos += ((float2(float(slice % 8), float(slice / 8)) - float2(3.5)) * 3.0);
     out.gl_Position = registers.view_projection * float4(pos, 0.0, 1.0);

--- a/shaders-msl-no-opt/comp/bda-restrict-pointer-variable.msl2.comp
+++ b/shaders-msl-no-opt/comp/bda-restrict-pointer-variable.msl2.comp
@@ -1,0 +1,18 @@
+#version 450
+#extension GL_EXT_buffer_reference : require
+
+layout(buffer_reference) buffer Ref
+{
+	vec4 v;
+};
+
+layout(push_constant) uniform Registers
+{
+	Ref foo;
+};
+
+void main()
+{
+	restrict Ref ref = foo;
+	ref.v = vec4(1.0);
+}

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -980,7 +980,7 @@ protected:
 	bool validate_member_packing_rules_msl(const SPIRType &type, uint32_t index) const;
 	std::string get_argument_address_space(const SPIRVariable &argument);
 	std::string get_type_address_space(const SPIRType &type, uint32_t id, bool argument = false);
-	const char *to_restrict(uint32_t id, bool space = true);
+	const char *to_restrict(uint32_t id, bool space);
 	SPIRType &get_stage_in_struct_type();
 	SPIRType &get_stage_out_struct_type();
 	SPIRType &get_patch_stage_in_struct_type();


### PR DESCRIPTION
restrict was supported, but it broke in MSL 3.0. __restrict works on all versions, so opt for that instead.

Also check for RestrictPointer decoration and refactor to_restrict() to not take optional parameter to make it more obvious when implied space character is added.

Fix #2038.