### PR TITLE
Fix declaration of `gl_SampleMaskIn` in HLSL backend.

### DIFF
--- a/reference/opt/shaders-hlsl/frag/sample-mask-in-and-out.frag
+++ b/reference/opt/shaders-hlsl/frag/sample-mask-in-and-out.frag
@@ -1,5 +1,5 @@
-static int gl_SampleMaskIn;
-static int gl_SampleMask;
+static uint gl_SampleMaskIn[1];
+static uint gl_SampleMask[1];
 static float4 FragColor;
 
 struct SPIRV_Cross_Input
@@ -16,15 +16,15 @@ struct SPIRV_Cross_Output
 void frag_main()
 {
     FragColor = 1.0f.xxxx;
-    gl_SampleMask = gl_SampleMaskIn;
+    gl_SampleMask[0] = uint(gl_SampleMaskIn[0]);
 }
 
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
-    gl_SampleMaskIn = stage_input.gl_SampleMaskIn;
+    gl_SampleMaskIn[0] = stage_input.gl_SampleMaskIn;
     frag_main();
     SPIRV_Cross_Output stage_output;
-    stage_output.gl_SampleMask = gl_SampleMask;
+    stage_output.gl_SampleMask = gl_SampleMask[0];
     stage_output.FragColor = FragColor;
     return stage_output;
 }

--- a/reference/opt/shaders-hlsl/frag/sample-mask-in.frag
+++ b/reference/opt/shaders-hlsl/frag/sample-mask-in.frag
@@ -1,5 +1,5 @@
 static int gl_SampleID;
-static int gl_SampleMaskIn;
+static uint gl_SampleMaskIn[1];
 static float4 FragColor;
 
 struct SPIRV_Cross_Input
@@ -15,7 +15,7 @@ struct SPIRV_Cross_Output
 
 void frag_main()
 {
-    if ((gl_SampleMaskIn & (1 << gl_SampleID)) != 0)
+    if ((gl_SampleMaskIn[0] & (1 << gl_SampleID)) != 0)
     {
         FragColor = 1.0f.xxxx;
     }
@@ -24,7 +24,7 @@ void frag_main()
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
     gl_SampleID = stage_input.gl_SampleID;
-    gl_SampleMaskIn = stage_input.gl_SampleMaskIn;
+    gl_SampleMaskIn[0] = stage_input.gl_SampleMaskIn;
     frag_main();
     SPIRV_Cross_Output stage_output;
     stage_output.FragColor = FragColor;

--- a/reference/opt/shaders-hlsl/frag/sample-mask-out.frag
+++ b/reference/opt/shaders-hlsl/frag/sample-mask-out.frag
@@ -1,4 +1,4 @@
-static int gl_SampleMask;
+static uint gl_SampleMask[1];
 static float4 FragColor;
 
 struct SPIRV_Cross_Output
@@ -10,14 +10,14 @@ struct SPIRV_Cross_Output
 void frag_main()
 {
     FragColor = 1.0f.xxxx;
-    gl_SampleMask = 0;
+    gl_SampleMask[0] = uint(0);
 }
 
 SPIRV_Cross_Output main()
 {
     frag_main();
     SPIRV_Cross_Output stage_output;
-    stage_output.gl_SampleMask = gl_SampleMask;
+    stage_output.gl_SampleMask = gl_SampleMask[0];
     stage_output.FragColor = FragColor;
     return stage_output;
 }

--- a/reference/shaders-hlsl/frag/sample-mask-in-and-out.frag
+++ b/reference/shaders-hlsl/frag/sample-mask-in-and-out.frag
@@ -1,5 +1,5 @@
-static int gl_SampleMaskIn;
-static int gl_SampleMask;
+static uint gl_SampleMaskIn[1];
+static uint gl_SampleMask[1];
 static float4 FragColor;
 
 struct SPIRV_Cross_Input
@@ -16,15 +16,15 @@ struct SPIRV_Cross_Output
 void frag_main()
 {
     FragColor = 1.0f.xxxx;
-    gl_SampleMask = gl_SampleMaskIn;
+    gl_SampleMask[0] = uint(gl_SampleMaskIn[0]);
 }
 
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
-    gl_SampleMaskIn = stage_input.gl_SampleMaskIn;
+    gl_SampleMaskIn[0] = stage_input.gl_SampleMaskIn;
     frag_main();
     SPIRV_Cross_Output stage_output;
-    stage_output.gl_SampleMask = gl_SampleMask;
+    stage_output.gl_SampleMask = gl_SampleMask[0];
     stage_output.FragColor = FragColor;
     return stage_output;
 }

--- a/reference/shaders-hlsl/frag/sample-mask-in.frag
+++ b/reference/shaders-hlsl/frag/sample-mask-in.frag
@@ -1,5 +1,5 @@
 static int gl_SampleID;
-static int gl_SampleMaskIn;
+static uint gl_SampleMaskIn[1];
 static float4 FragColor;
 
 struct SPIRV_Cross_Input
@@ -15,7 +15,7 @@ struct SPIRV_Cross_Output
 
 void frag_main()
 {
-    if ((gl_SampleMaskIn & (1 << gl_SampleID)) != 0)
+    if ((gl_SampleMaskIn[0] & (1 << gl_SampleID)) != 0)
     {
         FragColor = 1.0f.xxxx;
     }
@@ -24,7 +24,7 @@ void frag_main()
 SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 {
     gl_SampleID = stage_input.gl_SampleID;
-    gl_SampleMaskIn = stage_input.gl_SampleMaskIn;
+    gl_SampleMaskIn[0] = stage_input.gl_SampleMaskIn;
     frag_main();
     SPIRV_Cross_Output stage_output;
     stage_output.FragColor = FragColor;

--- a/reference/shaders-hlsl/frag/sample-mask-out.frag
+++ b/reference/shaders-hlsl/frag/sample-mask-out.frag
@@ -1,4 +1,4 @@
-static int gl_SampleMask;
+static uint gl_SampleMask[1];
 static float4 FragColor;
 
 struct SPIRV_Cross_Output
@@ -10,14 +10,14 @@ struct SPIRV_Cross_Output
 void frag_main()
 {
     FragColor = 1.0f.xxxx;
-    gl_SampleMask = 0;
+    gl_SampleMask[0] = uint(0);
 }
 
 SPIRV_Cross_Output main()
 {
     frag_main();
     SPIRV_Cross_Output stage_output;
-    stage_output.gl_SampleMask = gl_SampleMask;
+    stage_output.gl_SampleMask = gl_SampleMask[0];
     stage_output.FragColor = FragColor;
     return stage_output;
 }

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -17718,6 +17718,25 @@ void CompilerGLSL::cast_from_variable_load(uint32_t source_id, std::string &expr
 		expr = bitcast_expression(expr_type, expected_type, expr);
 }
 
+SPIRType::BaseType CompilerGLSL::get_builtin_basetype(BuiltIn builtin, SPIRType::BaseType default_type)
+{
+	// TODO: Fill in for more builtins.
+	switch (builtin)
+	{
+	case BuiltInLayer:
+	case BuiltInPrimitiveId:
+	case BuiltInViewportIndex:
+	case BuiltInFragStencilRefEXT:
+	case BuiltInSampleMask:
+	case BuiltInPrimitiveShadingRateKHR:
+	case BuiltInShadingRateKHR:
+		return SPIRType::Int;
+
+	default:
+		return default_type;
+	}
+}
+
 void CompilerGLSL::cast_to_variable_store(uint32_t target_id, std::string &expr, const SPIRType &expr_type)
 {
 	auto *var = maybe_get_backing_variable(target_id);
@@ -17729,24 +17748,7 @@ void CompilerGLSL::cast_to_variable_store(uint32_t target_id, std::string &expr,
 		return;
 
 	auto builtin = static_cast<BuiltIn>(get_decoration(target_id, DecorationBuiltIn));
-	auto expected_type = expr_type.basetype;
-
-	// TODO: Fill in for more builtins.
-	switch (builtin)
-	{
-	case BuiltInLayer:
-	case BuiltInPrimitiveId:
-	case BuiltInViewportIndex:
-	case BuiltInFragStencilRefEXT:
-	case BuiltInSampleMask:
-	case BuiltInPrimitiveShadingRateKHR:
-	case BuiltInShadingRateKHR:
-		expected_type = SPIRType::Int;
-		break;
-
-	default:
-		break;
-	}
+	auto expected_type = get_builtin_basetype(builtin, expr_type.basetype);
 
 	if (expected_type != expr_type.basetype)
 	{

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -993,6 +993,7 @@ protected:
 	// Builtins in GLSL are always specific signedness, but the SPIR-V can declare them
 	// as either unsigned or signed.
 	// Sometimes we will need to automatically perform casts on load and store to make this work.
+	virtual SPIRType::BaseType get_builtin_basetype(spv::BuiltIn builtin, SPIRType::BaseType default_type);
 	virtual void cast_to_variable_store(uint32_t target_id, std::string &expr, const SPIRType &expr_type);
 	virtual void cast_from_variable_load(uint32_t source_id, std::string &expr, const SPIRType &expr_type);
 	void unroll_array_from_complex_load(uint32_t target_id, uint32_t source_id, std::string &expr);

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -126,7 +126,7 @@ public:
 		// By default, a readonly storage buffer will be declared as ByteAddressBuffer (SRV) instead.
 		// Alternatively, use set_hlsl_force_storage_buffer_as_uav to specify individually.
 		bool force_storage_buffer_as_uav = false;
-
+	
 		// Forces any storage image type marked as NonWritable to be considered an SRV instead.
 		// For this to work with function call parameters, NonWritable must be considered to be part of the type system
 		// so that NonWritable image arguments are also translated to Texture rather than RWTexture.
@@ -290,6 +290,8 @@ private:
 	const char *to_storage_qualifiers_glsl(const SPIRVariable &var) override;
 	void replace_illegal_names() override;
 
+	SPIRType::BaseType get_builtin_basetype(spv::BuiltIn builtin, SPIRType::BaseType default_type) override;
+
 	bool is_hlsl_force_storage_buffer_as_uav(ID id) const;
 
 	Options hlsl_options;
@@ -399,9 +401,6 @@ private:
 		bool explicit_binding = false;
 		bool used = false;
 	} base_vertex_info;
-
-	// Returns true for BuiltInSampleMask because gl_SampleMask[] is an array in SPIR-V, but SV_Coverage is a scalar in HLSL.
-	bool builtin_translates_to_nonarray(spv::BuiltIn builtin) const override;
 
 	// Returns true if the specified ID has a UserTypeGOOGLE decoration for StructuredBuffer or RWStructuredBuffer resources.
 	bool is_user_type_structured(uint32_t id) const override;


### PR DESCRIPTION
This might not be the right place, but I wanted to start with a proposal to fix an issue with the cross-compilation of `gl_SampleMask` (GLSL) to `SV_Coverage` (HLSL).

I saw that SPIRV-Cross is already handling the case that `gl_SampleMask` is an array of bits while the corresponding `SV_Coverage` in HLSL is a scalar bitmask. However, the necessary information for that built-in type gets lost in `OpLoad` instructions because that decoration is not propagated to the resulting variable. I am not sure if this solution would break other cases that need the built-in types. A better solution would probably be to mark such variables in how their underlying type has to be interpreted for non-GLSL backends instead of copying the built-in decoration.

The issue can be observed with this simple HLSL fragment shader, compile it with DXC, and compile it back to HLSL with SPIRV-Cross:
```hlsl
float4 PSMain(uint mask : SV_Coverage) : SV_Target {
  return (float4)mask;
}
```
Permalink on shader-playground: https://shader-playground.timjones.io/7131a3e1959885f2afb4b8f897dadc2b