### PR TITLE
Fixup check for SPVFuncImplVariableSizedDescriptor

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -7290,7 +7290,8 @@ void CompilerMSL::emit_custom_functions()
 			end_scope_decl();
 			statement("");
 
-			if (msl_options.runtime_array_rich_descriptor)
+			if (msl_options.runtime_array_rich_descriptor &&
+			    spv_function_implementations.count(SPVFuncImplVariableSizedDescriptor) != 0)
 			{
 				statement("template<typename T>");
 				statement("struct spvDescriptorArray<device T*>");


### PR DESCRIPTION
There is a code-gen error, If shader uses runtime-array of images + rich descriptors:
No need to emit wrapper for `spvDescriptorArray<spvBufferDescriptor>`, since there is no `spvBufferDescriptor`