### PR TITLE
Fixed typo in CompilerGLSL::should_dereference()

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -10092,7 +10092,7 @@ bool CompilerGLSL::should_dereference(uint32_t id)
 			// same type. Can't check type.self, because for some reason that's
 			// usually the base type with pointers stripped off. This check is
 			// complex enough that I've hoisted it out of the while condition.
-			if (src_type.pointer != type.pointer || src_type.pointer_depth != type.pointer ||
+			if (src_type.pointer != type.pointer || src_type.pointer_depth != type.pointer_depth ||
 			    src_type.parent_type != type.parent_type)
 				break;
 			if ((var = maybe_get<SPIRVariable>(expr->loaded_from)))


### PR DESCRIPTION
This typo came to my attention when I saw a warning about a `bool != uint32_t` comparison.