### PR TITLE
HLSL: Add support to preserve (RW)StructuredBuffer resources.

### DIFF
--- a/reference/shaders-hlsl/asm/frag/array-of-structured-buffers.asm.frag
+++ b/reference/shaders-hlsl/asm/frag/array-of-structured-buffers.asm.frag
@@ -1,0 +1,26 @@
+struct Data
+{
+    float4 Color;
+};
+
+StructuredBuffer<Data> Colors[2] : register(t0);
+
+static float4 out_var_SV_Target;
+
+struct SPIRV_Cross_Output
+{
+    float4 out_var_SV_Target : COLOR0;
+};
+
+void frag_main()
+{
+    out_var_SV_Target = Colors[1][3u].Color;
+}
+
+SPIRV_Cross_Output main()
+{
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.out_var_SV_Target = float4(out_var_SV_Target);
+    return stage_output;
+}

--- a/reference/shaders-hlsl/asm/frag/structured-buffer.asm.frag
+++ b/reference/shaders-hlsl/asm/frag/structured-buffer.asm.frag
@@ -1,0 +1,26 @@
+struct Data
+{
+    float4 Color;
+};
+
+StructuredBuffer<Data> Colors : register(t0);
+
+static float4 out_var_SV_Target;
+
+struct SPIRV_Cross_Output
+{
+    float4 out_var_SV_Target : COLOR0;
+};
+
+void frag_main()
+{
+    out_var_SV_Target = Colors[3u].Color;
+}
+
+SPIRV_Cross_Output main()
+{
+    frag_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.out_var_SV_Target = float4(out_var_SV_Target);
+    return stage_output;
+}

--- a/shaders-hlsl/asm/frag/array-of-structured-buffers.frag
+++ b/shaders-hlsl/asm/frag/array-of-structured-buffers.frag
@@ -1,0 +1,55 @@
+; SPIR-V
+; Version: 1.3
+; Generator: Google spiregg; 0
+; Bound: 25
+; Schema: 0
+               OpCapability Shader
+               OpExtension "SPV_GOOGLE_hlsl_functionality1"
+               OpExtension "SPV_GOOGLE_user_type"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %out_var_SV_Target
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 660
+               OpName %type_StructuredBuffer_Data "type.StructuredBuffer.Data"
+               OpName %Data "Data"
+               OpMemberName %Data 0 "Color"
+               OpName %Colors "Colors"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpName %main "main"
+               OpDecorateString %out_var_SV_Target UserSemantic "SV_Target"
+               OpDecorate %out_var_SV_Target Location 0
+               OpDecorate %Colors DescriptorSet 0
+               OpDecorate %Colors Binding 0
+               OpMemberDecorate %Data 0 Offset 0
+               OpDecorate %_runtimearr_Data ArrayStride 16
+               OpMemberDecorate %type_StructuredBuffer_Data 0 Offset 0
+               OpMemberDecorate %type_StructuredBuffer_Data 0 NonWritable
+               OpDecorate %type_StructuredBuffer_Data BufferBlock
+               OpDecorateString %Colors UserTypeGOOGLE "structuredbuffer:<Data>"
+        %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
+      %int_0 = OpConstant %int 0
+       %uint = OpTypeInt 32 0
+     %uint_3 = OpConstant %uint 3
+     %uint_2 = OpConstant %uint 2
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+       %Data = OpTypeStruct %v4float
+%_runtimearr_Data = OpTypeRuntimeArray %Data
+%type_StructuredBuffer_Data = OpTypeStruct %_runtimearr_Data
+%_arr_type_StructuredBuffer_Data_uint_2 = OpTypeArray %type_StructuredBuffer_Data %uint_2
+%_ptr_Uniform__arr_type_StructuredBuffer_Data_uint_2 = OpTypePointer Uniform %_arr_type_StructuredBuffer_Data_uint_2
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+       %void = OpTypeVoid
+         %20 = OpTypeFunction %void
+%_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
+     %Colors = OpVariable %_ptr_Uniform__arr_type_StructuredBuffer_Data_uint_2 Uniform
+%out_var_SV_Target = OpVariable %_ptr_Output_v4float Output
+       %main = OpFunction %void None %20
+         %22 = OpLabel
+         %23 = OpAccessChain %_ptr_Uniform_v4float %Colors %int_1 %int_0 %uint_3 %int_0
+         %24 = OpLoad %v4float %23
+               OpStore %out_var_SV_Target %24
+               OpReturn
+               OpFunctionEnd

--- a/shaders-hlsl/asm/frag/structured-buffer.frag
+++ b/shaders-hlsl/asm/frag/structured-buffer.frag
@@ -1,0 +1,52 @@
+; SPIR-V
+; Version: 1.3
+; Generator: Google spiregg; 0
+; Bound: 22
+; Schema: 0
+               OpCapability Shader
+               OpExtension "SPV_GOOGLE_hlsl_functionality1"
+               OpExtension "SPV_GOOGLE_user_type"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %out_var_SV_Target
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 660
+               OpName %type_StructuredBuffer_Data "type.StructuredBuffer.Data"
+               OpName %Data "Data"
+               OpMemberName %Data 0 "Color"
+               OpName %Colors "Colors"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpName %main "main"
+               OpDecorateString %out_var_SV_Target UserSemantic "SV_Target"
+               OpDecorate %out_var_SV_Target Location 0
+               OpDecorate %Colors DescriptorSet 0
+               OpDecorate %Colors Binding 0
+               OpMemberDecorate %Data 0 Offset 0
+               OpDecorate %_runtimearr_Data ArrayStride 16
+               OpMemberDecorate %type_StructuredBuffer_Data 0 Offset 0
+               OpMemberDecorate %type_StructuredBuffer_Data 0 NonWritable
+               OpDecorate %type_StructuredBuffer_Data BufferBlock
+               OpDecorateString %Colors UserTypeGOOGLE "structuredbuffer:<Data>"
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+       %uint = OpTypeInt 32 0
+     %uint_3 = OpConstant %uint 3
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+       %Data = OpTypeStruct %v4float
+%_runtimearr_Data = OpTypeRuntimeArray %Data
+%type_StructuredBuffer_Data = OpTypeStruct %_runtimearr_Data
+%_ptr_Uniform_type_StructuredBuffer_Data = OpTypePointer Uniform %type_StructuredBuffer_Data
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+       %void = OpTypeVoid
+         %17 = OpTypeFunction %void
+%_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
+     %Colors = OpVariable %_ptr_Uniform_type_StructuredBuffer_Data Uniform
+%out_var_SV_Target = OpVariable %_ptr_Output_v4float Output
+       %main = OpFunction %void None %17
+         %19 = OpLabel
+         %20 = OpAccessChain %_ptr_Uniform_v4float %Colors %int_0 %uint_3 %int_0
+         %21 = OpLoad %v4float %20
+               OpStore %out_var_SV_Target %21
+               OpReturn
+               OpFunctionEnd

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -1663,6 +1663,7 @@ struct Meta
 		std::string alias;
 		std::string qualified_alias;
 		std::string hlsl_semantic;
+		std::string user_type;
 		Bitset decoration_flags;
 		spv::BuiltIn builtin_type = spv::BuiltInMax;
 		uint32_t location = 0;

--- a/spirv_cross_parsed_ir.cpp
+++ b/spirv_cross_parsed_ir.cpp
@@ -370,6 +370,10 @@ void ParsedIR::set_decoration_string(ID id, Decoration decoration, const string 
 		dec.hlsl_semantic = argument;
 		break;
 
+	case DecorationUserTypeGOOGLE:
+		dec.user_type = argument;
+		break;
+
 	default:
 		break;
 	}
@@ -658,6 +662,9 @@ const string &ParsedIR::get_decoration_string(ID id, Decoration decoration) cons
 	{
 	case DecorationHlslSemanticGOOGLE:
 		return dec.hlsl_semantic;
+
+	case DecorationUserTypeGOOGLE:
+		return dec.user_type;
 
 	default:
 		return empty_string;

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -9606,6 +9606,9 @@ string CompilerGLSL::access_chain_internal(uint32_t base, const uint32_t *indice
 	bool pending_array_enclose = false;
 	bool dimension_flatten = false;
 
+	// If we are translating access to a structured buffer, the first subscript '._m0' must be hidden
+	bool hide_first_subscript = count > 1 && is_user_type_structured(base);
+
 	const auto append_index = [&](uint32_t index, bool is_literal, bool is_ptr_chain = false) {
 		AccessChainFlags mod_flags = flags;
 		if (!is_literal)
@@ -9792,32 +9795,40 @@ string CompilerGLSL::access_chain_internal(uint32_t base, const uint32_t *indice
 			if (index >= type->member_types.size())
 				SPIRV_CROSS_THROW("Member index is out of bounds!");
 
-			BuiltIn builtin = BuiltInMax;
-			if (is_member_builtin(*type, index, &builtin) && access_chain_needs_stage_io_builtin_translation(base))
+			if (hide_first_subscript)
 			{
-				if (access_chain_is_arrayed)
-				{
-					expr += ".";
-					expr += builtin_to_glsl(builtin, type->storage);
-				}
-				else
-					expr = builtin_to_glsl(builtin, type->storage);
+				// First "._m0" subscript has been hidden, subsequent fields must be emitted even for structured buffers
+				hide_first_subscript = false;
 			}
 			else
 			{
-				// If the member has a qualified name, use it as the entire chain
-				string qual_mbr_name = get_member_qualified_name(type_id, index);
-				if (!qual_mbr_name.empty())
-					expr = qual_mbr_name;
-				else if (flatten_member_reference)
-					expr += join("_", to_member_name(*type, index));
+				BuiltIn builtin = BuiltInMax;
+				if (is_member_builtin(*type, index, &builtin) && access_chain_needs_stage_io_builtin_translation(base))
+				{
+					if (access_chain_is_arrayed)
+					{
+						expr += ".";
+						expr += builtin_to_glsl(builtin, type->storage);
+					}
+					else
+						expr = builtin_to_glsl(builtin, type->storage);
+				}
 				else
 				{
-					// Any pointer de-refences for values are handled in the first access chain.
-					// For pointer chains, the pointer-ness is resolved through an array access.
-					// The only time this is not true is when accessing array of SSBO/UBO.
-					// This case is explicitly handled.
-					expr += to_member_reference(base, *type, index, ptr_chain || i != 0);
+					// If the member has a qualified name, use it as the entire chain
+					string qual_mbr_name = get_member_qualified_name(type_id, index);
+					if (!qual_mbr_name.empty())
+						expr = qual_mbr_name;
+					else if (flatten_member_reference)
+						expr += join("_", to_member_name(*type, index));
+					else
+					{
+						// Any pointer de-refences for values are handled in the first access chain.
+						// For pointer chains, the pointer-ness is resolved through an array access.
+						// The only time this is not true is when accessing array of SSBO/UBO.
+						// This case is explicitly handled.
+						expr += to_member_reference(base, *type, index, ptr_chain || i != 0);
+					}
 				}
 			}
 
@@ -15333,6 +15344,11 @@ void CompilerGLSL::flatten_buffer_block(VariableID id)
 bool CompilerGLSL::builtin_translates_to_nonarray(spv::BuiltIn /*builtin*/) const
 {
 	return false; // GLSL itself does not need to translate array builtin types to non-array builtin types
+}
+
+bool CompilerGLSL::is_user_type_structured(uint32_t /*id*/) const
+{
+	return false; // GLSL itself does not have structured user type, but HLSL does with StructuredBuffer and RWStructuredBuffer resources.
 }
 
 bool CompilerGLSL::check_atomic_image(uint32_t id)

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -465,6 +465,8 @@ protected:
 
 	virtual bool builtin_translates_to_nonarray(spv::BuiltIn builtin) const;
 
+	virtual bool is_user_type_structured(uint32_t id) const;
+
 	void emit_copy_logical_type(uint32_t lhs_id, uint32_t lhs_type_id, uint32_t rhs_id, uint32_t rhs_type_id,
 	                            SmallVector<uint32_t> chain);
 

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -145,6 +145,11 @@ public:
 
 		// Rather than emitting main() for the entry point, use the name in SPIR-V.
 		bool use_entry_point_name = false;
+
+		// Preserve (RW)StructuredBuffer types if the input source was HLSL.
+		// This relies on UserTypeGOOGLE to encode the buffer type either as "structuredbuffer" or "rwstructuredbuffer"
+		// whereas the type can be extended with an optional subtype, e.g. "structuredbuffer:int".
+		bool preserve_structured_buffers = false;
 	};
 
 	explicit CompilerHLSL(std::vector<uint32_t> spirv_)
@@ -397,6 +402,9 @@ private:
 
 	// Returns true for BuiltInSampleMask because gl_SampleMask[] is an array in SPIR-V, but SV_Coverage is a scalar in HLSL.
 	bool builtin_translates_to_nonarray(spv::BuiltIn builtin) const override;
+
+	// Returns true if the specified ID has a UserTypeGOOGLE decoration for StructuredBuffer or RWStructuredBuffer resources.
+	bool is_user_type_structured(uint32_t id) const override;
 
 	std::vector<TypeID> composite_selection_workaround_types;
 


### PR DESCRIPTION
This PR adds support to the HLSL backend to preserve `RW`-/`StructuredBuffer` resources when cross-compiling HLSL-to-HLSL. UE5 does this to support modern HLSL2021 features such as templates across all platforms including the D3D11 RHI where DXBC is the only supported shader bytecode but FXC does not support those features. Translating `StructuredBuffer` to `ByteAddressBuffer` breaks the resource binding. These changes make use of the `UserTypeGOOGLE` extension to preserve the original resource type. This feature is disable by default and can be enabled via the `preserve_structured_buffers` option.