### PR TITLE
Add early exit for test_shaders if compilation fails

### DIFF
--- a/test_shaders.sh
+++ b/test_shaders.sh
@@ -6,7 +6,7 @@ OPTS=$@
 
 if [ -z "$SPIRV_CROSS_PATH" ]; then
 	echo "Building spirv-cross"
-	make -j$(nproc)
+	make -j$(nproc) || exit 1
 	SPIRV_CROSS_PATH="./spirv-cross"
 fi
 


### PR DESCRIPTION
This has stung me a couple of times now.  I thought it was useful that test_shaders ran the build automatically, so I started relying on it, but it doesn't early-out if compilation fails and the error messages immediately get lost amid the stream of printed paths, leading me think that my changes were OK.