### PR TITLE
MSL: Don't append v_ identifier

### DIFF
--- a/reference/opt/shaders-hlsl/task/task-basic.spv14.vk.nocompat.task
+++ b/reference/opt/shaders-hlsl/task/task-basic.spv14.vk.nocompat.task
@@ -1,0 +1,24 @@
+struct TaskPayload
+{
+    float a;
+    float b;
+    int c;
+};
+
+static const uint3 gl_WorkGroupSize = uint3(1u, 1u, 1u);
+
+groupshared TaskPayload _payload;
+
+void task_main()
+{
+    _payload.a = 1.2000000476837158203125f;
+    _payload.b = 2.2999999523162841796875f;
+    _payload.c = 3;
+    DispatchMesh(1u, 2u, 3u, _payload);
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    task_main();
+}

--- a/reference/shaders-msl-no-opt/asm/frag/pixel-interlock-callstack.msl2.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/pixel-interlock-callstack.msl2.asm.frag
@@ -16,22 +16,22 @@ struct SSBO0
 };
 
 static inline __attribute__((always_inline))
-void callee2(thread float4& gl_FragCoord, device SSBO1& v_7)
+void callee2(thread float4& gl_FragCoord, device SSBO1& _7)
 {
     int _31 = int(gl_FragCoord.x);
-    v_7.values1[_31]++;
+    _7.values1[_31]++;
 }
 
 static inline __attribute__((always_inline))
-void callee(thread float4& gl_FragCoord, device SSBO1& v_7, device SSBO0& v_9)
+void callee(thread float4& gl_FragCoord, device SSBO1& _7, device SSBO0& _9)
 {
     int _39 = int(gl_FragCoord.x);
-    v_9.values0[_39]++;
-    callee2(gl_FragCoord, v_7);
+    _9.values0[_39]++;
+    callee2(gl_FragCoord, _7);
 }
 
-fragment void main0(device SSBO1& v_7 [[buffer(0), raster_order_group(0)]], device SSBO0& v_9 [[buffer(1)]], float4 gl_FragCoord [[position]])
+fragment void main0(device SSBO1& _7 [[buffer(0), raster_order_group(0)]], device SSBO0& _9 [[buffer(1)]], float4 gl_FragCoord [[position]])
 {
-    callee(gl_FragCoord, v_7, v_9);
+    callee(gl_FragCoord, _7, _9);
 }
 

--- a/reference/shaders-msl-no-opt/asm/frag/pixel-interlock-control-flow.msl2.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/pixel-interlock-control-flow.msl2.asm.frag
@@ -21,32 +21,32 @@ struct SSBO0
 };
 
 static inline __attribute__((always_inline))
-void callee2(thread float4& gl_FragCoord, device SSBO1& v_7)
+void callee2(thread float4& gl_FragCoord, device SSBO1& _7)
 {
     int _44 = int(gl_FragCoord.x);
-    v_7.values1[_44]++;
+    _7.values1[_44]++;
 }
 
 static inline __attribute__((always_inline))
-void callee(thread float4& gl_FragCoord, device SSBO1& v_7, device SSBO0& v_9)
+void callee(thread float4& gl_FragCoord, device SSBO1& _7, device SSBO0& _9)
 {
     int _52 = int(gl_FragCoord.x);
-    v_9.values0[_52]++;
-    callee2(gl_FragCoord, v_7);
+    _9.values0[_52]++;
+    callee2(gl_FragCoord, _7);
     if (true)
     {
     }
 }
 
 static inline __attribute__((always_inline))
-void _35(thread float4& gl_FragCoord, device _12& v_13)
+void _35(thread float4& gl_FragCoord, device _12& _13)
 {
-    v_13._m0[int(gl_FragCoord.x)] = 4u;
+    _13._m0[int(gl_FragCoord.x)] = 4u;
 }
 
-fragment void main0(device SSBO1& v_7 [[buffer(0), raster_order_group(0)]], device _12& v_13 [[buffer(1)]], device SSBO0& v_9 [[buffer(2), raster_order_group(0)]], float4 gl_FragCoord [[position]])
+fragment void main0(device SSBO1& _7 [[buffer(0), raster_order_group(0)]], device _12& _13 [[buffer(1)]], device SSBO0& _9 [[buffer(2), raster_order_group(0)]], float4 gl_FragCoord [[position]])
 {
-    callee(gl_FragCoord, v_7, v_9);
-    _35(gl_FragCoord, v_13);
+    callee(gl_FragCoord, _7, _9);
+    _35(gl_FragCoord, _13);
 }
 

--- a/reference/shaders-msl-no-opt/asm/frag/pixel-interlock-split-functions.msl2.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/pixel-interlock-split-functions.msl2.asm.frag
@@ -16,18 +16,18 @@ struct SSBO0
 };
 
 static inline __attribute__((always_inline))
-void callee2(thread float4& gl_FragCoord, device SSBO1& v_7)
+void callee2(thread float4& gl_FragCoord, device SSBO1& _7)
 {
     int _37 = int(gl_FragCoord.x);
-    v_7.values1[_37]++;
+    _7.values1[_37]++;
 }
 
 static inline __attribute__((always_inline))
-void callee(thread float4& gl_FragCoord, device SSBO1& v_7, device SSBO0& v_9)
+void callee(thread float4& gl_FragCoord, device SSBO1& _7, device SSBO0& _9)
 {
     int _45 = int(gl_FragCoord.x);
-    v_9.values0[_45]++;
-    callee2(gl_FragCoord, v_7);
+    _9.values0[_45]++;
+    callee2(gl_FragCoord, _7);
 }
 
 static inline __attribute__((always_inline))
@@ -40,9 +40,9 @@ void _31()
 {
 }
 
-fragment void main0(device SSBO1& v_7 [[buffer(0), raster_order_group(0)]], device SSBO0& v_9 [[buffer(1), raster_order_group(0)]], float4 gl_FragCoord [[position]])
+fragment void main0(device SSBO1& _7 [[buffer(0), raster_order_group(0)]], device SSBO0& _9 [[buffer(1), raster_order_group(0)]], float4 gl_FragCoord [[position]])
 {
-    callee(gl_FragCoord, v_7, v_9);
+    callee(gl_FragCoord, _7, _9);
     _29();
     _31();
 }

--- a/reference/shaders-msl-no-opt/asm/tesc/copy-memory-control-point.asm.tesc
+++ b/reference/shaders-msl-no-opt/asm/tesc/copy-memory-control-point.asm.tesc
@@ -72,15 +72,15 @@ void fork0_epilogue(thread const float4& _87, thread const float4& _88, thread c
 }
 
 static inline __attribute__((always_inline))
-void fork0(uint vForkInstanceId, device half (&gl_TessLevelOuter)[3], thread spvUnsafeArray<float4, 4>& opc, constant cb1_struct& cb0_0, thread float4& v_48, thread float4& v_49, thread float4& v_50)
+void fork0(uint vForkInstanceId, device half (&gl_TessLevelOuter)[3], thread spvUnsafeArray<float4, 4>& opc, constant cb1_struct& cb0_0, thread float4& _48, thread float4& _49, thread float4& _50)
 {
     float4 r0;
     r0.x = as_type<float>(vForkInstanceId);
     opc[as_type<int>(r0.x)].x = cb0_0._m0[0u].x;
-    v_48 = opc[0u];
-    v_49 = opc[1u];
-    v_50 = opc[2u];
-    fork0_epilogue(v_48, v_49, v_50, gl_TessLevelOuter);
+    _48 = opc[0u];
+    _49 = opc[1u];
+    _50 = opc[2u];
+    fork0_epilogue(_48, _49, _50, gl_TessLevelOuter);
 }
 
 static inline __attribute__((always_inline))
@@ -90,11 +90,11 @@ void fork1_epilogue(thread const float4& _109, device half &gl_TessLevelInner)
 }
 
 static inline __attribute__((always_inline))
-void fork1(device half &gl_TessLevelInner, thread spvUnsafeArray<float4, 4>& opc, constant cb1_struct& cb0_0, thread float4& v_56)
+void fork1(device half &gl_TessLevelInner, thread spvUnsafeArray<float4, 4>& opc, constant cb1_struct& cb0_0, thread float4& _56)
 {
     opc[3u].x = cb0_0._m0[0u].x;
-    v_56 = opc[3u];
-    fork1_epilogue(v_56, gl_TessLevelInner);
+    _56 = opc[3u];
+    fork1_epilogue(_56, gl_TessLevelInner);
 }
 
 kernel void main0(main0_in in [[stage_in]], constant cb1_struct& cb0_0 [[buffer(0)]], uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], device main0_out* spvOut [[buffer(28)]], constant uint* spvIndirectParams [[buffer(29)]], device MTLTriangleTessellationFactorsHalf* spvTessLevel [[buffer(26)]], threadgroup main0_in* gl_in [[threadgroup(0)]])
@@ -113,13 +113,13 @@ kernel void main0(main0_in in [[stage_in]], constant cb1_struct& cb0_0 [[buffer(
     gl_out[gl_InvocationID].vocp0 = gl_in[gl_InvocationID].vicp0;
     gl_out[gl_InvocationID].vocp1 = gl_in[gl_InvocationID].vicp1;
     spvUnsafeArray<float4, 4> opc;
-    float4 v_48;
-    float4 v_49;
-    float4 v_50;
-    fork0(0u, spvTessLevel[gl_PrimitiveID].edgeTessellationFactor, opc, cb0_0, v_48, v_49, v_50);
-    fork0(1u, spvTessLevel[gl_PrimitiveID].edgeTessellationFactor, opc, cb0_0, v_48, v_49, v_50);
-    fork0(2u, spvTessLevel[gl_PrimitiveID].edgeTessellationFactor, opc, cb0_0, v_48, v_49, v_50);
-    float4 v_56;
-    fork1(spvTessLevel[gl_PrimitiveID].insideTessellationFactor, opc, cb0_0, v_56);
+    float4 _48;
+    float4 _49;
+    float4 _50;
+    fork0(0u, spvTessLevel[gl_PrimitiveID].edgeTessellationFactor, opc, cb0_0, _48, _49, _50);
+    fork0(1u, spvTessLevel[gl_PrimitiveID].edgeTessellationFactor, opc, cb0_0, _48, _49, _50);
+    fork0(2u, spvTessLevel[gl_PrimitiveID].edgeTessellationFactor, opc, cb0_0, _48, _49, _50);
+    float4 _56;
+    fork1(spvTessLevel[gl_PrimitiveID].insideTessellationFactor, opc, cb0_0, _56);
 }
 

--- a/reference/shaders-msl-no-opt/asm/vert/block-io-use-in-function.asm.vert
+++ b/reference/shaders-msl-no-opt/asm/vert/block-io-use-in-function.asm.vert
@@ -1,0 +1,128 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct PerVertex
+{
+    float4 v_color;
+    float2 v_texPos;
+    float3 v_worldPosition;
+};
+
+struct u_objToWorlds
+{
+    float4x4 u_objToWorld;
+};
+
+struct CameraData
+{
+    float4x4 u_projectFromView;
+    float4x4 u_projectFromWorld;
+    float4x4 u_clipFromPixels;
+    float4x4 u_viewFromWorld;
+    float4x4 u_worldFromView;
+    float4x4 u_viewFromProject;
+    packed_float3 u_cameraPosition;
+    float pad0;
+    packed_float3 u_cameraRight;
+    float pad1;
+    packed_float3 u_cameraUp;
+    float pad2;
+    packed_float3 u_cameraForward;
+    float pad3;
+    float2 u_clipPlanes;
+    float2 u_invProjParams;
+    float2 u_viewportSize;
+    float2 u_invViewportSize;
+    float2 u_viewportOffset;
+    float2 u_fragToLightGrid;
+    float2 u_screenToLightGrid;
+    float2 pad4;
+    float4 u_lightGridZParams;
+};
+
+struct LightData
+{
+    float4 posRadius;
+    float3 color;
+    float4 axis;
+    float3 directionalParams;
+    float4 spotParams;
+    float4 shadowSize;
+    float4x4 cookieFromWorld;
+    float4x4 shadowFromWorld;
+    uint shadowTextureValid;
+    uint lightCookieValid;
+    float minLightDistance;
+    float pad;
+};
+
+struct SceneSettings
+{
+    CameraData u_cameras[2];
+    float3 u_centerPosition;
+    float3 u_centerRight;
+    float3 u_centerUp;
+    float3 u_centerForward;
+    float2 u_times;
+    uint u_lightFXMask;
+    LightData u_lights[8];
+    float3 u_globalLightDir;
+    float3 u_globalLightDiffuseColor;
+    float3 u_globalLightSpecularColor;
+    float2 u_distanceFog;
+    float2 u_heightFog;
+    float4 u_fogColor;
+    uint u_debugMode;
+};
+
+struct LightContext
+{
+    float3 u_ambientIBLTint;
+    float3 u_specularIBLTint;
+    float3 u_iblAABBMin;
+    float3 u_iblAABBMax;
+    float3 u_iblAABBCenter;
+    float LightContext_unusued0;
+    float u_exposureMultiplier;
+};
+
+struct main0_out
+{
+    float4 m_3_v_color [[user(locn1)]];
+    float2 m_3_v_texPos [[user(locn2)]];
+    float3 m_3_v_worldPosition [[user(locn3)]];
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float3 a_position [[attribute(0)]];
+    float2 a_texcoord [[attribute(1)]];
+    float4 a_color [[attribute(2)]];
+};
+
+static inline __attribute__((always_inline))
+void DrawWorldVS(thread PerVertex& _3, thread float4& a_color, thread float2& a_texcoord, thread float3& a_position, thread float4& gl_Position, constant u_objToWorlds& _12, constant SceneSettings& _17)
+{
+    _3.v_color = a_color;
+    _3.v_texPos = a_texcoord;
+    _3.v_worldPosition = a_position;
+    float4 worldSpacePosition = _12.u_objToWorld * float4(a_position, 1.0);
+    gl_Position = _17.u_cameras[0].u_projectFromWorld * worldSpacePosition;
+}
+
+vertex main0_out main0(main0_in in [[stage_in]], constant u_objToWorlds& _12 [[buffer(0)]], constant SceneSettings& _17 [[buffer(1)]])
+{
+    main0_out out = {};
+    PerVertex _3 = {};
+    DrawWorldVS(_3, in.a_color, in.a_texcoord, in.a_position, out.gl_Position, _12, _17);
+    out.m_3_v_color = _3.v_color;
+    out.m_3_v_texPos = _3.v_texPos;
+    out.m_3_v_worldPosition = _3.v_worldPosition;
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/comp/implicit-integer-promotion.comp
+++ b/reference/shaders-msl-no-opt/comp/implicit-integer-promotion.comp
@@ -16,78 +16,78 @@ struct BUF0
 };
 
 static inline __attribute__((always_inline))
-void test_u16(device BUF0& v_24)
+void test_u16(device BUF0& _24)
 {
-    v_24.f16 += as_type<half>(ushort(((device ushort*)&v_24.u16)[0u] + ((device ushort*)&v_24.u16)[1u]));
-    v_24.f16 += as_type<half>(ushort(((device ushort*)&v_24.u16)[0u] - ((device ushort*)&v_24.u16)[1u]));
-    v_24.f16 += as_type<half>(ushort(((device ushort*)&v_24.u16)[0u] * ((device ushort*)&v_24.u16)[1u]));
-    v_24.f16 += as_type<half>(ushort(((device ushort*)&v_24.u16)[0u] / ((device ushort*)&v_24.u16)[1u]));
-    v_24.f16 += as_type<half>(ushort(((device ushort*)&v_24.u16)[0u] % ((device ushort*)&v_24.u16)[1u]));
-    v_24.f16 += as_type<half>(ushort(((device ushort*)&v_24.u16)[0u] << ((device ushort*)&v_24.u16)[1u]));
-    v_24.f16 += as_type<half>(ushort(((device ushort*)&v_24.u16)[0u] >> ((device ushort*)&v_24.u16)[1u]));
-    v_24.f16 += as_type<half>(ushort(~((device ushort*)&v_24.u16)[0u]));
-    v_24.f16 += as_type<half>(ushort(-((device ushort*)&v_24.u16)[0u]));
-    v_24.f16 += as_type<half>(ushort(((device ushort*)&v_24.u16)[0u] ^ ((device ushort*)&v_24.u16)[1u]));
-    v_24.f16 += as_type<half>(ushort(((device ushort*)&v_24.u16)[0u] & ((device ushort*)&v_24.u16)[1u]));
-    v_24.f16 += as_type<half>(ushort(((device ushort*)&v_24.u16)[0u] | ((device ushort*)&v_24.u16)[1u]));
+    _24.f16 += as_type<half>(ushort(((device ushort*)&_24.u16)[0u] + ((device ushort*)&_24.u16)[1u]));
+    _24.f16 += as_type<half>(ushort(((device ushort*)&_24.u16)[0u] - ((device ushort*)&_24.u16)[1u]));
+    _24.f16 += as_type<half>(ushort(((device ushort*)&_24.u16)[0u] * ((device ushort*)&_24.u16)[1u]));
+    _24.f16 += as_type<half>(ushort(((device ushort*)&_24.u16)[0u] / ((device ushort*)&_24.u16)[1u]));
+    _24.f16 += as_type<half>(ushort(((device ushort*)&_24.u16)[0u] % ((device ushort*)&_24.u16)[1u]));
+    _24.f16 += as_type<half>(ushort(((device ushort*)&_24.u16)[0u] << ((device ushort*)&_24.u16)[1u]));
+    _24.f16 += as_type<half>(ushort(((device ushort*)&_24.u16)[0u] >> ((device ushort*)&_24.u16)[1u]));
+    _24.f16 += as_type<half>(ushort(~((device ushort*)&_24.u16)[0u]));
+    _24.f16 += as_type<half>(ushort(-((device ushort*)&_24.u16)[0u]));
+    _24.f16 += as_type<half>(ushort(((device ushort*)&_24.u16)[0u] ^ ((device ushort*)&_24.u16)[1u]));
+    _24.f16 += as_type<half>(ushort(((device ushort*)&_24.u16)[0u] & ((device ushort*)&_24.u16)[1u]));
+    _24.f16 += as_type<half>(ushort(((device ushort*)&_24.u16)[0u] | ((device ushort*)&_24.u16)[1u]));
 }
 
 static inline __attribute__((always_inline))
-void test_i16(device BUF0& v_24)
+void test_i16(device BUF0& _24)
 {
-    v_24.f16 += as_type<half>(short(((device short*)&v_24.i16)[0u] + ((device short*)&v_24.i16)[1u]));
-    v_24.f16 += as_type<half>(short(((device short*)&v_24.i16)[0u] - ((device short*)&v_24.i16)[1u]));
-    v_24.f16 += as_type<half>(short(((device short*)&v_24.i16)[0u] * ((device short*)&v_24.i16)[1u]));
-    v_24.f16 += as_type<half>(short(((device short*)&v_24.i16)[0u] / ((device short*)&v_24.i16)[1u]));
-    v_24.f16 += as_type<half>(short(((device short*)&v_24.i16)[0u] % ((device short*)&v_24.i16)[1u]));
-    v_24.f16 += as_type<half>(short(((device short*)&v_24.i16)[0u] << ((device short*)&v_24.i16)[1u]));
-    v_24.f16 += as_type<half>(short(((device short*)&v_24.i16)[0u] >> ((device short*)&v_24.i16)[1u]));
-    v_24.f16 += as_type<half>(short(~((device short*)&v_24.i16)[0u]));
-    v_24.f16 += as_type<half>(short(-((device short*)&v_24.i16)[0u]));
-    v_24.f16 += as_type<half>(short(((device short*)&v_24.i16)[0u] ^ ((device short*)&v_24.i16)[1u]));
-    v_24.f16 += as_type<half>(short(((device short*)&v_24.i16)[0u] & ((device short*)&v_24.i16)[1u]));
-    v_24.f16 += as_type<half>(short(((device short*)&v_24.i16)[0u] | ((device short*)&v_24.i16)[1u]));
+    _24.f16 += as_type<half>(short(((device short*)&_24.i16)[0u] + ((device short*)&_24.i16)[1u]));
+    _24.f16 += as_type<half>(short(((device short*)&_24.i16)[0u] - ((device short*)&_24.i16)[1u]));
+    _24.f16 += as_type<half>(short(((device short*)&_24.i16)[0u] * ((device short*)&_24.i16)[1u]));
+    _24.f16 += as_type<half>(short(((device short*)&_24.i16)[0u] / ((device short*)&_24.i16)[1u]));
+    _24.f16 += as_type<half>(short(((device short*)&_24.i16)[0u] % ((device short*)&_24.i16)[1u]));
+    _24.f16 += as_type<half>(short(((device short*)&_24.i16)[0u] << ((device short*)&_24.i16)[1u]));
+    _24.f16 += as_type<half>(short(((device short*)&_24.i16)[0u] >> ((device short*)&_24.i16)[1u]));
+    _24.f16 += as_type<half>(short(~((device short*)&_24.i16)[0u]));
+    _24.f16 += as_type<half>(short(-((device short*)&_24.i16)[0u]));
+    _24.f16 += as_type<half>(short(((device short*)&_24.i16)[0u] ^ ((device short*)&_24.i16)[1u]));
+    _24.f16 += as_type<half>(short(((device short*)&_24.i16)[0u] & ((device short*)&_24.i16)[1u]));
+    _24.f16 += as_type<half>(short(((device short*)&_24.i16)[0u] | ((device short*)&_24.i16)[1u]));
 }
 
 static inline __attribute__((always_inline))
-void test_u16s(device BUF0& v_24)
+void test_u16s(device BUF0& _24)
 {
-    v_24.f16s += as_type<half2>(v_24.u16s.xy + v_24.u16s.zw);
-    v_24.f16s += as_type<half2>(v_24.u16s.xy - v_24.u16s.zw);
-    v_24.f16s += as_type<half2>(v_24.u16s.xy * v_24.u16s.zw);
-    v_24.f16s += as_type<half2>(v_24.u16s.xy / v_24.u16s.zw);
-    v_24.f16s += as_type<half2>(v_24.u16s.xy % v_24.u16s.zw);
-    v_24.f16s += as_type<half2>(v_24.u16s.xy << v_24.u16s.zw);
-    v_24.f16s += as_type<half2>(v_24.u16s.xy >> v_24.u16s.zw);
-    v_24.f16s += as_type<half2>(~v_24.u16s.xy);
-    v_24.f16s += as_type<half2>(-v_24.u16s.xy);
-    v_24.f16s += as_type<half2>(v_24.u16s.xy ^ v_24.u16s.zw);
-    v_24.f16s += as_type<half2>(v_24.u16s.xy & v_24.u16s.zw);
-    v_24.f16s += as_type<half2>(v_24.u16s.xy | v_24.u16s.zw);
+    _24.f16s += as_type<half2>(_24.u16s.xy + _24.u16s.zw);
+    _24.f16s += as_type<half2>(_24.u16s.xy - _24.u16s.zw);
+    _24.f16s += as_type<half2>(_24.u16s.xy * _24.u16s.zw);
+    _24.f16s += as_type<half2>(_24.u16s.xy / _24.u16s.zw);
+    _24.f16s += as_type<half2>(_24.u16s.xy % _24.u16s.zw);
+    _24.f16s += as_type<half2>(_24.u16s.xy << _24.u16s.zw);
+    _24.f16s += as_type<half2>(_24.u16s.xy >> _24.u16s.zw);
+    _24.f16s += as_type<half2>(~_24.u16s.xy);
+    _24.f16s += as_type<half2>(-_24.u16s.xy);
+    _24.f16s += as_type<half2>(_24.u16s.xy ^ _24.u16s.zw);
+    _24.f16s += as_type<half2>(_24.u16s.xy & _24.u16s.zw);
+    _24.f16s += as_type<half2>(_24.u16s.xy | _24.u16s.zw);
 }
 
 static inline __attribute__((always_inline))
-void test_i16s(device BUF0& v_24)
+void test_i16s(device BUF0& _24)
 {
-    v_24.f16s += as_type<half2>(v_24.i16s.xy + v_24.i16s.zw);
-    v_24.f16s += as_type<half2>(v_24.i16s.xy - v_24.i16s.zw);
-    v_24.f16s += as_type<half2>(v_24.i16s.xy * v_24.i16s.zw);
-    v_24.f16s += as_type<half2>(v_24.i16s.xy / v_24.i16s.zw);
-    v_24.f16s += as_type<half2>(v_24.i16s.xy % v_24.i16s.zw);
-    v_24.f16s += as_type<half2>(v_24.i16s.xy << v_24.i16s.zw);
-    v_24.f16s += as_type<half2>(v_24.i16s.xy >> v_24.i16s.zw);
-    v_24.f16s += as_type<half2>(~v_24.i16s.xy);
-    v_24.f16s += as_type<half2>(-v_24.i16s.xy);
-    v_24.f16s += as_type<half2>(v_24.i16s.xy ^ v_24.i16s.zw);
-    v_24.f16s += as_type<half2>(v_24.i16s.xy & v_24.i16s.zw);
-    v_24.f16s += as_type<half2>(v_24.i16s.xy | v_24.i16s.zw);
+    _24.f16s += as_type<half2>(_24.i16s.xy + _24.i16s.zw);
+    _24.f16s += as_type<half2>(_24.i16s.xy - _24.i16s.zw);
+    _24.f16s += as_type<half2>(_24.i16s.xy * _24.i16s.zw);
+    _24.f16s += as_type<half2>(_24.i16s.xy / _24.i16s.zw);
+    _24.f16s += as_type<half2>(_24.i16s.xy % _24.i16s.zw);
+    _24.f16s += as_type<half2>(_24.i16s.xy << _24.i16s.zw);
+    _24.f16s += as_type<half2>(_24.i16s.xy >> _24.i16s.zw);
+    _24.f16s += as_type<half2>(~_24.i16s.xy);
+    _24.f16s += as_type<half2>(-_24.i16s.xy);
+    _24.f16s += as_type<half2>(_24.i16s.xy ^ _24.i16s.zw);
+    _24.f16s += as_type<half2>(_24.i16s.xy & _24.i16s.zw);
+    _24.f16s += as_type<half2>(_24.i16s.xy | _24.i16s.zw);
 }
 
-kernel void main0(device BUF0& v_24 [[buffer(0)]])
+kernel void main0(device BUF0& _24 [[buffer(0)]])
 {
-    test_u16(v_24);
-    test_i16(v_24);
-    test_u16s(v_24);
-    test_i16s(v_24);
+    test_u16(_24);
+    test_i16(_24);
+    test_u16s(_24);
+    test_i16s(_24);
 }
 

--- a/reference/shaders-msl-no-opt/frag/pixel-interlock-simple-callstack.msl2.frag
+++ b/reference/shaders-msl-no-opt/frag/pixel-interlock-simple-callstack.msl2.frag
@@ -16,22 +16,22 @@ struct SSBO0
 };
 
 static inline __attribute__((always_inline))
-void callee2(device SSBO1& v_14, thread float4& gl_FragCoord)
+void callee2(device SSBO1& _14, thread float4& gl_FragCoord)
 {
     int _25 = int(gl_FragCoord.x);
-    v_14.values1[_25]++;
+    _14.values1[_25]++;
 }
 
 static inline __attribute__((always_inline))
-void callee(device SSBO1& v_14, thread float4& gl_FragCoord, device SSBO0& v_35)
+void callee(device SSBO1& _14, thread float4& gl_FragCoord, device SSBO0& _35)
 {
     int _38 = int(gl_FragCoord.x);
-    v_35.values0[_38]++;
-    callee2(v_14, gl_FragCoord);
+    _35.values0[_38]++;
+    callee2(_14, gl_FragCoord);
 }
 
-fragment void main0(device SSBO1& v_14 [[buffer(0), raster_order_group(0)]], device SSBO0& v_35 [[buffer(1), raster_order_group(0)]], float4 gl_FragCoord [[position]])
+fragment void main0(device SSBO1& _14 [[buffer(0), raster_order_group(0)]], device SSBO0& _35 [[buffer(1), raster_order_group(0)]], float4 gl_FragCoord [[position]])
 {
-    callee(v_14, gl_FragCoord, v_35);
+    callee(_14, gl_FragCoord, _35);
 }
 

--- a/reference/shaders-msl-no-opt/packing/load-store-col-rows.comp
+++ b/reference/shaders-msl-no-opt/packing/load-store-col-rows.comp
@@ -23,54 +23,54 @@ struct SSBO2
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_column(device SSBO1& v_21)
+void load_store_column(device SSBO1& _21)
 {
-    float2 u = v_21.a[0].xy;
-    float2 v = v_21.a[1].xy;
+    float2 u = _21.a[0].xy;
+    float2 v = _21.a[1].xy;
     u += v;
-    (device float2&)v_21.a[0] = u;
-    (device float2&)v_21.a[1] = v;
+    (device float2&)_21.a[0] = u;
+    (device float2&)_21.a[1] = v;
 }
 
 static inline __attribute__((always_inline))
-void load_store_row(device SSBO1& v_21)
+void load_store_row(device SSBO1& _21)
 {
-    float2 u = float2(v_21.a2[0][0], v_21.a2[1][0]);
-    float2 v = float2(v_21.a2[0][1], v_21.a2[1][1]);
+    float2 u = float2(_21.a2[0][0], _21.a2[1][0]);
+    float2 v = float2(_21.a2[0][1], _21.a2[1][1]);
     u += v;
-    ((device float*)&v_21.a2[0])[0] = u.x;
-    ((device float*)&v_21.a2[1])[0] = u.y;
-    ((device float*)&v_21.a2[0])[1] = v.x;
-    ((device float*)&v_21.a2[1])[1] = v.y;
+    ((device float*)&_21.a2[0])[0] = u.x;
+    ((device float*)&_21.a2[1])[0] = u.y;
+    ((device float*)&_21.a2[0])[1] = v.x;
+    ((device float*)&_21.a2[1])[1] = v.y;
 }
 
 static inline __attribute__((always_inline))
-void load_store_packed_column(device SSBO2& v_58)
+void load_store_packed_column(device SSBO2& _58)
 {
-    float3 u = float3(v_58.b[0]);
-    float3 v = float3(v_58.b[1]);
+    float3 u = float3(_58.b[0]);
+    float3 v = float3(_58.b[1]);
     u += v;
-    v_58.b[0] = u;
-    v_58.b[1] = v;
+    _58.b[0] = u;
+    _58.b[1] = v;
 }
 
 static inline __attribute__((always_inline))
-void load_store_packed_row(device SSBO2& v_58)
+void load_store_packed_row(device SSBO2& _58)
 {
-    float2 u = float2(v_58.b2[0][0], v_58.b2[1][0]);
-    float2 v = float2(v_58.b2[0][1], v_58.b2[1][1]);
+    float2 u = float2(_58.b2[0][0], _58.b2[1][0]);
+    float2 v = float2(_58.b2[0][1], _58.b2[1][1]);
     u += v;
-    ((device float*)&v_58.b2[0])[0] = u.x;
-    ((device float*)&v_58.b2[1])[0] = u.y;
-    ((device float*)&v_58.b2[0])[1] = v.x;
-    ((device float*)&v_58.b2[1])[1] = v.y;
+    ((device float*)&_58.b2[0])[0] = u.x;
+    ((device float*)&_58.b2[1])[0] = u.y;
+    ((device float*)&_58.b2[0])[1] = v.x;
+    ((device float*)&_58.b2[1])[1] = v.y;
 }
 
-kernel void main0(device SSBO1& v_21 [[buffer(0)]], device SSBO2& v_58 [[buffer(1)]])
+kernel void main0(device SSBO1& _21 [[buffer(0)]], device SSBO2& _58 [[buffer(1)]])
 {
-    load_store_column(v_21);
-    load_store_row(v_21);
-    load_store_packed_column(v_58);
-    load_store_packed_row(v_58);
+    load_store_column(_21);
+    load_store_row(_21);
+    load_store_packed_column(_58);
+    load_store_packed_row(_58);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-2x2-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-2x2-scalar.comp
@@ -20,67 +20,67 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float2x2 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float2x2 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float2x2 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float2x2 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(v_29.col_major0);
+    _41.row_major0 = transpose(_29.col_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(v_41.row_major0);
+    _29.col_major0 = transpose(_41.row_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1].x;
-    v_41.row_major0[1][1] = v_29.col_major0[1].y;
+    _29.col_major0[1] = float2(_41.row_major0[0][1], _41.row_major0[1][1]);
+    _41.row_major0[0][1] = _29.col_major0[1].x;
+    _41.row_major0[1][1] = _29.col_major0[1].y;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-2x2-std140.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-2x2-std140.comp
@@ -20,73 +20,73 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float2x2 loaded = float2x2(v_29.col_major0[0].xy, v_29.col_major0[1].xy);
-    (device float2&)v_29.col_major1[0] = loaded[0];
-    (device float2&)v_29.col_major1[1] = loaded[1];
+    float2x2 loaded = float2x2(_29.col_major0[0].xy, _29.col_major0[1].xy);
+    (device float2&)_29.col_major1[0] = loaded[0];
+    (device float2&)_29.col_major1[1] = loaded[1];
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float2x2 loaded = transpose(float2x2(v_41.row_major0[0].xy, v_41.row_major0[1].xy));
-    (device float2&)v_41.row_major0[0] = float2(loaded[0][0], loaded[1][0]);
-    (device float2&)v_41.row_major0[1] = float2(loaded[0][1], loaded[1][1]);
+    float2x2 loaded = transpose(float2x2(_41.row_major0[0].xy, _41.row_major0[1].xy));
+    (device float2&)_41.row_major0[0] = float2(loaded[0][0], loaded[1][0]);
+    (device float2&)_41.row_major0[1] = float2(loaded[0][1], loaded[1][1]);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    (device float2&)v_29.col_major0[0] = float2x2(v_29.col_major1[0].xy, v_29.col_major1[1].xy)[0];
-    (device float2&)v_29.col_major0[1] = float2x2(v_29.col_major1[0].xy, v_29.col_major1[1].xy)[1];
+    (device float2&)_29.col_major0[0] = float2x2(_29.col_major1[0].xy, _29.col_major1[1].xy)[0];
+    (device float2&)_29.col_major0[1] = float2x2(_29.col_major1[0].xy, _29.col_major1[1].xy)[1];
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    (device float2&)v_41.row_major0[0] = float2(float2x2(v_29.col_major0[0].xy, v_29.col_major0[1].xy)[0][0], float2x2(v_29.col_major0[0].xy, v_29.col_major0[1].xy)[1][0]);
-    (device float2&)v_41.row_major0[1] = float2(float2x2(v_29.col_major0[0].xy, v_29.col_major0[1].xy)[0][1], float2x2(v_29.col_major0[0].xy, v_29.col_major0[1].xy)[1][1]);
+    (device float2&)_41.row_major0[0] = float2(float2x2(_29.col_major0[0].xy, _29.col_major0[1].xy)[0][0], float2x2(_29.col_major0[0].xy, _29.col_major0[1].xy)[1][0]);
+    (device float2&)_41.row_major0[1] = float2(float2x2(_29.col_major0[0].xy, _29.col_major0[1].xy)[0][1], float2x2(_29.col_major0[0].xy, _29.col_major0[1].xy)[1][1]);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    (device float2&)v_29.col_major0[0] = float2(float2x2(v_41.row_major0[0].xy, v_41.row_major0[1].xy)[0][0], float2x2(v_41.row_major0[0].xy, v_41.row_major0[1].xy)[1][0]);
-    (device float2&)v_29.col_major0[1] = float2(float2x2(v_41.row_major0[0].xy, v_41.row_major0[1].xy)[0][1], float2x2(v_41.row_major0[0].xy, v_41.row_major0[1].xy)[1][1]);
+    (device float2&)_29.col_major0[0] = float2(float2x2(_41.row_major0[0].xy, _41.row_major0[1].xy)[0][0], float2x2(_41.row_major0[0].xy, _41.row_major0[1].xy)[1][0]);
+    (device float2&)_29.col_major0[1] = float2(float2x2(_41.row_major0[0].xy, _41.row_major0[1].xy)[0][1], float2x2(_41.row_major0[0].xy, _41.row_major0[1].xy)[1][1]);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    (device float2&)v_41.row_major0[0] = float2x2(v_41.row_major1[0].xy, v_41.row_major1[1].xy)[0];
-    (device float2&)v_41.row_major0[1] = float2x2(v_41.row_major1[0].xy, v_41.row_major1[1].xy)[1];
+    (device float2&)_41.row_major0[0] = float2x2(_41.row_major1[0].xy, _41.row_major1[1].xy)[0];
+    (device float2&)_41.row_major0[1] = float2x2(_41.row_major1[0].xy, _41.row_major1[1].xy)[1];
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    (device float2&)v_29.col_major0[1] = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
-    ((device float*)&v_41.row_major0[0])[1] = v_29.col_major0[1].x;
-    ((device float*)&v_41.row_major0[1])[1] = v_29.col_major0[1].y;
+    (device float2&)_29.col_major0[1] = float2(_41.row_major0[0][1], _41.row_major0[1][1]);
+    ((device float*)&_41.row_major0[0])[1] = _29.col_major0[1].x;
+    ((device float*)&_41.row_major0[1])[1] = _29.col_major0[1].y;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-2x2-std430.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-2x2-std430.comp
@@ -20,67 +20,67 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float2x2 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float2x2 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float2x2 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float2x2 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(v_29.col_major0);
+    _41.row_major0 = transpose(_29.col_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(v_41.row_major0);
+    _29.col_major0 = transpose(_41.row_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1].x;
-    v_41.row_major0[1][1] = v_29.col_major0[1].y;
+    _29.col_major0[1] = float2(_41.row_major0[0][1], _41.row_major0[1][1]);
+    _41.row_major0[0][1] = _29.col_major0[1].x;
+    _41.row_major0[1][1] = _29.col_major0[1].y;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-2x3-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-2x3-scalar.comp
@@ -22,71 +22,71 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float2x3 loaded = float2x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]));
-    v_29.col_major1[0] = loaded[0];
-    v_29.col_major1[1] = loaded[1];
+    float2x3 loaded = float2x3(float3(_29.col_major0[0]), float3(_29.col_major0[1]));
+    _29.col_major1[0] = loaded[0];
+    _29.col_major1[1] = loaded[1];
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float2x3 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float2x3 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0[0] = float2x3(float3(v_29.col_major1[0]), float3(v_29.col_major1[1]))[0];
-    v_29.col_major0[1] = float2x3(float3(v_29.col_major1[0]), float3(v_29.col_major1[1]))[1];
+    _29.col_major0[0] = float2x3(float3(_29.col_major1[0]), float3(_29.col_major1[1]))[0];
+    _29.col_major0[1] = float2x3(float3(_29.col_major1[0]), float3(_29.col_major1[1]))[1];
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(float2x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1])));
+    _41.row_major0 = transpose(float2x3(float3(_29.col_major0[0]), float3(_29.col_major0[1])));
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[0] = float3(v_41.row_major0[0][0], v_41.row_major0[1][0], v_41.row_major0[2][0]);
-    v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
+    _29.col_major0[0] = float3(_41.row_major0[0][0], _41.row_major0[1][0], _41.row_major0[2][0]);
+    _29.col_major0[1] = float3(_41.row_major0[0][1], _41.row_major0[1][1], _41.row_major0[2][1]);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1][0];
-    v_41.row_major0[1][1] = v_29.col_major0[1][1];
-    v_41.row_major0[2][1] = v_29.col_major0[1][2];
+    _29.col_major0[1] = float3(_41.row_major0[0][1], _41.row_major0[1][1], _41.row_major0[2][1]);
+    _41.row_major0[0][1] = _29.col_major0[1][0];
+    _41.row_major0[1][1] = _29.col_major0[1][1];
+    _41.row_major0[2][1] = _29.col_major0[1][2];
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[0][1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = v_29.col_major0[0][1u];
+    _29.col_major0[0][1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = _29.col_major0[0][1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-2x3-std140.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-2x3-std140.comp
@@ -20,74 +20,74 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float2x3 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float2x3 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float2x3 loaded = transpose(float3x2(v_41.row_major0[0].xy, v_41.row_major0[1].xy, v_41.row_major0[2].xy));
-    (device float2&)v_41.row_major0[0] = float2(loaded[0][0], loaded[1][0]);
-    (device float2&)v_41.row_major0[1] = float2(loaded[0][1], loaded[1][1]);
-    (device float2&)v_41.row_major0[2] = float2(loaded[0][2], loaded[1][2]);
+    float2x3 loaded = transpose(float3x2(_41.row_major0[0].xy, _41.row_major0[1].xy, _41.row_major0[2].xy));
+    (device float2&)_41.row_major0[0] = float2(loaded[0][0], loaded[1][0]);
+    (device float2&)_41.row_major0[1] = float2(loaded[0][1], loaded[1][1]);
+    (device float2&)_41.row_major0[2] = float2(loaded[0][2], loaded[1][2]);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    (device float2&)v_41.row_major0[0] = float2(v_29.col_major0[0][0], v_29.col_major0[1][0]);
-    (device float2&)v_41.row_major0[1] = float2(v_29.col_major0[0][1], v_29.col_major0[1][1]);
-    (device float2&)v_41.row_major0[2] = float2(v_29.col_major0[0][2], v_29.col_major0[1][2]);
+    (device float2&)_41.row_major0[0] = float2(_29.col_major0[0][0], _29.col_major0[1][0]);
+    (device float2&)_41.row_major0[1] = float2(_29.col_major0[0][1], _29.col_major0[1][1]);
+    (device float2&)_41.row_major0[2] = float2(_29.col_major0[0][2], _29.col_major0[1][2]);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(float3x2(v_41.row_major0[0].xy, v_41.row_major0[1].xy, v_41.row_major0[2].xy));
+    _29.col_major0 = transpose(float3x2(_41.row_major0[0].xy, _41.row_major0[1].xy, _41.row_major0[2].xy));
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    (device float2&)v_41.row_major0[0] = float3x2(v_41.row_major1[0].xy, v_41.row_major1[1].xy, v_41.row_major1[2].xy)[0];
-    (device float2&)v_41.row_major0[1] = float3x2(v_41.row_major1[0].xy, v_41.row_major1[1].xy, v_41.row_major1[2].xy)[1];
-    (device float2&)v_41.row_major0[2] = float3x2(v_41.row_major1[0].xy, v_41.row_major1[1].xy, v_41.row_major1[2].xy)[2];
+    (device float2&)_41.row_major0[0] = float3x2(_41.row_major1[0].xy, _41.row_major1[1].xy, _41.row_major1[2].xy)[0];
+    (device float2&)_41.row_major0[1] = float3x2(_41.row_major1[0].xy, _41.row_major1[1].xy, _41.row_major1[2].xy)[1];
+    (device float2&)_41.row_major0[2] = float3x2(_41.row_major1[0].xy, _41.row_major1[1].xy, _41.row_major1[2].xy)[2];
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
-    ((device float*)&v_41.row_major0[0])[1] = v_29.col_major0[1].x;
-    ((device float*)&v_41.row_major0[1])[1] = v_29.col_major0[1].y;
-    ((device float*)&v_41.row_major0[2])[1] = v_29.col_major0[1].z;
+    _29.col_major0[1] = float3(_41.row_major0[0][1], _41.row_major0[1][1], _41.row_major0[2][1]);
+    ((device float*)&_41.row_major0[0])[1] = _29.col_major0[1].x;
+    ((device float*)&_41.row_major0[1])[1] = _29.col_major0[1].y;
+    ((device float*)&_41.row_major0[2])[1] = _29.col_major0[1].z;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-2x3-std430.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-2x3-std430.comp
@@ -20,68 +20,68 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float2x3 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float2x3 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float2x3 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float2x3 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(v_29.col_major0);
+    _41.row_major0 = transpose(_29.col_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(v_41.row_major0);
+    _29.col_major0 = transpose(_41.row_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1].x;
-    v_41.row_major0[1][1] = v_29.col_major0[1].y;
-    v_41.row_major0[2][1] = v_29.col_major0[1].z;
+    _29.col_major0[1] = float3(_41.row_major0[0][1], _41.row_major0[1][1], _41.row_major0[2][1]);
+    _41.row_major0[0][1] = _29.col_major0[1].x;
+    _41.row_major0[1][1] = _29.col_major0[1].y;
+    _41.row_major0[2][1] = _29.col_major0[1].z;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-2x4-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-2x4-scalar.comp
@@ -20,69 +20,69 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float2x4 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float2x4 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float2x4 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float2x4 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(v_29.col_major0);
+    _41.row_major0 = transpose(_29.col_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(v_41.row_major0);
+    _29.col_major0 = transpose(_41.row_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float4(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1], v_41.row_major0[3][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1].x;
-    v_41.row_major0[1][1] = v_29.col_major0[1].y;
-    v_41.row_major0[2][1] = v_29.col_major0[1].z;
-    v_41.row_major0[3][1] = v_29.col_major0[1].w;
+    _29.col_major0[1] = float4(_41.row_major0[0][1], _41.row_major0[1][1], _41.row_major0[2][1], _41.row_major0[3][1]);
+    _41.row_major0[0][1] = _29.col_major0[1].x;
+    _41.row_major0[1][1] = _29.col_major0[1].y;
+    _41.row_major0[2][1] = _29.col_major0[1].z;
+    _41.row_major0[3][1] = _29.col_major0[1].w;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-2x4-std140.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-2x4-std140.comp
@@ -20,78 +20,78 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float2x4 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float2x4 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float2x4 loaded = transpose(float4x2(v_41.row_major0[0].xy, v_41.row_major0[1].xy, v_41.row_major0[2].xy, v_41.row_major0[3].xy));
-    (device float2&)v_41.row_major0[0] = float2(loaded[0][0], loaded[1][0]);
-    (device float2&)v_41.row_major0[1] = float2(loaded[0][1], loaded[1][1]);
-    (device float2&)v_41.row_major0[2] = float2(loaded[0][2], loaded[1][2]);
-    (device float2&)v_41.row_major0[3] = float2(loaded[0][3], loaded[1][3]);
+    float2x4 loaded = transpose(float4x2(_41.row_major0[0].xy, _41.row_major0[1].xy, _41.row_major0[2].xy, _41.row_major0[3].xy));
+    (device float2&)_41.row_major0[0] = float2(loaded[0][0], loaded[1][0]);
+    (device float2&)_41.row_major0[1] = float2(loaded[0][1], loaded[1][1]);
+    (device float2&)_41.row_major0[2] = float2(loaded[0][2], loaded[1][2]);
+    (device float2&)_41.row_major0[3] = float2(loaded[0][3], loaded[1][3]);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    (device float2&)v_41.row_major0[0] = float2(v_29.col_major0[0][0], v_29.col_major0[1][0]);
-    (device float2&)v_41.row_major0[1] = float2(v_29.col_major0[0][1], v_29.col_major0[1][1]);
-    (device float2&)v_41.row_major0[2] = float2(v_29.col_major0[0][2], v_29.col_major0[1][2]);
-    (device float2&)v_41.row_major0[3] = float2(v_29.col_major0[0][3], v_29.col_major0[1][3]);
+    (device float2&)_41.row_major0[0] = float2(_29.col_major0[0][0], _29.col_major0[1][0]);
+    (device float2&)_41.row_major0[1] = float2(_29.col_major0[0][1], _29.col_major0[1][1]);
+    (device float2&)_41.row_major0[2] = float2(_29.col_major0[0][2], _29.col_major0[1][2]);
+    (device float2&)_41.row_major0[3] = float2(_29.col_major0[0][3], _29.col_major0[1][3]);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(float4x2(v_41.row_major0[0].xy, v_41.row_major0[1].xy, v_41.row_major0[2].xy, v_41.row_major0[3].xy));
+    _29.col_major0 = transpose(float4x2(_41.row_major0[0].xy, _41.row_major0[1].xy, _41.row_major0[2].xy, _41.row_major0[3].xy));
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    (device float2&)v_41.row_major0[0] = float4x2(v_41.row_major1[0].xy, v_41.row_major1[1].xy, v_41.row_major1[2].xy, v_41.row_major1[3].xy)[0];
-    (device float2&)v_41.row_major0[1] = float4x2(v_41.row_major1[0].xy, v_41.row_major1[1].xy, v_41.row_major1[2].xy, v_41.row_major1[3].xy)[1];
-    (device float2&)v_41.row_major0[2] = float4x2(v_41.row_major1[0].xy, v_41.row_major1[1].xy, v_41.row_major1[2].xy, v_41.row_major1[3].xy)[2];
-    (device float2&)v_41.row_major0[3] = float4x2(v_41.row_major1[0].xy, v_41.row_major1[1].xy, v_41.row_major1[2].xy, v_41.row_major1[3].xy)[3];
+    (device float2&)_41.row_major0[0] = float4x2(_41.row_major1[0].xy, _41.row_major1[1].xy, _41.row_major1[2].xy, _41.row_major1[3].xy)[0];
+    (device float2&)_41.row_major0[1] = float4x2(_41.row_major1[0].xy, _41.row_major1[1].xy, _41.row_major1[2].xy, _41.row_major1[3].xy)[1];
+    (device float2&)_41.row_major0[2] = float4x2(_41.row_major1[0].xy, _41.row_major1[1].xy, _41.row_major1[2].xy, _41.row_major1[3].xy)[2];
+    (device float2&)_41.row_major0[3] = float4x2(_41.row_major1[0].xy, _41.row_major1[1].xy, _41.row_major1[2].xy, _41.row_major1[3].xy)[3];
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float4(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1], v_41.row_major0[3][1]);
-    ((device float*)&v_41.row_major0[0])[1] = v_29.col_major0[1].x;
-    ((device float*)&v_41.row_major0[1])[1] = v_29.col_major0[1].y;
-    ((device float*)&v_41.row_major0[2])[1] = v_29.col_major0[1].z;
-    ((device float*)&v_41.row_major0[3])[1] = v_29.col_major0[1].w;
+    _29.col_major0[1] = float4(_41.row_major0[0][1], _41.row_major0[1][1], _41.row_major0[2][1], _41.row_major0[3][1]);
+    ((device float*)&_41.row_major0[0])[1] = _29.col_major0[1].x;
+    ((device float*)&_41.row_major0[1])[1] = _29.col_major0[1].y;
+    ((device float*)&_41.row_major0[2])[1] = _29.col_major0[1].z;
+    ((device float*)&_41.row_major0[3])[1] = _29.col_major0[1].w;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-2x4-std430.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-2x4-std430.comp
@@ -20,69 +20,69 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float2x4 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float2x4 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float2x4 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float2x4 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(v_29.col_major0);
+    _41.row_major0 = transpose(_29.col_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(v_41.row_major0);
+    _29.col_major0 = transpose(_41.row_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float4(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1], v_41.row_major0[3][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1].x;
-    v_41.row_major0[1][1] = v_29.col_major0[1].y;
-    v_41.row_major0[2][1] = v_29.col_major0[1].z;
-    v_41.row_major0[3][1] = v_29.col_major0[1].w;
+    _29.col_major0[1] = float4(_41.row_major0[0][1], _41.row_major0[1][1], _41.row_major0[2][1], _41.row_major0[3][1]);
+    _41.row_major0[0][1] = _29.col_major0[1].x;
+    _41.row_major0[1][1] = _29.col_major0[1].y;
+    _41.row_major0[2][1] = _29.col_major0[1].z;
+    _41.row_major0[3][1] = _29.col_major0[1].w;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-3x2-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x2-scalar.comp
@@ -22,70 +22,70 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float3x2 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float3x2 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float3x2 loaded = transpose(float2x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1])));
-    v_41.row_major0[0] = float3(loaded[0][0], loaded[1][0], loaded[2][0]);
-    v_41.row_major0[1] = float3(loaded[0][1], loaded[1][1], loaded[2][1]);
+    float3x2 loaded = transpose(float2x3(float3(_41.row_major0[0]), float3(_41.row_major0[1])));
+    _41.row_major0[0] = float3(loaded[0][0], loaded[1][0], loaded[2][0]);
+    _41.row_major0[1] = float3(loaded[0][1], loaded[1][1], loaded[2][1]);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0[0] = float3(v_29.col_major0[0][0], v_29.col_major0[1][0], v_29.col_major0[2][0]);
-    v_41.row_major0[1] = float3(v_29.col_major0[0][1], v_29.col_major0[1][1], v_29.col_major0[2][1]);
+    _41.row_major0[0] = float3(_29.col_major0[0][0], _29.col_major0[1][0], _29.col_major0[2][0]);
+    _41.row_major0[1] = float3(_29.col_major0[0][1], _29.col_major0[1][1], _29.col_major0[2][1]);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(float2x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1])));
+    _29.col_major0 = transpose(float2x3(float3(_41.row_major0[0]), float3(_41.row_major0[1])));
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0[0] = float2x3(float3(v_41.row_major1[0]), float3(v_41.row_major1[1]))[0];
-    v_41.row_major0[1] = float2x3(float3(v_41.row_major1[0]), float3(v_41.row_major1[1]))[1];
+    _41.row_major0[0] = float2x3(float3(_41.row_major1[0]), float3(_41.row_major1[1]))[0];
+    _41.row_major0[1] = float2x3(float3(_41.row_major1[0]), float3(_41.row_major1[1]))[1];
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
-    ((device float*)&v_41.row_major0[0])[1] = v_29.col_major0[1].x;
-    ((device float*)&v_41.row_major0[1])[1] = v_29.col_major0[1].y;
+    _29.col_major0[1] = float2(_41.row_major0[0][1], _41.row_major0[1][1]);
+    ((device float*)&_41.row_major0[0])[1] = _29.col_major0[1].x;
+    ((device float*)&_41.row_major0[1])[1] = _29.col_major0[1].y;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = v_41.row_major0[1u][0];
-    v_41.row_major0[1u][0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = _41.row_major0[1u][0];
+    _41.row_major0[1u][0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-3x2-std140.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x2-std140.comp
@@ -20,73 +20,73 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float3x2 loaded = float3x2(v_29.col_major0[0].xy, v_29.col_major0[1].xy, v_29.col_major0[2].xy);
-    (device float2&)v_29.col_major1[0] = loaded[0];
-    (device float2&)v_29.col_major1[1] = loaded[1];
-    (device float2&)v_29.col_major1[2] = loaded[2];
+    float3x2 loaded = float3x2(_29.col_major0[0].xy, _29.col_major0[1].xy, _29.col_major0[2].xy);
+    (device float2&)_29.col_major1[0] = loaded[0];
+    (device float2&)_29.col_major1[1] = loaded[1];
+    (device float2&)_29.col_major1[2] = loaded[2];
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float3x2 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float3x2 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    (device float2&)v_29.col_major0[0] = float3x2(v_29.col_major1[0].xy, v_29.col_major1[1].xy, v_29.col_major1[2].xy)[0];
-    (device float2&)v_29.col_major0[1] = float3x2(v_29.col_major1[0].xy, v_29.col_major1[1].xy, v_29.col_major1[2].xy)[1];
-    (device float2&)v_29.col_major0[2] = float3x2(v_29.col_major1[0].xy, v_29.col_major1[1].xy, v_29.col_major1[2].xy)[2];
+    (device float2&)_29.col_major0[0] = float3x2(_29.col_major1[0].xy, _29.col_major1[1].xy, _29.col_major1[2].xy)[0];
+    (device float2&)_29.col_major0[1] = float3x2(_29.col_major1[0].xy, _29.col_major1[1].xy, _29.col_major1[2].xy)[1];
+    (device float2&)_29.col_major0[2] = float3x2(_29.col_major1[0].xy, _29.col_major1[1].xy, _29.col_major1[2].xy)[2];
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(float3x2(v_29.col_major0[0].xy, v_29.col_major0[1].xy, v_29.col_major0[2].xy));
+    _41.row_major0 = transpose(float3x2(_29.col_major0[0].xy, _29.col_major0[1].xy, _29.col_major0[2].xy));
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    (device float2&)v_29.col_major0[0] = float2(v_41.row_major0[0][0], v_41.row_major0[1][0]);
-    (device float2&)v_29.col_major0[1] = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
-    (device float2&)v_29.col_major0[2] = float2(v_41.row_major0[0][2], v_41.row_major0[1][2]);
+    (device float2&)_29.col_major0[0] = float2(_41.row_major0[0][0], _41.row_major0[1][0]);
+    (device float2&)_29.col_major0[1] = float2(_41.row_major0[0][1], _41.row_major0[1][1]);
+    (device float2&)_29.col_major0[2] = float2(_41.row_major0[0][2], _41.row_major0[1][2]);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    (device float2&)v_29.col_major0[1] = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1].x;
-    v_41.row_major0[1][1] = v_29.col_major0[1].y;
+    (device float2&)_29.col_major0[1] = float2(_41.row_major0[0][1], _41.row_major0[1][1]);
+    _41.row_major0[0][1] = _29.col_major0[1].x;
+    _41.row_major0[1][1] = _29.col_major0[1].y;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-3x2-std430.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x2-std430.comp
@@ -20,67 +20,67 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float3x2 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float3x2 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float3x2 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float3x2 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(v_29.col_major0);
+    _41.row_major0 = transpose(_29.col_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(v_41.row_major0);
+    _29.col_major0 = transpose(_41.row_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1].x;
-    v_41.row_major0[1][1] = v_29.col_major0[1].y;
+    _29.col_major0[1] = float2(_41.row_major0[0][1], _41.row_major0[1][1]);
+    _41.row_major0[0][1] = _29.col_major0[1].x;
+    _41.row_major0[1][1] = _29.col_major0[1].y;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-3x3-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x3-scalar.comp
@@ -23,80 +23,80 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float3x3 loaded = float3x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]));
-    v_29.col_major1[0] = loaded[0];
-    v_29.col_major1[1] = loaded[1];
-    v_29.col_major1[2] = loaded[2];
+    float3x3 loaded = float3x3(float3(_29.col_major0[0]), float3(_29.col_major0[1]), float3(_29.col_major0[2]));
+    _29.col_major1[0] = loaded[0];
+    _29.col_major1[1] = loaded[1];
+    _29.col_major1[2] = loaded[2];
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float3x3 loaded = transpose(float3x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2])));
-    v_41.row_major0[0] = float3(loaded[0][0], loaded[1][0], loaded[2][0]);
-    v_41.row_major0[1] = float3(loaded[0][1], loaded[1][1], loaded[2][1]);
-    v_41.row_major0[2] = float3(loaded[0][2], loaded[1][2], loaded[2][2]);
+    float3x3 loaded = transpose(float3x3(float3(_41.row_major0[0]), float3(_41.row_major0[1]), float3(_41.row_major0[2])));
+    _41.row_major0[0] = float3(loaded[0][0], loaded[1][0], loaded[2][0]);
+    _41.row_major0[1] = float3(loaded[0][1], loaded[1][1], loaded[2][1]);
+    _41.row_major0[2] = float3(loaded[0][2], loaded[1][2], loaded[2][2]);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0[0] = float3x3(float3(v_29.col_major1[0]), float3(v_29.col_major1[1]), float3(v_29.col_major1[2]))[0];
-    v_29.col_major0[1] = float3x3(float3(v_29.col_major1[0]), float3(v_29.col_major1[1]), float3(v_29.col_major1[2]))[1];
-    v_29.col_major0[2] = float3x3(float3(v_29.col_major1[0]), float3(v_29.col_major1[1]), float3(v_29.col_major1[2]))[2];
+    _29.col_major0[0] = float3x3(float3(_29.col_major1[0]), float3(_29.col_major1[1]), float3(_29.col_major1[2]))[0];
+    _29.col_major0[1] = float3x3(float3(_29.col_major1[0]), float3(_29.col_major1[1]), float3(_29.col_major1[2]))[1];
+    _29.col_major0[2] = float3x3(float3(_29.col_major1[0]), float3(_29.col_major1[1]), float3(_29.col_major1[2]))[2];
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0[0] = float3(float3x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]))[0][0], float3x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]))[1][0], float3x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]))[2][0]);
-    v_41.row_major0[1] = float3(float3x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]))[0][1], float3x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]))[1][1], float3x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]))[2][1]);
-    v_41.row_major0[2] = float3(float3x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]))[0][2], float3x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]))[1][2], float3x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]))[2][2]);
+    _41.row_major0[0] = float3(float3x3(float3(_29.col_major0[0]), float3(_29.col_major0[1]), float3(_29.col_major0[2]))[0][0], float3x3(float3(_29.col_major0[0]), float3(_29.col_major0[1]), float3(_29.col_major0[2]))[1][0], float3x3(float3(_29.col_major0[0]), float3(_29.col_major0[1]), float3(_29.col_major0[2]))[2][0]);
+    _41.row_major0[1] = float3(float3x3(float3(_29.col_major0[0]), float3(_29.col_major0[1]), float3(_29.col_major0[2]))[0][1], float3x3(float3(_29.col_major0[0]), float3(_29.col_major0[1]), float3(_29.col_major0[2]))[1][1], float3x3(float3(_29.col_major0[0]), float3(_29.col_major0[1]), float3(_29.col_major0[2]))[2][1]);
+    _41.row_major0[2] = float3(float3x3(float3(_29.col_major0[0]), float3(_29.col_major0[1]), float3(_29.col_major0[2]))[0][2], float3x3(float3(_29.col_major0[0]), float3(_29.col_major0[1]), float3(_29.col_major0[2]))[1][2], float3x3(float3(_29.col_major0[0]), float3(_29.col_major0[1]), float3(_29.col_major0[2]))[2][2]);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[0] = float3(float3x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]))[0][0], float3x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]))[1][0], float3x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]))[2][0]);
-    v_29.col_major0[1] = float3(float3x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]))[0][1], float3x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]))[1][1], float3x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]))[2][1]);
-    v_29.col_major0[2] = float3(float3x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]))[0][2], float3x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]))[1][2], float3x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]))[2][2]);
+    _29.col_major0[0] = float3(float3x3(float3(_41.row_major0[0]), float3(_41.row_major0[1]), float3(_41.row_major0[2]))[0][0], float3x3(float3(_41.row_major0[0]), float3(_41.row_major0[1]), float3(_41.row_major0[2]))[1][0], float3x3(float3(_41.row_major0[0]), float3(_41.row_major0[1]), float3(_41.row_major0[2]))[2][0]);
+    _29.col_major0[1] = float3(float3x3(float3(_41.row_major0[0]), float3(_41.row_major0[1]), float3(_41.row_major0[2]))[0][1], float3x3(float3(_41.row_major0[0]), float3(_41.row_major0[1]), float3(_41.row_major0[2]))[1][1], float3x3(float3(_41.row_major0[0]), float3(_41.row_major0[1]), float3(_41.row_major0[2]))[2][1]);
+    _29.col_major0[2] = float3(float3x3(float3(_41.row_major0[0]), float3(_41.row_major0[1]), float3(_41.row_major0[2]))[0][2], float3x3(float3(_41.row_major0[0]), float3(_41.row_major0[1]), float3(_41.row_major0[2]))[1][2], float3x3(float3(_41.row_major0[0]), float3(_41.row_major0[1]), float3(_41.row_major0[2]))[2][2]);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0[0] = float3x3(float3(v_41.row_major1[0]), float3(v_41.row_major1[1]), float3(v_41.row_major1[2]))[0];
-    v_41.row_major0[1] = float3x3(float3(v_41.row_major1[0]), float3(v_41.row_major1[1]), float3(v_41.row_major1[2]))[1];
-    v_41.row_major0[2] = float3x3(float3(v_41.row_major1[0]), float3(v_41.row_major1[1]), float3(v_41.row_major1[2]))[2];
+    _41.row_major0[0] = float3x3(float3(_41.row_major1[0]), float3(_41.row_major1[1]), float3(_41.row_major1[2]))[0];
+    _41.row_major0[1] = float3x3(float3(_41.row_major1[0]), float3(_41.row_major1[1]), float3(_41.row_major1[2]))[1];
+    _41.row_major0[2] = float3x3(float3(_41.row_major1[0]), float3(_41.row_major1[1]), float3(_41.row_major1[2]))[2];
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
-    ((device float*)&v_41.row_major0[0])[1] = v_29.col_major0[1][0];
-    ((device float*)&v_41.row_major0[1])[1] = v_29.col_major0[1][1];
-    ((device float*)&v_41.row_major0[2])[1] = v_29.col_major0[1][2];
+    _29.col_major0[1] = float3(_41.row_major0[0][1], _41.row_major0[1][1], _41.row_major0[2][1]);
+    ((device float*)&_41.row_major0[0])[1] = _29.col_major0[1][0];
+    ((device float*)&_41.row_major0[1])[1] = _29.col_major0[1][1];
+    ((device float*)&_41.row_major0[2])[1] = _29.col_major0[1][2];
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[0][1u] = v_41.row_major0[1u][0];
-    v_41.row_major0[1u][0] = v_29.col_major0[0][1u];
+    _29.col_major0[0][1u] = _41.row_major0[1u][0];
+    _41.row_major0[1u][0] = _29.col_major0[0][1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-3x3-std140.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x3-std140.comp
@@ -20,68 +20,68 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float3x3 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float3x3 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float3x3 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float3x3 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(v_29.col_major0);
+    _41.row_major0 = transpose(_29.col_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(v_41.row_major0);
+    _29.col_major0 = transpose(_41.row_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1].x;
-    v_41.row_major0[1][1] = v_29.col_major0[1].y;
-    v_41.row_major0[2][1] = v_29.col_major0[1].z;
+    _29.col_major0[1] = float3(_41.row_major0[0][1], _41.row_major0[1][1], _41.row_major0[2][1]);
+    _41.row_major0[0][1] = _29.col_major0[1].x;
+    _41.row_major0[1][1] = _29.col_major0[1].y;
+    _41.row_major0[2][1] = _29.col_major0[1].z;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-3x3-std430.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x3-std430.comp
@@ -20,68 +20,68 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float3x3 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float3x3 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float3x3 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float3x3 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(v_29.col_major0);
+    _41.row_major0 = transpose(_29.col_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(v_41.row_major0);
+    _29.col_major0 = transpose(_41.row_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1].x;
-    v_41.row_major0[1][1] = v_29.col_major0[1].y;
-    v_41.row_major0[2][1] = v_29.col_major0[1].z;
+    _29.col_major0[1] = float3(_41.row_major0[0][1], _41.row_major0[1][1], _41.row_major0[2][1]);
+    _41.row_major0[0][1] = _29.col_major0[1].x;
+    _41.row_major0[1][1] = _29.col_major0[1].y;
+    _41.row_major0[2][1] = _29.col_major0[1].z;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-3x4-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x4-scalar.comp
@@ -22,78 +22,78 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float3x4 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float3x4 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float3x4 loaded = transpose(float4x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]), float3(v_41.row_major0[3])));
-    v_41.row_major0[0] = float3(loaded[0][0], loaded[1][0], loaded[2][0]);
-    v_41.row_major0[1] = float3(loaded[0][1], loaded[1][1], loaded[2][1]);
-    v_41.row_major0[2] = float3(loaded[0][2], loaded[1][2], loaded[2][2]);
-    v_41.row_major0[3] = float3(loaded[0][3], loaded[1][3], loaded[2][3]);
+    float3x4 loaded = transpose(float4x3(float3(_41.row_major0[0]), float3(_41.row_major0[1]), float3(_41.row_major0[2]), float3(_41.row_major0[3])));
+    _41.row_major0[0] = float3(loaded[0][0], loaded[1][0], loaded[2][0]);
+    _41.row_major0[1] = float3(loaded[0][1], loaded[1][1], loaded[2][1]);
+    _41.row_major0[2] = float3(loaded[0][2], loaded[1][2], loaded[2][2]);
+    _41.row_major0[3] = float3(loaded[0][3], loaded[1][3], loaded[2][3]);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0[0] = float3(v_29.col_major0[0][0], v_29.col_major0[1][0], v_29.col_major0[2][0]);
-    v_41.row_major0[1] = float3(v_29.col_major0[0][1], v_29.col_major0[1][1], v_29.col_major0[2][1]);
-    v_41.row_major0[2] = float3(v_29.col_major0[0][2], v_29.col_major0[1][2], v_29.col_major0[2][2]);
-    v_41.row_major0[3] = float3(v_29.col_major0[0][3], v_29.col_major0[1][3], v_29.col_major0[2][3]);
+    _41.row_major0[0] = float3(_29.col_major0[0][0], _29.col_major0[1][0], _29.col_major0[2][0]);
+    _41.row_major0[1] = float3(_29.col_major0[0][1], _29.col_major0[1][1], _29.col_major0[2][1]);
+    _41.row_major0[2] = float3(_29.col_major0[0][2], _29.col_major0[1][2], _29.col_major0[2][2]);
+    _41.row_major0[3] = float3(_29.col_major0[0][3], _29.col_major0[1][3], _29.col_major0[2][3]);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(float4x3(float3(v_41.row_major0[0]), float3(v_41.row_major0[1]), float3(v_41.row_major0[2]), float3(v_41.row_major0[3])));
+    _29.col_major0 = transpose(float4x3(float3(_41.row_major0[0]), float3(_41.row_major0[1]), float3(_41.row_major0[2]), float3(_41.row_major0[3])));
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0[0] = float4x3(float3(v_41.row_major1[0]), float3(v_41.row_major1[1]), float3(v_41.row_major1[2]), float3(v_41.row_major1[3]))[0];
-    v_41.row_major0[1] = float4x3(float3(v_41.row_major1[0]), float3(v_41.row_major1[1]), float3(v_41.row_major1[2]), float3(v_41.row_major1[3]))[1];
-    v_41.row_major0[2] = float4x3(float3(v_41.row_major1[0]), float3(v_41.row_major1[1]), float3(v_41.row_major1[2]), float3(v_41.row_major1[3]))[2];
-    v_41.row_major0[3] = float4x3(float3(v_41.row_major1[0]), float3(v_41.row_major1[1]), float3(v_41.row_major1[2]), float3(v_41.row_major1[3]))[3];
+    _41.row_major0[0] = float4x3(float3(_41.row_major1[0]), float3(_41.row_major1[1]), float3(_41.row_major1[2]), float3(_41.row_major1[3]))[0];
+    _41.row_major0[1] = float4x3(float3(_41.row_major1[0]), float3(_41.row_major1[1]), float3(_41.row_major1[2]), float3(_41.row_major1[3]))[1];
+    _41.row_major0[2] = float4x3(float3(_41.row_major1[0]), float3(_41.row_major1[1]), float3(_41.row_major1[2]), float3(_41.row_major1[3]))[2];
+    _41.row_major0[3] = float4x3(float3(_41.row_major1[0]), float3(_41.row_major1[1]), float3(_41.row_major1[2]), float3(_41.row_major1[3]))[3];
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float4(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1], v_41.row_major0[3][1]);
-    ((device float*)&v_41.row_major0[0])[1] = v_29.col_major0[1].x;
-    ((device float*)&v_41.row_major0[1])[1] = v_29.col_major0[1].y;
-    ((device float*)&v_41.row_major0[2])[1] = v_29.col_major0[1].z;
-    ((device float*)&v_41.row_major0[3])[1] = v_29.col_major0[1].w;
+    _29.col_major0[1] = float4(_41.row_major0[0][1], _41.row_major0[1][1], _41.row_major0[2][1], _41.row_major0[3][1]);
+    ((device float*)&_41.row_major0[0])[1] = _29.col_major0[1].x;
+    ((device float*)&_41.row_major0[1])[1] = _29.col_major0[1].y;
+    ((device float*)&_41.row_major0[2])[1] = _29.col_major0[1].z;
+    ((device float*)&_41.row_major0[3])[1] = _29.col_major0[1].w;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = v_41.row_major0[1u][0];
-    v_41.row_major0[1u][0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = _41.row_major0[1u][0];
+    _41.row_major0[1u][0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-3x4-std140.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x4-std140.comp
@@ -20,69 +20,69 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float3x4 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float3x4 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float3x4 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float3x4 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(v_29.col_major0);
+    _41.row_major0 = transpose(_29.col_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(v_41.row_major0);
+    _29.col_major0 = transpose(_41.row_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float4(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1], v_41.row_major0[3][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1].x;
-    v_41.row_major0[1][1] = v_29.col_major0[1].y;
-    v_41.row_major0[2][1] = v_29.col_major0[1].z;
-    v_41.row_major0[3][1] = v_29.col_major0[1].w;
+    _29.col_major0[1] = float4(_41.row_major0[0][1], _41.row_major0[1][1], _41.row_major0[2][1], _41.row_major0[3][1]);
+    _41.row_major0[0][1] = _29.col_major0[1].x;
+    _41.row_major0[1][1] = _29.col_major0[1].y;
+    _41.row_major0[2][1] = _29.col_major0[1].z;
+    _41.row_major0[3][1] = _29.col_major0[1].w;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-3x4-std430.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x4-std430.comp
@@ -20,69 +20,69 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float3x4 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float3x4 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float3x4 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float3x4 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(v_29.col_major0);
+    _41.row_major0 = transpose(_29.col_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(v_41.row_major0);
+    _29.col_major0 = transpose(_41.row_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float4(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1], v_41.row_major0[3][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1].x;
-    v_41.row_major0[1][1] = v_29.col_major0[1].y;
-    v_41.row_major0[2][1] = v_29.col_major0[1].z;
-    v_41.row_major0[3][1] = v_29.col_major0[1].w;
+    _29.col_major0[1] = float4(_41.row_major0[0][1], _41.row_major0[1][1], _41.row_major0[2][1], _41.row_major0[3][1]);
+    _41.row_major0[0][1] = _29.col_major0[1].x;
+    _41.row_major0[1][1] = _29.col_major0[1].y;
+    _41.row_major0[2][1] = _29.col_major0[1].z;
+    _41.row_major0[3][1] = _29.col_major0[1].w;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-4x2-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-4x2-scalar.comp
@@ -20,67 +20,67 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float4x2 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float4x2 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float4x2 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float4x2 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(v_29.col_major0);
+    _41.row_major0 = transpose(_29.col_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(v_41.row_major0);
+    _29.col_major0 = transpose(_41.row_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1].x;
-    v_41.row_major0[1][1] = v_29.col_major0[1].y;
+    _29.col_major0[1] = float2(_41.row_major0[0][1], _41.row_major0[1][1]);
+    _41.row_major0[0][1] = _29.col_major0[1].x;
+    _41.row_major0[1][1] = _29.col_major0[1].y;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-4x2-std140.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-4x2-std140.comp
@@ -20,76 +20,76 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float4x2 loaded = float4x2(v_29.col_major0[0].xy, v_29.col_major0[1].xy, v_29.col_major0[2].xy, v_29.col_major0[3].xy);
-    (device float2&)v_29.col_major1[0] = loaded[0];
-    (device float2&)v_29.col_major1[1] = loaded[1];
-    (device float2&)v_29.col_major1[2] = loaded[2];
-    (device float2&)v_29.col_major1[3] = loaded[3];
+    float4x2 loaded = float4x2(_29.col_major0[0].xy, _29.col_major0[1].xy, _29.col_major0[2].xy, _29.col_major0[3].xy);
+    (device float2&)_29.col_major1[0] = loaded[0];
+    (device float2&)_29.col_major1[1] = loaded[1];
+    (device float2&)_29.col_major1[2] = loaded[2];
+    (device float2&)_29.col_major1[3] = loaded[3];
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float4x2 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float4x2 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    (device float2&)v_29.col_major0[0] = float4x2(v_29.col_major1[0].xy, v_29.col_major1[1].xy, v_29.col_major1[2].xy, v_29.col_major1[3].xy)[0];
-    (device float2&)v_29.col_major0[1] = float4x2(v_29.col_major1[0].xy, v_29.col_major1[1].xy, v_29.col_major1[2].xy, v_29.col_major1[3].xy)[1];
-    (device float2&)v_29.col_major0[2] = float4x2(v_29.col_major1[0].xy, v_29.col_major1[1].xy, v_29.col_major1[2].xy, v_29.col_major1[3].xy)[2];
-    (device float2&)v_29.col_major0[3] = float4x2(v_29.col_major1[0].xy, v_29.col_major1[1].xy, v_29.col_major1[2].xy, v_29.col_major1[3].xy)[3];
+    (device float2&)_29.col_major0[0] = float4x2(_29.col_major1[0].xy, _29.col_major1[1].xy, _29.col_major1[2].xy, _29.col_major1[3].xy)[0];
+    (device float2&)_29.col_major0[1] = float4x2(_29.col_major1[0].xy, _29.col_major1[1].xy, _29.col_major1[2].xy, _29.col_major1[3].xy)[1];
+    (device float2&)_29.col_major0[2] = float4x2(_29.col_major1[0].xy, _29.col_major1[1].xy, _29.col_major1[2].xy, _29.col_major1[3].xy)[2];
+    (device float2&)_29.col_major0[3] = float4x2(_29.col_major1[0].xy, _29.col_major1[1].xy, _29.col_major1[2].xy, _29.col_major1[3].xy)[3];
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(float4x2(v_29.col_major0[0].xy, v_29.col_major0[1].xy, v_29.col_major0[2].xy, v_29.col_major0[3].xy));
+    _41.row_major0 = transpose(float4x2(_29.col_major0[0].xy, _29.col_major0[1].xy, _29.col_major0[2].xy, _29.col_major0[3].xy));
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    (device float2&)v_29.col_major0[0] = float2(v_41.row_major0[0][0], v_41.row_major0[1][0]);
-    (device float2&)v_29.col_major0[1] = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
-    (device float2&)v_29.col_major0[2] = float2(v_41.row_major0[0][2], v_41.row_major0[1][2]);
-    (device float2&)v_29.col_major0[3] = float2(v_41.row_major0[0][3], v_41.row_major0[1][3]);
+    (device float2&)_29.col_major0[0] = float2(_41.row_major0[0][0], _41.row_major0[1][0]);
+    (device float2&)_29.col_major0[1] = float2(_41.row_major0[0][1], _41.row_major0[1][1]);
+    (device float2&)_29.col_major0[2] = float2(_41.row_major0[0][2], _41.row_major0[1][2]);
+    (device float2&)_29.col_major0[3] = float2(_41.row_major0[0][3], _41.row_major0[1][3]);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    (device float2&)v_29.col_major0[1] = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1].x;
-    v_41.row_major0[1][1] = v_29.col_major0[1].y;
+    (device float2&)_29.col_major0[1] = float2(_41.row_major0[0][1], _41.row_major0[1][1]);
+    _41.row_major0[0][1] = _29.col_major0[1].x;
+    _41.row_major0[1][1] = _29.col_major0[1].y;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-4x2-std430.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-4x2-std430.comp
@@ -20,67 +20,67 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float4x2 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float4x2 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float4x2 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float4x2 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(v_29.col_major0);
+    _41.row_major0 = transpose(_29.col_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(v_41.row_major0);
+    _29.col_major0 = transpose(_41.row_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float2(v_41.row_major0[0][1], v_41.row_major0[1][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1].x;
-    v_41.row_major0[1][1] = v_29.col_major0[1].y;
+    _29.col_major0[1] = float2(_41.row_major0[0][1], _41.row_major0[1][1]);
+    _41.row_major0[0][1] = _29.col_major0[1].x;
+    _41.row_major0[1][1] = _29.col_major0[1].y;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-4x3-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-4x3-scalar.comp
@@ -22,77 +22,77 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float4x3 loaded = float4x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]), float3(v_29.col_major0[3]));
-    v_29.col_major1[0] = loaded[0];
-    v_29.col_major1[1] = loaded[1];
-    v_29.col_major1[2] = loaded[2];
-    v_29.col_major1[3] = loaded[3];
+    float4x3 loaded = float4x3(float3(_29.col_major0[0]), float3(_29.col_major0[1]), float3(_29.col_major0[2]), float3(_29.col_major0[3]));
+    _29.col_major1[0] = loaded[0];
+    _29.col_major1[1] = loaded[1];
+    _29.col_major1[2] = loaded[2];
+    _29.col_major1[3] = loaded[3];
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float4x3 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float4x3 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0[0] = float4x3(float3(v_29.col_major1[0]), float3(v_29.col_major1[1]), float3(v_29.col_major1[2]), float3(v_29.col_major1[3]))[0];
-    v_29.col_major0[1] = float4x3(float3(v_29.col_major1[0]), float3(v_29.col_major1[1]), float3(v_29.col_major1[2]), float3(v_29.col_major1[3]))[1];
-    v_29.col_major0[2] = float4x3(float3(v_29.col_major1[0]), float3(v_29.col_major1[1]), float3(v_29.col_major1[2]), float3(v_29.col_major1[3]))[2];
-    v_29.col_major0[3] = float4x3(float3(v_29.col_major1[0]), float3(v_29.col_major1[1]), float3(v_29.col_major1[2]), float3(v_29.col_major1[3]))[3];
+    _29.col_major0[0] = float4x3(float3(_29.col_major1[0]), float3(_29.col_major1[1]), float3(_29.col_major1[2]), float3(_29.col_major1[3]))[0];
+    _29.col_major0[1] = float4x3(float3(_29.col_major1[0]), float3(_29.col_major1[1]), float3(_29.col_major1[2]), float3(_29.col_major1[3]))[1];
+    _29.col_major0[2] = float4x3(float3(_29.col_major1[0]), float3(_29.col_major1[1]), float3(_29.col_major1[2]), float3(_29.col_major1[3]))[2];
+    _29.col_major0[3] = float4x3(float3(_29.col_major1[0]), float3(_29.col_major1[1]), float3(_29.col_major1[2]), float3(_29.col_major1[3]))[3];
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(float4x3(float3(v_29.col_major0[0]), float3(v_29.col_major0[1]), float3(v_29.col_major0[2]), float3(v_29.col_major0[3])));
+    _41.row_major0 = transpose(float4x3(float3(_29.col_major0[0]), float3(_29.col_major0[1]), float3(_29.col_major0[2]), float3(_29.col_major0[3])));
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[0] = float3(v_41.row_major0[0][0], v_41.row_major0[1][0], v_41.row_major0[2][0]);
-    v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
-    v_29.col_major0[2] = float3(v_41.row_major0[0][2], v_41.row_major0[1][2], v_41.row_major0[2][2]);
-    v_29.col_major0[3] = float3(v_41.row_major0[0][3], v_41.row_major0[1][3], v_41.row_major0[2][3]);
+    _29.col_major0[0] = float3(_41.row_major0[0][0], _41.row_major0[1][0], _41.row_major0[2][0]);
+    _29.col_major0[1] = float3(_41.row_major0[0][1], _41.row_major0[1][1], _41.row_major0[2][1]);
+    _29.col_major0[2] = float3(_41.row_major0[0][2], _41.row_major0[1][2], _41.row_major0[2][2]);
+    _29.col_major0[3] = float3(_41.row_major0[0][3], _41.row_major0[1][3], _41.row_major0[2][3]);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1][0];
-    v_41.row_major0[1][1] = v_29.col_major0[1][1];
-    v_41.row_major0[2][1] = v_29.col_major0[1][2];
+    _29.col_major0[1] = float3(_41.row_major0[0][1], _41.row_major0[1][1], _41.row_major0[2][1]);
+    _41.row_major0[0][1] = _29.col_major0[1][0];
+    _41.row_major0[1][1] = _29.col_major0[1][1];
+    _41.row_major0[2][1] = _29.col_major0[1][2];
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[0][1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = v_29.col_major0[0][1u];
+    _29.col_major0[0][1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = _29.col_major0[0][1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-4x3-std140.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-4x3-std140.comp
@@ -20,68 +20,68 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float4x3 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float4x3 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float4x3 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float4x3 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(v_29.col_major0);
+    _41.row_major0 = transpose(_29.col_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(v_41.row_major0);
+    _29.col_major0 = transpose(_41.row_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1].x;
-    v_41.row_major0[1][1] = v_29.col_major0[1].y;
-    v_41.row_major0[2][1] = v_29.col_major0[1].z;
+    _29.col_major0[1] = float3(_41.row_major0[0][1], _41.row_major0[1][1], _41.row_major0[2][1]);
+    _41.row_major0[0][1] = _29.col_major0[1].x;
+    _41.row_major0[1][1] = _29.col_major0[1].y;
+    _41.row_major0[2][1] = _29.col_major0[1].z;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-4x3-std430.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-4x3-std430.comp
@@ -20,68 +20,68 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float4x3 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float4x3 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float4x3 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float4x3 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(v_29.col_major0);
+    _41.row_major0 = transpose(_29.col_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(v_41.row_major0);
+    _29.col_major0 = transpose(_41.row_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float3(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1].x;
-    v_41.row_major0[1][1] = v_29.col_major0[1].y;
-    v_41.row_major0[2][1] = v_29.col_major0[1].z;
+    _29.col_major0[1] = float3(_41.row_major0[0][1], _41.row_major0[1][1], _41.row_major0[2][1]);
+    _41.row_major0[0][1] = _29.col_major0[1].x;
+    _41.row_major0[1][1] = _29.col_major0[1].y;
+    _41.row_major0[2][1] = _29.col_major0[1].z;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-4x4-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-4x4-scalar.comp
@@ -20,69 +20,69 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float4x4 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float4x4 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float4x4 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float4x4 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(v_29.col_major0);
+    _41.row_major0 = transpose(_29.col_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(v_41.row_major0);
+    _29.col_major0 = transpose(_41.row_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float4(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1], v_41.row_major0[3][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1].x;
-    v_41.row_major0[1][1] = v_29.col_major0[1].y;
-    v_41.row_major0[2][1] = v_29.col_major0[1].z;
-    v_41.row_major0[3][1] = v_29.col_major0[1].w;
+    _29.col_major0[1] = float4(_41.row_major0[0][1], _41.row_major0[1][1], _41.row_major0[2][1], _41.row_major0[3][1]);
+    _41.row_major0[0][1] = _29.col_major0[1].x;
+    _41.row_major0[1][1] = _29.col_major0[1].y;
+    _41.row_major0[2][1] = _29.col_major0[1].z;
+    _41.row_major0[3][1] = _29.col_major0[1].w;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-4x4-std140.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-4x4-std140.comp
@@ -20,69 +20,69 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float4x4 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float4x4 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float4x4 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float4x4 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(v_29.col_major0);
+    _41.row_major0 = transpose(_29.col_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(v_41.row_major0);
+    _29.col_major0 = transpose(_41.row_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float4(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1], v_41.row_major0[3][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1].x;
-    v_41.row_major0[1][1] = v_29.col_major0[1].y;
-    v_41.row_major0[2][1] = v_29.col_major0[1].z;
-    v_41.row_major0[3][1] = v_29.col_major0[1].w;
+    _29.col_major0[1] = float4(_41.row_major0[0][1], _41.row_major0[1][1], _41.row_major0[2][1], _41.row_major0[3][1]);
+    _41.row_major0[0][1] = _29.col_major0[1].x;
+    _41.row_major0[1][1] = _29.col_major0[1].y;
+    _41.row_major0[2][1] = _29.col_major0[1].z;
+    _41.row_major0[3][1] = _29.col_major0[1].w;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/packing/matrix-4x4-std430.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-4x4-std430.comp
@@ -20,69 +20,69 @@ struct SSBORow
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_col_major(device SSBOCol& v_29)
+void load_store_to_variable_col_major(device SSBOCol& _29)
 {
-    float4x4 loaded = v_29.col_major0;
-    v_29.col_major1 = loaded;
+    float4x4 loaded = _29.col_major0;
+    _29.col_major1 = loaded;
 }
 
 static inline __attribute__((always_inline))
-void load_store_to_variable_row_major(device SSBORow& v_41)
+void load_store_to_variable_row_major(device SSBORow& _41)
 {
-    float4x4 loaded = transpose(v_41.row_major0);
-    v_41.row_major0 = transpose(loaded);
+    float4x4 loaded = transpose(_41.row_major0);
+    _41.row_major0 = transpose(loaded);
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_col_major(device SSBOCol& v_29)
+void copy_col_major_to_col_major(device SSBOCol& _29)
 {
-    v_29.col_major0 = v_29.col_major1;
+    _29.col_major0 = _29.col_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_col_major_to_row_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_col_major_to_row_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_41.row_major0 = transpose(v_29.col_major0);
+    _41.row_major0 = transpose(_29.col_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_col_major(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_row_major_to_col_major(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0 = transpose(v_41.row_major0);
+    _29.col_major0 = transpose(_41.row_major0);
 }
 
 static inline __attribute__((always_inline))
-void copy_row_major_to_row_major(device SSBORow& v_41)
+void copy_row_major_to_row_major(device SSBORow& _41)
 {
-    v_41.row_major0 = v_41.row_major1;
+    _41.row_major0 = _41.row_major1;
 }
 
 static inline __attribute__((always_inline))
-void copy_columns(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 {
-    v_29.col_major0[1] = float4(v_41.row_major0[0][1], v_41.row_major0[1][1], v_41.row_major0[2][1], v_41.row_major0[3][1]);
-    v_41.row_major0[0][1] = v_29.col_major0[1].x;
-    v_41.row_major0[1][1] = v_29.col_major0[1].y;
-    v_41.row_major0[2][1] = v_29.col_major0[1].z;
-    v_41.row_major0[3][1] = v_29.col_major0[1].w;
+    _29.col_major0[1] = float4(_41.row_major0[0][1], _41.row_major0[1][1], _41.row_major0[2][1], _41.row_major0[3][1]);
+    _41.row_major0[0][1] = _29.col_major0[1].x;
+    _41.row_major0[1][1] = _29.col_major0[1].y;
+    _41.row_major0[2][1] = _29.col_major0[1].z;
+    _41.row_major0[3][1] = _29.col_major0[1].w;
 }
 
 static inline __attribute__((always_inline))
-void copy_elements(device SSBOCol& v_29, device SSBORow& v_41)
+void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&v_29.col_major0[0])[1u] = ((device float*)&v_41.row_major0[1u])[0];
-    ((device float*)&v_41.row_major0[1u])[0] = ((device float*)&v_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
-kernel void main0(device SSBOCol& v_29 [[buffer(0)]], device SSBORow& v_41 [[buffer(1)]])
+kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])
 {
-    load_store_to_variable_col_major(v_29);
-    load_store_to_variable_row_major(v_41);
-    copy_col_major_to_col_major(v_29);
-    copy_col_major_to_row_major(v_29, v_41);
-    copy_row_major_to_col_major(v_29, v_41);
-    copy_row_major_to_row_major(v_41);
-    copy_columns(v_29, v_41);
-    copy_elements(v_29, v_41);
+    load_store_to_variable_col_major(_29);
+    load_store_to_variable_row_major(_41);
+    copy_col_major_to_col_major(_29);
+    copy_col_major_to_row_major(_29, _41);
+    copy_row_major_to_col_major(_29, _41);
+    copy_row_major_to_row_major(_41);
+    copy_columns(_29, _41);
+    copy_elements(_29, _41);
 }
 

--- a/reference/shaders-msl-no-opt/vert/functions_nested.vert
+++ b/reference/shaders-msl-no-opt/vert/functions_nested.vert
@@ -42,13 +42,13 @@ struct main0_out
 };
 
 static inline __attribute__((always_inline))
-attr_desc fetch_desc(thread const int& location, constant VertexBuffer& v_227)
+attr_desc fetch_desc(thread const int& location, constant VertexBuffer& _227)
 {
-    int attribute_flags = v_227.input_attributes[location].w;
+    int attribute_flags = _227.input_attributes[location].w;
     attr_desc result;
-    result.type = v_227.input_attributes[location].x;
-    result.attribute_size = v_227.input_attributes[location].y;
-    result.starting_offset = v_227.input_attributes[location].z;
+    result.type = _227.input_attributes[location].x;
+    result.attribute_size = _227.input_attributes[location].y;
+    result.starting_offset = _227.input_attributes[location].z;
     result.stride = attribute_flags & 255;
     result.swap_bytes = (attribute_flags >> 8) & 1;
     result.is_volatile = (attribute_flags >> 9) & 1;
@@ -135,11 +135,11 @@ float4 fetch_attr(thread const attr_desc& desc, thread const int& vertex_id, tex
 }
 
 static inline __attribute__((always_inline))
-float4 read_location(thread const int& location, constant VertexBuffer& v_227, thread uint& gl_VertexIndex, texture2d<uint> buff_in_2, texture2d<uint> buff_in_1)
+float4 read_location(thread const int& location, constant VertexBuffer& _227, thread uint& gl_VertexIndex, texture2d<uint> buff_in_2, texture2d<uint> buff_in_1)
 {
     int param = location;
-    attr_desc desc = fetch_desc(param, v_227);
-    int vertex_id = int(gl_VertexIndex) - int(v_227.vertex_base_index);
+    attr_desc desc = fetch_desc(param, _227);
+    int vertex_id = int(gl_VertexIndex) - int(_227.vertex_base_index);
     if (desc.is_volatile != 0)
     {
         attr_desc param_1 = desc;
@@ -155,30 +155,30 @@ float4 read_location(thread const int& location, constant VertexBuffer& v_227, t
 }
 
 static inline __attribute__((always_inline))
-void vs_adjust(thread float4& dst_reg0, thread float4& dst_reg1, thread float4& dst_reg7, constant VertexBuffer& v_227, thread uint& gl_VertexIndex, texture2d<uint> buff_in_2, texture2d<uint> buff_in_1, constant VertexConstantsBuffer& v_309)
+void vs_adjust(thread float4& dst_reg0, thread float4& dst_reg1, thread float4& dst_reg7, constant VertexBuffer& _227, thread uint& gl_VertexIndex, texture2d<uint> buff_in_2, texture2d<uint> buff_in_1, constant VertexConstantsBuffer& _309)
 {
     int param = 3;
-    float4 in_diff_color = read_location(param, v_227, gl_VertexIndex, buff_in_2, buff_in_1);
+    float4 in_diff_color = read_location(param, _227, gl_VertexIndex, buff_in_2, buff_in_1);
     int param_1 = 0;
-    float4 in_pos = read_location(param_1, v_227, gl_VertexIndex, buff_in_2, buff_in_1);
+    float4 in_pos = read_location(param_1, _227, gl_VertexIndex, buff_in_2, buff_in_1);
     int param_2 = 8;
-    float4 in_tc0 = read_location(param_2, v_227, gl_VertexIndex, buff_in_2, buff_in_1);
-    dst_reg1 = in_diff_color * v_309.vc[13];
+    float4 in_tc0 = read_location(param_2, _227, gl_VertexIndex, buff_in_2, buff_in_1);
+    dst_reg1 = in_diff_color * _309.vc[13];
     float4 tmp0;
-    tmp0.x = float4(dot(float4(in_pos.xyz, 1.0), v_309.vc[4])).x;
-    tmp0.y = float4(dot(float4(in_pos.xyz, 1.0), v_309.vc[5])).y;
-    tmp0.z = float4(dot(float4(in_pos.xyz, 1.0), v_309.vc[6])).z;
+    tmp0.x = float4(dot(float4(in_pos.xyz, 1.0), _309.vc[4])).x;
+    tmp0.y = float4(dot(float4(in_pos.xyz, 1.0), _309.vc[5])).y;
+    tmp0.z = float4(dot(float4(in_pos.xyz, 1.0), _309.vc[6])).z;
     float4 tmp1;
     tmp1.x = in_tc0.xy.x;
     tmp1.y = in_tc0.xy.y;
-    tmp1.z = v_309.vc[15].x;
-    dst_reg7.y = float4(dot(float4(tmp1.xyz, 1.0), v_309.vc[8])).y;
-    dst_reg7.x = float4(dot(float4(tmp1.xyz, 1.0), v_309.vc[7])).x;
-    dst_reg0.y = float4(dot(float4(tmp0.xyz, 1.0), v_309.vc[1])).y;
-    dst_reg0.x = float4(dot(float4(tmp0.xyz, 1.0), v_309.vc[0])).x;
+    tmp1.z = _309.vc[15].x;
+    dst_reg7.y = float4(dot(float4(tmp1.xyz, 1.0), _309.vc[8])).y;
+    dst_reg7.x = float4(dot(float4(tmp1.xyz, 1.0), _309.vc[7])).x;
+    dst_reg0.y = float4(dot(float4(tmp0.xyz, 1.0), _309.vc[1])).y;
+    dst_reg0.x = float4(dot(float4(tmp0.xyz, 1.0), _309.vc[0])).x;
 }
 
-vertex main0_out main0(constant VertexBuffer& v_227 [[buffer(0)]], constant VertexConstantsBuffer& v_309 [[buffer(1)]], texture2d<uint> buff_in_2 [[texture(0)]], texture2d<uint> buff_in_1 [[texture(1)]], uint gl_VertexIndex [[vertex_id]])
+vertex main0_out main0(constant VertexBuffer& _227 [[buffer(0)]], constant VertexConstantsBuffer& _309 [[buffer(1)]], texture2d<uint> buff_in_2 [[texture(0)]], texture2d<uint> buff_in_1 [[texture(1)]], uint gl_VertexIndex [[vertex_id]])
 {
     main0_out out = {};
     float4 dst_reg0 = float4(0.0, 0.0, 0.0, 1.0);
@@ -187,14 +187,14 @@ vertex main0_out main0(constant VertexBuffer& v_227 [[buffer(0)]], constant Vert
     float4 param = dst_reg0;
     float4 param_1 = dst_reg1;
     float4 param_2 = dst_reg7;
-    vs_adjust(param, param_1, param_2, v_227, gl_VertexIndex, buff_in_2, buff_in_1, v_309);
+    vs_adjust(param, param_1, param_2, _227, gl_VertexIndex, buff_in_2, buff_in_1, _309);
     dst_reg0 = param;
     dst_reg1 = param_1;
     dst_reg7 = param_2;
     out.gl_Position = dst_reg0;
     out.back_color = dst_reg1;
     out.tc0 = dst_reg7;
-    out.gl_Position *= v_227.scale_offset_mat;
+    out.gl_Position *= _227.scale_offset_mat;
     return out;
 }
 

--- a/reference/shaders-msl/asm/frag/depth-image-color-format-fetch.asm.frag
+++ b/reference/shaders-msl/asm/frag/depth-image-color-format-fetch.asm.frag
@@ -21,26 +21,26 @@ struct main0_in
 };
 
 static inline __attribute__((always_inline))
-void _108(int _109, texture2d<float> v_8, device _7& v_10)
+void _108(int _109, texture2d<float> _8, device _7& _10)
 {
     int2 _113 = int2(_109 - 8 * (_109 / 8), _109 / 8);
-    v_10._m0[_109] = v_8.read(uint2(_113), 0);
+    _10._m0[_109] = _8.read(uint2(_113), 0);
 }
 
 static inline __attribute__((always_inline))
-float4 _98(float4 _119, texture2d<float> v_8, device _7& v_10)
+float4 _98(float4 _119, texture2d<float> _8, device _7& _10)
 {
     for (int _121 = 0; _121 < 64; _121++)
     {
-        _108(_121, v_8, v_10);
+        _108(_121, _8, _10);
     }
     return _119;
 }
 
-fragment main0_out main0(main0_in in [[stage_in]], device _7& v_10 [[buffer(0)]], texture2d<float> v_8 [[texture(0)]])
+fragment main0_out main0(main0_in in [[stage_in]], device _7& _10 [[buffer(0)]], texture2d<float> _8 [[texture(0)]])
 {
     main0_out out = {};
-    float4 _97 = _98(in.m_2, v_8, v_10);
+    float4 _97 = _98(in.m_2, _8, _10);
     out.m_3 = _97;
     return out;
 }

--- a/reference/shaders-msl/asm/frag/depth-image-color-format-sampled.asm.frag
+++ b/reference/shaders-msl/asm/frag/depth-image-color-format-sampled.asm.frag
@@ -21,25 +21,25 @@ struct main0_in
 };
 
 static inline __attribute__((always_inline))
-void _108(int _109, texture2d<float> v_8, sampler v_9, device _7& v_10)
+void _108(int _109, texture2d<float> _8, sampler _9, device _7& _10)
 {
-    v_10._m0[_109] = v_8.sample(v_9, (float2(int2(_109 - 8 * (_109 / 8), _109 / 8)) / float2(8.0)), level(0.0));
+    _10._m0[_109] = _8.sample(_9, (float2(int2(_109 - 8 * (_109 / 8), _109 / 8)) / float2(8.0)), level(0.0));
 }
 
 static inline __attribute__((always_inline))
-float4 _98(float4 _121, texture2d<float> v_8, sampler v_9, device _7& v_10)
+float4 _98(float4 _121, texture2d<float> _8, sampler _9, device _7& _10)
 {
     for (int _123 = 0; _123 < 64; _123++)
     {
-        _108(_123, v_8, v_9, v_10);
+        _108(_123, _8, _9, _10);
     }
     return _121;
 }
 
-fragment main0_out main0(main0_in in [[stage_in]], device _7& v_10 [[buffer(0)]], texture2d<float> v_8 [[texture(0)]], sampler v_9 [[sampler(0)]])
+fragment main0_out main0(main0_in in [[stage_in]], device _7& _10 [[buffer(0)]], texture2d<float> _8 [[texture(0)]], sampler _9 [[sampler(0)]])
 {
     main0_out out = {};
-    float4 _97 = _98(in.m_2, v_8, v_9, v_10);
+    float4 _97 = _98(in.m_2, _8, _9, _10);
     out.m_3 = _97;
     return out;
 }

--- a/reference/shaders-msl/asm/frag/extract-packed-from-composite.asm.frag
+++ b/reference/shaders-msl/asm/frag/extract-packed-from-composite.asm.frag
@@ -29,21 +29,21 @@ struct main0_out
 };
 
 static inline __attribute__((always_inline))
-float4 _main(thread const float4& pos, constant buf& v_11)
+float4 _main(thread const float4& pos, constant buf& _11)
 {
     int _46 = int(pos.x) % 16;
     Foo foo;
-    foo.a = float3(v_11.results[_46].a);
-    foo.b = v_11.results[_46].b;
-    return float4(dot(foo.a, v_11.bar.xyz), foo.b, 0.0, 0.0);
+    foo.a = float3(_11.results[_46].a);
+    foo.b = _11.results[_46].b;
+    return float4(dot(foo.a, _11.bar.xyz), foo.b, 0.0, 0.0);
 }
 
-fragment main0_out main0(constant buf& v_11 [[buffer(0)]], float4 gl_FragCoord [[position]])
+fragment main0_out main0(constant buf& _11 [[buffer(0)]], float4 gl_FragCoord [[position]])
 {
     main0_out out = {};
     float4 pos = gl_FragCoord;
     float4 param = pos;
-    out._entryPointOutput = _main(param, v_11);
+    out._entryPointOutput = _main(param, _11);
     return out;
 }
 

--- a/reference/shaders-msl/comp/array-length.comp
+++ b/reference/shaders-msl/comp/array-length.comp
@@ -19,12 +19,12 @@ struct SSBO1
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 static inline __attribute__((always_inline))
-uint get_size(device SSBO& v_14, constant uint& v_14BufferSize, device SSBO1* (&ssbos)[2], constant uint* ssbosBufferSize)
+uint get_size(device SSBO& _14, constant uint& _14BufferSize, device SSBO1* (&ssbos)[2], constant uint* ssbosBufferSize)
 {
-    return uint(int((v_14BufferSize - 16) / 16) + int((ssbosBufferSize[1] - 0) / 4));
+    return uint(int((_14BufferSize - 16) / 16) + int((ssbosBufferSize[1] - 0) / 4));
 }
 
-kernel void main0(constant uint* spvBufferSizeConstants [[buffer(25)]], device SSBO& v_14 [[buffer(0)]], device SSBO1* ssbos_0 [[buffer(1)]], device SSBO1* ssbos_1 [[buffer(2)]])
+kernel void main0(constant uint* spvBufferSizeConstants [[buffer(25)]], device SSBO& _14 [[buffer(0)]], device SSBO1* ssbos_0 [[buffer(1)]], device SSBO1* ssbos_1 [[buffer(2)]])
 {
     device SSBO1* ssbos[] =
     {
@@ -32,8 +32,8 @@ kernel void main0(constant uint* spvBufferSizeConstants [[buffer(25)]], device S
         ssbos_1,
     };
 
-    constant uint& v_14BufferSize = spvBufferSizeConstants[0];
+    constant uint& _14BufferSize = spvBufferSizeConstants[0];
     constant uint* ssbosBufferSize = &spvBufferSizeConstants[1];
-    v_14.size = get_size(v_14, v_14BufferSize, ssbos, ssbosBufferSize);
+    _14.size = get_size(_14, _14BufferSize, ssbos, ssbosBufferSize);
 }
 

--- a/reference/shaders-msl/comp/array-length.msl2.argument.discrete.comp
+++ b/reference/shaders-msl/comp/array-length.msl2.argument.discrete.comp
@@ -31,7 +31,7 @@ constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 struct spvDescriptorSetBuffer0
 {
-    device SSBO* v_16 [[id(0)]];
+    device SSBO* m_16 [[id(0)]];
     constant uint* spvBufferSizeConstants [[id(1)]];
 };
 
@@ -42,16 +42,16 @@ struct spvDescriptorSetBuffer1
 };
 
 static inline __attribute__((always_inline))
-uint get_size(device SSBO& v_16, constant uint& v_16BufferSize, device SSBO1* constant (&ssbos)[2], constant uint* ssbosBufferSize, device SSBO2& v_38, constant uint& v_38BufferSize, device SSBO3* (&ssbos2)[2], constant uint* ssbos2BufferSize)
+uint get_size(device SSBO& _16, constant uint& _16BufferSize, device SSBO1* constant (&ssbos)[2], constant uint* ssbosBufferSize, device SSBO2& _38, constant uint& _38BufferSize, device SSBO3* (&ssbos2)[2], constant uint* ssbos2BufferSize)
 {
-    uint len = uint(int((v_16BufferSize - 16) / 16));
+    uint len = uint(int((_16BufferSize - 16) / 16));
     len += uint(int((ssbosBufferSize[1] - 0) / 4));
-    len += uint(int((v_38BufferSize - 16) / 16));
+    len += uint(int((_38BufferSize - 16) / 16));
     len += uint(int((ssbos2BufferSize[0] - 0) / 4));
     return len;
 }
 
-kernel void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], constant spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], constant uint* spvBufferSizeConstants [[buffer(25)]], device SSBO2& v_38 [[buffer(2)]], device SSBO3* ssbos2_0 [[buffer(3)]], device SSBO3* ssbos2_1 [[buffer(4)]])
+kernel void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], constant spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], constant uint* spvBufferSizeConstants [[buffer(25)]], device SSBO2& _38 [[buffer(2)]], device SSBO3* ssbos2_0 [[buffer(3)]], device SSBO3* ssbos2_1 [[buffer(4)]])
 {
     device SSBO3* ssbos2[] =
     {
@@ -59,10 +59,10 @@ kernel void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0
         ssbos2_1,
     };
 
-    constant uint& spvDescriptorSet0_v_16BufferSize = spvDescriptorSet0.spvBufferSizeConstants[0];
+    constant uint& spvDescriptorSet0_m_16BufferSize = spvDescriptorSet0.spvBufferSizeConstants[0];
     constant uint* spvDescriptorSet1_ssbosBufferSize = &spvDescriptorSet1.spvBufferSizeConstants[0];
-    constant uint& v_38BufferSize = spvBufferSizeConstants[2];
+    constant uint& _38BufferSize = spvBufferSizeConstants[2];
     constant uint* ssbos2BufferSize = &spvBufferSizeConstants[3];
-    (*spvDescriptorSet0.v_16).size = get_size((*spvDescriptorSet0.v_16), spvDescriptorSet0_v_16BufferSize, spvDescriptorSet1.ssbos, spvDescriptorSet1_ssbosBufferSize, v_38, v_38BufferSize, ssbos2, ssbos2BufferSize);
+    (*spvDescriptorSet0.m_16).size = get_size((*spvDescriptorSet0.m_16), spvDescriptorSet0_m_16BufferSize, spvDescriptorSet1.ssbos, spvDescriptorSet1_ssbosBufferSize, _38, _38BufferSize, ssbos2, ssbos2BufferSize);
 }
 

--- a/reference/shaders-msl/comp/complex-composite-constant-array.comp
+++ b/reference/shaders-msl/comp/complex-composite-constant-array.comp
@@ -53,13 +53,13 @@ struct SSBO
 constant spvUnsafeArray<float4x4, 2> _32 = spvUnsafeArray<float4x4, 2>({ float4x4(float4(1.0, 0.0, 0.0, 0.0), float4(0.0, 1.0, 0.0, 0.0), float4(0.0, 0.0, 1.0, 0.0), float4(0.0, 0.0, 0.0, 1.0)), float4x4(float4(2.0, 0.0, 0.0, 0.0), float4(0.0, 2.0, 0.0, 0.0), float4(0.0, 0.0, 2.0, 0.0), float4(0.0, 0.0, 0.0, 2.0)) });
 
 static inline __attribute__((always_inline))
-void write_global(device SSBO& v_14)
+void write_global(device SSBO& _14)
 {
-    v_14.a = _32[v_14.index];
+    _14.a = _32[_14.index];
 }
 
-kernel void main0(device SSBO& v_14 [[buffer(0)]])
+kernel void main0(device SSBO& _14 [[buffer(0)]])
 {
-    write_global(v_14);
+    write_global(_14);
 }
 

--- a/reference/shaders-msl/comp/raw-buffer-descriptor-aliasing.argument.discrete.device-argument-buffer.msl2.comp
+++ b/reference/shaders-msl/comp/raw-buffer-descriptor-aliasing.argument.discrete.device-argument-buffer.msl2.comp
@@ -96,9 +96,9 @@ struct spvDescriptorSetBuffer0
 };
 
 static inline __attribute__((always_inline))
-void func0(device SSBO_A& ssbo_a, thread uint3& gl_GlobalInvocationID, constant UBO_C& ubo_c, thread uint3& gl_WorkGroupID, constant Registers& v_42, device SSBO_B& ssbo_b, constant UBO_D& ubo_d, const device SSBO_BRO& ssbo_b_readonly)
+void func0(device SSBO_A& ssbo_a, thread uint3& gl_GlobalInvocationID, constant UBO_C& ubo_c, thread uint3& gl_WorkGroupID, constant Registers& _42, device SSBO_B& ssbo_b, constant UBO_D& ubo_d, const device SSBO_BRO& ssbo_b_readonly)
 {
-    ssbo_a.data[gl_GlobalInvocationID.x] = ubo_c.data[gl_WorkGroupID.x].x + v_42.reg;
+    ssbo_a.data[gl_GlobalInvocationID.x] = ubo_c.data[gl_WorkGroupID.x].x + _42.reg;
     ssbo_b.data[gl_GlobalInvocationID.x] = ubo_d.data[gl_WorkGroupID.y].xy + ssbo_b_readonly.data[gl_GlobalInvocationID.x];
 }
 
@@ -121,7 +121,7 @@ void func3(thread uint3& gl_GlobalInvocationID, thread uint3& gl_WorkGroupID, de
     ssbo_f.data[gl_GlobalInvocationID.x] = ubo_h.data[gl_WorkGroupID.y].xy + ssbo_i.data[gl_GlobalInvocationID.x];
 }
 
-kernel void main0(const device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], constant Registers& v_42 [[buffer(1)]], device void* spvBufferAliasSet2Binding0 [[buffer(2)]], constant void* spvBufferAliasSet2Binding1 [[buffer(3)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
+kernel void main0(const device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], constant Registers& _42 [[buffer(1)]], device void* spvBufferAliasSet2Binding0 [[buffer(2)]], constant void* spvBufferAliasSet2Binding1 [[buffer(3)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
 {
     device auto& ssbo_e = *(device SSBO_E*)spvBufferAliasSet2Binding0;
     constant auto& ubo_g = *(constant UBO_G*)spvBufferAliasSet2Binding1;
@@ -134,7 +134,7 @@ kernel void main0(const device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buff
     const device auto& ssbo_bs = (device SSBO_Bs* const device (&)[4])spvDescriptorSet0.ssbo_as;
     const device auto& ubo_ds = (constant UBO_Ds* const device (&)[4])spvDescriptorSet0.ubo_cs;
     const device auto& ssbo_bs_readonly = (const device SSBO_BsRO* const device (&)[4])spvDescriptorSet0.ssbo_as;
-    func0((*spvDescriptorSet0.ssbo_a), gl_GlobalInvocationID, (*spvDescriptorSet0.ubo_c), gl_WorkGroupID, v_42, ssbo_b, ubo_d, ssbo_b_readonly);
+    func0((*spvDescriptorSet0.ssbo_a), gl_GlobalInvocationID, (*spvDescriptorSet0.ubo_c), gl_WorkGroupID, _42, ssbo_b, ubo_d, ssbo_b_readonly);
     func1(gl_GlobalInvocationID, gl_WorkGroupID, spvDescriptorSet0.ssbo_as, spvDescriptorSet0.ubo_cs);
     func2(gl_GlobalInvocationID, gl_WorkGroupID, ssbo_bs, ubo_ds, ssbo_bs_readonly);
     func3(gl_GlobalInvocationID, gl_WorkGroupID, ssbo_e, ubo_g, ssbo_f, ubo_h, ssbo_i);

--- a/reference/shaders-msl/comp/raw-buffer-descriptor-aliasing.argument.discrete.msl2.comp
+++ b/reference/shaders-msl/comp/raw-buffer-descriptor-aliasing.argument.discrete.msl2.comp
@@ -96,9 +96,9 @@ struct spvDescriptorSetBuffer0
 };
 
 static inline __attribute__((always_inline))
-void func0(device SSBO_A& ssbo_a, thread uint3& gl_GlobalInvocationID, constant UBO_C& ubo_c, thread uint3& gl_WorkGroupID, constant Registers& v_42, device SSBO_B& ssbo_b, constant UBO_D& ubo_d, const device SSBO_BRO& ssbo_b_readonly)
+void func0(device SSBO_A& ssbo_a, thread uint3& gl_GlobalInvocationID, constant UBO_C& ubo_c, thread uint3& gl_WorkGroupID, constant Registers& _42, device SSBO_B& ssbo_b, constant UBO_D& ubo_d, const device SSBO_BRO& ssbo_b_readonly)
 {
-    ssbo_a.data[gl_GlobalInvocationID.x] = ubo_c.data[gl_WorkGroupID.x].x + v_42.reg;
+    ssbo_a.data[gl_GlobalInvocationID.x] = ubo_c.data[gl_WorkGroupID.x].x + _42.reg;
     ssbo_b.data[gl_GlobalInvocationID.x] = ubo_d.data[gl_WorkGroupID.y].xy + ssbo_b_readonly.data[gl_GlobalInvocationID.x];
 }
 
@@ -121,7 +121,7 @@ void func3(thread uint3& gl_GlobalInvocationID, thread uint3& gl_WorkGroupID, de
     ssbo_f.data[gl_GlobalInvocationID.x] = ubo_h.data[gl_WorkGroupID.y].xy + ssbo_i.data[gl_GlobalInvocationID.x];
 }
 
-kernel void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], constant Registers& v_42 [[buffer(1)]], device void* spvBufferAliasSet2Binding0 [[buffer(2)]], constant void* spvBufferAliasSet2Binding1 [[buffer(3)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
+kernel void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], constant Registers& _42 [[buffer(1)]], device void* spvBufferAliasSet2Binding0 [[buffer(2)]], constant void* spvBufferAliasSet2Binding1 [[buffer(3)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
 {
     device auto& ssbo_e = *(device SSBO_E*)spvBufferAliasSet2Binding0;
     constant auto& ubo_g = *(constant UBO_G*)spvBufferAliasSet2Binding1;
@@ -134,7 +134,7 @@ kernel void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0
     constant auto& ssbo_bs = (device SSBO_Bs* constant (&)[4])spvDescriptorSet0.ssbo_as;
     constant auto& ubo_ds = (constant UBO_Ds* constant (&)[4])spvDescriptorSet0.ubo_cs;
     constant auto& ssbo_bs_readonly = (const device SSBO_BsRO* constant (&)[4])spvDescriptorSet0.ssbo_as;
-    func0((*spvDescriptorSet0.ssbo_a), gl_GlobalInvocationID, (*spvDescriptorSet0.ubo_c), gl_WorkGroupID, v_42, ssbo_b, ubo_d, ssbo_b_readonly);
+    func0((*spvDescriptorSet0.ssbo_a), gl_GlobalInvocationID, (*spvDescriptorSet0.ubo_c), gl_WorkGroupID, _42, ssbo_b, ubo_d, ssbo_b_readonly);
     func1(gl_GlobalInvocationID, gl_WorkGroupID, spvDescriptorSet0.ssbo_as, spvDescriptorSet0.ubo_cs);
     func2(gl_GlobalInvocationID, gl_WorkGroupID, ssbo_bs, ubo_ds, ssbo_bs_readonly);
     func3(gl_GlobalInvocationID, gl_WorkGroupID, ssbo_e, ubo_g, ssbo_f, ubo_h, ssbo_i);

--- a/reference/shaders-msl/comp/shared-array-of-arrays.comp
+++ b/reference/shaders-msl/comp/shared-array-of-arrays.comp
@@ -13,7 +13,7 @@ struct SSBO
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(4u, 4u, 1u);
 
 static inline __attribute__((always_inline))
-void work(threadgroup float (&foo)[4][4], thread uint3& gl_LocalInvocationID, thread uint& gl_LocalInvocationIndex, device SSBO& v_67, thread uint3& gl_GlobalInvocationID)
+void work(threadgroup float (&foo)[4][4], thread uint3& gl_LocalInvocationID, thread uint& gl_LocalInvocationIndex, device SSBO& _67, thread uint3& gl_GlobalInvocationID)
 {
     foo[gl_LocalInvocationID.x][gl_LocalInvocationID.y] = float(gl_LocalInvocationIndex);
     threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -22,12 +22,12 @@ void work(threadgroup float (&foo)[4][4], thread uint3& gl_LocalInvocationID, th
     x += foo[gl_LocalInvocationID.x][1];
     x += foo[gl_LocalInvocationID.x][2];
     x += foo[gl_LocalInvocationID.x][3];
-    v_67.out_data[gl_GlobalInvocationID.x] = x;
+    _67.out_data[gl_GlobalInvocationID.x] = x;
 }
 
-kernel void main0(device SSBO& v_67 [[buffer(0)]], uint3 gl_LocalInvocationID [[thread_position_in_threadgroup]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(device SSBO& _67 [[buffer(0)]], uint3 gl_LocalInvocationID [[thread_position_in_threadgroup]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
     threadgroup float foo[4][4];
-    work(foo, gl_LocalInvocationID, gl_LocalInvocationIndex, v_67, gl_GlobalInvocationID);
+    work(foo, gl_LocalInvocationID, gl_LocalInvocationIndex, _67, gl_GlobalInvocationID);
 }
 

--- a/reference/shaders-msl/comp/threadgroup-boolean-workaround.comp
+++ b/reference/shaders-msl/comp/threadgroup-boolean-workaround.comp
@@ -13,16 +13,16 @@ struct SSBO
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(4u, 1u, 1u);
 
 static inline __attribute__((always_inline))
-void in_function(threadgroup short4 (&foo)[4], thread uint& gl_LocalInvocationIndex, device SSBO& v_23, thread uint3& gl_GlobalInvocationID)
+void in_function(threadgroup short4 (&foo)[4], thread uint& gl_LocalInvocationIndex, device SSBO& _23, thread uint3& gl_GlobalInvocationID)
 {
-    foo[gl_LocalInvocationIndex] = short4(v_23.values[gl_GlobalInvocationID.x] != float4(10.0));
+    foo[gl_LocalInvocationIndex] = short4(_23.values[gl_GlobalInvocationID.x] != float4(10.0));
     threadgroup_barrier(mem_flags::mem_threadgroup);
-    v_23.values[gl_GlobalInvocationID.x] = select(float4(40.0), float4(30.0), bool4(foo[gl_LocalInvocationIndex ^ 3u]));
+    _23.values[gl_GlobalInvocationID.x] = select(float4(40.0), float4(30.0), bool4(foo[gl_LocalInvocationIndex ^ 3u]));
 }
 
-kernel void main0(device SSBO& v_23 [[buffer(0)]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(device SSBO& _23 [[buffer(0)]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
     threadgroup short4 foo[4];
-    in_function(foo, gl_LocalInvocationIndex, v_23, gl_GlobalInvocationID);
+    in_function(foo, gl_LocalInvocationIndex, _23, gl_GlobalInvocationID);
 }
 

--- a/reference/shaders-msl/frag/argument-buffers.msl2.argument.frag
+++ b/reference/shaders-msl/frag/argument-buffers.msl2.argument.frag
@@ -36,14 +36,14 @@ struct spvDescriptorSetBuffer0
     sampler uTextureSmplr [[id(1)]];
     array<texture2d<float>, 2> uTextures [[id(2)]];
     array<sampler, 2> uTexturesSmplr [[id(4)]];
-    constant UBO* v_90 [[id(6)]];
+    constant UBO* m_90 [[id(6)]];
 };
 
 struct spvDescriptorSetBuffer1
 {
     array<texture2d<float>, 4> uTexture2 [[id(0)]];
     array<sampler, 2> uSampler [[id(4)]];
-    device SSBO* v_60 [[id(6)]];
+    device SSBO* m_60 [[id(6)]];
     const device SSBOs* ssbos [[id(7)]][2];
 };
 
@@ -63,22 +63,22 @@ struct main0_in
 };
 
 static inline __attribute__((always_inline))
-float4 sample_in_function2(texture2d<float> uTexture, sampler uTextureSmplr, thread float2& vUV, constant array<texture2d<float>, 4>& uTexture2, constant array<sampler, 2>& uSampler, constant array<texture2d<float>, 2>& uTextures, constant array<sampler, 2>& uTexturesSmplr, device SSBO& v_60, const device SSBOs* constant (&ssbos)[2], constant Push& registers)
+float4 sample_in_function2(texture2d<float> uTexture, sampler uTextureSmplr, thread float2& vUV, constant array<texture2d<float>, 4>& uTexture2, constant array<sampler, 2>& uSampler, constant array<texture2d<float>, 2>& uTextures, constant array<sampler, 2>& uTexturesSmplr, device SSBO& _60, const device SSBOs* constant (&ssbos)[2], constant Push& registers)
 {
     float4 ret = uTexture.sample(uTextureSmplr, vUV);
     ret += uTexture2[2].sample(uSampler[1], vUV);
     ret += uTextures[1].sample(uTexturesSmplr[1], vUV);
-    ret += v_60.ssbo;
+    ret += _60.ssbo;
     ret += ssbos[0]->ssbo;
     ret += registers.push;
     return ret;
 }
 
 static inline __attribute__((always_inline))
-float4 sample_in_function(texture2d<float> uTexture, sampler uTextureSmplr, thread float2& vUV, constant array<texture2d<float>, 4>& uTexture2, constant array<sampler, 2>& uSampler, constant array<texture2d<float>, 2>& uTextures, constant array<sampler, 2>& uTexturesSmplr, device SSBO& v_60, const device SSBOs* constant (&ssbos)[2], constant Push& registers, constant UBO& v_90, constant UBOs* constant (&ubos)[4])
+float4 sample_in_function(texture2d<float> uTexture, sampler uTextureSmplr, thread float2& vUV, constant array<texture2d<float>, 4>& uTexture2, constant array<sampler, 2>& uSampler, constant array<texture2d<float>, 2>& uTextures, constant array<sampler, 2>& uTexturesSmplr, device SSBO& _60, const device SSBOs* constant (&ssbos)[2], constant Push& registers, constant UBO& _90, constant UBOs* constant (&ubos)[4])
 {
-    float4 ret = sample_in_function2(uTexture, uTextureSmplr, vUV, uTexture2, uSampler, uTextures, uTexturesSmplr, v_60, ssbos, registers);
-    ret += v_90.ubo;
+    float4 ret = sample_in_function2(uTexture, uTextureSmplr, vUV, uTexture2, uSampler, uTextures, uTexturesSmplr, _60, ssbos, registers);
+    ret += _90.ubo;
     ret += ubos[0]->ubo;
     return ret;
 }
@@ -86,9 +86,9 @@ float4 sample_in_function(texture2d<float> uTexture, sampler uTextureSmplr, thre
 fragment main0_out main0(main0_in in [[stage_in]], constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], constant spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], constant spvDescriptorSetBuffer2& spvDescriptorSet2 [[buffer(2)]], constant Push& registers [[buffer(3)]])
 {
     main0_out out = {};
-    out.FragColor = sample_in_function(spvDescriptorSet0.uTexture, spvDescriptorSet0.uTextureSmplr, in.vUV, spvDescriptorSet1.uTexture2, spvDescriptorSet1.uSampler, spvDescriptorSet0.uTextures, spvDescriptorSet0.uTexturesSmplr, (*spvDescriptorSet1.v_60), spvDescriptorSet1.ssbos, registers, (*spvDescriptorSet0.v_90), spvDescriptorSet2.ubos);
-    out.FragColor += (*spvDescriptorSet0.v_90).ubo;
-    out.FragColor += (*spvDescriptorSet1.v_60).ssbo;
+    out.FragColor = sample_in_function(spvDescriptorSet0.uTexture, spvDescriptorSet0.uTextureSmplr, in.vUV, spvDescriptorSet1.uTexture2, spvDescriptorSet1.uSampler, spvDescriptorSet0.uTextures, spvDescriptorSet0.uTexturesSmplr, (*spvDescriptorSet1.m_60), spvDescriptorSet1.ssbos, registers, (*spvDescriptorSet0.m_90), spvDescriptorSet2.ubos);
+    out.FragColor += (*spvDescriptorSet0.m_90).ubo;
+    out.FragColor += (*spvDescriptorSet1.m_60).ssbo;
     out.FragColor += spvDescriptorSet2.ubos[1]->ubo;
     out.FragColor += registers.push;
     return out;

--- a/reference/shaders-msl/frag/readonly-ssbo.frag
+++ b/reference/shaders-msl/frag/readonly-ssbo.frag
@@ -16,15 +16,15 @@ struct main0_out
 };
 
 static inline __attribute__((always_inline))
-float4 read_from_function(const device SSBO& v_13)
+float4 read_from_function(const device SSBO& _13)
 {
-    return v_13.v;
+    return _13.v;
 }
 
-fragment main0_out main0(const device SSBO& v_13 [[buffer(0)]])
+fragment main0_out main0(const device SSBO& _13 [[buffer(0)]])
 {
     main0_out out = {};
-    out.FragColor = v_13.v + read_from_function(v_13);
+    out.FragColor = _13.v + read_from_function(_13);
     return out;
 }
 

--- a/reference/shaders-msl/tesc/water_tess.multi-patch.tesc
+++ b/reference/shaders-msl/tesc/water_tess.multi-patch.tesc
@@ -28,16 +28,16 @@ struct main0_in
 };
 
 static inline __attribute__((always_inline))
-bool frustum_cull(thread const float2& p0, constant UBO& v_41)
+bool frustum_cull(thread const float2& p0, constant UBO& _41)
 {
-    float2 min_xz = (p0 - float2(10.0)) * v_41.uScale.xy;
-    float2 max_xz = ((p0 + v_41.uPatchSize) + float2(10.0)) * v_41.uScale.xy;
+    float2 min_xz = (p0 - float2(10.0)) * _41.uScale.xy;
+    float2 max_xz = ((p0 + _41.uPatchSize) + float2(10.0)) * _41.uScale.xy;
     float3 bb_min = float3(min_xz.x, -10.0, min_xz.y);
     float3 bb_max = float3(max_xz.x, 10.0, max_xz.y);
     float3 center = (bb_min + bb_max) * 0.5;
     float radius = 0.5 * length(bb_max - bb_min);
-    float3 f0 = float3(dot(v_41.uFrustum[0], float4(center, 1.0)), dot(v_41.uFrustum[1], float4(center, 1.0)), dot(v_41.uFrustum[2], float4(center, 1.0)));
-    float3 f1 = float3(dot(v_41.uFrustum[3], float4(center, 1.0)), dot(v_41.uFrustum[4], float4(center, 1.0)), dot(v_41.uFrustum[5], float4(center, 1.0)));
+    float3 f0 = float3(dot(_41.uFrustum[0], float4(center, 1.0)), dot(_41.uFrustum[1], float4(center, 1.0)), dot(_41.uFrustum[2], float4(center, 1.0)));
+    float3 f1 = float3(dot(_41.uFrustum[3], float4(center, 1.0)), dot(_41.uFrustum[4], float4(center, 1.0)), dot(_41.uFrustum[5], float4(center, 1.0)));
     bool _205 = any(f0 <= float3(-radius));
     bool _215;
     if (!_205)
@@ -52,72 +52,72 @@ bool frustum_cull(thread const float2& p0, constant UBO& v_41)
 }
 
 static inline __attribute__((always_inline))
-float lod_factor(thread const float2& pos_, constant UBO& v_41)
+float lod_factor(thread const float2& pos_, constant UBO& _41)
 {
-    float2 pos = pos_ * v_41.uScale.xy;
-    float3 dist_to_cam = v_41.uCamPos - float3(pos.x, 0.0, pos.y);
-    float level0 = log2((length(dist_to_cam) + 9.9999997473787516355514526367188e-05) * v_41.uDistanceMod);
-    return fast::clamp(level0, 0.0, v_41.uMaxTessLevel.x);
+    float2 pos = pos_ * _41.uScale.xy;
+    float3 dist_to_cam = _41.uCamPos - float3(pos.x, 0.0, pos.y);
+    float level0 = log2((length(dist_to_cam) + 9.9999997473787516355514526367188e-05) * _41.uDistanceMod);
+    return fast::clamp(level0, 0.0, _41.uMaxTessLevel.x);
 }
 
 static inline __attribute__((always_inline))
-float4 tess_level(thread const float4& lod, constant UBO& v_41)
+float4 tess_level(thread const float4& lod, constant UBO& _41)
 {
-    return exp2(-lod) * v_41.uMaxTessLevel.y;
+    return exp2(-lod) * _41.uMaxTessLevel.y;
 }
 
 static inline __attribute__((always_inline))
-float tess_level(thread const float& lod, constant UBO& v_41)
+float tess_level(thread const float& lod, constant UBO& _41)
 {
-    return v_41.uMaxTessLevel.y * exp2(-lod);
+    return _41.uMaxTessLevel.y * exp2(-lod);
 }
 
 static inline __attribute__((always_inline))
-void compute_tess_levels(thread const float2& p0, constant UBO& v_41, device float2& vOutPatchPosBase, device float4& vPatchLods, device half (&gl_TessLevelOuter)[4], device half (&gl_TessLevelInner)[2])
+void compute_tess_levels(thread const float2& p0, constant UBO& _41, device float2& vOutPatchPosBase, device float4& vPatchLods, device half (&gl_TessLevelOuter)[4], device half (&gl_TessLevelInner)[2])
 {
     vOutPatchPosBase = p0;
-    float2 param = p0 + (float2(-0.5) * v_41.uPatchSize);
-    float l00 = lod_factor(param, v_41);
-    float2 param_1 = p0 + (float2(0.5, -0.5) * v_41.uPatchSize);
-    float l10 = lod_factor(param_1, v_41);
-    float2 param_2 = p0 + (float2(1.5, -0.5) * v_41.uPatchSize);
-    float l20 = lod_factor(param_2, v_41);
-    float2 param_3 = p0 + (float2(-0.5, 0.5) * v_41.uPatchSize);
-    float l01 = lod_factor(param_3, v_41);
-    float2 param_4 = p0 + (float2(0.5) * v_41.uPatchSize);
-    float l11 = lod_factor(param_4, v_41);
-    float2 param_5 = p0 + (float2(1.5, 0.5) * v_41.uPatchSize);
-    float l21 = lod_factor(param_5, v_41);
-    float2 param_6 = p0 + (float2(-0.5, 1.5) * v_41.uPatchSize);
-    float l02 = lod_factor(param_6, v_41);
-    float2 param_7 = p0 + (float2(0.5, 1.5) * v_41.uPatchSize);
-    float l12 = lod_factor(param_7, v_41);
-    float2 param_8 = p0 + (float2(1.5) * v_41.uPatchSize);
-    float l22 = lod_factor(param_8, v_41);
+    float2 param = p0 + (float2(-0.5) * _41.uPatchSize);
+    float l00 = lod_factor(param, _41);
+    float2 param_1 = p0 + (float2(0.5, -0.5) * _41.uPatchSize);
+    float l10 = lod_factor(param_1, _41);
+    float2 param_2 = p0 + (float2(1.5, -0.5) * _41.uPatchSize);
+    float l20 = lod_factor(param_2, _41);
+    float2 param_3 = p0 + (float2(-0.5, 0.5) * _41.uPatchSize);
+    float l01 = lod_factor(param_3, _41);
+    float2 param_4 = p0 + (float2(0.5) * _41.uPatchSize);
+    float l11 = lod_factor(param_4, _41);
+    float2 param_5 = p0 + (float2(1.5, 0.5) * _41.uPatchSize);
+    float l21 = lod_factor(param_5, _41);
+    float2 param_6 = p0 + (float2(-0.5, 1.5) * _41.uPatchSize);
+    float l02 = lod_factor(param_6, _41);
+    float2 param_7 = p0 + (float2(0.5, 1.5) * _41.uPatchSize);
+    float l12 = lod_factor(param_7, _41);
+    float2 param_8 = p0 + (float2(1.5) * _41.uPatchSize);
+    float l22 = lod_factor(param_8, _41);
     float4 lods = float4(dot(float4(l01, l11, l02, l12), float4(0.25)), dot(float4(l00, l10, l01, l11), float4(0.25)), dot(float4(l10, l20, l11, l21), float4(0.25)), dot(float4(l11, l21, l12, l22), float4(0.25)));
     vPatchLods = lods;
     float4 outer_lods = fast::min(lods, lods.yzwx);
     float4 param_9 = outer_lods;
-    float4 levels = tess_level(param_9, v_41);
+    float4 levels = tess_level(param_9, _41);
     gl_TessLevelOuter[0] = half(levels.x);
     gl_TessLevelOuter[1] = half(levels.y);
     gl_TessLevelOuter[2] = half(levels.z);
     gl_TessLevelOuter[3] = half(levels.w);
     float min_lod = fast::min(fast::min(lods.x, lods.y), fast::min(lods.z, lods.w));
     float param_10 = fast::min(min_lod, l11);
-    float inner = tess_level(param_10, v_41);
+    float inner = tess_level(param_10, _41);
     gl_TessLevelInner[0] = half(inner);
     gl_TessLevelInner[1] = half(inner);
 }
 
-kernel void main0(constant UBO& v_41 [[buffer(0)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], constant uint* spvIndirectParams [[buffer(29)]], device main0_patchOut* spvPatchOut [[buffer(27)]], device MTLQuadTessellationFactorsHalf* spvTessLevel [[buffer(26)]], device main0_in* spvIn [[buffer(22)]])
+kernel void main0(constant UBO& _41 [[buffer(0)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], constant uint* spvIndirectParams [[buffer(29)]], device main0_patchOut* spvPatchOut [[buffer(27)]], device MTLQuadTessellationFactorsHalf* spvTessLevel [[buffer(26)]], device main0_in* spvIn [[buffer(22)]])
 {
     device main0_patchOut& patchOut = spvPatchOut[gl_GlobalInvocationID.x / 1];
     device main0_in* gl_in = &spvIn[min(gl_GlobalInvocationID.x / 1, spvIndirectParams[1] - 1) * spvIndirectParams[0]];
     uint gl_PrimitiveID = min(gl_GlobalInvocationID.x / 1, spvIndirectParams[1] - 1);
     float2 p0 = gl_in[0].vPatchPosBase.xy;
     float2 param = p0;
-    if (!frustum_cull(param, v_41))
+    if (!frustum_cull(param, _41))
     {
         spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(-1.0);
         spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(-1.0);
@@ -129,7 +129,7 @@ kernel void main0(constant UBO& v_41 [[buffer(0)]], uint3 gl_GlobalInvocationID 
     else
     {
         float2 param_1 = p0;
-        compute_tess_levels(param_1, v_41, patchOut.vOutPatchPosBase, patchOut.vPatchLods, spvTessLevel[gl_PrimitiveID].edgeTessellationFactor, spvTessLevel[gl_PrimitiveID].insideTessellationFactor);
+        compute_tess_levels(param_1, _41, patchOut.vOutPatchPosBase, patchOut.vPatchLods, spvTessLevel[gl_PrimitiveID].edgeTessellationFactor, spvTessLevel[gl_PrimitiveID].insideTessellationFactor);
     }
 }
 

--- a/reference/shaders-msl/tesc/water_tess.tesc
+++ b/reference/shaders-msl/tesc/water_tess.tesc
@@ -27,16 +27,16 @@ struct main0_in
 };
 
 static inline __attribute__((always_inline))
-bool frustum_cull(thread const float2& p0, constant UBO& v_41)
+bool frustum_cull(thread const float2& p0, constant UBO& _41)
 {
-    float2 min_xz = (p0 - float2(10.0)) * v_41.uScale.xy;
-    float2 max_xz = ((p0 + v_41.uPatchSize) + float2(10.0)) * v_41.uScale.xy;
+    float2 min_xz = (p0 - float2(10.0)) * _41.uScale.xy;
+    float2 max_xz = ((p0 + _41.uPatchSize) + float2(10.0)) * _41.uScale.xy;
     float3 bb_min = float3(min_xz.x, -10.0, min_xz.y);
     float3 bb_max = float3(max_xz.x, 10.0, max_xz.y);
     float3 center = (bb_min + bb_max) * 0.5;
     float radius = 0.5 * length(bb_max - bb_min);
-    float3 f0 = float3(dot(v_41.uFrustum[0], float4(center, 1.0)), dot(v_41.uFrustum[1], float4(center, 1.0)), dot(v_41.uFrustum[2], float4(center, 1.0)));
-    float3 f1 = float3(dot(v_41.uFrustum[3], float4(center, 1.0)), dot(v_41.uFrustum[4], float4(center, 1.0)), dot(v_41.uFrustum[5], float4(center, 1.0)));
+    float3 f0 = float3(dot(_41.uFrustum[0], float4(center, 1.0)), dot(_41.uFrustum[1], float4(center, 1.0)), dot(_41.uFrustum[2], float4(center, 1.0)));
+    float3 f1 = float3(dot(_41.uFrustum[3], float4(center, 1.0)), dot(_41.uFrustum[4], float4(center, 1.0)), dot(_41.uFrustum[5], float4(center, 1.0)));
     bool _205 = any(f0 <= float3(-radius));
     bool _215;
     if (!_205)
@@ -51,65 +51,65 @@ bool frustum_cull(thread const float2& p0, constant UBO& v_41)
 }
 
 static inline __attribute__((always_inline))
-float lod_factor(thread const float2& pos_, constant UBO& v_41)
+float lod_factor(thread const float2& pos_, constant UBO& _41)
 {
-    float2 pos = pos_ * v_41.uScale.xy;
-    float3 dist_to_cam = v_41.uCamPos - float3(pos.x, 0.0, pos.y);
-    float level0 = log2((length(dist_to_cam) + 9.9999997473787516355514526367188e-05) * v_41.uDistanceMod);
-    return fast::clamp(level0, 0.0, v_41.uMaxTessLevel.x);
+    float2 pos = pos_ * _41.uScale.xy;
+    float3 dist_to_cam = _41.uCamPos - float3(pos.x, 0.0, pos.y);
+    float level0 = log2((length(dist_to_cam) + 9.9999997473787516355514526367188e-05) * _41.uDistanceMod);
+    return fast::clamp(level0, 0.0, _41.uMaxTessLevel.x);
 }
 
 static inline __attribute__((always_inline))
-float4 tess_level(thread const float4& lod, constant UBO& v_41)
+float4 tess_level(thread const float4& lod, constant UBO& _41)
 {
-    return exp2(-lod) * v_41.uMaxTessLevel.y;
+    return exp2(-lod) * _41.uMaxTessLevel.y;
 }
 
 static inline __attribute__((always_inline))
-float tess_level(thread const float& lod, constant UBO& v_41)
+float tess_level(thread const float& lod, constant UBO& _41)
 {
-    return v_41.uMaxTessLevel.y * exp2(-lod);
+    return _41.uMaxTessLevel.y * exp2(-lod);
 }
 
 static inline __attribute__((always_inline))
-void compute_tess_levels(thread const float2& p0, constant UBO& v_41, device float2& vOutPatchPosBase, device float4& vPatchLods, device half (&gl_TessLevelOuter)[4], device half (&gl_TessLevelInner)[2])
+void compute_tess_levels(thread const float2& p0, constant UBO& _41, device float2& vOutPatchPosBase, device float4& vPatchLods, device half (&gl_TessLevelOuter)[4], device half (&gl_TessLevelInner)[2])
 {
     vOutPatchPosBase = p0;
-    float2 param = p0 + (float2(-0.5) * v_41.uPatchSize);
-    float l00 = lod_factor(param, v_41);
-    float2 param_1 = p0 + (float2(0.5, -0.5) * v_41.uPatchSize);
-    float l10 = lod_factor(param_1, v_41);
-    float2 param_2 = p0 + (float2(1.5, -0.5) * v_41.uPatchSize);
-    float l20 = lod_factor(param_2, v_41);
-    float2 param_3 = p0 + (float2(-0.5, 0.5) * v_41.uPatchSize);
-    float l01 = lod_factor(param_3, v_41);
-    float2 param_4 = p0 + (float2(0.5) * v_41.uPatchSize);
-    float l11 = lod_factor(param_4, v_41);
-    float2 param_5 = p0 + (float2(1.5, 0.5) * v_41.uPatchSize);
-    float l21 = lod_factor(param_5, v_41);
-    float2 param_6 = p0 + (float2(-0.5, 1.5) * v_41.uPatchSize);
-    float l02 = lod_factor(param_6, v_41);
-    float2 param_7 = p0 + (float2(0.5, 1.5) * v_41.uPatchSize);
-    float l12 = lod_factor(param_7, v_41);
-    float2 param_8 = p0 + (float2(1.5) * v_41.uPatchSize);
-    float l22 = lod_factor(param_8, v_41);
+    float2 param = p0 + (float2(-0.5) * _41.uPatchSize);
+    float l00 = lod_factor(param, _41);
+    float2 param_1 = p0 + (float2(0.5, -0.5) * _41.uPatchSize);
+    float l10 = lod_factor(param_1, _41);
+    float2 param_2 = p0 + (float2(1.5, -0.5) * _41.uPatchSize);
+    float l20 = lod_factor(param_2, _41);
+    float2 param_3 = p0 + (float2(-0.5, 0.5) * _41.uPatchSize);
+    float l01 = lod_factor(param_3, _41);
+    float2 param_4 = p0 + (float2(0.5) * _41.uPatchSize);
+    float l11 = lod_factor(param_4, _41);
+    float2 param_5 = p0 + (float2(1.5, 0.5) * _41.uPatchSize);
+    float l21 = lod_factor(param_5, _41);
+    float2 param_6 = p0 + (float2(-0.5, 1.5) * _41.uPatchSize);
+    float l02 = lod_factor(param_6, _41);
+    float2 param_7 = p0 + (float2(0.5, 1.5) * _41.uPatchSize);
+    float l12 = lod_factor(param_7, _41);
+    float2 param_8 = p0 + (float2(1.5) * _41.uPatchSize);
+    float l22 = lod_factor(param_8, _41);
     float4 lods = float4(dot(float4(l01, l11, l02, l12), float4(0.25)), dot(float4(l00, l10, l01, l11), float4(0.25)), dot(float4(l10, l20, l11, l21), float4(0.25)), dot(float4(l11, l21, l12, l22), float4(0.25)));
     vPatchLods = lods;
     float4 outer_lods = fast::min(lods, lods.yzwx);
     float4 param_9 = outer_lods;
-    float4 levels = tess_level(param_9, v_41);
+    float4 levels = tess_level(param_9, _41);
     gl_TessLevelOuter[0] = half(levels.x);
     gl_TessLevelOuter[1] = half(levels.y);
     gl_TessLevelOuter[2] = half(levels.z);
     gl_TessLevelOuter[3] = half(levels.w);
     float min_lod = fast::min(fast::min(lods.x, lods.y), fast::min(lods.z, lods.w));
     float param_10 = fast::min(min_lod, l11);
-    float inner = tess_level(param_10, v_41);
+    float inner = tess_level(param_10, _41);
     gl_TessLevelInner[0] = half(inner);
     gl_TessLevelInner[1] = half(inner);
 }
 
-kernel void main0(main0_in in [[stage_in]], constant UBO& v_41 [[buffer(0)]], uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], constant uint* spvIndirectParams [[buffer(29)]], device main0_patchOut* spvPatchOut [[buffer(27)]], device MTLQuadTessellationFactorsHalf* spvTessLevel [[buffer(26)]], threadgroup main0_in* gl_in [[threadgroup(0)]])
+kernel void main0(main0_in in [[stage_in]], constant UBO& _41 [[buffer(0)]], uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], constant uint* spvIndirectParams [[buffer(29)]], device main0_patchOut* spvPatchOut [[buffer(27)]], device MTLQuadTessellationFactorsHalf* spvTessLevel [[buffer(26)]], threadgroup main0_in* gl_in [[threadgroup(0)]])
 {
     device main0_patchOut& patchOut = spvPatchOut[gl_PrimitiveID];
     if (gl_InvocationID < spvIndirectParams[0])
@@ -119,7 +119,7 @@ kernel void main0(main0_in in [[stage_in]], constant UBO& v_41 [[buffer(0)]], ui
         return;
     float2 p0 = gl_in[0].vPatchPosBase;
     float2 param = p0;
-    if (!frustum_cull(param, v_41))
+    if (!frustum_cull(param, _41))
     {
         spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(-1.0);
         spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[1] = half(-1.0);
@@ -131,7 +131,7 @@ kernel void main0(main0_in in [[stage_in]], constant UBO& v_41 [[buffer(0)]], ui
     else
     {
         float2 param_1 = p0;
-        compute_tess_levels(param_1, v_41, patchOut.vOutPatchPosBase, patchOut.vPatchLods, spvTessLevel[gl_PrimitiveID].edgeTessellationFactor, spvTessLevel[gl_PrimitiveID].insideTessellationFactor);
+        compute_tess_levels(param_1, _41, patchOut.vOutPatchPosBase, patchOut.vPatchLods, spvTessLevel[gl_PrimitiveID].edgeTessellationFactor, spvTessLevel[gl_PrimitiveID].insideTessellationFactor);
     }
 }
 

--- a/reference/shaders-msl/tese/water_tess.raw-tess-in.tese
+++ b/reference/shaders-msl/tese/water_tess.raw-tess-in.tese
@@ -29,9 +29,9 @@ struct main0_patchIn
 };
 
 static inline __attribute__((always_inline))
-float2 lerp_vertex(thread const float2& tess_coord, const device float2& vOutPatchPosBase, constant UBO& v_31)
+float2 lerp_vertex(thread const float2& tess_coord, const device float2& vOutPatchPosBase, constant UBO& _31)
 {
-    return vOutPatchPosBase + (tess_coord * v_31.uPatchSize);
+    return vOutPatchPosBase + (tess_coord * _31.uPatchSize);
 }
 
 static inline __attribute__((always_inline))
@@ -50,28 +50,28 @@ float3 sample_height_displacement(thread const float2& uv, thread const float2& 
     return mix(uHeightmapDisplacement.sample(uHeightmapDisplacementSmplr, (uv + (off * 0.5)), level(lod.x)).xyz, uHeightmapDisplacement.sample(uHeightmapDisplacementSmplr, (uv + (off * 1.0)), level(lod.x + 1.0)).xyz, float3(lod.y));
 }
 
-[[ patch(quad, 0) ]] vertex main0_out main0(constant UBO& v_31 [[buffer(0)]], texture2d<float> uHeightmapDisplacement [[texture(0)]], sampler uHeightmapDisplacementSmplr [[sampler(0)]], float2 gl_TessCoordIn [[position_in_patch]], uint gl_PrimitiveID [[patch_id]], const device main0_patchIn* spvPatchIn [[buffer(20)]])
+[[ patch(quad, 0) ]] vertex main0_out main0(constant UBO& _31 [[buffer(0)]], texture2d<float> uHeightmapDisplacement [[texture(0)]], sampler uHeightmapDisplacementSmplr [[sampler(0)]], float2 gl_TessCoordIn [[position_in_patch]], uint gl_PrimitiveID [[patch_id]], const device main0_patchIn* spvPatchIn [[buffer(20)]])
 {
     main0_out out = {};
     const device main0_patchIn& patchIn = spvPatchIn[gl_PrimitiveID];
     float3 gl_TessCoord = float3(gl_TessCoordIn.x, gl_TessCoordIn.y, 0.0);
     float2 tess_coord = gl_TessCoord.xy;
     float2 param = tess_coord;
-    float2 pos = lerp_vertex(param, patchIn.vOutPatchPosBase, v_31);
+    float2 pos = lerp_vertex(param, patchIn.vOutPatchPosBase, _31);
     float2 param_1 = tess_coord;
     float2 lod = lod_factor(param_1, patchIn.vPatchLods);
-    float2 tex = pos * v_31.uInvHeightmapSize;
-    pos *= v_31.uScale.xy;
+    float2 tex = pos * _31.uInvHeightmapSize;
+    pos *= _31.uScale.xy;
     float delta_mod = exp2(lod.x);
-    float2 off = v_31.uInvHeightmapSize * delta_mod;
-    out.vGradNormalTex = float4(tex + (v_31.uInvHeightmapSize * 0.5), tex * v_31.uScale.zw);
+    float2 off = _31.uInvHeightmapSize * delta_mod;
+    out.vGradNormalTex = float4(tex + (_31.uInvHeightmapSize * 0.5), tex * _31.uScale.zw);
     float2 param_2 = tex;
     float2 param_3 = off;
     float2 param_4 = lod;
     float3 height_displacement = sample_height_displacement(param_2, param_3, param_4, uHeightmapDisplacement, uHeightmapDisplacementSmplr);
     pos += height_displacement.yz;
     out.vWorld = float3(pos.x, height_displacement.x, pos.y);
-    out.gl_Position = v_31.uMVP * float4(out.vWorld, 1.0);
+    out.gl_Position = _31.uMVP * float4(out.vWorld, 1.0);
     return out;
 }
 

--- a/reference/shaders-msl/tese/water_tess.tese
+++ b/reference/shaders-msl/tese/water_tess.tese
@@ -29,9 +29,9 @@ struct main0_patchIn
 };
 
 static inline __attribute__((always_inline))
-float2 lerp_vertex(thread const float2& tess_coord, thread float2& vOutPatchPosBase, constant UBO& v_31)
+float2 lerp_vertex(thread const float2& tess_coord, thread float2& vOutPatchPosBase, constant UBO& _31)
 {
-    return vOutPatchPosBase + (tess_coord * v_31.uPatchSize);
+    return vOutPatchPosBase + (tess_coord * _31.uPatchSize);
 }
 
 static inline __attribute__((always_inline))
@@ -50,27 +50,27 @@ float3 sample_height_displacement(thread const float2& uv, thread const float2& 
     return mix(uHeightmapDisplacement.sample(uHeightmapDisplacementSmplr, (uv + (off * 0.5)), level(lod.x)).xyz, uHeightmapDisplacement.sample(uHeightmapDisplacementSmplr, (uv + (off * 1.0)), level(lod.x + 1.0)).xyz, float3(lod.y));
 }
 
-[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], constant UBO& v_31 [[buffer(0)]], texture2d<float> uHeightmapDisplacement [[texture(0)]], sampler uHeightmapDisplacementSmplr [[sampler(0)]], float2 gl_TessCoordIn [[position_in_patch]])
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], constant UBO& _31 [[buffer(0)]], texture2d<float> uHeightmapDisplacement [[texture(0)]], sampler uHeightmapDisplacementSmplr [[sampler(0)]], float2 gl_TessCoordIn [[position_in_patch]])
 {
     main0_out out = {};
     float3 gl_TessCoord = float3(gl_TessCoordIn.x, gl_TessCoordIn.y, 0.0);
     float2 tess_coord = gl_TessCoord.xy;
     float2 param = tess_coord;
-    float2 pos = lerp_vertex(param, patchIn.vOutPatchPosBase, v_31);
+    float2 pos = lerp_vertex(param, patchIn.vOutPatchPosBase, _31);
     float2 param_1 = tess_coord;
     float2 lod = lod_factor(param_1, patchIn.vPatchLods);
-    float2 tex = pos * v_31.uInvHeightmapSize;
-    pos *= v_31.uScale.xy;
+    float2 tex = pos * _31.uInvHeightmapSize;
+    pos *= _31.uScale.xy;
     float delta_mod = exp2(lod.x);
-    float2 off = v_31.uInvHeightmapSize * delta_mod;
-    out.vGradNormalTex = float4(tex + (v_31.uInvHeightmapSize * 0.5), tex * v_31.uScale.zw);
+    float2 off = _31.uInvHeightmapSize * delta_mod;
+    out.vGradNormalTex = float4(tex + (_31.uInvHeightmapSize * 0.5), tex * _31.uScale.zw);
     float2 param_2 = tex;
     float2 param_3 = off;
     float2 param_4 = lod;
     float3 height_displacement = sample_height_displacement(param_2, param_3, param_4, uHeightmapDisplacement, uHeightmapDisplacementSmplr);
     pos += height_displacement.yz;
     out.vWorld = float3(pos.x, height_displacement.x, pos.y);
-    out.gl_Position = v_31.uMVP * float4(out.vWorld, 1.0);
+    out.gl_Position = _31.uMVP * float4(out.vWorld, 1.0);
     return out;
 }
 

--- a/reference/shaders-msl/vert/leaf-function.capture.vert
+++ b/reference/shaders-msl/vert/leaf-function.capture.vert
@@ -23,15 +23,15 @@ struct main0_in
 };
 
 static inline __attribute__((always_inline))
-void set_output(device float4& gl_Position, constant UBO& v_18, thread float4& aVertex, device float3& vNormal, thread float3& aNormal)
+void set_output(device float4& gl_Position, constant UBO& _18, thread float4& aVertex, device float3& vNormal, thread float3& aNormal)
 {
-    gl_Position = v_18.uMVP * aVertex;
+    gl_Position = _18.uMVP * aVertex;
     vNormal = aNormal;
 }
 
-vertex void main0(main0_in in [[stage_in]], constant UBO& v_18 [[buffer(0)]], uint gl_VertexIndex [[vertex_id]], uint gl_BaseVertex [[base_vertex]], uint gl_InstanceIndex [[instance_id]], uint gl_BaseInstance [[base_instance]], device main0_out* spvOut [[buffer(28)]], device uint* spvIndirectParams [[buffer(29)]])
+vertex void main0(main0_in in [[stage_in]], constant UBO& _18 [[buffer(0)]], uint gl_VertexIndex [[vertex_id]], uint gl_BaseVertex [[base_vertex]], uint gl_InstanceIndex [[instance_id]], uint gl_BaseInstance [[base_instance]], device main0_out* spvOut [[buffer(28)]], device uint* spvIndirectParams [[buffer(29)]])
 {
     device main0_out& out = spvOut[(gl_InstanceIndex - gl_BaseInstance) * spvIndirectParams[0] + gl_VertexIndex - gl_BaseVertex];
-    set_output(out.gl_Position, v_18, in.aVertex, out.vNormal, in.aNormal);
+    set_output(out.gl_Position, _18, in.aVertex, out.vNormal, in.aNormal);
 }
 

--- a/reference/shaders-msl/vert/leaf-function.for-tess.vert
+++ b/reference/shaders-msl/vert/leaf-function.for-tess.vert
@@ -23,17 +23,17 @@ struct main0_in
 };
 
 static inline __attribute__((always_inline))
-void set_output(device float4& gl_Position, constant UBO& v_18, thread float4& aVertex, device float3& vNormal, thread float3& aNormal)
+void set_output(device float4& gl_Position, constant UBO& _18, thread float4& aVertex, device float3& vNormal, thread float3& aNormal)
 {
-    gl_Position = v_18.uMVP * aVertex;
+    gl_Position = _18.uMVP * aVertex;
     vNormal = aNormal;
 }
 
-kernel void main0(main0_in in [[stage_in]], constant UBO& v_18 [[buffer(0)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 spvStageInputSize [[grid_size]], device main0_out* spvOut [[buffer(28)]])
+kernel void main0(main0_in in [[stage_in]], constant UBO& _18 [[buffer(0)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 spvStageInputSize [[grid_size]], device main0_out* spvOut [[buffer(28)]])
 {
     device main0_out& out = spvOut[gl_GlobalInvocationID.y * spvStageInputSize.x + gl_GlobalInvocationID.x];
     if (any(gl_GlobalInvocationID >= spvStageInputSize))
         return;
-    set_output(out.gl_Position, v_18, in.aVertex, out.vNormal, in.aNormal);
+    set_output(out.gl_Position, _18, in.aVertex, out.vNormal, in.aNormal);
 }
 

--- a/shaders-msl-no-opt/asm/vert/block-io-use-in-function.asm.vert
+++ b/shaders-msl-no-opt/asm/vert/block-io-use-in-function.asm.vert
@@ -1,0 +1,314 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 102
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main" %_ %a_color %a_texcoord %a_position %__1
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_separate_shader_objects"
+               OpSourceExtension "GL_ARB_shading_language_420pack"
+               OpSourceExtension "GL_EXT_multiview"
+               OpName %main "main"
+               OpName %DrawWorldVS_ "DrawWorldVS("
+               OpName %PerVertex "PerVertex"
+               OpMemberName %PerVertex 0 "v_color"
+               OpMemberName %PerVertex 1 "v_texPos"
+               OpMemberName %PerVertex 2 "v_worldPosition"
+               OpName %_ ""
+               OpName %a_color "a_color"
+               OpName %a_texcoord "a_texcoord"
+               OpName %a_position "a_position"
+               OpName %worldSpacePosition "worldSpacePosition"
+               OpName %u_objToWorlds "u_objToWorlds"
+               OpMemberName %u_objToWorlds 0 "u_objToWorld"
+               OpName %__0 ""
+               OpName %gl_PerVertex "gl_PerVertex"
+               OpMemberName %gl_PerVertex 0 "gl_Position"
+               OpMemberName %gl_PerVertex 1 "gl_PointSize"
+               OpMemberName %gl_PerVertex 2 "gl_ClipDistance"
+               OpMemberName %gl_PerVertex 3 "gl_CullDistance"
+               OpName %__1 ""
+               OpName %CameraData "CameraData"
+               OpMemberName %CameraData 0 "u_projectFromView"
+               OpMemberName %CameraData 1 "u_projectFromWorld"
+               OpMemberName %CameraData 2 "u_clipFromPixels"
+               OpMemberName %CameraData 3 "u_viewFromWorld"
+               OpMemberName %CameraData 4 "u_worldFromView"
+               OpMemberName %CameraData 5 "u_viewFromProject"
+               OpMemberName %CameraData 6 "u_cameraPosition"
+               OpMemberName %CameraData 7 "pad0"
+               OpMemberName %CameraData 8 "u_cameraRight"
+               OpMemberName %CameraData 9 "pad1"
+               OpMemberName %CameraData 10 "u_cameraUp"
+               OpMemberName %CameraData 11 "pad2"
+               OpMemberName %CameraData 12 "u_cameraForward"
+               OpMemberName %CameraData 13 "pad3"
+               OpMemberName %CameraData 14 "u_clipPlanes"
+               OpMemberName %CameraData 15 "u_invProjParams"
+               OpMemberName %CameraData 16 "u_viewportSize"
+               OpMemberName %CameraData 17 "u_invViewportSize"
+               OpMemberName %CameraData 18 "u_viewportOffset"
+               OpMemberName %CameraData 19 "u_fragToLightGrid"
+               OpMemberName %CameraData 20 "u_screenToLightGrid"
+               OpMemberName %CameraData 21 "pad4"
+               OpMemberName %CameraData 22 "u_lightGridZParams"
+               OpName %LightData "LightData"
+               OpMemberName %LightData 0 "posRadius"
+               OpMemberName %LightData 1 "color"
+               OpMemberName %LightData 2 "axis"
+               OpMemberName %LightData 3 "directionalParams"
+               OpMemberName %LightData 4 "spotParams"
+               OpMemberName %LightData 5 "shadowSize"
+               OpMemberName %LightData 6 "cookieFromWorld"
+               OpMemberName %LightData 7 "shadowFromWorld"
+               OpMemberName %LightData 8 "shadowTextureValid"
+               OpMemberName %LightData 9 "lightCookieValid"
+               OpMemberName %LightData 10 "minLightDistance"
+               OpMemberName %LightData 11 "pad"
+               OpName %SceneSettings "SceneSettings"
+               OpMemberName %SceneSettings 0 "u_cameras"
+               OpMemberName %SceneSettings 1 "u_centerPosition"
+               OpMemberName %SceneSettings 2 "u_centerRight"
+               OpMemberName %SceneSettings 3 "u_centerUp"
+               OpMemberName %SceneSettings 4 "u_centerForward"
+               OpMemberName %SceneSettings 5 "u_times"
+               OpMemberName %SceneSettings 6 "u_lightFXMask"
+               OpMemberName %SceneSettings 7 "u_lights"
+               OpMemberName %SceneSettings 8 "u_globalLightDir"
+               OpMemberName %SceneSettings 9 "u_globalLightDiffuseColor"
+               OpMemberName %SceneSettings 10 "u_globalLightSpecularColor"
+               OpMemberName %SceneSettings 11 "u_distanceFog"
+               OpMemberName %SceneSettings 12 "u_heightFog"
+               OpMemberName %SceneSettings 13 "u_fogColor"
+               OpMemberName %SceneSettings 14 "u_debugMode"
+               OpName %__2 ""
+               OpName %LightContext "LightContext"
+               OpMemberName %LightContext 0 "u_ambientIBLTint"
+               OpMemberName %LightContext 1 "u_specularIBLTint"
+               OpMemberName %LightContext 2 "u_iblAABBMin"
+               OpMemberName %LightContext 3 "u_iblAABBMax"
+               OpMemberName %LightContext 4 "u_iblAABBCenter"
+               OpMemberName %LightContext 5 "LightContext_unusued0"
+               OpMemberName %LightContext 6 "u_exposureMultiplier"
+               OpName %__3 ""
+               OpName %u_sceneDepthMS "u_sceneDepthMS"
+               OpName %u_sceneStencilMS "u_sceneStencilMS"
+               OpName %u_lightGrid "u_lightGrid"
+               OpName %u_texture "u_texture"
+               OpDecorate %PerVertex Block
+               OpDecorate %_ Location 1
+               OpDecorate %a_color Location 2
+               OpDecorate %a_texcoord Location 1
+               OpDecorate %a_position Location 0
+               OpMemberDecorate %u_objToWorlds 0 ColMajor
+               OpMemberDecorate %u_objToWorlds 0 Offset 0
+               OpMemberDecorate %u_objToWorlds 0 MatrixStride 16
+               OpDecorate %u_objToWorlds Block
+               OpDecorate %__0 DescriptorSet 0
+               OpDecorate %__0 Binding 1
+               OpMemberDecorate %gl_PerVertex 0 BuiltIn Position
+               OpMemberDecorate %gl_PerVertex 1 BuiltIn PointSize
+               OpMemberDecorate %gl_PerVertex 2 BuiltIn ClipDistance
+               OpMemberDecorate %gl_PerVertex 3 BuiltIn CullDistance
+               OpDecorate %gl_PerVertex Block
+               OpMemberDecorate %CameraData 0 ColMajor
+               OpMemberDecorate %CameraData 0 Offset 0
+               OpMemberDecorate %CameraData 0 MatrixStride 16
+               OpMemberDecorate %CameraData 1 ColMajor
+               OpMemberDecorate %CameraData 1 Offset 64
+               OpMemberDecorate %CameraData 1 MatrixStride 16
+               OpMemberDecorate %CameraData 2 ColMajor
+               OpMemberDecorate %CameraData 2 Offset 128
+               OpMemberDecorate %CameraData 2 MatrixStride 16
+               OpMemberDecorate %CameraData 3 ColMajor
+               OpMemberDecorate %CameraData 3 Offset 192
+               OpMemberDecorate %CameraData 3 MatrixStride 16
+               OpMemberDecorate %CameraData 4 ColMajor
+               OpMemberDecorate %CameraData 4 Offset 256
+               OpMemberDecorate %CameraData 4 MatrixStride 16
+               OpMemberDecorate %CameraData 5 ColMajor
+               OpMemberDecorate %CameraData 5 Offset 320
+               OpMemberDecorate %CameraData 5 MatrixStride 16
+               OpMemberDecorate %CameraData 6 Offset 384
+               OpMemberDecorate %CameraData 7 Offset 396
+               OpMemberDecorate %CameraData 8 Offset 400
+               OpMemberDecorate %CameraData 9 Offset 412
+               OpMemberDecorate %CameraData 10 Offset 416
+               OpMemberDecorate %CameraData 11 Offset 428
+               OpMemberDecorate %CameraData 12 Offset 432
+               OpMemberDecorate %CameraData 13 Offset 444
+               OpMemberDecorate %CameraData 14 Offset 448
+               OpMemberDecorate %CameraData 15 Offset 456
+               OpMemberDecorate %CameraData 16 Offset 464
+               OpMemberDecorate %CameraData 17 Offset 472
+               OpMemberDecorate %CameraData 18 Offset 480
+               OpMemberDecorate %CameraData 19 Offset 488
+               OpMemberDecorate %CameraData 20 Offset 496
+               OpMemberDecorate %CameraData 21 Offset 504
+               OpMemberDecorate %CameraData 22 Offset 512
+               OpDecorate %_arr_CameraData_uint_2 ArrayStride 528
+               OpMemberDecorate %LightData 0 Offset 0
+               OpMemberDecorate %LightData 1 Offset 16
+               OpMemberDecorate %LightData 2 Offset 32
+               OpMemberDecorate %LightData 3 Offset 48
+               OpMemberDecorate %LightData 4 Offset 64
+               OpMemberDecorate %LightData 5 Offset 80
+               OpMemberDecorate %LightData 6 ColMajor
+               OpMemberDecorate %LightData 6 Offset 96
+               OpMemberDecorate %LightData 6 MatrixStride 16
+               OpMemberDecorate %LightData 7 ColMajor
+               OpMemberDecorate %LightData 7 Offset 160
+               OpMemberDecorate %LightData 7 MatrixStride 16
+               OpMemberDecorate %LightData 8 Offset 224
+               OpMemberDecorate %LightData 9 Offset 228
+               OpMemberDecorate %LightData 10 Offset 232
+               OpMemberDecorate %LightData 11 Offset 236
+               OpDecorate %_arr_LightData_uint_8 ArrayStride 240
+               OpMemberDecorate %SceneSettings 0 Offset 0
+               OpMemberDecorate %SceneSettings 1 Offset 1056
+               OpMemberDecorate %SceneSettings 2 Offset 1072
+               OpMemberDecorate %SceneSettings 3 Offset 1088
+               OpMemberDecorate %SceneSettings 4 Offset 1104
+               OpMemberDecorate %SceneSettings 5 Offset 1120
+               OpMemberDecorate %SceneSettings 6 Offset 1128
+               OpMemberDecorate %SceneSettings 7 Offset 1136
+               OpMemberDecorate %SceneSettings 8 Offset 3056
+               OpMemberDecorate %SceneSettings 9 Offset 3072
+               OpMemberDecorate %SceneSettings 10 Offset 3088
+               OpMemberDecorate %SceneSettings 11 Offset 3104
+               OpMemberDecorate %SceneSettings 12 Offset 3112
+               OpMemberDecorate %SceneSettings 13 Offset 3120
+               OpMemberDecorate %SceneSettings 14 Offset 3136
+               OpDecorate %SceneSettings Block
+               OpDecorate %__2 DescriptorSet 0
+               OpDecorate %__2 Binding 0
+               OpMemberDecorate %LightContext 0 Offset 0
+               OpMemberDecorate %LightContext 1 Offset 16
+               OpMemberDecorate %LightContext 2 Offset 32
+               OpMemberDecorate %LightContext 3 Offset 48
+               OpMemberDecorate %LightContext 4 Offset 64
+               OpMemberDecorate %LightContext 5 Offset 76
+               OpMemberDecorate %LightContext 6 Offset 80
+               OpDecorate %LightContext Block
+               OpDecorate %__3 DescriptorSet 0
+               OpDecorate %__3 Binding 0
+               OpDecorate %u_sceneDepthMS DescriptorSet 0
+               OpDecorate %u_sceneDepthMS Binding 0
+               OpDecorate %u_sceneStencilMS DescriptorSet 0
+               OpDecorate %u_sceneStencilMS Binding 0
+               OpDecorate %u_lightGrid DescriptorSet 0
+               OpDecorate %u_lightGrid Binding 0
+               OpDecorate %u_texture DescriptorSet 0
+               OpDecorate %u_texture Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+    %v2float = OpTypeVector %float 2
+    %v3float = OpTypeVector %float 3
+  %PerVertex = OpTypeStruct %v4float %v2float %v3float
+%_ptr_Output_PerVertex = OpTypePointer Output %PerVertex
+          %_ = OpVariable %_ptr_Output_PerVertex Output
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+    %a_color = OpVariable %_ptr_Input_v4float Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+      %int_1 = OpConstant %int 1
+%_ptr_Input_v2float = OpTypePointer Input %v2float
+ %a_texcoord = OpVariable %_ptr_Input_v2float Input
+%_ptr_Output_v2float = OpTypePointer Output %v2float
+      %int_2 = OpConstant %int 2
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+ %a_position = OpVariable %_ptr_Input_v3float Input
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+%mat4v4float = OpTypeMatrix %v4float 4
+%u_objToWorlds = OpTypeStruct %mat4v4float
+%_ptr_Uniform_u_objToWorlds = OpTypePointer Uniform %u_objToWorlds
+        %__0 = OpVariable %_ptr_Uniform_u_objToWorlds Uniform
+%_ptr_Uniform_mat4v4float = OpTypePointer Uniform %mat4v4float
+    %float_1 = OpConstant %float 1
+       %uint = OpTypeInt 32 0
+     %uint_1 = OpConstant %uint 1
+%_arr_float_uint_1 = OpTypeArray %float %uint_1
+%gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
+%_ptr_Output_gl_PerVertex = OpTypePointer Output %gl_PerVertex
+        %__1 = OpVariable %_ptr_Output_gl_PerVertex Output
+ %CameraData = OpTypeStruct %mat4v4float %mat4v4float %mat4v4float %mat4v4float %mat4v4float %mat4v4float %v3float %float %v3float %float %v3float %float %v3float %float %v2float %v2float %v2float %v2float %v2float %v2float %v2float %v2float %v4float
+     %uint_2 = OpConstant %uint 2
+%_arr_CameraData_uint_2 = OpTypeArray %CameraData %uint_2
+  %LightData = OpTypeStruct %v4float %v3float %v4float %v3float %v4float %v4float %mat4v4float %mat4v4float %uint %uint %float %float
+     %uint_8 = OpConstant %uint 8
+%_arr_LightData_uint_8 = OpTypeArray %LightData %uint_8
+%SceneSettings = OpTypeStruct %_arr_CameraData_uint_2 %v3float %v3float %v3float %v3float %v2float %uint %_arr_LightData_uint_8 %v3float %v3float %v3float %v2float %v2float %v4float %uint
+%_ptr_Uniform_SceneSettings = OpTypePointer Uniform %SceneSettings
+        %__2 = OpVariable %_ptr_Uniform_SceneSettings Uniform
+     %uint_0 = OpConstant %uint 0
+     %uint_3 = OpConstant %uint 3
+     %uint_4 = OpConstant %uint 4
+     %uint_5 = OpConstant %uint 5
+     %uint_6 = OpConstant %uint 6
+     %uint_7 = OpConstant %uint 7
+     %uint_9 = OpConstant %uint 9
+    %uint_10 = OpConstant %uint 10
+    %uint_11 = OpConstant %uint 11
+    %uint_12 = OpConstant %uint 12
+    %uint_13 = OpConstant %uint 13
+    %uint_14 = OpConstant %uint 14
+%LightContext = OpTypeStruct %v3float %v3float %v3float %v3float %v3float %float %float
+%_ptr_Uniform_LightContext = OpTypePointer Uniform %LightContext
+        %__3 = OpVariable %_ptr_Uniform_LightContext Uniform
+         %86 = OpTypeImage %float 2D 0 0 1 1 Unknown
+         %87 = OpTypeSampledImage %86
+%_ptr_UniformConstant_87 = OpTypePointer UniformConstant %87
+%u_sceneDepthMS = OpVariable %_ptr_UniformConstant_87 UniformConstant
+         %90 = OpTypeImage %uint 2D 0 0 1 1 Unknown
+         %91 = OpTypeSampledImage %90
+%_ptr_UniformConstant_91 = OpTypePointer UniformConstant %91
+%u_sceneStencilMS = OpVariable %_ptr_UniformConstant_91 UniformConstant
+         %94 = OpTypeImage %uint 3D 0 0 0 1 Unknown
+         %95 = OpTypeSampledImage %94
+%_ptr_UniformConstant_95 = OpTypePointer UniformConstant %95
+%u_lightGrid = OpVariable %_ptr_UniformConstant_95 UniformConstant
+         %98 = OpTypeImage %float 2D 0 1 0 1 Unknown
+         %99 = OpTypeSampledImage %98
+%_ptr_UniformConstant_99 = OpTypePointer UniformConstant %99
+  %u_texture = OpVariable %_ptr_UniformConstant_99 UniformConstant
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %70 = OpFunctionCall %void %DrawWorldVS_
+               OpReturn
+               OpFunctionEnd
+%DrawWorldVS_ = OpFunction %void None %3
+          %7 = OpLabel
+%worldSpacePosition = OpVariable %_ptr_Function_v4float Function
+         %19 = OpLoad %v4float %a_color
+         %21 = OpAccessChain %_ptr_Output_v4float %_ %int_0
+               OpStore %21 %19
+         %25 = OpLoad %v2float %a_texcoord
+         %27 = OpAccessChain %_ptr_Output_v2float %_ %int_1
+               OpStore %27 %25
+         %31 = OpLoad %v3float %a_position
+         %33 = OpAccessChain %_ptr_Output_v3float %_ %int_2
+               OpStore %33 %31
+         %41 = OpAccessChain %_ptr_Uniform_mat4v4float %__0 %int_0
+         %42 = OpLoad %mat4v4float %41
+         %43 = OpLoad %v3float %a_position
+         %45 = OpCompositeExtract %float %43 0
+         %46 = OpCompositeExtract %float %43 1
+         %47 = OpCompositeExtract %float %43 2
+         %48 = OpCompositeConstruct %v4float %45 %46 %47 %float_1
+         %49 = OpMatrixTimesVector %v4float %42 %48
+               OpStore %worldSpacePosition %49
+         %65 = OpAccessChain %_ptr_Uniform_mat4v4float %__2 %int_0 %int_0 %int_1
+         %66 = OpLoad %mat4v4float %65
+         %67 = OpLoad %v4float %worldSpacePosition
+         %68 = OpMatrixTimesVector %v4float %66 %67
+         %69 = OpAccessChain %_ptr_Output_v4float %__1 %int_0
+               OpStore %69 %68
+               OpReturn
+               OpFunctionEnd

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -2142,8 +2142,7 @@ void CompilerMSL::extract_global_variables_from_function(uint32_t func_id, std::
 				func.add_parameter(type_id, next_id, true);
 				set<SPIRVariable>(next_id, type_id, StorageClassFunction, 0, arg_id);
 
-				// Ensure the existing variable has a valid name and the new variable has all the same meta info
-				set_name(arg_id, ensure_valid_name(to_name(arg_id), "v"));
+				// Ensure the new variable has all the same meta info
 				ir.meta[next_id] = ir.meta[arg_id];
 			}
 		}


### PR DESCRIPTION
Fix #2128.

Breaks for block IO variables where they are later used as arguments. This modifies the variable name after it has been latched by patch-code which copies struct to IO members.

The identifiers should be fine to use as-is.