### PR TITLE
Implement set_scalar functions in the specialization constants C API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,7 +332,7 @@ if (SPIRV_CROSS_STATIC)
 endif()
 
 set(spirv-cross-abi-major 0)
-set(spirv-cross-abi-minor 55)
+set(spirv-cross-abi-minor 56)
 set(spirv-cross-abi-patch 0)
 
 if (SPIRV_CROSS_SHARED)

--- a/spirv_cross_c.cpp
+++ b/spirv_cross_c.cpp
@@ -2537,7 +2537,7 @@ spvc_type_id spvc_constant_get_type(spvc_constant constant)
 
 void spvc_constant_set_scalar_fp16(spvc_constant constant, unsigned column, unsigned row, unsigned short value)
 {
-	constant->m.c[column].r[row].f32 = value;
+	constant->m.c[column].r[row].u32 = value;
 }
 
 void spvc_constant_set_scalar_fp32(spvc_constant constant, unsigned column, unsigned row, float value)

--- a/spirv_cross_c.cpp
+++ b/spirv_cross_c.cpp
@@ -2535,6 +2535,51 @@ spvc_type_id spvc_constant_get_type(spvc_constant constant)
 	return constant->constant_type;
 }
 
+void spvc_constant_set_scalar_fp16(spvc_constant constant, unsigned column, unsigned row, float value)
+{
+	constant->m.c[column].r[row].f32 = value;
+}
+
+void spvc_constant_set_scalar_fp32(spvc_constant constant, unsigned column, unsigned row, float value)
+{
+	constant->m.c[column].r[row].f32 = value;
+}
+
+void spvc_constant_set_scalar_fp64(spvc_constant constant, unsigned column, unsigned row, double value)
+{
+	constant->m.c[column].r[row].f64 = value;
+}
+
+void spvc_constant_set_scalar_u32(spvc_constant constant, unsigned column, unsigned row, unsigned value)
+{
+	constant->m.c[column].r[row].u32 = value;
+}
+
+void spvc_constant_set_scalar_i32(spvc_constant constant, unsigned column, unsigned row, int value)
+{
+	constant->m.c[column].r[row].i32 = value;
+}
+
+void spvc_constant_set_scalar_u16(spvc_constant constant, unsigned column, unsigned row, unsigned value)
+{
+	constant->m.c[column].r[row].u32 = uint32_t(value);
+}
+
+void spvc_constant_set_scalar_i16(spvc_constant constant, unsigned column, unsigned row, int value)
+{
+	constant->m.c[column].r[row].u32 = uint32_t(value);
+}
+
+void spvc_constant_set_scalar_u8(spvc_constant constant, unsigned column, unsigned row, unsigned value)
+{
+	constant->m.c[column].r[row].u32 = uint32_t(value);
+}
+
+void spvc_constant_set_scalar_i8(spvc_constant constant, unsigned column, unsigned row, int value)
+{
+	constant->m.c[column].r[row].u32 = uint32_t(value);
+}
+
 spvc_bool spvc_compiler_get_binary_offset_for_decoration(spvc_compiler compiler, spvc_variable_id id,
                                                          SpvDecoration decoration,
                                                          unsigned *word_offset)

--- a/spirv_cross_c.cpp
+++ b/spirv_cross_c.cpp
@@ -2535,7 +2535,7 @@ spvc_type_id spvc_constant_get_type(spvc_constant constant)
 	return constant->constant_type;
 }
 
-void spvc_constant_set_scalar_fp16(spvc_constant constant, unsigned column, unsigned row, float value)
+void spvc_constant_set_scalar_fp16(spvc_constant constant, unsigned column, unsigned row, unsigned short value)
 {
 	constant->m.c[column].r[row].f32 = value;
 }
@@ -2560,22 +2560,22 @@ void spvc_constant_set_scalar_i32(spvc_constant constant, unsigned column, unsig
 	constant->m.c[column].r[row].i32 = value;
 }
 
-void spvc_constant_set_scalar_u16(spvc_constant constant, unsigned column, unsigned row, unsigned value)
+void spvc_constant_set_scalar_u16(spvc_constant constant, unsigned column, unsigned row, unsigned short value)
 {
 	constant->m.c[column].r[row].u32 = uint32_t(value);
 }
 
-void spvc_constant_set_scalar_i16(spvc_constant constant, unsigned column, unsigned row, int value)
+void spvc_constant_set_scalar_i16(spvc_constant constant, unsigned column, unsigned row, signed short value)
 {
 	constant->m.c[column].r[row].u32 = uint32_t(value);
 }
 
-void spvc_constant_set_scalar_u8(spvc_constant constant, unsigned column, unsigned row, unsigned value)
+void spvc_constant_set_scalar_u8(spvc_constant constant, unsigned column, unsigned row, unsigned char value)
 {
 	constant->m.c[column].r[row].u32 = uint32_t(value);
 }
 
-void spvc_constant_set_scalar_i8(spvc_constant constant, unsigned column, unsigned row, int value)
+void spvc_constant_set_scalar_i8(spvc_constant constant, unsigned column, unsigned row, signed char value)
 {
 	constant->m.c[column].r[row].u32 = uint32_t(value);
 }

--- a/spirv_cross_c.h
+++ b/spirv_cross_c.h
@@ -40,7 +40,7 @@ extern "C" {
 /* Bumped if ABI or API breaks backwards compatibility. */
 #define SPVC_C_API_VERSION_MAJOR 0
 /* Bumped if APIs or enumerations are added in a backwards compatible way. */
-#define SPVC_C_API_VERSION_MINOR 55
+#define SPVC_C_API_VERSION_MINOR 56
 /* Bumped if internal implementation details change. */
 #define SPVC_C_API_VERSION_PATCH 0
 
@@ -1052,15 +1052,15 @@ SPVC_PUBLIC_API spvc_type_id spvc_constant_get_type(spvc_constant constant);
 /*
  * C implementation of the C++ api.
  */
-SPVC_PUBLIC_API void spvc_constant_set_scalar_fp16(spvc_constant constant, unsigned column, unsigned row, float value);
+SPVC_PUBLIC_API void spvc_constant_set_scalar_fp16(spvc_constant constant, unsigned column, unsigned row, unsigned short value);
 SPVC_PUBLIC_API void spvc_constant_set_scalar_fp32(spvc_constant constant, unsigned column, unsigned row, float value);
 SPVC_PUBLIC_API void spvc_constant_set_scalar_fp64(spvc_constant constant, unsigned column, unsigned row, double value);
 SPVC_PUBLIC_API void spvc_constant_set_scalar_u32(spvc_constant constant, unsigned column, unsigned row, unsigned value);
 SPVC_PUBLIC_API void spvc_constant_set_scalar_i32(spvc_constant constant, unsigned column, unsigned row, int value);
-SPVC_PUBLIC_API void spvc_constant_set_scalar_u16(spvc_constant constant, unsigned column, unsigned row, unsigned value);
-SPVC_PUBLIC_API void spvc_constant_set_scalar_i16(spvc_constant constant, unsigned column, unsigned row, int value);
-SPVC_PUBLIC_API void spvc_constant_set_scalar_u8(spvc_constant constant, unsigned column, unsigned row, unsigned value);
-SPVC_PUBLIC_API void spvc_constant_set_scalar_i8(spvc_constant constant, unsigned column, unsigned row, int value);
+SPVC_PUBLIC_API void spvc_constant_set_scalar_u16(spvc_constant constant, unsigned column, unsigned row, unsigned short value);
+SPVC_PUBLIC_API void spvc_constant_set_scalar_i16(spvc_constant constant, unsigned column, unsigned row, signed short value);
+SPVC_PUBLIC_API void spvc_constant_set_scalar_u8(spvc_constant constant, unsigned column, unsigned row, unsigned char value);
+SPVC_PUBLIC_API void spvc_constant_set_scalar_i8(spvc_constant constant, unsigned column, unsigned row, signed char value);
 
 /*
  * Misc reflection

--- a/spirv_cross_c.h
+++ b/spirv_cross_c.h
@@ -1050,6 +1050,19 @@ SPVC_PUBLIC_API void spvc_constant_get_subconstants(spvc_constant constant, cons
 SPVC_PUBLIC_API spvc_type_id spvc_constant_get_type(spvc_constant constant);
 
 /*
+ * C implementation of the C++ api.
+ */
+SPVC_PUBLIC_API void spvc_constant_set_scalar_fp16(spvc_constant constant, unsigned column, unsigned row, float value);
+SPVC_PUBLIC_API void spvc_constant_set_scalar_fp32(spvc_constant constant, unsigned column, unsigned row, float value);
+SPVC_PUBLIC_API void spvc_constant_set_scalar_fp64(spvc_constant constant, unsigned column, unsigned row, double value);
+SPVC_PUBLIC_API void spvc_constant_set_scalar_u32(spvc_constant constant, unsigned column, unsigned row, unsigned value);
+SPVC_PUBLIC_API void spvc_constant_set_scalar_i32(spvc_constant constant, unsigned column, unsigned row, int value);
+SPVC_PUBLIC_API void spvc_constant_set_scalar_u16(spvc_constant constant, unsigned column, unsigned row, unsigned value);
+SPVC_PUBLIC_API void spvc_constant_set_scalar_i16(spvc_constant constant, unsigned column, unsigned row, int value);
+SPVC_PUBLIC_API void spvc_constant_set_scalar_u8(spvc_constant constant, unsigned column, unsigned row, unsigned value);
+SPVC_PUBLIC_API void spvc_constant_set_scalar_i8(spvc_constant constant, unsigned column, unsigned row, int value);
+
+/*
  * Misc reflection
  * Maps to C++ API.
  */


### PR DESCRIPTION
This PR adds set_scalar functions for all equivalent get_scalar functions in the specialization constants part of the C API.

I've tested this and it seems to work fine.