### PR TITLE
Accept glslang's new loop behavior

### DIFF
--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -752,6 +752,7 @@ protected:
 	bool is_force_recompile = false;
 	bool is_force_recompile_forward_progress = false;
 
+	bool block_is_noop(const SPIRBlock &block) const;
 	bool block_is_loop_candidate(const SPIRBlock &block, SPIRBlock::Method method) const;
 
 	bool types_are_logically_equivalent(const SPIRType &a, const SPIRType &b) const;


### PR DESCRIPTION
After https://github.com/KhronosGroup/glslang/commit/7a914ce9261dd591ec793df42b5aba11d6c02848, glslang emits a new `OpLine` in for loops. This can be safely ignored.

Relevant specification docs:
1. https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_miscellaneous_instructions
2. https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_debug_instructions

Addresses https://github.com/KhronosGroup/SPIRV-Cross/issues/2079