### PR TITLE
MSL: Add divide to reserved function names.

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -14602,6 +14602,7 @@ const std::unordered_set<std::string> &CompilerMSL::get_illegal_func_names()
 		"assert",
 		"fmin3",
 		"fmax3",
+		"divide",
 		"VARIABLE_TRACEPOINT",
 		"STATIC_DATA_TRACEPOINT",
 		"STATIC_DATA_TRACEPOINT_V",


### PR DESCRIPTION
Fix #2228.

Blind fix, but it's so trivial.