### PR TITLE
Remove disabled MSVC warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ if (CMAKE_COMPILER_IS_GNUCXX OR ((${CMAKE_CXX_COMPILER_ID} MATCHES "Clang") AND 
 	endif()
 elseif (MSVC)
 	# AppVeyor spuriously fails in debug build on older MSVC without /bigobj.
-	set(spirv-compiler-options ${spirv-compiler-options} /wd4267 /wd4996 $<$<CONFIG:DEBUG>:/bigobj>)
+	set(spirv-compiler-options ${spirv-compiler-options} $<$<CONFIG:DEBUG>:/bigobj>)
 endif()
 
 macro(extract_headers out_abs file_list)


### PR DESCRIPTION
[BinSkim](https://github.com/microsoft/binskim) is flagging these warnings as problematic. They don't seem to need to be disabled anymore.