### PR TITLE
Add missing <exception> include

### DIFF
--- a/spirv_cross_containers.hpp
+++ b/spirv_cross_containers.hpp
@@ -26,6 +26,7 @@
 
 #include "spirv_cross_error_handling.hpp"
 #include <algorithm>
+#include <exception>
 #include <functional>
 #include <iterator>
 #include <limits>


### PR DESCRIPTION
https://reviews.llvm.org/D146097 removed the transitive include for <exception>, which caused the following issue:

In file included from ../../third_party/spirv-cross/spirv_common.hpp:28: ../../third_party/spirv-cross/spirv_cross_containers.hpp:334:9: error: no member named 'terminate' in namespace 'std

This patch adds the missing include to fix the issue.