### PR TITLE
GLSL/HLSL: Add legacy handling for int vertex attributes

### DIFF
--- a/reference/opt/shaders-hlsl/vert/legacy-int-attribute.sm30.vert
+++ b/reference/opt/shaders-hlsl/vert/legacy-int-attribute.sm30.vert
@@ -1,0 +1,36 @@
+uniform float4 gl_HalfPixel;
+
+static float4 gl_Position;
+static int4 attr_int4;
+static int attr_int1;
+
+struct SPIRV_Cross_Input
+{
+    float4 attr_int4 : TEXCOORD0;
+    float attr_int1 : TEXCOORD1;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 gl_Position : POSITION;
+};
+
+void vert_main()
+{
+    gl_Position.x = float(attr_int4[attr_int1]);
+    gl_Position.y = 0.0f;
+    gl_Position.z = 0.0f;
+    gl_Position.w = 0.0f;
+    gl_Position.x = gl_Position.x - gl_HalfPixel.x * gl_Position.w;
+    gl_Position.y = gl_Position.y + gl_HalfPixel.y * gl_Position.w;
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    attr_int4 = stage_input.attr_int4;
+    attr_int1 = stage_input.attr_int1;
+    vert_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    return stage_output;
+}

--- a/reference/opt/shaders/legacy/vert/int-attribute.legacy.vert
+++ b/reference/opt/shaders/legacy/vert/int-attribute.legacy.vert
@@ -1,0 +1,13 @@
+#version 100
+
+attribute vec4 attr_int4;
+attribute float attr_int1;
+
+void main()
+{
+    gl_Position.x = float(int(attr_int4[int(attr_int1)]));
+    gl_Position.y = 0.0;
+    gl_Position.z = 0.0;
+    gl_Position.w = 0.0;
+}
+

--- a/reference/shaders-hlsl/vert/legacy-int-attribute.sm30.vert
+++ b/reference/shaders-hlsl/vert/legacy-int-attribute.sm30.vert
@@ -1,0 +1,36 @@
+uniform float4 gl_HalfPixel;
+
+static float4 gl_Position;
+static int4 attr_int4;
+static int attr_int1;
+
+struct SPIRV_Cross_Input
+{
+    float4 attr_int4 : TEXCOORD0;
+    float attr_int1 : TEXCOORD1;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 gl_Position : POSITION;
+};
+
+void vert_main()
+{
+    gl_Position.x = float(attr_int4[attr_int1]);
+    gl_Position.y = 0.0f;
+    gl_Position.z = 0.0f;
+    gl_Position.w = 0.0f;
+    gl_Position.x = gl_Position.x - gl_HalfPixel.x * gl_Position.w;
+    gl_Position.y = gl_Position.y + gl_HalfPixel.y * gl_Position.w;
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    attr_int4 = stage_input.attr_int4;
+    attr_int1 = stage_input.attr_int1;
+    vert_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    return stage_output;
+}

--- a/reference/shaders/legacy/vert/int-attribute.legacy.vert
+++ b/reference/shaders/legacy/vert/int-attribute.legacy.vert
@@ -1,0 +1,13 @@
+#version 100
+
+attribute vec4 attr_int4;
+attribute float attr_int1;
+
+void main()
+{
+    gl_Position.x = float(int(attr_int4[int(attr_int1)]));
+    gl_Position.y = 0.0;
+    gl_Position.z = 0.0;
+    gl_Position.w = 0.0;
+}
+

--- a/shaders-hlsl/vert/legacy-int-attribute.sm30.vert
+++ b/shaders-hlsl/vert/legacy-int-attribute.sm30.vert
@@ -1,0 +1,10 @@
+#version 310 es
+
+layout(location=0) in ivec4 attr_int4;
+layout(location=1) in int attr_int1;
+
+void main()
+{
+	gl_Position.x = float(attr_int4[attr_int1]);
+	gl_Position.yzw = vec3(0.0f, 0.0f, 0.0f);
+}

--- a/shaders/legacy/vert/int-attribute.legacy.vert
+++ b/shaders/legacy/vert/int-attribute.legacy.vert
@@ -1,0 +1,10 @@
+#version 310 es
+
+layout(location=0) in ivec4 attr_int4;
+layout(location=1) in int attr_int1;
+
+void main()
+{
+	gl_Position.x = float(attr_int4[attr_int1]);
+	gl_Position.yzw = vec3(0.0f, 0.0f, 0.0f);
+}


### PR DESCRIPTION
Hi, I'm back with more legacy fixes :)

spirv-cross rightly rejects uint vertex attributes, because uints are not supported by legacy GLSL at all.  However it does pass through *signed* integer inputs, even though they are not supported by legacy GLSL (the spec is very explicit that attributes must be float, even if this is popularly accepted, see also KhronosGroup/glslang#3111).

This PR changes these attributes to be declared as float and then automatically generates a typecast to convert them to int/ivec at OpLoad time.  The assumption is that the engine will just use plain old glVertexAttribPointer (since glVertexAttribIPointer is not available in legacy GL anyway) with the normalized flag set to GL_FALSE to supply these attributes.

This change is necessary for our vertex skinning shaders to be portable to legacy targets.

Same change for HLSL, except this case is a little bit simpler as it already generates code to copy the input variables to static globals, so that's where the (implicit, which seems to be OK in HLSL) type cast happens.