### PR TITLE
Support integer samplers in Shader Model 6.7

### DIFF
--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -3494,9 +3494,9 @@ void CompilerHLSL::emit_texture_op(const Instruction &i, bool sparse)
 	else
 	{
 		auto &imgformat = get<SPIRType>(imgtype.image.type);
-		if (imgformat.basetype != SPIRType::Float)
+		if (hlsl_options.shader_model < 67 && imgformat.basetype != SPIRType::Float)
 		{
-			SPIRV_CROSS_THROW("Sampling non-float textures is not supported in HLSL.");
+			SPIRV_CROSS_THROW("Sampling non-float textures is not supported in HLSL SM < 6.7.");
 		}
 
 		if (hlsl_options.shader_model >= 40)


### PR DESCRIPTION
Shader Model 6.7 introduces integer samplers: https://microsoft.github.io/DirectX-Specs/d3d/HLSL_SM_6_7_Advanced_Texture_Ops.html#integer-sampling. However, if one tries to transpile this simple GLSL shader to HLSL, even with setting the shader model to 67, they will get the error message `Sampling non-float textures is not supported in HLSL`. 

```glsl
#version 450

layout(push_constant) uniform UniformBufferObject{
    mat4 viewProj;
} ubo;

layout(location = 0) in vec3 inPosition;
layout(location = 1) in vec3 inNormal;
layout(location = 2) in vec2 inUV;

layout(location = 0) out vec3 fragColor;
layout(location = 1) out vec2 outUV;

void main() {
    mat4 model = mat4(1);
    
    vec4 worldpos = model * vec4(inPosition,1);
    
    gl_Position = ubo.viewProj * worldpos;
    fragColor = vec3(1,1,1);
    outUV = inUV;
}
```
```cpp
spirv_cross::CompilerHLSL hlsl(bin);
	
spirv_cross::CompilerHLSL::Options options;
options.shader_model = 67;
return hlsl.compile();    // throws error
```

With this change, SPIRV-Cross is able to create a HLSL shader with an integer texture and sampler, which compiles successfully with DXC:
```hlsl
Texture2D<uint4> texSampler : register(t0, space0);
SamplerState _texSampler_sampler : register(s0, space0);

static float2 inUV;
static float4 outColor;
static float3 fragColor;

struct SPIRV_Cross_Input
{
    float3 fragColor : TEXCOORD0;
    float2 inUV : TEXCOORD1;
};

struct SPIRV_Cross_Output
{
    float4 outColor : SV_Target0;
};

void frag_main()
{
    float3 sampled = float3(texSampler.Sample(_texSampler_sampler, inUV).xyz) / 255.0f.xxx;
    outColor = float4(sampled, 1.0f);
}

SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
{
    inUV = stage_input.inUV;
    fragColor = stage_input.fragColor;
    frag_main();
    SPIRV_Cross_Output stage_output;
    stage_output.outColor = outColor;
    return stage_output;
}
```
`dxc.exe -T ps_6_7 -E main -Fo shader.bin -Fd shader.pdb -Zi .\shader.hlsl`