### PR TITLE
Improve CI build times

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         if: steps.cache-externals.outputs.cache-hit != 'true'
         shell: bash
         working-directory: ${{github.workspace}}
-        run: ./build_glslang_spirv_tools.sh Release
+        run: ./build_glslang_spirv_tools.sh Release 4
 
       - name: Configure SPIRV-Cross
         shell: bash
@@ -56,7 +56,7 @@ jobs:
         shell: bash
         working-directory: ${{github.workspace}}/build
         run: |
-          cmake --build . --config Release
+          cmake --build . --config Release --parallel 4
           cmake --build . --config Release --target install
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,12 +26,21 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Cache glslang / SPIRV-Tools
+        id: cache-externals
+        uses: actions/cache@v3
+        with:
+          path: external/*-build/output
+          key: ${{ matrix.platform }} externals ${{ hashFiles('checkout_glslang_spirv_tools.sh', 'build_glslang_spirv_tools.sh') }}
+
       - name: Pull glslang / SPIRV-Tools
+        if: steps.cache-externals.outputs.cache-hit != 'true'
         shell: bash
         working-directory: ${{github.workspace}}
         run: ./checkout_glslang_spirv_tools.sh
 
       - name: Build glslang / SPIRV-Tools
+        if: steps.cache-externals.outputs.cache-hit != 'true'
         shell: bash
         working-directory: ${{github.workspace}}
         run: ./build_glslang_spirv_tools.sh Release


### PR DESCRIPTION
- Caches externals so they don't get rebuilt every time
- Parallelizes build

macOS build time goes from 30m to 15m (no cache) / 7m (with cache)
In addition, when the cache is available, you should get feedback on compilation errors within a minute or so