### PR TITLE
Allow to customize float literals in output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.o
 *.d
 *.txt
+/build
 /test
 /spirv-cross
 /obj

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -295,6 +295,20 @@ inline std::string convert_to_string(double t, char locale_radix_point)
 	return buf;
 }
 
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+class FloatFormatter
+{
+public:
+	virtual ~FloatFormatter() = default;
+	virtual std::string format_float(float value) = 0;
+	virtual std::string format_double(double value) = 0;
+};
+
 template <typename T>
 struct ValueSaver
 {
@@ -317,12 +331,6 @@ struct ValueSaver
 	T &current;
 	T saved;
 };
-
-#if defined(__clang__) || defined(__GNUC__)
-#pragma GCC diagnostic pop
-#elif defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 
 struct Instruction
 {

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -5936,7 +5936,7 @@ string CompilerGLSL::convert_half_to_string(const SPIRConstant &c, uint32_t col,
 		type.basetype = SPIRType::Half;
 		type.vecsize = 1;
 		type.columns = 1;
-		res = join(type_to_glsl(type), "(", convert_to_string(float_value, current_locale_radix_character), ")");
+		res = join(type_to_glsl(type), "(", format_float(float_value), ")");
 	}
 
 	return res;
@@ -6004,7 +6004,7 @@ string CompilerGLSL::convert_float_to_string(const SPIRConstant &c, uint32_t col
 	}
 	else
 	{
-		res = convert_to_string(float_value, current_locale_radix_character);
+		res = format_float(float_value);
 		if (backend.float_literal_suffix)
 			res += "f";
 	}
@@ -6087,7 +6087,7 @@ std::string CompilerGLSL::convert_double_to_string(const SPIRConstant &c, uint32
 	}
 	else
 	{
-		res = convert_to_string(double_value, current_locale_radix_character);
+		res = format_double(double_value);
 		if (backend.double_literal_suffix)
 			res += "lf";
 	}
@@ -18643,3 +18643,22 @@ uint32_t CompilerGLSL::type_to_location_count(const SPIRType &type) const
 
 	return count;
 }
+
+std::string CompilerGLSL::format_float(float value) const
+{
+	if (float_formatter)
+		return float_formatter->format_float(value);
+
+	// default behavior
+	return convert_to_string(value, current_locale_radix_character);
+}
+
+std::string CompilerGLSL::format_double(double value) const
+{
+	if (float_formatter)
+		return float_formatter->format_double(value);
+
+	// default behavior
+	return convert_to_string(value, current_locale_radix_character);
+}
+

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -1039,7 +1039,7 @@ protected:
 	std::unordered_set<LocationComponentPair, InternalHasher> masked_output_locations;
 	std::unordered_set<uint32_t> masked_output_builtins;
 
-	FloatFormatter* float_formatter = nullptr;
+	FloatFormatter *float_formatter = nullptr;
 	std::string format_float(float value) const;
 	std::string format_double(double value) const;
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -289,8 +289,8 @@ public:
 
 	// Allow to control how to format float literals in the output.
 	// Set to "nullptr" to use the default "convert_to_string" function.
-	// It needs to ensure that the pointer is valid before the compiler object destructs.
-	void set_float_formatter(FloatFormatter* formatter)
+	// This handle is not owned by SPIRV-Cross and must remain valid until compile() has been called.
+	void set_float_formatter(FloatFormatter *formatter)
 	{
 		float_formatter = formatter;
 	}

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -287,6 +287,14 @@ public:
 	void mask_stage_output_by_location(uint32_t location, uint32_t component);
 	void mask_stage_output_by_builtin(spv::BuiltIn builtin);
 
+	// Allow to control how to format float literals in the output.
+	// Set to "nullptr" to use the default "convert_to_string" function.
+	// It needs to ensure that the pointer is valid before the compiler object destructs.
+	void set_float_formatter(FloatFormatter* formatter)
+	{
+		float_formatter = formatter;
+	}
+
 protected:
 	struct ShaderSubgroupSupportHelper
 	{
@@ -1030,6 +1038,10 @@ protected:
 	uint32_t get_declared_member_location(const SPIRVariable &var, uint32_t mbr_idx, bool strip_array) const;
 	std::unordered_set<LocationComponentPair, InternalHasher> masked_output_locations;
 	std::unordered_set<uint32_t> masked_output_builtins;
+
+	FloatFormatter* float_formatter = nullptr;
+	std::string format_float(float value) const;
+	std::string format_double(double value) const;
 
 private:
 	void init();

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1274,8 +1274,7 @@ void CompilerMSL::emit_entry_point_declarations()
 			args.push_back(join("max_anisotropy(", s.max_anisotropy, ")"));
 		if (s.lod_clamp_enable)
 		{
-			args.push_back(join("lod_clamp(", convert_to_string(s.lod_clamp_min, current_locale_radix_character), ", ",
-			                    convert_to_string(s.lod_clamp_max, current_locale_radix_character), ")"));
+			args.push_back(join("lod_clamp(", format_float(s.lod_clamp_min), ", ", format_float(s.lod_clamp_max), ")"));
 		}
 
 		// If we would emit no arguments, then omit the parentheses entirely. Otherwise,


### PR DESCRIPTION
This PR does not change the current behavior. It only works when invoking `set_float_formatter()` with initiative.

I use `std::shared_ptr` to store a `FloatFormatter` virtual base object, because it can use customized deleter (compare to `std::unique_ptr`). Would it be better to just use a raw pointer `FloatFormatter*` and require the user to keep it valid?

Related issues: #2132 #1599