### PR TITLE
Remove disabled MSVC warnings and fix the warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ if (CMAKE_COMPILER_IS_GNUCXX OR ((${CMAKE_CXX_COMPILER_ID} MATCHES "Clang") AND 
 	endif()
 elseif (MSVC)
 	# AppVeyor spuriously fails in debug build on older MSVC without /bigobj.
-	set(spirv-compiler-options ${spirv-compiler-options} /wd4267 /wd4996 $<$<CONFIG:DEBUG>:/bigobj>)
+	set(spirv-compiler-options ${spirv-compiler-options} $<$<CONFIG:DEBUG>:/bigobj>)
 endif()
 
 macro(extract_headers out_abs file_list)

--- a/tests-other/c_api_test.c
+++ b/tests-other/c_api_test.c
@@ -183,7 +183,7 @@ int main(int argc, char **argv)
 		"EXT_second"
 	};
 
-	int ext_idx = 0;
+	size_t ext_idx = 0;
 	while (ext_idx < NUM_EXTS)
 	{
 		SPVC_CHECKED_CALL(spvc_compiler_require_extension(compiler_glsl, expected_exts[ext_idx]));
@@ -198,7 +198,7 @@ int main(int argc, char **argv)
 	compile(compiler_json, "JSON");
 	compile(compiler_cpp, "CPP");
 
-	int num_exts = spvc_compiler_get_num_required_extensions(compiler_glsl);
+	size_t num_exts = spvc_compiler_get_num_required_extensions(compiler_glsl);
 	if (num_exts != NUM_EXTS)
 	{
 		fprintf(stderr, "num_exts mismatch!\n");

--- a/tests-other/hlsl_resource_bindings.cpp
+++ b/tests-other/hlsl_resource_bindings.cpp
@@ -16,7 +16,16 @@
 static std::vector<SpvId> read_file(const char *path)
 {
 	long len;
+
+#ifdef _MSC_VER
+	FILE *file;
+	if (fopen_s(&file, path, "rb") == 0)
+	{
+		return;
+	}
+#else
 	FILE *file = fopen(path, "rb");
+#endif
 
 	if (!file)
 		return {};


### PR DESCRIPTION
[BinSkim](https://github.com/microsoft/binskim) is flagging these warnings as problematic as they may indicate security issues. This change includes fixes for the warnings.