### PR TITLE
HLSL:  flip-vert-y support for mesh-shader

### DIFF
--- a/reference/shaders-hlsl/mesh/mesh-shader-basic-triangle.spv14.vk.nocompat.flip-vert-y.mesh
+++ b/reference/shaders-hlsl/mesh/mesh-shader-basic-triangle.spv14.vk.nocompat.flip-vert-y.mesh
@@ -1,0 +1,78 @@
+static const uint3 gl_WorkGroupSize = uint3(2u, 3u, 4u);
+
+struct BlockOut
+{
+    float4 a;
+    float4 b;
+};
+
+struct TaskPayload
+{
+    float a;
+    float b;
+    int c;
+};
+
+static uint3 gl_WorkGroupID;
+static uint3 gl_GlobalInvocationID;
+static uint gl_LocalInvocationIndex;
+struct SPIRV_Cross_Input
+{
+    uint3 gl_WorkGroupID : SV_GroupID;
+    uint3 gl_GlobalInvocationID : SV_DispatchThreadID;
+    uint gl_LocalInvocationIndex : SV_GroupIndex;
+};
+
+struct gl_MeshPerVertexEXT
+{
+    float4 vOut : TEXCOORD0;
+    BlockOut outputs : TEXCOORD2;
+    float4 gl_Position : SV_Position;
+    float gl_ClipDistance[1] : SV_ClipDistance;
+    float2 gl_CullDistance : SV_CullDistance;
+};
+
+struct gl_MeshPerPrimitiveEXT
+{
+};
+
+groupshared float shared_float[16];
+
+float4 spvFlipVertY(float4 v)
+{
+    return float4(v.x, -v.y, v.z, v.w);
+}
+
+float spvFlipVertY(float v)
+{
+    return -v;
+}
+
+void mesh_main(inout gl_MeshPerVertexEXT gl_MeshVerticesEXT[24], inout uint3 gl_PrimitiveTriangleIndicesEXT[22])
+{
+    SetMeshOutputCounts(24u, 22u);
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position = spvFlipVertY(float4(float3(gl_GlobalInvocationID), 1.0f));
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position.y = spvFlipVertY(float3(gl_WorkGroupID).x);
+    float3 _46 = float3(gl_GlobalInvocationID);
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position.x = _46.x;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position.z = _46.y;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position.w = _46.z;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_ClipDistance[0] = 4.0f;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[0] = 3.0f;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[1] = 5.0f;
+    GroupMemoryBarrierWithGroupSync();
+    if (gl_LocalInvocationIndex < 22u)
+    {
+        gl_PrimitiveTriangleIndicesEXT[gl_LocalInvocationIndex] = uint3(0u, 1u, 2u) + gl_LocalInvocationIndex.xxx;
+    }
+}
+
+[outputtopology("triangle")]
+[numthreads(2, 3, 4)]
+void main(SPIRV_Cross_Input stage_input, out vertices gl_MeshPerVertexEXT gl_MeshVerticesEXT[24], out indices uint3 gl_PrimitiveTriangleIndicesEXT[22])
+{
+    gl_WorkGroupID = stage_input.gl_WorkGroupID;
+    gl_GlobalInvocationID = stage_input.gl_GlobalInvocationID;
+    gl_LocalInvocationIndex = stage_input.gl_LocalInvocationIndex;
+    mesh_main(gl_MeshVerticesEXT, gl_PrimitiveTriangleIndicesEXT);
+}

--- a/shaders-hlsl/mesh/mesh-shader-basic-triangle.spv14.vk.nocompat.flip-vert-y.mesh
+++ b/shaders-hlsl/mesh/mesh-shader-basic-triangle.spv14.vk.nocompat.flip-vert-y.mesh
@@ -1,0 +1,50 @@
+#version 450
+#extension GL_EXT_mesh_shader : require
+layout(local_size_x = 2, local_size_y = 3, local_size_z = 4) in;
+layout(triangles, max_vertices = 24, max_primitives = 22) out;
+
+out gl_MeshPerVertexEXT
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+	float gl_ClipDistance[1];
+	float gl_CullDistance[2];
+} gl_MeshVerticesEXT[];
+
+layout(location = 0) out vec4 vOut[];
+
+layout(location = 2) out BlockOut
+{
+	vec4 a;
+	vec4 b;
+} outputs[];
+
+shared float shared_float[16];
+
+struct TaskPayload
+{
+	float a;
+	float b;
+	int c;
+};
+
+taskPayloadSharedEXT TaskPayload payload;
+
+void main()
+{
+	SetMeshOutputsEXT(24, 22);
+
+  gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position = vec4(gl_GlobalInvocationID, 1.0);
+  gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position.y = float(gl_WorkGroupID);
+  gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position.xzw = vec3(gl_GlobalInvocationID);
+
+	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_ClipDistance[0] = 4.0;
+	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[0] = 3.0;
+  gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[1] = 5.0;
+
+	barrier();
+	if (gl_LocalInvocationIndex < 22)
+  {
+    gl_PrimitiveTriangleIndicesEXT[gl_LocalInvocationIndex] = uvec3(0, 1, 2) + gl_LocalInvocationIndex;
+	}
+}

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -363,6 +363,7 @@ private:
 	void analyze_meshlet_writes();
 	void analyze_meshlet_writes(uint32_t func_id, uint32_t id_per_vertex, uint32_t id_per_primitive,
 	                            std::unordered_set<uint32_t> &processed_func_ids);
+	std::unordered_set<uint32_t> access_to_meshlet_position;
 
 	BitcastType get_bitcast_type(uint32_t result_type, uint32_t op0);
 

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -517,6 +517,8 @@ def cross_compile_hlsl(shader, spirv, opt, force_no_external_validation, iterati
         hlsl_args.append('--relax-nan-checks')
     if '.structured.' in shader:
         hlsl_args.append('--hlsl-preserve-structured-buffers')
+    if '.flip-vert-y.' in shader:
+        hlsl_args.append('--flip-vert-y')
 
     subprocess.check_call(hlsl_args)
 


### PR DESCRIPTION
This PR adds missing functionality to #1974

This PR tracks `OpAccessChain` that point to eider:
* `gl_MeshVerticesEXT[].gl_Position`
* `gl_MeshVerticesEXT[].gl_Position.y`

and wraps relevant stores with newly introduced function `spvFlipVertY`.
This is very different form usual flip-y, because `gl_Position` is write-only in spec
