### PR TITLE
[WIP] MSL: Prevent RAW hazards on read_write textures

### DIFF
--- a/reference/opt/shaders-msl/asm/comp/image-load-store-short-vector.invalid.asm.comp
+++ b/reference/opt/shaders-msl/asm/comp/image-load-store-short-vector.invalid.asm.comp
@@ -8,6 +8,7 @@ using namespace metal;
 static inline __attribute__((always_inline))
 void _main(thread const uint3& id, texture2d<float, access::read_write> TargetTexture)
 {
+    TargetTexture.fence();
     float2 loaded = TargetTexture.read(uint2(id.xy)).xy;
     float2 storeTemp = loaded + float2(1.0);
     TargetTexture.write(storeTemp.xyyy, uint2((id.xy + uint2(1u))));

--- a/reference/opt/shaders-msl/desktop-only/frag/image-ms.desktop.frag
+++ b/reference/opt/shaders-msl/desktop-only/frag/image-ms.desktop.frag
@@ -5,6 +5,7 @@ using namespace metal;
 
 fragment void main0(texture2d_ms<float> uImageMS [[texture(0)]], texture2d_array<float, access::read_write> uImageArray [[texture(1)]], texture2d<float, access::write> uImage [[texture(2)]])
 {
+    uImageArray.fence();
     uImage.write(uImageMS.read(uint2(int2(1, 2)), 2), uint2(int2(2, 3)));
     uImageArray.write(uImageArray.read(uint2(int3(1, 2, 4).xy), uint(int3(1, 2, 4).z)), uint2(int3(2, 3, 7).xy), uint(int3(2, 3, 7).z));
 }

--- a/reference/shaders-msl/asm/comp/image-load-store-short-vector.invalid.asm.comp
+++ b/reference/shaders-msl/asm/comp/image-load-store-short-vector.invalid.asm.comp
@@ -8,6 +8,7 @@ using namespace metal;
 static inline __attribute__((always_inline))
 void _main(thread const uint3& id, texture2d<float, access::read_write> TargetTexture)
 {
+    TargetTexture.fence();
     float2 loaded = TargetTexture.read(uint2(id.xy)).xy;
     float2 storeTemp = loaded + float2(1.0);
     TargetTexture.write(storeTemp.xyyy, uint2((id.xy + uint2(1u))));

--- a/reference/shaders-msl/desktop-only/frag/image-ms.desktop.frag
+++ b/reference/shaders-msl/desktop-only/frag/image-ms.desktop.frag
@@ -6,6 +6,7 @@ using namespace metal;
 fragment void main0(texture2d_ms<float> uImageMS [[texture(0)]], texture2d_array<float, access::read_write> uImageArray [[texture(1)]], texture2d<float, access::write> uImage [[texture(2)]])
 {
     float4 a = uImageMS.read(uint2(int2(1, 2)), 2);
+    uImageArray.fence();
     float4 b = uImageArray.read(uint2(int3(1, 2, 4).xy), uint(int3(1, 2, 4).z));
     uImage.write(a, uint2(int2(2, 3)));
     uImageArray.write(b, uint2(int3(2, 3, 7).xy), uint(int3(2, 3, 7).z));

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -8686,7 +8686,7 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		}
 
 		// Metal requires explicit fences to break up RAW hazards, even within the same shader invocation
-		if (p_var && !has_decoration(p_var->self, DecorationNonWritable))
+		if (msl_options.readwrite_texture_fences && p_var && !has_decoration(p_var->self, DecorationNonWritable))
 			statement(to_expression(img_id), ".fence();");
 
 		emit_texture_op(instruction, false);

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -8675,15 +8675,19 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		// Mark that this shader reads from this image
 		uint32_t img_id = ops[2];
 		auto &type = expression_type(img_id);
+		auto *p_var = maybe_get_backing_variable(img_id);
 		if (type.image.dim != DimSubpassData)
 		{
-			auto *p_var = maybe_get_backing_variable(img_id);
 			if (p_var && has_decoration(p_var->self, DecorationNonReadable))
 			{
 				unset_decoration(p_var->self, DecorationNonReadable);
 				force_recompile();
 			}
 		}
+
+		// Metal requires explicit fences to break up RAW hazards, even within the same shader invocation
+		if (p_var && !has_decoration(p_var->self, DecorationNonWritable))
+			statement(to_expression(img_id), ".fence();");
 
 		emit_texture_op(instruction, false);
 		break;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -496,6 +496,12 @@ public:
 		// so it can be enabled only when the bug is present.
 		bool sample_dref_lod_array_as_grad = false;
 
+		// MSL doesn't guarantee coherence between writes and subsequent reads of read_write textures.
+		// This inserts fences before each read of a read_write texture to ensure coherency.
+		// If you're sure you never rely on this, you can set this to false for a possible performance improvement.
+		// Note: Only Apple's GPU compiler takes advantage of the lack of coherency, so make sure to test on Apple GPUs if you disable this.
+		bool readwrite_texture_fences = true;
+
 		bool is_ios() const
 		{
 			return platform == iOS;


### PR DESCRIPTION
MSL makes no guarantees on coherency of reads from textures, even if written earlier by the same thread.  This is isn't explicitly stated, but implied by section 6.12.17 of the [MSL spec](https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf), since the `fence()` method would be completely useless otherwise:
> The texture `fence()` member function ensures that writes to the texture by a thread become visible to subsequent reads from that texture by the same thread (the thread that is performing the write). Texture types (including texture buffers) that you can declare with the `access::read_write` attribute support the `Fence` function.

On the other hand, [GLSL makes stronger guarantees](https://www.khronos.org/opengl/wiki/Memory_Model#Incoherent_memory_access):
> If you perform an incoherent memory write, the value written will always be visible for reading. But only through that particular variable and only within the shader invocation that issued the write. You need not do anything special to make this happen. However, it is possible that, between writing and reading, another invocation may have stomped on that value. So long as that is not the case, reading it will produce the value you have written.

This is currently WIP pending the following things, which I'd like some input on:
- [ ] Adjust the pass to only add `fence()`s when needed (e.g. four reads in a row should only need one fence, and a shader that reads in the beginning and writes at the end should need no fences).
  - I'm not super familiar with writing optimization passes like this.  I was thinking something like this, but would like input on whether there's a better way of going about this
    1. Track three bits for each pair of (readwrite texture, block): input_clean, texture_used, output_clean
    2. Run over each block and set input_clean => true, texture_used => if any reads/writes are done to the texture and output_clean => false if the last action is a write
    3. For every block with output_clean == false, go to all its successors, set their input_clean to false, and if !texture_used, set their output_clean to false and add them to the processing list if it was previously true.
    4. Go through each block and use input_clean to mark the individual read operations as needing or not needing fences
- [x] Verify that SPIRV makes the same guarantees as GLSL.  I looked at the SPIRV spec, but couldn't find anything specific.  I'm also not very good at reading these kinds of spec documents.
- [ ] Maybe add tests to the Vulkan CTS?  I tried running `vk-default/glsl.txt` and `vk-default/image.txt`, and couldn't find any tests this fixes, are there any others I should try?  If there aren't any, is this something that should be added to the CTS?
