### PR TITLE
GLSL: Multiplying matrix with scalar shouldn't force transpose

### DIFF
--- a/reference/opt/shaders/legacy/vert/transpose.legacy.vert
+++ b/reference/opt/shaders/legacy/vert/transpose.legacy.vert
@@ -10,6 +10,10 @@ struct Buffer
 uniform Buffer _13;
 
 attribute vec4 Position;
+varying mat4 OutputMat1;
+varying mat4 OutputMat2;
+varying mat4 OutputMat3;
+varying mat4 OutputMat4;
 
 highp mat4 spvWorkaroundRowMajor(highp mat4 wrap) { return wrap; }
 mediump mat4 spvWorkaroundRowMajorMP(mediump mat4 wrap) { return wrap; }
@@ -23,8 +27,12 @@ void main()
 {
     mat4 _55 = _13.MVPRowMajor;
     mat4 _61 = spvWorkaroundRowMajor(_13.MVPColMajor);
-    mat4 _80 = spvTranspose(_13.MVPRowMajor) * 2.0;
-    mat4 _87 = spvTranspose(_61) * 2.0;
-    gl_Position = (((((((((((spvWorkaroundRowMajor(_13.M) * (Position * _13.MVPRowMajor)) + (spvWorkaroundRowMajor(_13.M) * (spvWorkaroundRowMajor(_13.MVPColMajor) * Position))) + (spvWorkaroundRowMajor(_13.M) * (_13.MVPRowMajor * Position))) + (spvWorkaroundRowMajor(_13.M) * (Position * spvWorkaroundRowMajor(_13.MVPColMajor)))) + (_55 * Position)) + (Position * _61)) + (Position * _55)) + (_61 * Position)) + (_80 * Position)) + (_87 * Position)) + (Position * _80)) + (Position * _87);
+    mat4 _80 = _13.MVPRowMajor * 2.0;
+    mat4 _87 = _61 * 2.0;
+    OutputMat1 = spvTranspose(_13.MVPRowMajor);
+    OutputMat2 = spvWorkaroundRowMajor(_13.MVPColMajor);
+    OutputMat3 = _55;
+    OutputMat4 = spvTranspose(_61);
+    gl_Position = (((((((((((spvWorkaroundRowMajor(_13.M) * (Position * _13.MVPRowMajor)) + (spvWorkaroundRowMajor(_13.M) * (spvWorkaroundRowMajor(_13.MVPColMajor) * Position))) + (spvWorkaroundRowMajor(_13.M) * (_13.MVPRowMajor * Position))) + (spvWorkaroundRowMajor(_13.M) * (Position * spvWorkaroundRowMajor(_13.MVPColMajor)))) + (_55 * Position)) + (Position * _61)) + (Position * _55)) + (_61 * Position)) + (Position * _80)) + (Position * _87)) + (_80 * Position)) + (_87 * Position);
 }
 

--- a/reference/shaders/legacy/vert/transpose.legacy.vert
+++ b/reference/shaders/legacy/vert/transpose.legacy.vert
@@ -10,6 +10,10 @@ struct Buffer
 uniform Buffer _13;
 
 attribute vec4 Position;
+varying mat4 OutputMat1;
+varying mat4 OutputMat2;
+varying mat4 OutputMat3;
+varying mat4 OutputMat4;
 
 highp mat4 spvWorkaroundRowMajor(highp mat4 wrap) { return wrap; }
 mediump mat4 spvWorkaroundRowMajorMP(mediump mat4 wrap) { return wrap; }
@@ -29,10 +33,14 @@ void main()
     vec4 c5 = Position * spvWorkaroundRowMajor(_13.MVPColMajor);
     vec4 c6 = Position * _13.MVPRowMajor;
     vec4 c7 = spvWorkaroundRowMajor(_13.MVPColMajor) * Position;
-    vec4 c8 = (spvTranspose(_13.MVPRowMajor) * 2.0) * Position;
-    vec4 c9 = (spvTranspose(spvWorkaroundRowMajor(_13.MVPColMajor)) * 2.0) * Position;
-    vec4 c10 = Position * (spvTranspose(_13.MVPRowMajor) * 2.0);
-    vec4 c11 = Position * (spvTranspose(spvWorkaroundRowMajor(_13.MVPColMajor)) * 2.0);
+    vec4 c8 = Position * (_13.MVPRowMajor * 2.0);
+    vec4 c9 = Position * (spvWorkaroundRowMajor(_13.MVPColMajor) * 2.0);
+    vec4 c10 = (_13.MVPRowMajor * 2.0) * Position;
+    vec4 c11 = (spvWorkaroundRowMajor(_13.MVPColMajor) * 2.0) * Position;
+    OutputMat1 = spvTranspose(_13.MVPRowMajor);
+    OutputMat2 = spvWorkaroundRowMajor(_13.MVPColMajor);
+    OutputMat3 = _13.MVPRowMajor;
+    OutputMat4 = spvTranspose(spvWorkaroundRowMajor(_13.MVPColMajor));
     gl_Position = ((((((((((c0 + c1) + c2) + c3) + c4) + c5) + c6) + c7) + c8) + c9) + c10) + c11;
 }
 

--- a/shaders/legacy/vert/transpose.legacy.vert
+++ b/shaders/legacy/vert/transpose.legacy.vert
@@ -9,6 +9,11 @@ uniform Buffer
 
 layout(location = 0) in vec4 Position;
 
+layout(location = 1) out mat4 OutputMat1;
+layout(location = 5) out mat4 OutputMat2;
+layout(location = 9) out mat4 OutputMat3;
+layout(location = 13) out mat4 OutputMat4;
+
 void main()
 {
 	vec4 c0 = M * (MVPRowMajor * Position);
@@ -21,11 +26,17 @@ void main()
 	vec4 c6 = Position * transpose(MVPRowMajor);
 	vec4 c7 = Position * transpose(MVPColMajor);
 
-	// Multiplying by scalar forces resolution of the transposition
+	// Multiplying by scalar does not affect transposition
 	vec4 c8 = (MVPRowMajor * 2.0) * Position;
 	vec4 c9 = (transpose(MVPColMajor) * 2.0) * Position;
 	vec4 c10 = Position * (MVPRowMajor * 2.0);
 	vec4 c11 = Position * (transpose(MVPColMajor) * 2.0);
+
+	// Outputting a matrix will trigger an actual transposition
+	OutputMat1 = MVPRowMajor;
+	OutputMat2 = MVPColMajor;
+	OutputMat3 = transpose(MVPRowMajor);
+	OutputMat4 = transpose(MVPColMajor);
 
 	gl_Position = c0 + c1 + c2 + c3 + c4 + c5 + c6 + c7 + c8 + c9 + c10 + c11;
 }


### PR DESCRIPTION
Sorry for bombarding you with PRs lately!

This one is simple, it just prevents forcing the transpose when multiplying a matrix times a scalar.  We can just set need_transpose on the result.  It should be rare to actually need a forced transpose.

This comes up in eg. skinning shaders where a matrices might be linearly interpolated based on a set of blend weights, then multiplied with a vector.  No need to force transpose on all those matrices when we can just flip the multiplication order in the end.