### PR TITLE
GLSL: Support OpReadClockKHR

### DIFF
--- a/reference/shaders/frag/shader-clock.frag
+++ b/reference/shaders/frag/shader-clock.frag
@@ -1,0 +1,19 @@
+#version 450
+#if defined(GL_ARB_gpu_shader_int64)
+#extension GL_ARB_gpu_shader_int64 : require
+#elif defined(GL_NV_gpu_shader5)
+#extension GL_NV_gpu_shader5 : require
+#else
+#error No extension available for 64-bit integers.
+#endif
+#extension GL_EXT_shader_realtime_clock : require
+#extension GL_ARB_shader_clock : require
+
+void main()
+{
+    uvec2 a = clockRealtime2x32EXT();
+    uint64_t b = clockRealtimeEXT();
+    uvec2 c = clock2x32ARB();
+    uint64_t d = clockARB();
+}
+

--- a/shaders/frag/shader-clock.frag
+++ b/shaders/frag/shader-clock.frag
@@ -1,0 +1,17 @@
+#version 450
+
+#extension GL_EXT_shader_realtime_clock : enable
+#extension GL_EXT_shader_explicit_arithmetic_types_int64 : enable
+
+#extension GL_ARB_shader_clock : enable
+#extension GL_ARB_gpu_shader_int64 : enable
+
+void main() {
+    // GL_EXT_shader_explicit_arithmetic_types_int64
+    uvec2 a = clockRealtime2x32EXT();
+    uint64_t b = clockRealtimeEXT();
+
+    // GL_ARB_shader_clock
+    uvec2 c = clock2x32ARB();
+    uint64_t d = clockARB();
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -13841,6 +13841,49 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		statement("SetMeshOutputsEXT(", to_unpacked_expression(ops[0]), ", ", to_unpacked_expression(ops[1]), ");");
 		break;
 
+	case OpReadClockKHR:
+	{
+		auto &type = get<SPIRType>(ops[0]);
+		Scope scope = static_cast<Scope>(get<SPIRConstant>(ops[2]).m.c[0].r[0].u32);
+		if (scope == ScopeDevice)
+		{
+			require_extension_internal("GL_EXT_shader_realtime_clock");
+			if (type.basetype == SPIRType::BaseType::UInt64)
+			{
+				emit_op(ops[0], ops[1], "clockRealtimeEXT()", true);
+			}
+			else if (type.basetype == SPIRType::BaseType::UInt && type.vecsize == 2)
+			{
+				emit_op(ops[0], ops[1], "clockRealtime2x32EXT()", true);
+			}
+			else
+			{
+				SPIRV_CROSS_THROW("Unsupported result type for OpReadClockKHR opcode.");
+			}
+		}
+		else if (scope == ScopeSubgroup)
+		{
+			require_extension_internal("GL_ARB_shader_clock");
+			if (type.basetype == SPIRType::BaseType::UInt64)
+			{
+				emit_op(ops[0], ops[1], "clockARB()", true);
+			}
+			else if (type.basetype == SPIRType::BaseType::UInt && type.vecsize == 2)
+			{
+				emit_op(ops[0], ops[1], "clock2x32ARB()", true);
+			}
+			else
+			{
+				SPIRV_CROSS_THROW("Unsupported result type for OpReadClockKHR opcode.");
+			}
+		}
+		else
+		{
+			SPIRV_CROSS_THROW("Unsupported scope for OpReadClockKHR opcode.");
+		}
+		break;
+	}
+
 	default:
 		statement("// unimplemented op ", instruction.op);
 		break;


### PR DESCRIPTION
This adds support for `OpReadClockKHR` to `CompilerGLSL`.

Relevant docs:
 - https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_shader_clock.html
 - https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/KHR/SPV_KHR_shader_clock.html
 - https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GL_EXT_shader_realtime_clock.txt
 - https://registry.khronos.org/OpenGL/extensions/ARB/ARB_shader_clock.txt