### PR TITLE
Handle row major matrix workaround more gracefully

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,7 +332,7 @@ if (SPIRV_CROSS_STATIC)
 endif()
 
 set(spirv-cross-abi-major 0)
-set(spirv-cross-abi-minor 52)
+set(spirv-cross-abi-minor 53)
 set(spirv-cross-abi-patch 0)
 
 if (SPIRV_CROSS_SHARED)

--- a/reference/opt/shaders/legacy/vert/transpose.legacy.vert
+++ b/reference/opt/shaders/legacy/vert/transpose.legacy.vert
@@ -11,7 +11,8 @@ uniform Buffer _13;
 
 attribute vec4 Position;
 
-mat4 spvWorkaroundRowMajor(mat4 wrap) { return wrap; }
+highp mat4 spvWorkaroundRowMajor(highp mat4 wrap) { return wrap; }
+mediump mat4 spvWorkaroundRowMajorMP(mediump mat4 wrap) { return wrap; }
 
 mat4 spvTranspose(mat4 m)
 {

--- a/reference/opt/shaders/vert/read-from-row-major-array.vert
+++ b/reference/opt/shaders/vert/read-from-row-major-array.vert
@@ -8,7 +8,8 @@ layout(binding = 0, std140) uniform Block
 layout(location = 0) in vec4 a_position;
 layout(location = 0) out mediump float v_vtxResult;
 
-mat2x3 spvWorkaroundRowMajor(mat2x3 wrap) { return wrap; }
+highp mat2x3 spvWorkaroundRowMajor(highp mat2x3 wrap) { return wrap; }
+mediump mat2x3 spvWorkaroundRowMajorMP(mediump mat2x3 wrap) { return wrap; }
 
 void main()
 {

--- a/reference/opt/shaders/vert/row-major-workaround.vert
+++ b/reference/opt/shaders/vert/row-major-workaround.vert
@@ -1,0 +1,30 @@
+#version 310 es
+
+layout(binding = 0, std140) uniform Buffer
+{
+    layout(row_major) mat4 HP;
+    layout(row_major) mediump mat4 MP;
+} _21;
+
+layout(binding = 1, std140) uniform Buffer2
+{
+    layout(row_major) mediump mat4 MP2;
+} _39;
+
+layout(location = 0) out vec4 H;
+layout(location = 0) in vec4 Hin;
+layout(location = 1) out mediump vec4 M;
+layout(location = 1) in mediump vec4 Min;
+layout(location = 2) out mediump vec4 M2;
+
+highp mat4 spvWorkaroundRowMajor(highp mat4 wrap) { return wrap; }
+mediump mat4 spvWorkaroundRowMajorMP(mediump mat4 wrap) { return wrap; }
+
+void main()
+{
+    gl_Position = vec4(1.0);
+    H = spvWorkaroundRowMajor(_21.HP) * Hin;
+    M = spvWorkaroundRowMajor(_21.MP) * Min;
+    M2 = spvWorkaroundRowMajorMP(_39.MP2) * Min;
+}
+

--- a/reference/shaders/legacy/vert/transpose.legacy.vert
+++ b/reference/shaders/legacy/vert/transpose.legacy.vert
@@ -11,7 +11,8 @@ uniform Buffer _13;
 
 attribute vec4 Position;
 
-mat4 spvWorkaroundRowMajor(mat4 wrap) { return wrap; }
+highp mat4 spvWorkaroundRowMajor(highp mat4 wrap) { return wrap; }
+mediump mat4 spvWorkaroundRowMajorMP(mediump mat4 wrap) { return wrap; }
 
 mat4 spvTranspose(mat4 m)
 {

--- a/reference/shaders/vert/read-from-row-major-array.vert
+++ b/reference/shaders/vert/read-from-row-major-array.vert
@@ -8,7 +8,8 @@ layout(binding = 0, std140) uniform Block
 layout(location = 0) in vec4 a_position;
 layout(location = 0) out mediump float v_vtxResult;
 
-mat2x3 spvWorkaroundRowMajor(mat2x3 wrap) { return wrap; }
+highp mat2x3 spvWorkaroundRowMajor(highp mat2x3 wrap) { return wrap; }
+mediump mat2x3 spvWorkaroundRowMajorMP(mediump mat2x3 wrap) { return wrap; }
 
 mediump float compare_float(float a, float b)
 {

--- a/reference/shaders/vert/row-major-workaround.vert
+++ b/reference/shaders/vert/row-major-workaround.vert
@@ -1,0 +1,30 @@
+#version 310 es
+
+layout(binding = 0, std140) uniform Buffer
+{
+    layout(row_major) mat4 HP;
+    layout(row_major) mediump mat4 MP;
+} _21;
+
+layout(binding = 1, std140) uniform Buffer2
+{
+    layout(row_major) mediump mat4 MP2;
+} _39;
+
+layout(location = 0) out vec4 H;
+layout(location = 0) in vec4 Hin;
+layout(location = 1) out mediump vec4 M;
+layout(location = 1) in mediump vec4 Min;
+layout(location = 2) out mediump vec4 M2;
+
+highp mat4 spvWorkaroundRowMajor(highp mat4 wrap) { return wrap; }
+mediump mat4 spvWorkaroundRowMajorMP(mediump mat4 wrap) { return wrap; }
+
+void main()
+{
+    gl_Position = vec4(1.0);
+    H = spvWorkaroundRowMajor(_21.HP) * Hin;
+    M = spvWorkaroundRowMajor(_21.MP) * Min;
+    M2 = spvWorkaroundRowMajorMP(_39.MP2) * Min;
+}
+

--- a/shaders/vert/row-major-workaround.vert
+++ b/shaders/vert/row-major-workaround.vert
@@ -1,0 +1,28 @@
+#version 310 es
+
+layout(binding = 0) uniform Buffer
+{
+	layout(row_major) highp mat4 HP;
+	layout(row_major) mediump mat4 MP;
+};
+
+layout(binding = 1) uniform Buffer2
+{
+	layout(row_major) mediump mat4 MP2;
+};
+
+
+layout(location = 0) in vec4 Hin;
+layout(location = 1) in mediump vec4 Min;
+layout(location = 0) out vec4 H;
+layout(location = 1) out mediump vec4 M;
+layout(location = 2) out mediump vec4 M2;
+
+void main()
+{
+	gl_Position = vec4(1.0);
+	H = HP * Hin;
+	M = MP * Min;
+	M2 = MP2 * Min;
+}
+

--- a/spirv_cross_c.cpp
+++ b/spirv_cross_c.cpp
@@ -479,6 +479,9 @@ spvc_result spvc_compiler_options_set_uint(spvc_compiler_options options, spvc_c
 	case SPVC_COMPILER_OPTION_RELAX_NAN_CHECKS:
 		options->glsl.relax_nan_checks = value != 0;
 		break;
+	case SPVC_COMPILER_OPTION_GLSL_ENABLE_ROW_MAJOR_LOAD_WORKAROUND:
+		options->glsl.enable_row_major_load_workaround = value != 0;
+		break;
 #endif
 
 #if SPIRV_CROSS_C_API_HLSL

--- a/spirv_cross_c.h
+++ b/spirv_cross_c.h
@@ -40,7 +40,7 @@ extern "C" {
 /* Bumped if ABI or API breaks backwards compatibility. */
 #define SPVC_C_API_VERSION_MAJOR 0
 /* Bumped if APIs or enumerations are added in a backwards compatible way. */
-#define SPVC_C_API_VERSION_MINOR 52
+#define SPVC_C_API_VERSION_MINOR 53
 /* Bumped if internal implementation details change. */
 #define SPVC_C_API_VERSION_PATCH 0
 
@@ -720,6 +720,8 @@ typedef enum spvc_compiler_option
 	SPVC_COMPILER_OPTION_MSL_SHADER_PATCH_INPUT_BUFFER_INDEX = 80 | SPVC_COMPILER_OPTION_MSL_BIT,
 	SPVC_COMPILER_OPTION_MSL_MANUAL_HELPER_INVOCATION_UPDATES = 81 | SPVC_COMPILER_OPTION_MSL_BIT,
 	SPVC_COMPILER_OPTION_MSL_CHECK_DISCARDED_FRAG_STORES = 82 | SPVC_COMPILER_OPTION_MSL_BIT,
+
+	SPVC_COMPILER_OPTION_GLSL_ENABLE_ROW_MAJOR_LOAD_WORKAROUND = 83 | SPVC_COMPILER_OPTION_GLSL_BIT,
 
 	SPVC_COMPILER_OPTION_INT_MAX = 0x7fffffff
 } spvc_compiler_option;


### PR DESCRIPTION
- Consider that matrices can be both mediump and highp.
- Add workaround enablement to C API.

Fix #2066.