### PR TITLE
Static pkg-config support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,15 @@ set(spirv-cross-util-sources
 		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross_util.hpp)
 
 if (SPIRV_CROSS_STATIC)
+	set(SPIRV_CROSS_VERSION ${spirv-cross-abi-major}.${spirv-cross-abi-minor}.${spirv-cross-abi-patch})
+
+	if (NOT SPIRV_CROSS_SKIP_INSTALL)
+		configure_file(
+			${CMAKE_CURRENT_SOURCE_DIR}/pkg-config/spirv-cross-c.pc.in
+			${CMAKE_CURRENT_BINARY_DIR}/spirv-cross-c.pc @ONLY)
+		install(FILES ${CMAKE_CURRENT_BINARY_DIR}/spirv-cross-c.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+	endif()
+
 	spirv_cross_add_library(spirv-cross-core spirv_cross_core STATIC
 			${spirv-cross-core-sources})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,9 +242,12 @@ set(spirv-cross-util-sources
 		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross_util.cpp
 		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross_util.hpp)
 
-if (SPIRV_CROSS_STATIC)
-	set(SPIRV_CROSS_VERSION ${spirv-cross-abi-major}.${spirv-cross-abi-minor}.${spirv-cross-abi-patch})
+set(spirv-cross-abi-major 0)
+set(spirv-cross-abi-minor 56)
+set(spirv-cross-abi-patch 0)
+set(SPIRV_CROSS_VERSION ${spirv-cross-abi-major}.${spirv-cross-abi-minor}.${spirv-cross-abi-patch})
 
+if (SPIRV_CROSS_STATIC)
 	if (NOT SPIRV_CROSS_SKIP_INSTALL)
 		configure_file(
 			${CMAKE_CURRENT_SOURCE_DIR}/pkg-config/spirv-cross-c.pc.in
@@ -340,13 +343,7 @@ if (SPIRV_CROSS_STATIC)
 	endif()
 endif()
 
-set(spirv-cross-abi-major 0)
-set(spirv-cross-abi-minor 56)
-set(spirv-cross-abi-patch 0)
-
 if (SPIRV_CROSS_SHARED)
-	set(SPIRV_CROSS_VERSION ${spirv-cross-abi-major}.${spirv-cross-abi-minor}.${spirv-cross-abi-patch})
-
 	if (NOT SPIRV_CROSS_SKIP_INSTALL)
 		configure_file(
 			${CMAKE_CURRENT_SOURCE_DIR}/pkg-config/spirv-cross-c-shared.pc.in

--- a/pkg-config/spirv-cross-c.pc.in
+++ b/pkg-config/spirv-cross-c.pc.in
@@ -1,0 +1,16 @@
+# Copyright 2020-2021 Hans-Kristian Arntzen
+# SPDX-License-Identifier: Apache-2.0
+
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+sharedlibdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/spirv_cross
+
+Name: spirv-cross-c
+Description: C API for SPIRV-Cross
+Version: @SPIRV_CROSS_VERSION@
+
+Requires:
+Libs: -L${libdir} -L${sharedlibdir} -lspirv-cross-c
+Cflags: -I${includedir}


### PR DESCRIPTION
Addresses issue #2117 to the extent that a .pc file is created and installed for static builds.

I'm not sure if anything actually needs to be added to `Libs.private` or `Requires.private` to align with @kasper93's comment about `pkg-config --static`, as there's nothing in my build notes indicating I'd ever had to mess with those fields after-the-fact.  I was overly cautious about removing the `sharedlibdir` references in the static .pc.in template, so if those aren't needed, it's easy enough to remove them.