### PR TITLE
Fix unroll, when storing to pointer to array

### DIFF
--- a/reference/shaders-hlsl/comp/ssbo-store-array.comp
+++ b/reference/shaders-hlsl/comp/ssbo-store-array.comp
@@ -1,0 +1,22 @@
+struct Data
+{
+    uint arr[3];
+};
+
+RWByteAddressBuffer _13 : register(u0);
+
+void comp_main()
+{
+    Data d1;
+    [unroll]
+    for (int _0ident = 0; _0ident < 3; _0ident++)
+    {
+        _13.Store(_0ident * 4 + 0, d1.arr[_0ident]);
+    }
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    comp_main();
+}

--- a/shaders-hlsl/comp/ssbo-store-array.comp
+++ b/shaders-hlsl/comp/ssbo-store-array.comp
@@ -1,0 +1,19 @@
+#version 460
+
+struct Data
+{
+    uint arr[3];
+};
+
+layout(set = 0, binding = 0, std430) buffer B0
+{
+    Data d[];
+};
+
+void main()
+{
+    Data d1;
+    d[0].arr = d1.arr;
+}
+
+

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -4696,7 +4696,12 @@ void CompilerHLSL::emit_load(const Instruction &instruction)
 void CompilerHLSL::write_access_chain_array(const SPIRAccessChain &chain, uint32_t value,
                                             const SmallVector<uint32_t> &composite_chain)
 {
-	auto &type = get<SPIRType>(chain.basetype);
+	auto *ptype = &get<SPIRType>(chain.basetype);
+	while (ptype->pointer)
+	{
+		ptype = &get<SPIRType>(ptype->basetype);
+	}
+	auto &type = *ptype;
 
 	// Need to use a reserved identifier here since it might shadow an identifier in the access chain input or other loops.
 	auto ident = get_unique_identifier();


### PR DESCRIPTION
Original code wasn't accounting for pointers, when unrolling types in `write_access_chain_array`
#fixed #2196