### PR TITLE
HLSL: Support PointSize output in vertex shader in SM 3.0

### DIFF
--- a/reference/opt/shaders-hlsl/vert/point-size.sm30.vert
+++ b/reference/opt/shaders-hlsl/vert/point-size.sm30.vert
@@ -1,0 +1,26 @@
+uniform float4 gl_HalfPixel;
+
+static float4 gl_Position;
+static float gl_PointSize;
+struct SPIRV_Cross_Output
+{
+    float4 gl_Position : POSITION;
+    float gl_PointSize : PSIZE;
+};
+
+void vert_main()
+{
+    gl_Position = 1.0f.xxxx;
+    gl_PointSize = 4.0f;
+    gl_Position.x = gl_Position.x - gl_HalfPixel.x * gl_Position.w;
+    gl_Position.y = gl_Position.y + gl_HalfPixel.y * gl_Position.w;
+}
+
+SPIRV_Cross_Output main()
+{
+    vert_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    stage_output.gl_PointSize = gl_PointSize;
+    return stage_output;
+}

--- a/reference/shaders-hlsl/vert/point-size.sm30.vert
+++ b/reference/shaders-hlsl/vert/point-size.sm30.vert
@@ -1,0 +1,26 @@
+uniform float4 gl_HalfPixel;
+
+static float4 gl_Position;
+static float gl_PointSize;
+struct SPIRV_Cross_Output
+{
+    float4 gl_Position : POSITION;
+    float gl_PointSize : PSIZE;
+};
+
+void vert_main()
+{
+    gl_Position = 1.0f.xxxx;
+    gl_PointSize = 4.0f;
+    gl_Position.x = gl_Position.x - gl_HalfPixel.x * gl_Position.w;
+    gl_Position.y = gl_Position.y + gl_HalfPixel.y * gl_Position.w;
+}
+
+SPIRV_Cross_Output main()
+{
+    vert_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    stage_output.gl_PointSize = gl_PointSize;
+    return stage_output;
+}

--- a/shaders-hlsl/vert/point-size.sm30.vert
+++ b/shaders-hlsl/vert/point-size.sm30.vert
@@ -1,0 +1,7 @@
+#version 310 es
+
+void main()
+{
+	gl_Position = vec4(1.0);
+	gl_PointSize = 4.0;
+}

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -110,7 +110,7 @@ public:
 	{
 		uint32_t shader_model = 30; // TODO: map ps_4_0_level_9_0,... somehow
 
-		// Allows the PointSize builtin, and ignores it, as PointSize is not supported in HLSL.
+		// Allows the PointSize builtin in SM 4.0+, and ignores it, as PointSize is not supported in SM 4+.
 		bool point_size_compat = false;
 
 		// Allows the PointCoord builtin, returns float2(0.5, 0.5), as PointCoord is not supported in HLSL.


### PR DESCRIPTION
Thank you for accepting my other PRs.

This one adds support for the `BuiltInPointSize` output in HLSL SM 3.0, which had a `PSIZE` semantic that matches the behaviour of `gl_PointSize`.

Tested to work with a shader that now shows identical results between DirectX 9 and OpenGL.

The `point_size_compat` option is now ignored if `shader_model <= 30`.