### PR TITLE
GLSL: Drop invariant keyword in GLSL 110

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1275,7 +1275,7 @@ string CompilerGLSL::to_interpolation_qualifiers(const Bitset &flags)
 		}
 		res += "sample ";
 	}
-	if (flags.get(DecorationInvariant))
+	if (flags.get(DecorationInvariant) && (options.es || options.version >= 120))
 		res += "invariant ";
 	if (flags.get(DecorationPerPrimitiveEXT))
 	    res += "perprimitiveEXT ";
@@ -3526,7 +3526,7 @@ void CompilerGLSL::emit_resources()
 			statement("");
 	}
 
-	if (position_invariant)
+	if (position_invariant && (options.es || options.version >= 120))
 	{
 		statement("invariant gl_Position;");
 		statement("");


### PR DESCRIPTION
GLSL 110 doesn't have `invariant`.  ESSL 100 does.

I don't personally care enough about GLSL 110 to add a feature check for this in our engine, maybe it's OK to just drop it?  If you prefer to throw then I can do that too.

I don't think emulating it is at all possible, other than in a very specific situation with `ftransform()`, and that requires setting the fixed-function GL modelview/projection matrices, I don't expect anyone will go through that bother either.