### PR TITLE
GLSL: Add support for trunc, modf, isnan and isinf in legacy GLSL

### DIFF
--- a/reference/opt/shaders/legacy/fragment/isnan-isinf.legacy.frag
+++ b/reference/opt/shaders/legacy/fragment/isnan-isinf.legacy.frag
@@ -1,0 +1,28 @@
+#version 100
+precision mediump float;
+precision highp int;
+
+varying highp float scalar;
+varying highp vec4 vector;
+
+void main()
+{
+    gl_FragData[0] = vec4(0.0);
+    if (scalar != scalar)
+    {
+        gl_FragData[0].x = 1.0;
+    }
+    if (scalar != 0.0 && 2.0 * scalar == scalar)
+    {
+        gl_FragData[0].y = 1.0;
+    }
+    if (any(notEqual(vector, vector)))
+    {
+        gl_FragData[0].z = 1.0;
+    }
+    if (any(bvec4(vector.x != 0.0 && 2.0 * vector.x == vector.x, vector.y != 0.0 && 2.0 * vector.y == vector.y, vector.z != 0.0 && 2.0 * vector.z == vector.z, vector.w != 0.0 && 2.0 * vector.w == vector.w)))
+    {
+        gl_FragData[0].w = 1.0;
+    }
+}
+

--- a/reference/opt/shaders/legacy/fragment/modf.legacy.frag
+++ b/reference/opt/shaders/legacy/fragment/modf.legacy.frag
@@ -1,0 +1,20 @@
+#version 100
+precision mediump float;
+precision highp int;
+
+varying highp float scalar;
+varying highp vec2 vector;
+
+void main()
+{
+    highp float sipart;
+    sipart = float(int(scalar));
+    gl_FragData[0].x = sipart;
+    gl_FragData[0].y = scalar - sipart;
+    highp vec2 vipart;
+    vipart = vec2(ivec2(vector));
+    highp vec2 _35 = vector - vipart;
+    gl_FragData[0].z = _35.x;
+    gl_FragData[0].w = _35.y;
+}
+

--- a/reference/shaders/legacy/fragment/isnan-isinf.legacy.frag
+++ b/reference/shaders/legacy/fragment/isnan-isinf.legacy.frag
@@ -1,0 +1,28 @@
+#version 100
+precision mediump float;
+precision highp int;
+
+varying highp float scalar;
+varying highp vec4 vector;
+
+void main()
+{
+    gl_FragData[0] = vec4(0.0);
+    if (scalar != scalar)
+    {
+        gl_FragData[0].x = 1.0;
+    }
+    if (scalar != 0.0 && 2.0 * scalar == scalar)
+    {
+        gl_FragData[0].y = 1.0;
+    }
+    if (any(notEqual(vector, vector)))
+    {
+        gl_FragData[0].z = 1.0;
+    }
+    if (any(bvec4(vector.x != 0.0 && 2.0 * vector.x == vector.x, vector.y != 0.0 && 2.0 * vector.y == vector.y, vector.z != 0.0 && 2.0 * vector.z == vector.z, vector.w != 0.0 && 2.0 * vector.w == vector.w)))
+    {
+        gl_FragData[0].w = 1.0;
+    }
+}
+

--- a/reference/shaders/legacy/fragment/modf.legacy.frag
+++ b/reference/shaders/legacy/fragment/modf.legacy.frag
@@ -1,0 +1,22 @@
+#version 100
+precision mediump float;
+precision highp int;
+
+varying highp float scalar;
+varying highp vec2 vector;
+
+void main()
+{
+    highp float sipart;
+    sipart = float(int(scalar));
+    highp float sfpart = scalar - sipart;
+    highp vec2 _20 = vec2(sipart, sfpart);
+    gl_FragData[0].x = _20.x;
+    gl_FragData[0].y = _20.y;
+    highp vec2 vipart;
+    vipart = vec2(ivec2(vector));
+    highp vec2 vfpart = vector - vipart;
+    gl_FragData[0].z = vfpart.x;
+    gl_FragData[0].w = vfpart.y;
+}
+

--- a/shaders/legacy/fragment/isnan-isinf.legacy.frag
+++ b/shaders/legacy/fragment/isnan-isinf.legacy.frag
@@ -1,0 +1,14 @@
+#version 450
+
+layout(location=0) in float scalar;
+layout(location=1) in vec4 vector;
+
+layout(location=0) out vec4 result;
+
+void main() {
+	result = vec4(0.0);
+	if (isnan(scalar)) result.r = 1.0;
+	if (isinf(scalar)) result.g = 1.0;
+	if (any(isnan(vector))) result.b = 1.0;
+	if (any(isinf(vector))) result.a = 1.0;
+}

--- a/shaders/legacy/fragment/modf.legacy.frag
+++ b/shaders/legacy/fragment/modf.legacy.frag
@@ -1,0 +1,16 @@
+#version 450
+
+layout(location=0) in float scalar;
+layout(location=1) in vec2 vector;
+
+layout(location=0) out vec4 result;
+
+void main() {
+	float sipart;
+	float sfpart = modf(scalar, sipart);
+	result.xy = vec2(sipart, sfpart);
+
+	vec2 vipart;
+	vec2 vfpart = modf(vector, vipart);
+	result.zw = vfpart;
+}

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -4124,6 +4124,10 @@ void CompilerHLSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop,
 		emit_unary_func_op(result_type, id, args[0], "round");
 		break;
 
+	case GLSLstd450Trunc:
+		emit_unary_func_op(result_type, id, args[0], "trunc");
+		break;
+
 	case GLSLstd450Acosh:
 	case GLSLstd450Asinh:
 	case GLSLstd450Atanh:


### PR DESCRIPTION
These functions are missing in legacy GLSL but added in 130 / 300es.  More coming soon (sinh and friends still missing) but wanted to get this out for review first.

I wanted to implement isinf as `v == v && v * 0.0 != v * 0.0` but that doesn't seem to work reliably on the implementations I tested.  The formula `v != 0.0 && 2.0 * v == v` , which is used in Cg, does work.  I didn't want to simply compare to `1.0 / 0.0` since the result of dividing by zero is unspecified in legacy GLSL, so it might produce false positives somewhere.

Unfortunately in GLSL the && operator doesn't work component-wise and it doesn't have an `and()` function, so I have to write out the isinf expression per component.  I'm not really worried about performance in any case, I'm just adding this function for completeness' sake.

As for GLSLstd450Modf, I couldn't figure out how to prevent it from writing out a temporary for the result.  I am personally not really bothered by it (the driver will probably just optimize them out anyway) but if you want me to fix that, I could use a hint.

trunc, modf, isinf, isnan tested to produce correct results with Intel drivers on Linux.  I haven't tested GLSLstd450ModfStruct because I don't know how to produce that in the SPIR-V.