### PR TITLE
add support for OpAtomicFAddEXT atomic add, and also Min, Max

### DIFF
--- a/reference/opt/shaders-msl/comp/atomic-float.msl3.comp
+++ b/reference/opt/shaders-msl/comp/atomic-float.msl3.comp
@@ -1,0 +1,20 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct SSBO
+{
+    float f32;
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
+
+kernel void main0(device SSBO& ssbo [[buffer(0)]])
+{
+    float _18 = atomic_fetch_add_explicit((device atomic_float*)&ssbo.f32, 1.0, memory_order_relaxed);
+}
+

--- a/reference/shaders-msl/comp/atomic-float.msl3.comp
+++ b/reference/shaders-msl/comp/atomic-float.msl3.comp
@@ -1,0 +1,20 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct SSBO
+{
+    float f32;
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
+
+kernel void main0(device SSBO& ssbo [[buffer(0)]])
+{
+    float _18 = atomic_fetch_add_explicit((device atomic_float*)&ssbo.f32, 1.0, memory_order_relaxed);
+}
+

--- a/shaders-msl/comp/atomic-float.msl3.comp
+++ b/shaders-msl/comp/atomic-float.msl3.comp
@@ -1,0 +1,15 @@
+#version 450
+#extension GL_EXT_shader_atomic_float : require
+layout(local_size_x = 1) in;
+
+layout(binding = 2, std430) buffer SSBO
+{
+    float f32;
+} ssbo;
+
+void main()
+{
+	// note: only works on ssbo targets
+    atomicAdd(ssbo.f32, 1.0);
+}
+

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1856,6 +1856,7 @@ void CompilerMSL::extract_global_variables_from_function(uint32_t func_id, std::
 			case OpAtomicIIncrement:
 			case OpAtomicIDecrement:
 			case OpAtomicIAdd:
+			case OpAtomicFAddEXT:
 			case OpAtomicISub:
 			case OpAtomicSMin:
 			case OpAtomicUMin:
@@ -8593,6 +8594,7 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		break;
 
 	case OpAtomicIAdd:
+	case OpAtomicFAddEXT:
 		MSL_AFMO(add);
 		break;
 
@@ -16300,6 +16302,7 @@ bool CompilerMSL::OpCodePreprocessor::handle(Op opcode, const uint32_t *args, ui
 	case OpAtomicIIncrement:
 	case OpAtomicIDecrement:
 	case OpAtomicIAdd:
+	case OpAtomicFAddEXT:
 	case OpAtomicISub:
 	case OpAtomicSMin:
 	case OpAtomicUMin:
@@ -16505,6 +16508,7 @@ CompilerMSL::SPVFuncImpl CompilerMSL::OpCodePreprocessor::get_spv_func_impl(Op o
 	case OpAtomicIIncrement:
 	case OpAtomicIDecrement:
 	case OpAtomicIAdd:
+	case OpAtomicFAddEXT:
 	case OpAtomicISub:
 	case OpAtomicSMin:
 	case OpAtomicUMin:

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1857,6 +1857,8 @@ void CompilerMSL::extract_global_variables_from_function(uint32_t func_id, std::
 			case OpAtomicIDecrement:
 			case OpAtomicIAdd:
 			case OpAtomicFAddEXT:
+			case OpAtomicFMinEXT:
+			case OpAtomicFMaxEXT:
 			case OpAtomicISub:
 			case OpAtomicSMin:
 			case OpAtomicUMin:
@@ -8604,11 +8606,13 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 
 	case OpAtomicSMin:
 	case OpAtomicUMin:
+	case OpAtomicFMinEXT:
 		MSL_AFMO(min);
 		break;
 
 	case OpAtomicSMax:
 	case OpAtomicUMax:
+	case OpAtomicFMaxEXT:
 		MSL_AFMO(max);
 		break;
 
@@ -16303,6 +16307,8 @@ bool CompilerMSL::OpCodePreprocessor::handle(Op opcode, const uint32_t *args, ui
 	case OpAtomicIDecrement:
 	case OpAtomicIAdd:
 	case OpAtomicFAddEXT:
+	case OpAtomicFMinEXT:
+	case OpAtomicFMaxEXT:
 	case OpAtomicISub:
 	case OpAtomicSMin:
 	case OpAtomicUMin:
@@ -16509,6 +16515,8 @@ CompilerMSL::SPVFuncImpl CompilerMSL::OpCodePreprocessor::get_spv_func_impl(Op o
 	case OpAtomicIDecrement:
 	case OpAtomicIAdd:
 	case OpAtomicFAddEXT:
+	case OpAtomicFMinEXT:
+	case OpAtomicFMaxEXT:
 	case OpAtomicISub:
 	case OpAtomicSMin:
 	case OpAtomicUMin:

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1857,8 +1857,6 @@ void CompilerMSL::extract_global_variables_from_function(uint32_t func_id, std::
 			case OpAtomicIDecrement:
 			case OpAtomicIAdd:
 			case OpAtomicFAddEXT:
-			case OpAtomicFMinEXT:
-			case OpAtomicFMaxEXT:
 			case OpAtomicISub:
 			case OpAtomicSMin:
 			case OpAtomicUMin:
@@ -8606,13 +8604,11 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 
 	case OpAtomicSMin:
 	case OpAtomicUMin:
-	case OpAtomicFMinEXT:
 		MSL_AFMO(min);
 		break;
 
 	case OpAtomicSMax:
 	case OpAtomicUMax:
-	case OpAtomicFMaxEXT:
 		MSL_AFMO(max);
 		break;
 
@@ -16307,8 +16303,6 @@ bool CompilerMSL::OpCodePreprocessor::handle(Op opcode, const uint32_t *args, ui
 	case OpAtomicIDecrement:
 	case OpAtomicIAdd:
 	case OpAtomicFAddEXT:
-	case OpAtomicFMinEXT:
-	case OpAtomicFMaxEXT:
 	case OpAtomicISub:
 	case OpAtomicSMin:
 	case OpAtomicUMin:
@@ -16515,8 +16509,6 @@ CompilerMSL::SPVFuncImpl CompilerMSL::OpCodePreprocessor::get_spv_func_impl(Op o
 	case OpAtomicIDecrement:
 	case OpAtomicIAdd:
 	case OpAtomicFAddEXT:
-	case OpAtomicFMinEXT:
-	case OpAtomicFMaxEXT:
 	case OpAtomicISub:
 	case OpAtomicSMin:
 	case OpAtomicUMin:

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -124,7 +124,9 @@ def msl_compiler_supports_version(version):
 
 def path_to_msl_standard(shader):
     if '.ios.' in shader:
-        if '.msl2.' in shader:
+        if '.msl3.' in shader:
+            return '-std=metal3.0'
+        elif '.msl2.' in shader:
             return '-std=ios-metal2.0'
         elif '.msl21.' in shader:
             return '-std=ios-metal2.1'
@@ -141,7 +143,9 @@ def path_to_msl_standard(shader):
         else:
             return '-std=ios-metal1.2'
     else:
-        if '.msl2.' in shader:
+        if '.msl3.' in shader:
+            return '-std=metal3.0'
+        elif '.msl2.' in shader:
             return '-std=macos-metal2.0'
         elif '.msl21.' in shader:
             return '-std=macos-metal2.1'
@@ -157,7 +161,9 @@ def path_to_msl_standard(shader):
             return '-std=macos-metal1.2'
 
 def path_to_msl_standard_cli(shader):
-    if '.msl2.' in shader:
+    if '.msl3.' in shader:
+        return '30000'
+    elif '.msl2.' in shader:
         return '20000'
     elif '.msl21.' in shader:
         return '20100'

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -110,17 +110,30 @@ def print_msl_compiler_version():
         pass
 
 def msl_compiler_supports_version(version):
-    try:
-        subprocess.check_call(['xcrun', '--sdk', 'macosx', 'metal', '-x', 'metal', '-std=macos-metal' + version, '-'],
+    if float(version) >= 3.0:
+        try:
+            subprocess.check_call(['xcrun', '--sdk', 'macosx', 'metal', '-x', 'metal', '-std=metal' + version, '-'],
                 stdin = subprocess.DEVNULL, stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL)
-        print('Current SDK supports MSL {0}. Enabling validation for MSL {0} shaders.'.format(version))
-        return True
-    except OSError as e:
-        print('Failed to check if MSL {} is not supported. It probably is not.'.format(version))
-        return False
-    except subprocess.CalledProcessError:
-        print('Current SDK does NOT support MSL {0}. Disabling validation for MSL {0} shaders.'.format(version))
-        return False
+            print('Current SDK supports MSL {0}. Enabling validation for MSL {0} shaders.'.format(version))
+            return True
+        except OSError as e:
+            print('Failed to check if MSL {} is not supported. It probably is not.'.format(version))
+            return False
+        except subprocess.CalledProcessError:
+            print('Current SDK does NOT support MSL {0}. Disabling validation for MSL {0} shaders.'.format(version))
+            return False
+    else:
+        try:
+            subprocess.check_call(['xcrun', '--sdk', 'macosx', 'metal', '-x', 'metal', '-std=macos-metal' + version, '-'],
+                stdin = subprocess.DEVNULL, stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL)
+            print('Current SDK supports MSL {0}. Enabling validation for MSL {0} shaders.'.format(version))
+            return True
+        except OSError as e:
+            print('Failed to check if MSL {} is not supported. It probably is not.'.format(version))
+            return False
+        except subprocess.CalledProcessError:
+            print('Current SDK does NOT support MSL {0}. Disabling validation for MSL {0} shaders.'.format(version))
+            return False
 
 def path_to_msl_standard(shader):
     if '.ios.' in shader:
@@ -1023,11 +1036,13 @@ def main():
     args.msl22 = False
     args.msl23 = False
     args.msl24 = False
+    args.msl30 = False
     if args.msl:
         print_msl_compiler_version()
         args.msl22 = msl_compiler_supports_version('2.2')
         args.msl23 = msl_compiler_supports_version('2.3')
         args.msl24 = msl_compiler_supports_version('2.4')
+        args.msl30 = msl_compiler_supports_version('3.0')
 
     backend = 'glsl'
     if (args.msl or args.metal):

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -110,30 +110,17 @@ def print_msl_compiler_version():
         pass
 
 def msl_compiler_supports_version(version):
-    if float(version) >= 3.0:
-        try:
-            subprocess.check_call(['xcrun', '--sdk', 'macosx', 'metal', '-x', 'metal', '-std=metal' + version, '-'],
-                stdin = subprocess.DEVNULL, stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL)
-            print('Current SDK supports MSL {0}. Enabling validation for MSL {0} shaders.'.format(version))
-            return True
-        except OSError as e:
-            print('Failed to check if MSL {} is not supported. It probably is not.'.format(version))
-            return False
-        except subprocess.CalledProcessError:
-            print('Current SDK does NOT support MSL {0}. Disabling validation for MSL {0} shaders.'.format(version))
-            return False
-    else:
-        try:
-            subprocess.check_call(['xcrun', '--sdk', 'macosx', 'metal', '-x', 'metal', '-std=macos-metal' + version, '-'],
-                stdin = subprocess.DEVNULL, stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL)
-            print('Current SDK supports MSL {0}. Enabling validation for MSL {0} shaders.'.format(version))
-            return True
-        except OSError as e:
-            print('Failed to check if MSL {} is not supported. It probably is not.'.format(version))
-            return False
-        except subprocess.CalledProcessError:
-            print('Current SDK does NOT support MSL {0}. Disabling validation for MSL {0} shaders.'.format(version))
-            return False
+    try:
+        subprocess.check_call(['xcrun', '--sdk', 'macosx', 'metal', '-x', 'metal', version, '-'],
+            stdin = subprocess.DEVNULL, stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL)
+        print('Current SDK supports MSL {0}. Enabling validation for MSL {0} shaders.'.format(version))
+        return True
+    except OSError as e:
+        print('Failed to check if MSL {} is not supported. It probably is not.'.format(version))
+        return False
+    except subprocess.CalledProcessError:
+        print('Current SDK does NOT support MSL {0}. Disabling validation for MSL {0} shaders.'.format(version))
+        return False
 
 def path_to_msl_standard(shader):
     if '.ios.' in shader:
@@ -1039,10 +1026,10 @@ def main():
     args.msl30 = False
     if args.msl:
         print_msl_compiler_version()
-        args.msl22 = msl_compiler_supports_version('2.2')
-        args.msl23 = msl_compiler_supports_version('2.3')
-        args.msl24 = msl_compiler_supports_version('2.4')
-        args.msl30 = msl_compiler_supports_version('3.0')
+        args.msl22 = msl_compiler_supports_version('-std=macos-metal2.2')
+        args.msl23 = msl_compiler_supports_version('-std=macos-metal2.3')
+        args.msl24 = msl_compiler_supports_version('-std=macos-metal2.4')
+        args.msl30 = msl_compiler_supports_version('-std=metal3.0')
 
     backend = 'glsl'
     if (args.msl or args.metal):


### PR DESCRIPTION
These are now available in Metal 3.0, which is only enabled on MacOS 13.x in MoltenVK, where OpAtomicFAddEXT has been tested all the way through, per this discussion: https://github.com/KhronosGroup/MoltenVK/discussions/1616#discussioncomment-4868519

Can also run the metal compiler on code generated using spirv-cross under 12.x and it works fine.

In my testing, it appeared to already have all the necessary logic to require the https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_shader_atomic_float.html and associated SPV extensions to actually enable the use of atomic add on float types, so all that was needed was to put the parsing in the right place.

