### PR TITLE
MSL: Fix regression error in argument buffer runtime arrays.

### DIFF
--- a/reference/shaders-msl-no-opt/frag/ray-query-mutability.spv14.vk.msl24.frag
+++ b/reference/shaders-msl-no-opt/frag/ray-query-mutability.spv14.vk.msl24.frag
@@ -61,7 +61,7 @@ uint proceeFn(thread raytracing::intersection_query<raytracing::instancing, rayt
     return _50;
 }
 
-fragment void main0(, raytracing::acceleration_structure<raytracing::instancing> topLevelAS [[buffer(0)]])
+fragment void main0(raytracing::acceleration_structure<raytracing::instancing> topLevelAS [[buffer(0)]])
 {
     raytracing::intersection_query<raytracing::instancing, raytracing::triangle_data> rayQuery;
     initFn(rayQuery, topLevelAS);

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -970,6 +970,7 @@ protected:
 	void emit_specialization_constants_and_structs();
 	void emit_interface_block(uint32_t ib_var_id);
 	bool maybe_emit_array_assignment(uint32_t id_lhs, uint32_t id_rhs);
+	bool is_var_runtime_size_array(const SPIRVariable &var) const;
 	uint32_t get_resource_array_size(uint32_t id) const;
 
 	void fix_up_shader_inputs_outputs();


### PR DESCRIPTION
Argument buffers can contain multiple runtime arrays if they have fixed lengths as specified by the binding API. Regression error had assumed each runtime array is in separate argument buffer with undefined array length.

- Add `CompilerMSL::is_var_runtime_size_array()` to include test for setting of array length via `CompilerMSL::add_msl_resource_binding()`.

- Fixed unrelated test case MSL compile syntax failure when acceleration structure is the first entry point function argument (unrelated).

This has been tested in MoltenVK, but I couldn't think of a way of defining a SPRIV-Cross unit test for this, as it would involve calling `add_msl_resource_binding()` with some complex input.