### PR TITLE
HLSL: support Texture2D::GatherCmp function

### DIFF
--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -3526,7 +3526,7 @@ void CompilerHLSL::emit_texture_op(const Instruction &i, bool sparse)
 			{
 				if (gather)
 				{
-					SPIRV_CROSS_THROW("GatherCmp does not exist in HLSL.");
+					texop += ".GatherCmp";
 				}
 				else if (lod || grad_x || grad_y)
 				{


### PR DESCRIPTION
refer to https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/sm5-object-texture2d-gathercmp
sample hlsl shader code:
```
Texture2D<float> depthTexture : register(t0);
SamplerComparisonState depthSampler : register(s0);

float4 main(float2 uv : TEXCOORD) : SV_Target
{
    float depth = 0.5f;
    float4 color = float4(1.0f, 1.0f, 1.0f, 1.0f);
    int2 offset = int2(1, 1);

    color = depthTexture.GatherCmp(depthSampler, uv, depth, offset);

    return color;
}
```