### PR TITLE
GLSL: Use actual field offset to validate vec4 boundary alignment.

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1786,16 +1786,17 @@ bool CompilerGLSL::buffer_is_packing_standard(const SPIRType &type, BufferPackin
 			packed_size = type_to_packed_size(memb_type, member_flags, packing);
 
 		// We only need to care about this if we have non-array types which can straddle the vec4 boundary.
+		uint32_t actual_offset = type_struct_member_offset(type, i);
+
 		if (packing_is_hlsl(packing))
 		{
 			// If a member straddles across a vec4 boundary, alignment is actually vec4.
-			uint32_t begin_word = offset / 16;
-			uint32_t end_word = (offset + packed_size - 1) / 16;
+			uint32_t begin_word = actual_offset / 16;
+			uint32_t end_word = (actual_offset + packed_size - 1) / 16;
 			if (begin_word != end_word)
 				packed_alignment = max<uint32_t>(packed_alignment, 16u);
 		}
 
-		uint32_t actual_offset = type_struct_member_offset(type, i);
 		// Field is not in the specified range anymore and we can ignore any further fields.
 		if (actual_offset >= end_offset)
 			break;


### PR DESCRIPTION
The vec4-boundary check for HLSL packing alignment must be done with the actual field offset. Otherwise, optimized SPIR-V (`spirv-opt -Os` in particular) will fail to be validated correctly.

This issue can be reproduced with the following HLSL input:
```hlsl
cbuffer Test {
    float3 V0_xyz_; // Offset:   0
    float  V0____w; // Offset:  12
    float2 V1_xy__; // Offset:  16
    float2 V1___zw; // Offset:  24
}
float4 PSMain() : SV_Target {
    return float4(V0_xyz_, V1___zw.r);
};
```
Compile with DXC as follows:
```
dxc Input.hlsl -T ps_6_0 -E PSMain -spirv -Fo Output.spv
```
Then optimize using SPIRV-Tools like this:
```
spirv-opt -Os Output.spv -o Optimized.spv
```
This will remove unused field from the struct but maintain the same offsets, i.e. SPIRV-Cross won't be able to track `V0____w` and `V1_xy__` during the validation unless the actual offset from the SPIR-V decorator is used. Then try to cross-compile with SPIRV-Cross:
```
spirv-cross Optimized.spv --hlsl --shader-model 50
```
This results in the following error:
```
SPIRV-Cross threw an exception: cbuffer ID 4 (name: type_Test), member index 1 (name: V1_zw) cannot be expressed with either HLSL packing layout or packoffset.
```