### PR TITLE
MSL: Implement MSL 3.1 image atomics natively

### DIFF
--- a/reference/opt/shaders-msl/comp/atomic-image.comp
+++ b/reference/opt/shaders-msl/comp/atomic-image.comp
@@ -1,0 +1,75 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+// The required alignment of a linear texture of R32Uint format.
+constant uint spvLinearTextureAlignmentOverride [[function_constant(65535)]];
+constant uint spvLinearTextureAlignment = is_function_constant_defined(spvLinearTextureAlignmentOverride) ? spvLinearTextureAlignmentOverride : 4;
+// Returns buffer coords corresponding to 2D texture coords for emulating 2D texture atomics
+#define spvImage2DAtomicCoord(tc, tex) (((((tex).get_width() +  spvLinearTextureAlignment / 4 - 1) & ~( spvLinearTextureAlignment / 4 - 1)) * (tc).y) + (tc).x)
+
+struct SSBO
+{
+    uint u32;
+    int i32;
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
+
+kernel void main0(device SSBO& ssbo [[buffer(2)]], texture2d<uint> uImage [[texture(0)]], device atomic_uint* uImage_atomic [[buffer(0)]], texture2d<int, access::write> iImage [[texture(1)]], device atomic_int* iImage_atomic [[buffer(1)]])
+{
+    uint _19 = atomic_fetch_add_explicit((device atomic_uint*)&uImage_atomic[spvImage2DAtomicCoord(int2(1, 5), uImage)], 1u, memory_order_relaxed);
+    uint _27 = atomic_fetch_add_explicit((device atomic_uint*)&uImage_atomic[spvImage2DAtomicCoord(int2(1, 5), uImage)], 1u, memory_order_relaxed);
+    iImage.write(int4(int(_27)), uint2(int2(1, 6)));
+    uint _32 = atomic_fetch_or_explicit((device atomic_uint*)&uImage_atomic[spvImage2DAtomicCoord(int2(1, 5), uImage)], 1u, memory_order_relaxed);
+    uint _34 = atomic_fetch_xor_explicit((device atomic_uint*)&uImage_atomic[spvImage2DAtomicCoord(int2(1, 5), uImage)], 1u, memory_order_relaxed);
+    uint _36 = atomic_fetch_and_explicit((device atomic_uint*)&uImage_atomic[spvImage2DAtomicCoord(int2(1, 5), uImage)], 1u, memory_order_relaxed);
+    uint _38 = atomic_fetch_min_explicit((device atomic_uint*)&uImage_atomic[spvImage2DAtomicCoord(int2(1, 5), uImage)], 1u, memory_order_relaxed);
+    uint _40 = atomic_fetch_max_explicit((device atomic_uint*)&uImage_atomic[spvImage2DAtomicCoord(int2(1, 5), uImage)], 1u, memory_order_relaxed);
+    uint _44;
+    do
+    {
+        _44 = 10u;
+    } while (!atomic_compare_exchange_weak_explicit((device atomic_uint*)&uImage_atomic[spvImage2DAtomicCoord(int2(1, 5), uImage)], &_44, 2u, memory_order_relaxed, memory_order_relaxed) && _44 == 10u);
+    int _47 = atomic_fetch_add_explicit((device atomic_int*)&iImage_atomic[spvImage2DAtomicCoord(int2(1, 6), iImage)], 1, memory_order_relaxed);
+    int _49 = atomic_fetch_or_explicit((device atomic_int*)&iImage_atomic[spvImage2DAtomicCoord(int2(1, 6), iImage)], 1, memory_order_relaxed);
+    int _51 = atomic_fetch_xor_explicit((device atomic_int*)&iImage_atomic[spvImage2DAtomicCoord(int2(1, 6), iImage)], 1, memory_order_relaxed);
+    int _53 = atomic_fetch_and_explicit((device atomic_int*)&iImage_atomic[spvImage2DAtomicCoord(int2(1, 6), iImage)], 1, memory_order_relaxed);
+    int _55 = atomic_fetch_min_explicit((device atomic_int*)&iImage_atomic[spvImage2DAtomicCoord(int2(1, 6), iImage)], 1, memory_order_relaxed);
+    int _57 = atomic_fetch_max_explicit((device atomic_int*)&iImage_atomic[spvImage2DAtomicCoord(int2(1, 6), iImage)], 1, memory_order_relaxed);
+    int _61;
+    do
+    {
+        _61 = 10;
+    } while (!atomic_compare_exchange_weak_explicit((device atomic_int*)&iImage_atomic[spvImage2DAtomicCoord(int2(1, 5), iImage)], &_61, 2, memory_order_relaxed, memory_order_relaxed) && _61 == 10);
+    uint _68 = atomic_fetch_add_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _70 = atomic_fetch_or_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _72 = atomic_fetch_xor_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _74 = atomic_fetch_and_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _76 = atomic_fetch_min_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _78 = atomic_fetch_max_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _80 = atomic_exchange_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _82;
+    do
+    {
+        _82 = 10u;
+    } while (!atomic_compare_exchange_weak_explicit((device atomic_uint*)&ssbo.u32, &_82, 2u, memory_order_relaxed, memory_order_relaxed) && _82 == 10u);
+    int _85 = atomic_fetch_add_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _87 = atomic_fetch_or_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _89 = atomic_fetch_xor_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _91 = atomic_fetch_and_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _93 = atomic_fetch_min_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _95 = atomic_fetch_max_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _97 = atomic_exchange_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _99;
+    do
+    {
+        _99 = 10;
+    } while (!atomic_compare_exchange_weak_explicit((device atomic_int*)&ssbo.i32, &_99, 2, memory_order_relaxed, memory_order_relaxed) && _99 == 10);
+}
+

--- a/reference/opt/shaders-msl/comp/atomic-image.msl31.comp
+++ b/reference/opt/shaders-msl/comp/atomic-image.msl31.comp
@@ -1,0 +1,72 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct SSBO
+{
+    uint u32;
+    int i32;
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
+
+kernel void main0(device SSBO& ssbo [[buffer(0)]], texture2d<uint, access::read_write> uImage [[texture(0)]], texture2d<int, access::read_write> iImage [[texture(1)]])
+{
+    uint _19 = uImage.atomic_fetch_add(uint2(int2(1, 5)), 1u).x;
+    uint _27 = uImage.atomic_fetch_add(uint2(int2(1, 5)), 1u).x;
+    iImage.write(int4(int(_27)), uint2(int2(1, 6)));
+    uint _32 = uImage.atomic_fetch_or(uint2(int2(1, 5)), 1u).x;
+    uint _34 = uImage.atomic_fetch_xor(uint2(int2(1, 5)), 1u).x;
+    uint _36 = uImage.atomic_fetch_and(uint2(int2(1, 5)), 1u).x;
+    uint _38 = uImage.atomic_fetch_min(uint2(int2(1, 5)), 1u).x;
+    uint _40 = uImage.atomic_fetch_max(uint2(int2(1, 5)), 1u).x;
+    uint _44;
+    uint4 _102;
+    do
+    {
+        _102.x = 10u;
+    } while (!uImage.atomic_compare_exchange_weak(uint2(int2(1, 5)), &_102, 2u) && _102.x == 10u);
+    _44 = _102.x;
+    int _47 = iImage.atomic_fetch_add(uint2(int2(1, 6)), 1).x;
+    int _49 = iImage.atomic_fetch_or(uint2(int2(1, 6)), 1).x;
+    int _51 = iImage.atomic_fetch_xor(uint2(int2(1, 6)), 1).x;
+    int _53 = iImage.atomic_fetch_and(uint2(int2(1, 6)), 1).x;
+    int _55 = iImage.atomic_fetch_min(uint2(int2(1, 6)), 1).x;
+    int _57 = iImage.atomic_fetch_max(uint2(int2(1, 6)), 1).x;
+    int _61;
+    int4 _104;
+    do
+    {
+        _104.x = 10;
+    } while (!iImage.atomic_compare_exchange_weak(uint2(int2(1, 5)), &_104, 2) && _104.x == 10);
+    _61 = _104.x;
+    uint _68 = atomic_fetch_add_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _70 = atomic_fetch_or_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _72 = atomic_fetch_xor_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _74 = atomic_fetch_and_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _76 = atomic_fetch_min_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _78 = atomic_fetch_max_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _80 = atomic_exchange_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _82;
+    do
+    {
+        _82 = 10u;
+    } while (!atomic_compare_exchange_weak_explicit((device atomic_uint*)&ssbo.u32, &_82, 2u, memory_order_relaxed, memory_order_relaxed) && _82 == 10u);
+    int _85 = atomic_fetch_add_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _87 = atomic_fetch_or_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _89 = atomic_fetch_xor_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _91 = atomic_fetch_and_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _93 = atomic_fetch_min_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _95 = atomic_fetch_max_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _97 = atomic_exchange_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _99;
+    do
+    {
+        _99 = 10;
+    } while (!atomic_compare_exchange_weak_explicit((device atomic_int*)&ssbo.i32, &_99, 2, memory_order_relaxed, memory_order_relaxed) && _99 == 10);
+}
+

--- a/reference/opt/shaders-msl/frag/frag-discard-checks-continue-block.discard-checks.msl31.frag
+++ b/reference/opt/shaders-msl/frag/frag-discard-checks-continue-block.discard-checks.msl31.frag
@@ -1,0 +1,40 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct foo
+{
+    int x;
+};
+
+struct main0_out
+{
+    float4 fragColor [[color(0)]];
+};
+
+fragment main0_out main0(device foo& _24 [[buffer(0)]], float4 gl_FragCoord [[position]])
+{
+    main0_out out = {};
+    bool gl_HelperInvocation = {};
+    gl_HelperInvocation = simd_is_helper_thread();
+    if (gl_FragCoord.y == 7.0)
+    {
+        gl_HelperInvocation = true, discard_fragment();
+    }
+    if (!gl_HelperInvocation)
+    {
+        _24.x = 0;
+    }
+    for (; float(_24.x) < gl_FragCoord.x; )
+    {
+        if (!gl_HelperInvocation)
+        {
+            _24.x++;
+        }
+        continue;
+    }
+    out.fragColor = float4(float(_24.x), 0.0, 0.0, 1.0);
+    return out;
+}
+

--- a/reference/opt/shaders-msl/frag/frag-discard-checks.discard-checks.msl31.frag
+++ b/reference/opt/shaders-msl/frag/frag-discard-checks.discard-checks.msl31.frag
@@ -1,4 +1,3 @@
-#pragma clang diagnostic ignored "-Wmissing-prototypes"
 #pragma clang diagnostic ignored "-Wunused-variable"
 
 #include <metal_stdlib>
@@ -6,12 +5,6 @@
 #include <metal_atomic>
 
 using namespace metal;
-
-// The required alignment of a linear texture of R32Uint format.
-constant uint spvLinearTextureAlignmentOverride [[function_constant(65535)]];
-constant uint spvLinearTextureAlignment = is_function_constant_defined(spvLinearTextureAlignmentOverride) ? spvLinearTextureAlignmentOverride : 4;
-// Returns buffer coords corresponding to 2D texture coords for emulating 2D texture atomics
-#define spvImage2DAtomicCoord(tc, tex) (((((tex).get_width() +  spvLinearTextureAlignment / 4 - 1) & ~( spvLinearTextureAlignment / 4 - 1)) * (tc).y) + (tc).x)
 
 struct foo_t
 {
@@ -24,7 +17,7 @@ struct main0_out
     float4 fragColor [[color(0)]];
 };
 
-fragment main0_out main0(device foo_t& foo [[buffer(0)]], texture2d<uint, access::write> bar [[texture(0)]], device atomic_uint* bar_atomic [[buffer(1)]], float4 gl_FragCoord [[position]])
+fragment main0_out main0(device foo_t& foo [[buffer(0)]], texture2d<uint, access::read_write> bar [[texture(0)]], float4 gl_FragCoord [[position]])
 {
     main0_out out = {};
     bool gl_HelperInvocation = {};
@@ -41,18 +34,20 @@ fragment main0_out main0(device foo_t& foo [[buffer(0)]], texture2d<uint, access
     int2 _100 = int2(gl_FragCoord.xy);
     (gl_HelperInvocation ? ((void)0) : bar.write(uint4(1u), uint2(_100)));
     uint _102 = (!gl_HelperInvocation ? atomic_fetch_add_explicit((device atomic_uint*)&foo.y, 42u, memory_order_relaxed) : uint{});
-    uint _107 = (!gl_HelperInvocation ? atomic_fetch_or_explicit((device atomic_uint*)&bar_atomic[spvImage2DAtomicCoord(_100, bar)], 62u, memory_order_relaxed) : uint{});
+    uint _107 = (!gl_HelperInvocation ? bar.atomic_fetch_or(uint2(_100), 62u).x : uint{});
     uint _109 = (!gl_HelperInvocation ? atomic_fetch_and_explicit((device atomic_uint*)&foo.y, 65535u, memory_order_relaxed) : uint{});
     uint _111 = (!gl_HelperInvocation ? atomic_fetch_xor_explicit((device atomic_uint*)&foo.y, 4294967040u, memory_order_relaxed) : uint{});
     uint _113 = (!gl_HelperInvocation ? atomic_fetch_min_explicit((device atomic_uint*)&foo.y, 1u, memory_order_relaxed) : uint{});
-    uint _118 = (!gl_HelperInvocation ? atomic_fetch_max_explicit((device atomic_uint*)&bar_atomic[spvImage2DAtomicCoord(_100, bar)], 100u, memory_order_relaxed) : uint{});
+    uint _118 = (!gl_HelperInvocation ? bar.atomic_fetch_max(uint2(_100), 100u).x : uint{});
     uint _123;
+    uint4 _131;
     if (!gl_HelperInvocation)
     {
         do
         {
-            _123 = 100u;
-        } while (!atomic_compare_exchange_weak_explicit((device atomic_uint*)&bar_atomic[spvImage2DAtomicCoord(_100, bar)], &_123, 42u, memory_order_relaxed, memory_order_relaxed) && _123 == 100u);
+            _131.x = 100u;
+        } while (!bar.atomic_compare_exchange_weak(uint2(_100), &_131, 42u) && _131.x == 100u);
+        _123 = _131.x;
     }
     else
     {

--- a/reference/opt/shaders-msl/frag/pixel-interlock-ordered.msl31.argument.frag
+++ b/reference/opt/shaders-msl/frag/pixel-interlock-ordered.msl31.argument.frag
@@ -1,0 +1,45 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct Buffer3
+{
+    int baz;
+};
+
+struct Buffer
+{
+    int foo;
+    uint bar;
+};
+
+struct Buffer2
+{
+    uint quux;
+};
+
+struct spvDescriptorSetBuffer0
+{
+    device Buffer3* m_9 [[id(0)]];
+    texture2d<float, access::write> img4 [[id(1)]];
+    texture2d<float, access::write> img [[id(2), raster_order_group(0)]];
+    texture2d<float> img3 [[id(3), raster_order_group(0)]];
+    texture2d<uint, access::read_write> img2 [[id(4), raster_order_group(0)]];
+    volatile device Buffer* m_42 [[id(5), raster_order_group(0)]];
+    device Buffer2* m_52 [[id(6), raster_order_group(0)]];
+};
+
+fragment void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]])
+{
+    (*spvDescriptorSet0.m_9).baz = 0;
+    spvDescriptorSet0.img4.write(float4(1.0, 0.0, 0.0, 1.0), uint2(int2(1)));
+    spvDescriptorSet0.img.write(spvDescriptorSet0.img3.read(uint2(int2(0))), uint2(int2(0)));
+    uint _39 = spvDescriptorSet0.img2.atomic_fetch_add(uint2(int2(0)), 1u).x;
+    (*spvDescriptorSet0.m_42).foo += 42;
+    uint _55 = atomic_fetch_and_explicit((volatile device atomic_uint*)&(*spvDescriptorSet0.m_42).bar, (*spvDescriptorSet0.m_52).quux, memory_order_relaxed);
+}
+

--- a/reference/opt/shaders-msl/frag/pixel-interlock-ordered.msl31.frag
+++ b/reference/opt/shaders-msl/frag/pixel-interlock-ordered.msl31.frag
@@ -1,0 +1,34 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct Buffer3
+{
+    int baz;
+};
+
+struct Buffer
+{
+    int foo;
+    uint bar;
+};
+
+struct Buffer2
+{
+    uint quux;
+};
+
+fragment void main0(device Buffer3& _9 [[buffer(0)]], volatile device Buffer& _42 [[buffer(1), raster_order_group(0)]], device Buffer2& _52 [[buffer(2), raster_order_group(0)]], texture2d<float, access::write> img4 [[texture(0)]], texture2d<float, access::write> img [[texture(1), raster_order_group(0)]], texture2d<float> img3 [[texture(2), raster_order_group(0)]], texture2d<uint, access::read_write> img2 [[texture(3), raster_order_group(0)]])
+{
+    _9.baz = 0;
+    img4.write(float4(1.0, 0.0, 0.0, 1.0), uint2(int2(1)));
+    img.write(img3.read(uint2(int2(0))), uint2(int2(0)));
+    uint _39 = img2.atomic_fetch_add(uint2(int2(0)), 1u).x;
+    _42.foo += 42;
+    uint _55 = atomic_fetch_and_explicit((volatile device atomic_uint*)&_42.bar, _52.quux, memory_order_relaxed);
+}
+

--- a/reference/shaders-msl-no-opt/comp/image-array-atomic.msl31.comp
+++ b/reference/shaders-msl-no-opt/comp/image-array-atomic.msl31.comp
@@ -1,0 +1,19 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct PushConst
+{
+    uint texture0;
+};
+
+kernel void main0(constant PushConst& pc [[buffer(0)]], array<texture2d<uint, access::read_write>, 8> kTextures2D [[texture(0)]])
+{
+    uint _30 = kTextures2D[pc.texture0].atomic_fetch_add(uint2(int2(0)), 1u).x;
+    uint i = _30;
+}
+

--- a/reference/shaders-msl/comp/atomic-image.comp
+++ b/reference/shaders-msl/comp/atomic-image.comp
@@ -1,0 +1,75 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+// The required alignment of a linear texture of R32Uint format.
+constant uint spvLinearTextureAlignmentOverride [[function_constant(65535)]];
+constant uint spvLinearTextureAlignment = is_function_constant_defined(spvLinearTextureAlignmentOverride) ? spvLinearTextureAlignmentOverride : 4;
+// Returns buffer coords corresponding to 2D texture coords for emulating 2D texture atomics
+#define spvImage2DAtomicCoord(tc, tex) (((((tex).get_width() +  spvLinearTextureAlignment / 4 - 1) & ~( spvLinearTextureAlignment / 4 - 1)) * (tc).y) + (tc).x)
+
+struct SSBO
+{
+    uint u32;
+    int i32;
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
+
+kernel void main0(device SSBO& ssbo [[buffer(2)]], texture2d<uint> uImage [[texture(0)]], device atomic_uint* uImage_atomic [[buffer(0)]], texture2d<int, access::write> iImage [[texture(1)]], device atomic_int* iImage_atomic [[buffer(1)]])
+{
+    uint _19 = atomic_fetch_add_explicit((device atomic_uint*)&uImage_atomic[spvImage2DAtomicCoord(int2(1, 5), uImage)], 1u, memory_order_relaxed);
+    uint _27 = atomic_fetch_add_explicit((device atomic_uint*)&uImage_atomic[spvImage2DAtomicCoord(int2(1, 5), uImage)], 1u, memory_order_relaxed);
+    iImage.write(int4(int(_27)), uint2(int2(1, 6)));
+    uint _32 = atomic_fetch_or_explicit((device atomic_uint*)&uImage_atomic[spvImage2DAtomicCoord(int2(1, 5), uImage)], 1u, memory_order_relaxed);
+    uint _34 = atomic_fetch_xor_explicit((device atomic_uint*)&uImage_atomic[spvImage2DAtomicCoord(int2(1, 5), uImage)], 1u, memory_order_relaxed);
+    uint _36 = atomic_fetch_and_explicit((device atomic_uint*)&uImage_atomic[spvImage2DAtomicCoord(int2(1, 5), uImage)], 1u, memory_order_relaxed);
+    uint _38 = atomic_fetch_min_explicit((device atomic_uint*)&uImage_atomic[spvImage2DAtomicCoord(int2(1, 5), uImage)], 1u, memory_order_relaxed);
+    uint _40 = atomic_fetch_max_explicit((device atomic_uint*)&uImage_atomic[spvImage2DAtomicCoord(int2(1, 5), uImage)], 1u, memory_order_relaxed);
+    uint _44;
+    do
+    {
+        _44 = 10u;
+    } while (!atomic_compare_exchange_weak_explicit((device atomic_uint*)&uImage_atomic[spvImage2DAtomicCoord(int2(1, 5), uImage)], &_44, 2u, memory_order_relaxed, memory_order_relaxed) && _44 == 10u);
+    int _47 = atomic_fetch_add_explicit((device atomic_int*)&iImage_atomic[spvImage2DAtomicCoord(int2(1, 6), iImage)], 1, memory_order_relaxed);
+    int _49 = atomic_fetch_or_explicit((device atomic_int*)&iImage_atomic[spvImage2DAtomicCoord(int2(1, 6), iImage)], 1, memory_order_relaxed);
+    int _51 = atomic_fetch_xor_explicit((device atomic_int*)&iImage_atomic[spvImage2DAtomicCoord(int2(1, 6), iImage)], 1, memory_order_relaxed);
+    int _53 = atomic_fetch_and_explicit((device atomic_int*)&iImage_atomic[spvImage2DAtomicCoord(int2(1, 6), iImage)], 1, memory_order_relaxed);
+    int _55 = atomic_fetch_min_explicit((device atomic_int*)&iImage_atomic[spvImage2DAtomicCoord(int2(1, 6), iImage)], 1, memory_order_relaxed);
+    int _57 = atomic_fetch_max_explicit((device atomic_int*)&iImage_atomic[spvImage2DAtomicCoord(int2(1, 6), iImage)], 1, memory_order_relaxed);
+    int _61;
+    do
+    {
+        _61 = 10;
+    } while (!atomic_compare_exchange_weak_explicit((device atomic_int*)&iImage_atomic[spvImage2DAtomicCoord(int2(1, 5), iImage)], &_61, 2, memory_order_relaxed, memory_order_relaxed) && _61 == 10);
+    uint _68 = atomic_fetch_add_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _70 = atomic_fetch_or_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _72 = atomic_fetch_xor_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _74 = atomic_fetch_and_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _76 = atomic_fetch_min_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _78 = atomic_fetch_max_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _80 = atomic_exchange_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _82;
+    do
+    {
+        _82 = 10u;
+    } while (!atomic_compare_exchange_weak_explicit((device atomic_uint*)&ssbo.u32, &_82, 2u, memory_order_relaxed, memory_order_relaxed) && _82 == 10u);
+    int _85 = atomic_fetch_add_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _87 = atomic_fetch_or_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _89 = atomic_fetch_xor_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _91 = atomic_fetch_and_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _93 = atomic_fetch_min_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _95 = atomic_fetch_max_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _97 = atomic_exchange_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _99;
+    do
+    {
+        _99 = 10;
+    } while (!atomic_compare_exchange_weak_explicit((device atomic_int*)&ssbo.i32, &_99, 2, memory_order_relaxed, memory_order_relaxed) && _99 == 10);
+}
+

--- a/reference/shaders-msl/comp/atomic-image.msl31.comp
+++ b/reference/shaders-msl/comp/atomic-image.msl31.comp
@@ -1,0 +1,72 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct SSBO
+{
+    uint u32;
+    int i32;
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
+
+kernel void main0(device SSBO& ssbo [[buffer(0)]], texture2d<uint, access::read_write> uImage [[texture(0)]], texture2d<int, access::read_write> iImage [[texture(1)]])
+{
+    uint _19 = uImage.atomic_fetch_add(uint2(int2(1, 5)), 1u).x;
+    uint _27 = uImage.atomic_fetch_add(uint2(int2(1, 5)), 1u).x;
+    iImage.write(int4(int(_27)), uint2(int2(1, 6)));
+    uint _32 = uImage.atomic_fetch_or(uint2(int2(1, 5)), 1u).x;
+    uint _34 = uImage.atomic_fetch_xor(uint2(int2(1, 5)), 1u).x;
+    uint _36 = uImage.atomic_fetch_and(uint2(int2(1, 5)), 1u).x;
+    uint _38 = uImage.atomic_fetch_min(uint2(int2(1, 5)), 1u).x;
+    uint _40 = uImage.atomic_fetch_max(uint2(int2(1, 5)), 1u).x;
+    uint _44;
+    uint4 _102;
+    do
+    {
+        _102.x = 10u;
+    } while (!uImage.atomic_compare_exchange_weak(uint2(int2(1, 5)), &_102, 2u) && _102.x == 10u);
+    _44 = _102.x;
+    int _47 = iImage.atomic_fetch_add(uint2(int2(1, 6)), 1).x;
+    int _49 = iImage.atomic_fetch_or(uint2(int2(1, 6)), 1).x;
+    int _51 = iImage.atomic_fetch_xor(uint2(int2(1, 6)), 1).x;
+    int _53 = iImage.atomic_fetch_and(uint2(int2(1, 6)), 1).x;
+    int _55 = iImage.atomic_fetch_min(uint2(int2(1, 6)), 1).x;
+    int _57 = iImage.atomic_fetch_max(uint2(int2(1, 6)), 1).x;
+    int _61;
+    int4 _104;
+    do
+    {
+        _104.x = 10;
+    } while (!iImage.atomic_compare_exchange_weak(uint2(int2(1, 5)), &_104, 2) && _104.x == 10);
+    _61 = _104.x;
+    uint _68 = atomic_fetch_add_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _70 = atomic_fetch_or_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _72 = atomic_fetch_xor_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _74 = atomic_fetch_and_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _76 = atomic_fetch_min_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _78 = atomic_fetch_max_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _80 = atomic_exchange_explicit((device atomic_uint*)&ssbo.u32, 1u, memory_order_relaxed);
+    uint _82;
+    do
+    {
+        _82 = 10u;
+    } while (!atomic_compare_exchange_weak_explicit((device atomic_uint*)&ssbo.u32, &_82, 2u, memory_order_relaxed, memory_order_relaxed) && _82 == 10u);
+    int _85 = atomic_fetch_add_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _87 = atomic_fetch_or_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _89 = atomic_fetch_xor_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _91 = atomic_fetch_and_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _93 = atomic_fetch_min_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _95 = atomic_fetch_max_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _97 = atomic_exchange_explicit((device atomic_int*)&ssbo.i32, 1, memory_order_relaxed);
+    int _99;
+    do
+    {
+        _99 = 10;
+    } while (!atomic_compare_exchange_weak_explicit((device atomic_int*)&ssbo.i32, &_99, 2, memory_order_relaxed, memory_order_relaxed) && _99 == 10);
+}
+

--- a/reference/shaders-msl/frag/frag-demote-checks.discard-checks.msl31.frag
+++ b/reference/shaders-msl/frag/frag-demote-checks.discard-checks.msl31.frag
@@ -7,12 +7,6 @@
 
 using namespace metal;
 
-// The required alignment of a linear texture of R32Uint format.
-constant uint spvLinearTextureAlignmentOverride [[function_constant(65535)]];
-constant uint spvLinearTextureAlignment = is_function_constant_defined(spvLinearTextureAlignmentOverride) ? spvLinearTextureAlignmentOverride : 4;
-// Returns buffer coords corresponding to 2D texture coords for emulating 2D texture atomics
-#define spvImage2DAtomicCoord(tc, tex) (((((tex).get_width() +  spvLinearTextureAlignment / 4 - 1) & ~( spvLinearTextureAlignment / 4 - 1)) * (tc).y) + (tc).x)
-
 struct foo_t
 {
     float x;
@@ -25,7 +19,7 @@ struct main0_out
 };
 
 static inline __attribute__((always_inline))
-float4 frag_body(device foo_t& foo, thread float4& gl_FragCoord, texture2d<uint, access::write> bar, device atomic_uint* bar_atomic, thread bool& gl_HelperInvocation)
+float4 frag_body(device foo_t& foo, thread float4& gl_FragCoord, texture2d<uint, access::read_write> bar, thread bool& gl_HelperInvocation)
 {
     if (!gl_HelperInvocation)
     {
@@ -38,18 +32,20 @@ float4 frag_body(device foo_t& foo, thread float4& gl_FragCoord, texture2d<uint,
     }
     (gl_HelperInvocation ? ((void)0) : bar.write(uint4(1u), uint2(int2(gl_FragCoord.xy))));
     uint _50 = (!gl_HelperInvocation ? atomic_fetch_add_explicit((device atomic_uint*)&foo.y, 42u, memory_order_relaxed) : uint{});
-    uint _57 = (!gl_HelperInvocation ? atomic_fetch_or_explicit((device atomic_uint*)&bar_atomic[spvImage2DAtomicCoord(int2(gl_FragCoord.xy), bar)], 62u, memory_order_relaxed) : uint{});
+    uint _57 = (!gl_HelperInvocation ? bar.atomic_fetch_or(uint2(int2(gl_FragCoord.xy)), 62u).x : uint{});
     uint _60 = (!gl_HelperInvocation ? atomic_fetch_and_explicit((device atomic_uint*)&foo.y, 65535u, memory_order_relaxed) : uint{});
     uint _63 = (!gl_HelperInvocation ? atomic_fetch_xor_explicit((device atomic_uint*)&foo.y, 4294967040u, memory_order_relaxed) : uint{});
     uint _65 = (!gl_HelperInvocation ? atomic_fetch_min_explicit((device atomic_uint*)&foo.y, 1u, memory_order_relaxed) : uint{});
-    uint _71 = (!gl_HelperInvocation ? atomic_fetch_max_explicit((device atomic_uint*)&bar_atomic[spvImage2DAtomicCoord(int2(gl_FragCoord.xy), bar)], 100u, memory_order_relaxed) : uint{});
+    uint _71 = (!gl_HelperInvocation ? bar.atomic_fetch_max(uint2(int2(gl_FragCoord.xy)), 100u).x : uint{});
     uint _76;
+    uint4 _96;
     if (!gl_HelperInvocation)
     {
         do
         {
-            _76 = 100u;
-        } while (!atomic_compare_exchange_weak_explicit((device atomic_uint*)&bar_atomic[spvImage2DAtomicCoord(int2(gl_FragCoord.xy), bar)], &_76, 42u, memory_order_relaxed, memory_order_relaxed) && _76 == 100u);
+            _96.x = 100u;
+        } while (!bar.atomic_compare_exchange_weak(uint2(int2(gl_FragCoord.xy)), &_96, 42u) && _96.x == 100u);
+        _76 = _96.x;
     }
     else
     {
@@ -59,12 +55,12 @@ float4 frag_body(device foo_t& foo, thread float4& gl_FragCoord, texture2d<uint,
     return float4(1.0, float(_77), 0.0, 1.0);
 }
 
-fragment main0_out main0(device foo_t& foo [[buffer(0)]], texture2d<uint, access::write> bar [[texture(0)]], device atomic_uint* bar_atomic [[buffer(1)]], float4 gl_FragCoord [[position]])
+fragment main0_out main0(device foo_t& foo [[buffer(0)]], texture2d<uint, access::read_write> bar [[texture(0)]], float4 gl_FragCoord [[position]])
 {
     main0_out out = {};
     bool gl_HelperInvocation = {};
     gl_HelperInvocation = simd_is_helper_thread();
-    float4 _85 = frag_body(foo, gl_FragCoord, bar, bar_atomic, gl_HelperInvocation);
+    float4 _85 = frag_body(foo, gl_FragCoord, bar, gl_HelperInvocation);
     out.fragColor = _85;
     return out;
 }

--- a/reference/shaders-msl/frag/frag-discard-checks-continue-block.discard-checks.msl31.frag
+++ b/reference/shaders-msl/frag/frag-discard-checks-continue-block.discard-checks.msl31.frag
@@ -1,0 +1,49 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct foo
+{
+    int x;
+};
+
+struct main0_out
+{
+    float4 fragColor [[color(0)]];
+};
+
+fragment main0_out main0(device foo& _24 [[buffer(0)]], float4 gl_FragCoord [[position]])
+{
+    main0_out out = {};
+    bool gl_HelperInvocation = {};
+    gl_HelperInvocation = simd_is_helper_thread();
+    if (gl_FragCoord.y == 7.0)
+    {
+        gl_HelperInvocation = true, discard_fragment();
+    }
+    if (!gl_HelperInvocation)
+    {
+        _24.x = 0;
+    }
+    for (;;)
+    {
+        if (float(_24.x) < gl_FragCoord.x)
+        {
+            int _41 = _24.x;
+            int _43 = _41 + 1;
+            if (!gl_HelperInvocation)
+            {
+                _24.x = _43;
+            }
+            continue;
+        }
+        else
+        {
+            break;
+        }
+    }
+    out.fragColor = float4(float(_24.x), 0.0, 0.0, 1.0);
+    return out;
+}
+

--- a/reference/shaders-msl/frag/frag-discard-checks.discard-checks.msl23.frag
+++ b/reference/shaders-msl/frag/frag-discard-checks.discard-checks.msl23.frag
@@ -31,18 +31,18 @@ float4 frag_body(device foo_t& foo, thread float4& gl_FragCoord, texture2d<uint,
     {
         foo.x = 1.0;
     }
-    uint _25 = (!gl_HelperInvocation ? atomic_exchange_explicit((device atomic_uint*)&foo.y, 0u, memory_order_relaxed) : atomic_load_explicit((device atomic_uint*)&foo.y, memory_order_relaxed));
+    uint _25 = (!gl_HelperInvocation ? atomic_exchange_explicit((device atomic_uint*)&foo.y, 0u, memory_order_relaxed) : uint{});
     if (int(gl_FragCoord.x) == 3)
     {
         gl_HelperInvocation = true, discard_fragment();
     }
     (gl_HelperInvocation ? ((void)0) : bar.write(uint4(1u), uint2(int2(gl_FragCoord.xy))));
-    uint _51 = (!gl_HelperInvocation ? atomic_fetch_add_explicit((device atomic_uint*)&foo.y, 42u, memory_order_relaxed) : atomic_load_explicit((device atomic_uint*)&foo.y, memory_order_relaxed));
-    uint _58 = (!gl_HelperInvocation ? atomic_fetch_or_explicit((device atomic_uint*)&bar_atomic[spvImage2DAtomicCoord(int2(gl_FragCoord.xy), bar)], 62u, memory_order_relaxed) : atomic_load_explicit((device atomic_uint*)&bar_atomic[spvImage2DAtomicCoord(int2(gl_FragCoord.xy), bar)], memory_order_relaxed));
-    uint _61 = (!gl_HelperInvocation ? atomic_fetch_and_explicit((device atomic_uint*)&foo.y, 65535u, memory_order_relaxed) : atomic_load_explicit((device atomic_uint*)&foo.y, memory_order_relaxed));
-    uint _64 = (!gl_HelperInvocation ? atomic_fetch_xor_explicit((device atomic_uint*)&foo.y, 4294967040u, memory_order_relaxed) : atomic_load_explicit((device atomic_uint*)&foo.y, memory_order_relaxed));
-    uint _66 = (!gl_HelperInvocation ? atomic_fetch_min_explicit((device atomic_uint*)&foo.y, 1u, memory_order_relaxed) : atomic_load_explicit((device atomic_uint*)&foo.y, memory_order_relaxed));
-    uint _72 = (!gl_HelperInvocation ? atomic_fetch_max_explicit((device atomic_uint*)&bar_atomic[spvImage2DAtomicCoord(int2(gl_FragCoord.xy), bar)], 100u, memory_order_relaxed) : atomic_load_explicit((device atomic_uint*)&bar_atomic[spvImage2DAtomicCoord(int2(gl_FragCoord.xy), bar)], memory_order_relaxed));
+    uint _51 = (!gl_HelperInvocation ? atomic_fetch_add_explicit((device atomic_uint*)&foo.y, 42u, memory_order_relaxed) : uint{});
+    uint _58 = (!gl_HelperInvocation ? atomic_fetch_or_explicit((device atomic_uint*)&bar_atomic[spvImage2DAtomicCoord(int2(gl_FragCoord.xy), bar)], 62u, memory_order_relaxed) : uint{});
+    uint _61 = (!gl_HelperInvocation ? atomic_fetch_and_explicit((device atomic_uint*)&foo.y, 65535u, memory_order_relaxed) : uint{});
+    uint _64 = (!gl_HelperInvocation ? atomic_fetch_xor_explicit((device atomic_uint*)&foo.y, 4294967040u, memory_order_relaxed) : uint{});
+    uint _66 = (!gl_HelperInvocation ? atomic_fetch_min_explicit((device atomic_uint*)&foo.y, 1u, memory_order_relaxed) : uint{});
+    uint _72 = (!gl_HelperInvocation ? atomic_fetch_max_explicit((device atomic_uint*)&bar_atomic[spvImage2DAtomicCoord(int2(gl_FragCoord.xy), bar)], 100u, memory_order_relaxed) : uint{});
     uint _77;
     if (!gl_HelperInvocation)
     {
@@ -53,7 +53,7 @@ float4 frag_body(device foo_t& foo, thread float4& gl_FragCoord, texture2d<uint,
     }
     else
     {
-        _77 = atomic_load_explicit((device atomic_uint*)&bar_atomic[spvImage2DAtomicCoord(int2(gl_FragCoord.xy), bar)], memory_order_relaxed);
+        _77 = {};
     }
     return float4(1.0, 0.0, 0.0, 1.0);
 }

--- a/reference/shaders-msl/frag/frag-discard-checks.discard-checks.msl31.frag
+++ b/reference/shaders-msl/frag/frag-discard-checks.discard-checks.msl31.frag
@@ -1,0 +1,66 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct foo_t
+{
+    float x;
+    uint y;
+};
+
+struct main0_out
+{
+    float4 fragColor [[color(0)]];
+};
+
+static inline __attribute__((always_inline))
+float4 frag_body(device foo_t& foo, thread float4& gl_FragCoord, texture2d<uint, access::read_write> bar, thread bool& gl_HelperInvocation)
+{
+    if (!gl_HelperInvocation)
+    {
+        foo.x = 1.0;
+    }
+    uint _25 = (!gl_HelperInvocation ? atomic_exchange_explicit((device atomic_uint*)&foo.y, 0u, memory_order_relaxed) : uint{});
+    if (int(gl_FragCoord.x) == 3)
+    {
+        gl_HelperInvocation = true, discard_fragment();
+    }
+    (gl_HelperInvocation ? ((void)0) : bar.write(uint4(1u), uint2(int2(gl_FragCoord.xy))));
+    uint _51 = (!gl_HelperInvocation ? atomic_fetch_add_explicit((device atomic_uint*)&foo.y, 42u, memory_order_relaxed) : uint{});
+    uint _58 = (!gl_HelperInvocation ? bar.atomic_fetch_or(uint2(int2(gl_FragCoord.xy)), 62u).x : uint{});
+    uint _61 = (!gl_HelperInvocation ? atomic_fetch_and_explicit((device atomic_uint*)&foo.y, 65535u, memory_order_relaxed) : uint{});
+    uint _64 = (!gl_HelperInvocation ? atomic_fetch_xor_explicit((device atomic_uint*)&foo.y, 4294967040u, memory_order_relaxed) : uint{});
+    uint _66 = (!gl_HelperInvocation ? atomic_fetch_min_explicit((device atomic_uint*)&foo.y, 1u, memory_order_relaxed) : uint{});
+    uint _72 = (!gl_HelperInvocation ? bar.atomic_fetch_max(uint2(int2(gl_FragCoord.xy)), 100u).x : uint{});
+    uint _77;
+    uint4 _95;
+    if (!gl_HelperInvocation)
+    {
+        do
+        {
+            _95.x = 100u;
+        } while (!bar.atomic_compare_exchange_weak(uint2(int2(gl_FragCoord.xy)), &_95, 42u) && _95.x == 100u);
+        _77 = _95.x;
+    }
+    else
+    {
+        _77 = {};
+    }
+    return float4(1.0, 0.0, 0.0, 1.0);
+}
+
+fragment main0_out main0(device foo_t& foo [[buffer(0)]], texture2d<uint, access::read_write> bar [[texture(0)]], float4 gl_FragCoord [[position]])
+{
+    main0_out out = {};
+    bool gl_HelperInvocation = {};
+    gl_HelperInvocation = simd_is_helper_thread();
+    float4 _84 = frag_body(foo, gl_FragCoord, bar, gl_HelperInvocation);
+    out.fragColor = _84;
+    return out;
+}
+

--- a/reference/shaders-msl/frag/pixel-interlock-ordered.msl31.argument.frag
+++ b/reference/shaders-msl/frag/pixel-interlock-ordered.msl31.argument.frag
@@ -1,0 +1,45 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct Buffer3
+{
+    int baz;
+};
+
+struct Buffer
+{
+    int foo;
+    uint bar;
+};
+
+struct Buffer2
+{
+    uint quux;
+};
+
+struct spvDescriptorSetBuffer0
+{
+    device Buffer3* m_9 [[id(0)]];
+    texture2d<float, access::write> img4 [[id(1)]];
+    texture2d<float, access::write> img [[id(2), raster_order_group(0)]];
+    texture2d<float> img3 [[id(3), raster_order_group(0)]];
+    texture2d<uint, access::read_write> img2 [[id(4), raster_order_group(0)]];
+    volatile device Buffer* m_42 [[id(5), raster_order_group(0)]];
+    device Buffer2* m_52 [[id(6), raster_order_group(0)]];
+};
+
+fragment void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]])
+{
+    (*spvDescriptorSet0.m_9).baz = 0;
+    spvDescriptorSet0.img4.write(float4(1.0, 0.0, 0.0, 1.0), uint2(int2(1)));
+    spvDescriptorSet0.img.write(spvDescriptorSet0.img3.read(uint2(int2(0))), uint2(int2(0)));
+    uint _39 = spvDescriptorSet0.img2.atomic_fetch_add(uint2(int2(0)), 1u).x;
+    (*spvDescriptorSet0.m_42).foo += 42;
+    uint _55 = atomic_fetch_and_explicit((volatile device atomic_uint*)&(*spvDescriptorSet0.m_42).bar, (*spvDescriptorSet0.m_52).quux, memory_order_relaxed);
+}
+

--- a/reference/shaders-msl/frag/pixel-interlock-ordered.msl31.frag
+++ b/reference/shaders-msl/frag/pixel-interlock-ordered.msl31.frag
@@ -1,0 +1,34 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct Buffer3
+{
+    int baz;
+};
+
+struct Buffer
+{
+    int foo;
+    uint bar;
+};
+
+struct Buffer2
+{
+    uint quux;
+};
+
+fragment void main0(device Buffer3& _9 [[buffer(0)]], volatile device Buffer& _42 [[buffer(1), raster_order_group(0)]], device Buffer2& _52 [[buffer(2), raster_order_group(0)]], texture2d<float, access::write> img4 [[texture(0)]], texture2d<float, access::write> img [[texture(1), raster_order_group(0)]], texture2d<float> img3 [[texture(2), raster_order_group(0)]], texture2d<uint, access::read_write> img2 [[texture(3), raster_order_group(0)]])
+{
+    _9.baz = 0;
+    img4.write(float4(1.0, 0.0, 0.0, 1.0), uint2(int2(1)));
+    img.write(img3.read(uint2(int2(0))), uint2(int2(0)));
+    uint _39 = img2.atomic_fetch_add(uint2(int2(0)), 1u).x;
+    _42.foo += 42;
+    uint _55 = atomic_fetch_and_explicit((volatile device atomic_uint*)&_42.bar, _52.quux, memory_order_relaxed);
+}
+

--- a/shaders-msl-no-opt/comp/image-array-atomic.msl31.comp
+++ b/shaders-msl-no-opt/comp/image-array-atomic.msl31.comp
@@ -1,0 +1,14 @@
+#version 460
+#extension GL_EXT_buffer_reference : require
+#extension GL_EXT_nonuniform_qualifier : require
+
+layout (set = 0, binding = 0, r32ui) uniform uimage2D kTextures2D[8];
+
+layout(push_constant) uniform PushConst {
+  uint texture0;
+} pc;
+
+void main() {
+    uint i = imageAtomicAdd(kTextures2D[pc.texture0], ivec2(0, 0), 1);
+}
+

--- a/shaders-msl/comp/atomic-image.comp
+++ b/shaders-msl/comp/atomic-image.comp
@@ -1,0 +1,56 @@
+#version 310 es
+#extension GL_OES_shader_image_atomic : require
+layout(local_size_x = 1) in;
+
+layout(r32ui, binding = 0) uniform highp uimage2D uImage;
+layout(r32i, binding = 1) uniform highp iimage2D iImage;
+layout(binding = 2, std430) buffer SSBO
+{
+    uint u32;
+    int i32;
+} ssbo;
+
+void main()
+{
+    imageAtomicAdd(uImage, ivec2(1, 5), 1u);
+
+    // Test that we do not invalidate OpImage variables which are loaded from UniformConstant
+    // address space.
+    imageStore(iImage, ivec2(1, 6), ivec4(imageAtomicAdd(uImage, ivec2(1, 5), 1u)));
+
+    imageAtomicOr(uImage, ivec2(1, 5), 1u);
+    imageAtomicXor(uImage, ivec2(1, 5), 1u);
+    imageAtomicAnd(uImage, ivec2(1, 5), 1u);
+    imageAtomicMin(uImage, ivec2(1, 5), 1u);
+    imageAtomicMax(uImage, ivec2(1, 5), 1u);
+    //imageAtomicExchange(uImage, ivec2(1, 5), 1u);
+    imageAtomicCompSwap(uImage, ivec2(1, 5), 10u, 2u);
+
+    imageAtomicAdd(iImage, ivec2(1, 6), 1);
+    imageAtomicOr(iImage, ivec2(1, 6), 1);
+    imageAtomicXor(iImage, ivec2(1, 6), 1);
+    imageAtomicAnd(iImage, ivec2(1, 6), 1);
+    imageAtomicMin(iImage, ivec2(1, 6), 1);
+    imageAtomicMax(iImage, ivec2(1, 6), 1);
+    //imageAtomicExchange(iImage, ivec2(1, 5), 1u);
+    imageAtomicCompSwap(iImage, ivec2(1, 5), 10, 2);
+
+    atomicAdd(ssbo.u32, 1u);
+    atomicOr(ssbo.u32, 1u);
+    atomicXor(ssbo.u32, 1u);
+    atomicAnd(ssbo.u32, 1u);
+    atomicMin(ssbo.u32, 1u);
+    atomicMax(ssbo.u32, 1u);
+    atomicExchange(ssbo.u32, 1u);
+    atomicCompSwap(ssbo.u32, 10u, 2u);
+
+    atomicAdd(ssbo.i32, 1);
+    atomicOr(ssbo.i32, 1);
+    atomicXor(ssbo.i32, 1);
+    atomicAnd(ssbo.i32, 1);
+    atomicMin(ssbo.i32, 1);
+    atomicMax(ssbo.i32, 1);
+    atomicExchange(ssbo.i32, 1);
+    atomicCompSwap(ssbo.i32, 10, 2);
+}
+

--- a/shaders-msl/comp/atomic-image.msl31.comp
+++ b/shaders-msl/comp/atomic-image.msl31.comp
@@ -1,0 +1,56 @@
+#version 310 es
+#extension GL_OES_shader_image_atomic : require
+layout(local_size_x = 1) in;
+
+layout(r32ui, binding = 0) uniform highp uimage2D uImage;
+layout(r32i, binding = 1) uniform highp iimage2D iImage;
+layout(binding = 2, std430) buffer SSBO
+{
+    uint u32;
+    int i32;
+} ssbo;
+
+void main()
+{
+    imageAtomicAdd(uImage, ivec2(1, 5), 1u);
+
+    // Test that we do not invalidate OpImage variables which are loaded from UniformConstant
+    // address space.
+    imageStore(iImage, ivec2(1, 6), ivec4(imageAtomicAdd(uImage, ivec2(1, 5), 1u)));
+
+    imageAtomicOr(uImage, ivec2(1, 5), 1u);
+    imageAtomicXor(uImage, ivec2(1, 5), 1u);
+    imageAtomicAnd(uImage, ivec2(1, 5), 1u);
+    imageAtomicMin(uImage, ivec2(1, 5), 1u);
+    imageAtomicMax(uImage, ivec2(1, 5), 1u);
+    //imageAtomicExchange(uImage, ivec2(1, 5), 1u);
+    imageAtomicCompSwap(uImage, ivec2(1, 5), 10u, 2u);
+
+    imageAtomicAdd(iImage, ivec2(1, 6), 1);
+    imageAtomicOr(iImage, ivec2(1, 6), 1);
+    imageAtomicXor(iImage, ivec2(1, 6), 1);
+    imageAtomicAnd(iImage, ivec2(1, 6), 1);
+    imageAtomicMin(iImage, ivec2(1, 6), 1);
+    imageAtomicMax(iImage, ivec2(1, 6), 1);
+    //imageAtomicExchange(iImage, ivec2(1, 5), 1u);
+    imageAtomicCompSwap(iImage, ivec2(1, 5), 10, 2);
+
+    atomicAdd(ssbo.u32, 1u);
+    atomicOr(ssbo.u32, 1u);
+    atomicXor(ssbo.u32, 1u);
+    atomicAnd(ssbo.u32, 1u);
+    atomicMin(ssbo.u32, 1u);
+    atomicMax(ssbo.u32, 1u);
+    atomicExchange(ssbo.u32, 1u);
+    atomicCompSwap(ssbo.u32, 10u, 2u);
+
+    atomicAdd(ssbo.i32, 1);
+    atomicOr(ssbo.i32, 1);
+    atomicXor(ssbo.i32, 1);
+    atomicAnd(ssbo.i32, 1);
+    atomicMin(ssbo.i32, 1);
+    atomicMax(ssbo.i32, 1);
+    atomicExchange(ssbo.i32, 1);
+    atomicCompSwap(ssbo.i32, 10, 2);
+}
+

--- a/shaders-msl/frag/frag-demote-checks.discard-checks.msl31.frag
+++ b/shaders-msl/frag/frag-demote-checks.discard-checks.msl31.frag
@@ -1,0 +1,33 @@
+#version 450
+#extension GL_EXT_demote_to_helper_invocation : enable
+
+layout(set=0, binding=0, std430) buffer foo_t
+{
+	float x;
+	uint y;
+} foo;
+
+layout(r32ui, set=0, binding=1) uniform uimage2D bar;
+
+layout(location=0) out vec4 fragColor;
+
+vec4 frag_body() {
+	foo.x = 1.0f;
+	atomicExchange(foo.y, 0);
+	if (int(gl_FragCoord.x) == 3)
+		demote;
+	imageStore(bar, ivec2(gl_FragCoord.xy), uvec4(1));
+	atomicAdd(foo.y, 42);
+	imageAtomicOr(bar, ivec2(gl_FragCoord.xy), 0x3e);
+	atomicAnd(foo.y, 0xffff);
+	atomicXor(foo.y, 0xffffff00);
+	atomicMin(foo.y, 1);
+	imageAtomicMax(bar, ivec2(gl_FragCoord.xy), 100);
+	imageAtomicCompSwap(bar, ivec2(gl_FragCoord.xy), 100, 42);
+	return vec4(1.0f, float(helperInvocationEXT()), 0.0f, 1.0f);
+}
+
+void main() {
+	fragColor = frag_body();
+}
+

--- a/shaders-msl/frag/frag-discard-checks-continue-block.discard-checks.msl31.frag
+++ b/shaders-msl/frag/frag-discard-checks-continue-block.discard-checks.msl31.frag
@@ -1,0 +1,17 @@
+#version 450
+
+layout(binding=0, set=0, std430) buffer foo
+{
+	int x;
+};
+
+layout(location=0) out vec4 fragColor;
+
+void main(void)
+{
+	if (gl_FragCoord.y == 7)
+		discard;
+	for (x = 0; x < gl_FragCoord.x; ++x)
+		;
+	fragColor = vec4(x, 0, 0, 1);
+}

--- a/shaders-msl/frag/frag-discard-checks.discard-checks.msl31.frag
+++ b/shaders-msl/frag/frag-discard-checks.discard-checks.msl31.frag
@@ -1,0 +1,32 @@
+#version 450
+
+layout(set=0, binding=0, std430) buffer foo_t
+{
+	float x;
+	uint y;
+} foo;
+
+layout(r32ui, set=0, binding=1) uniform uimage2D bar;
+
+layout(location=0) out vec4 fragColor;
+
+vec4 frag_body() {
+	foo.x = 1.0f;
+	atomicExchange(foo.y, 0);
+	if (int(gl_FragCoord.x) == 3)
+		discard;
+	imageStore(bar, ivec2(gl_FragCoord.xy), uvec4(1));
+	atomicAdd(foo.y, 42);
+	imageAtomicOr(bar, ivec2(gl_FragCoord.xy), 0x3e);
+	atomicAnd(foo.y, 0xffff);
+	atomicXor(foo.y, 0xffffff00);
+	atomicMin(foo.y, 1);
+	imageAtomicMax(bar, ivec2(gl_FragCoord.xy), 100);
+	imageAtomicCompSwap(bar, ivec2(gl_FragCoord.xy), 100, 42);
+	return vec4(1.0f, 0.0f, 0.0f, 1.0f);
+}
+
+void main() {
+	fragColor = frag_body();
+}
+

--- a/shaders-msl/frag/pixel-interlock-ordered.msl31.argument.frag
+++ b/shaders-msl/frag/pixel-interlock-ordered.msl31.argument.frag
@@ -1,0 +1,36 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+
+layout(pixel_interlock_ordered) in;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+layout(binding = 2, rgba8) uniform readonly image2D img3;
+layout(binding = 3) coherent buffer Buffer
+{
+	int foo;
+	uint bar;
+};
+layout(binding = 4) buffer Buffer2
+{
+	uint quux;
+};
+
+layout(binding = 5, rgba8) uniform writeonly image2D img4;
+layout(binding = 6) buffer Buffer3
+{
+	int baz;
+};
+
+void main()
+{
+	// Deliberately outside the critical section to test usage tracking.
+	baz = 0;
+	imageStore(img4, ivec2(1, 1), vec4(1.0, 0.0, 0.0, 1.0));
+	beginInvocationInterlockARB();
+	imageStore(img, ivec2(0, 0), imageLoad(img3, ivec2(0, 0)));
+	imageAtomicAdd(img2, ivec2(0, 0), 1u);
+	foo += 42;
+	atomicAnd(bar, quux);
+	endInvocationInterlockARB();
+}

--- a/shaders-msl/frag/pixel-interlock-ordered.msl31.frag
+++ b/shaders-msl/frag/pixel-interlock-ordered.msl31.frag
@@ -1,0 +1,36 @@
+#version 450
+#extension GL_ARB_fragment_shader_interlock : require
+
+layout(pixel_interlock_ordered) in;
+
+layout(binding = 0, rgba8) uniform writeonly image2D img;
+layout(binding = 1, r32ui) uniform uimage2D img2;
+layout(binding = 2, rgba8) uniform readonly image2D img3;
+layout(binding = 3) coherent buffer Buffer
+{
+	int foo;
+	uint bar;
+};
+layout(binding = 4) buffer Buffer2
+{
+	uint quux;
+};
+
+layout(binding = 5, rgba8) uniform writeonly image2D img4;
+layout(binding = 6) buffer Buffer3
+{
+	int baz;
+};
+
+void main()
+{
+	// Deliberately outside the critical section to test usage tracking.
+	baz = 0;
+	imageStore(img4, ivec2(1, 1), vec4(1.0, 0.0, 0.0, 1.0));
+	beginInvocationInterlockARB();
+	imageStore(img, ivec2(0, 0), imageLoad(img3, ivec2(0, 0)));
+	imageAtomicAdd(img2, ivec2(0, 0), 1u);
+	foo += 42;
+	atomicAnd(bar, quux);
+	endInvocationInterlockARB();
+}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1923,6 +1923,9 @@ void CompilerMSL::extract_global_variables_from_function(uint32_t func_id, std::
 				auto *var = maybe_get_backing_variable(base_id);
 				if (var && atomic_image_vars_emulated.count(var->self))
 				{
+					if (!get<SPIRType>(var->basetype).array.empty())
+						SPIRV_CROSS_THROW("Cannot emulate array of storage images with atomics. Use MSL 3.1 for native support.");
+
 					if (global_var_ids.find(base_id) != global_var_ids.end())
 						added_arg_ids.insert(base_id);
 				}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1921,7 +1921,7 @@ void CompilerMSL::extract_global_variables_from_function(uint32_t func_id, std::
 				// When using the pointer, we need to know which variable it is actually loaded from.
 				uint32_t base_id = ops[2];
 				auto *var = maybe_get_backing_variable(base_id);
-				if (var && atomic_image_vars.count(var->self))
+				if (var && atomic_image_vars_emulated.count(var->self))
 				{
 					if (global_var_ids.find(base_id) != global_var_ids.end())
 						added_arg_ids.insert(base_id);
@@ -8756,7 +8756,7 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		uint32_t ptr = ops[2];
 		uint32_t mem_sem = ops[4];
 		uint32_t val = ops[5];
-		emit_atomic_func_op(result_type, id, "atomic_exchange_explicit", opcode, mem_sem, mem_sem, false, ptr, val);
+		emit_atomic_func_op(result_type, id, "atomic_exchange", opcode, mem_sem, mem_sem, false, ptr, val);
 		break;
 	}
 
@@ -8769,7 +8769,7 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		uint32_t mem_sem_fail = ops[5];
 		uint32_t val = ops[6];
 		uint32_t comp = ops[7];
-		emit_atomic_func_op(result_type, id, "atomic_compare_exchange_weak_explicit", opcode,
+		emit_atomic_func_op(result_type, id, "atomic_compare_exchange_weak", opcode,
 		                    mem_sem_pass, mem_sem_fail, true,
 		                    ptr, comp, true, false, val);
 		break;
@@ -8784,7 +8784,8 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		uint32_t id = ops[1];
 		uint32_t ptr = ops[2];
 		uint32_t mem_sem = ops[4];
-		emit_atomic_func_op(result_type, id, "atomic_load_explicit", opcode, mem_sem, mem_sem, false, ptr, 0);
+		check_atomic_image(ptr);
+		emit_atomic_func_op(result_type, id, "atomic_load", opcode, mem_sem, mem_sem, false, ptr, 0);
 		break;
 	}
 
@@ -8795,7 +8796,8 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		uint32_t ptr = ops[0];
 		uint32_t mem_sem = ops[2];
 		uint32_t val = ops[3];
-		emit_atomic_func_op(result_type, id, "atomic_store_explicit", opcode, mem_sem, mem_sem, false, ptr, val);
+		check_atomic_image(ptr);
+		emit_atomic_func_op(result_type, id, "atomic_store", opcode, mem_sem, mem_sem, false, ptr, val);
 		break;
 	}
 
@@ -8807,7 +8809,7 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		uint32_t ptr = ops[2];                                                                                   \
 		uint32_t mem_sem = ops[4];                                                                               \
 		uint32_t val = valsrc;                                                                                   \
-		emit_atomic_func_op(result_type, id, "atomic_fetch_" #op "_explicit", opcode,                            \
+		emit_atomic_func_op(result_type, id, "atomic_fetch_" #op, opcode,                                        \
 		                    mem_sem, mem_sem, false, ptr, val,                                                   \
 		                    false, valconst);                                                                    \
 	} while (false)
@@ -8885,7 +8887,7 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 	{
 		// When using the pointer, we need to know which variable it is actually loaded from.
 		auto *var = maybe_get_backing_variable(ops[2]);
-		if (var && atomic_image_vars.count(var->self))
+		if (var && atomic_image_vars_emulated.count(var->self))
 		{
 			uint32_t result_type = ops[0];
 			uint32_t id = ops[1];
@@ -8905,8 +8907,14 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		{
 			uint32_t result_type = ops[0];
 			uint32_t id = ops[1];
+
+			// Virtual expression. Split this up in the actual image atomic.
+			// In GLSL and HLSL we are able to resolve the dereference inline, but MSL has
+			// image.op(coord, ...) syntax.
 			auto &e =
-			    set<SPIRExpression>(id, join(to_expression(ops[2]), ", ", to_expression(ops[3])), result_type, true);
+				set<SPIRExpression>(id, join(to_expression(ops[2]), "@",
+				                             bitcast_expression(SPIRType::UInt, ops[3])),
+				                    result_type, true);
 
 			// When using the pointer, we need to know which variable it is actually loaded from.
 			e.loaded_from = var ? var->self : ID(0);
@@ -9915,6 +9923,12 @@ void CompilerMSL::emit_atomic_func_op(uint32_t result_type, uint32_t result_id, 
 	else if (opcode == OpAtomicSMax || opcode == OpAtomicSMin)
 		expected_type = to_signed_basetype(type.width);
 
+	bool use_native_image_atomic;
+	if (msl_options.supports_msl_version(3, 1))
+		use_native_image_atomic = check_atomic_image(obj);
+	else
+		use_native_image_atomic = false;
+
 	if (type.width == 64)
 		SPIRV_CROSS_THROW("MSL currently does not support 64-bit atomics.");
 
@@ -9932,12 +9946,31 @@ void CompilerMSL::emit_atomic_func_op(uint32_t result_type, uint32_t result_id, 
 	                     ((res_type.storage == StorageClassUniformConstant && res_type.basetype == SPIRType::Image) ||
 	                      var->storage == StorageClassStorageBuffer || var->storage == StorageClassUniform);
 
+	// Even compare exchange atomics are vec4 on metal for ... reasons :v
+	uint32_t vec4_temporary_id = 0;
+	if (use_native_image_atomic && is_atomic_compare_exchange_strong)
+	{
+		uint32_t &tmp_id = extra_sub_expressions[result_id];
+		if (!tmp_id)
+		{
+			tmp_id = ir.increase_bound_by(2);
+
+			auto vec4_type = get<SPIRType>(result_type);
+			vec4_type.vecsize = 4;
+			set<SPIRType>(tmp_id + 1, vec4_type);
+		}
+
+		vec4_temporary_id = tmp_id;
+	}
+
 	if (check_discard)
 	{
 		if (is_atomic_compare_exchange_strong)
 		{
 			// We're already emitting a CAS loop here; a conditional won't hurt.
 			emit_uninitialized_temporary_expression(result_type, result_id);
+			if (vec4_temporary_id)
+				emit_uninitialized_temporary_expression(vec4_temporary_id + 1, vec4_temporary_id);
 			statement("if (!", builtin_to_glsl(BuiltInHelperInvocation, StorageClassInput), ")");
 			begin_scope();
 		}
@@ -9945,131 +9978,132 @@ void CompilerMSL::emit_atomic_func_op(uint32_t result_type, uint32_t result_id, 
 			exp = join("(!", builtin_to_glsl(BuiltInHelperInvocation, StorageClassInput), " ? ");
 	}
 
-	exp += string(op) + "(";
-	exp += "(";
-	// Emulate texture2D atomic operations
-	if (res_type.storage == StorageClassUniformConstant && res_type.basetype == SPIRType::Image)
+	if (use_native_image_atomic)
 	{
-		exp += "device";
+		auto obj_expression = to_expression(obj);
+		auto split_index = obj_expression.find_first_of('@');
+
+		// Will only be false if we're in "force recompile later" mode.
+		if (split_index != string::npos)
+			exp += join(obj_expression.substr(0, split_index), ".", op, "(", obj_expression.substr(split_index + 1));
+		else
+			exp += obj_expression;
 	}
 	else
 	{
-		exp += get_argument_address_space(*var);
+		exp += string(op) + "_explicit(";
+		exp += "(";
+		// Emulate texture2D atomic operations
+		if (res_type.storage == StorageClassUniformConstant && res_type.basetype == SPIRType::Image)
+		{
+			exp += "device";
+		}
+		else
+		{
+			exp += get_argument_address_space(*var);
+		}
+
+		exp += " atomic_";
+		// For signed and unsigned min/max, we can signal this through the pointer type.
+		// There is no other way, since C++ does not have explicit signage for atomics.
+		exp += type_to_glsl(remapped_type);
+		exp += "*)";
+
+		exp += "&";
+		exp += to_enclosed_expression(obj);
 	}
-
-	exp += " atomic_";
-	// For signed and unsigned min/max, we can signal this through the pointer type.
-	// There is no other way, since C++ does not have explicit signage for atomics.
-	exp += type_to_glsl(remapped_type);
-	exp += "*)";
-
-	exp += "&";
-	exp += to_enclosed_expression(obj);
 
 	if (is_atomic_compare_exchange_strong)
 	{
-		assert(strcmp(op, "atomic_compare_exchange_weak_explicit") == 0);
+		assert(strcmp(op, "atomic_compare_exchange_weak") == 0);
 		assert(op2);
 		assert(has_mem_order_2);
 		exp += ", &";
-		exp += to_name(result_id);
+		exp += to_name(vec4_temporary_id ? vec4_temporary_id : result_id);
 		exp += ", ";
 		exp += to_expression(op2);
-		exp += ", ";
-		exp += get_memory_order(mem_order_1);
-		exp += ", ";
-		exp += get_memory_order(mem_order_2);
+
+		if (!use_native_image_atomic)
+		{
+			exp += ", ";
+			exp += get_memory_order(mem_order_1);
+			exp += ", ";
+			exp += get_memory_order(mem_order_2);
+		}
 		exp += ")";
 
 		// MSL only supports the weak atomic compare exchange, so emit a CAS loop here.
 		// The MSL function returns false if the atomic write fails OR the comparison test fails,
 		// so we must validate that it wasn't the comparison test that failed before continuing
 		// the CAS loop, otherwise it will loop infinitely, with the comparison test always failing.
-		// The function updates the comparitor value from the memory value, so the additional
+		// The function updates the comparator value from the memory value, so the additional
 		// comparison test evaluates the memory value against the expected value.
 		if (!check_discard)
+		{
 			emit_uninitialized_temporary_expression(result_type, result_id);
+			if (vec4_temporary_id)
+				emit_uninitialized_temporary_expression(vec4_temporary_id + 1, vec4_temporary_id);
+		}
+
 		statement("do");
 		begin_scope();
-		statement(to_name(result_id), " = ", to_expression(op1), ";");
-		end_scope_decl(join("while (!", exp, " && ", to_name(result_id), " == ", to_enclosed_expression(op1), ")"));
+
+		string scalar_expression;
+		if (vec4_temporary_id)
+			scalar_expression = join(to_expression(vec4_temporary_id), ".x");
+		else
+			scalar_expression = to_expression(result_id);
+
+		statement(scalar_expression, " = ", to_expression(op1), ";");
+		end_scope_decl(join("while (!", exp, " && ", scalar_expression, " == ", to_enclosed_expression(op1), ")"));
+		if (vec4_temporary_id)
+			statement(to_expression(result_id), " = ", scalar_expression, ";");
+
+		// Vulkan: (section 9.29: ...  and values returned by atomic instructions in helper invocations are undefined)
 		if (check_discard)
 		{
 			end_scope();
 			statement("else");
 			begin_scope();
-			exp = "atomic_load_explicit(";
-			exp += "(";
-			// Emulate texture2D atomic operations
-			if (res_type.storage == StorageClassUniformConstant && res_type.basetype == SPIRType::Image)
-				exp += "device";
-			else
-				exp += get_argument_address_space(*var);
-
-			exp += " atomic_";
-			exp += type_to_glsl(remapped_type);
-			exp += "*)";
-
-			exp += "&";
-			exp += to_enclosed_expression(obj);
-
-			if (has_mem_order_2)
-				exp += string(", ") + get_memory_order(mem_order_2);
-			else
-				exp += string(", ") + get_memory_order(mem_order_1);
-
-			exp += ")";
-
-			statement(to_name(result_id), " = ", exp, ";");
+			statement(to_expression(result_id), " = {};");
 			end_scope();
 		}
 	}
 	else
 	{
-		assert(strcmp(op, "atomic_compare_exchange_weak_explicit") != 0);
+		assert(strcmp(op, "atomic_compare_exchange_weak") != 0);
+
 		if (op1)
 		{
+			exp += ", ";
 			if (op1_is_literal)
-				exp += join(", ", op1);
+				exp += to_string(op1);
 			else
-				exp += ", " + bitcast_expression(expected_type, op1);
+				exp += bitcast_expression(expected_type, op1);
 		}
+
 		if (op2)
 			exp += ", " + to_expression(op2);
 
-		exp += string(", ") + get_memory_order(mem_order_1);
-		if (has_mem_order_2)
-			exp += string(", ") + get_memory_order(mem_order_2);
+		if (!use_native_image_atomic)
+		{
+			exp += string(", ") + get_memory_order(mem_order_1);
+			if (has_mem_order_2)
+				exp += string(", ") + get_memory_order(mem_order_2);
+		}
 
 		exp += ")";
 
+		// For some particular reason, atomics return vec4 in Metal ...
+		if (use_native_image_atomic)
+			exp += ".x";
+
+		// Vulkan: (section 9.29: ...  and values returned by atomic instructions in helper invocations are undefined)
 		if (check_discard)
 		{
 			exp += " : ";
-			if (strcmp(op, "atomic_store_explicit") != 0)
-			{
-				exp += "atomic_load_explicit(";
-				exp += "(";
-				// Emulate texture2D atomic operations
-				if (res_type.storage == StorageClassUniformConstant && res_type.basetype == SPIRType::Image)
-					exp += "device";
-				else
-					exp += get_argument_address_space(*var);
-
-				exp += " atomic_";
-				exp += type_to_glsl(remapped_type);
-				exp += "*)";
-
-				exp += "&";
-				exp += to_enclosed_expression(obj);
-
-				if (has_mem_order_2)
-					exp += string(", ") + get_memory_order(mem_order_2);
-				else
-					exp += string(", ") + get_memory_order(mem_order_1);
-
-				exp += ")";
-			}
+			if (strcmp(op, "atomic_store") != 0)
+				exp += join(type_to_glsl(get<SPIRType>(result_type)), "{}");
 			else
 				exp += "((void)0)";
 			exp += ")";
@@ -10078,7 +10112,7 @@ void CompilerMSL::emit_atomic_func_op(uint32_t result_type, uint32_t result_id, 
 		if (expected_type != type.basetype)
 			exp = bitcast_expression(type, expected_type, exp);
 
-		if (strcmp(op, "atomic_store_explicit") != 0)
+		if (strcmp(op, "atomic_store") != 0)
 			emit_op(result_type, result_id, exp, false);
 		else
 			statement(exp, ";");
@@ -11708,7 +11742,7 @@ string CompilerMSL::to_func_call_arg(const SPIRFunction::Parameter &arg, uint32_
 
 	// Emulate texture2D atomic operations
 	auto *backing_var = maybe_get_backing_variable(var_id);
-	if (backing_var && atomic_image_vars.count(backing_var->self))
+	if (backing_var && atomic_image_vars_emulated.count(backing_var->self))
 	{
 		arg_str += ", " + to_expression(var_id) + "_atomic";
 	}
@@ -13244,7 +13278,7 @@ void CompilerMSL::entry_point_args_discrete_descriptors(string &ep_args)
 
 			// Emulate texture2D atomic operations
 			uint32_t secondary_index = 0;
-			if (atomic_image_vars.count(var.self))
+			if (atomic_image_vars_emulated.count(var.self))
 			{
 				secondary_index = get_metal_resource_index(var, SPIRType::AtomicCounter, 0);
 			}
@@ -13434,7 +13468,7 @@ void CompilerMSL::entry_point_args_discrete_descriptors(string &ep_args)
 			}
 
 			// Emulate texture2D atomic operations
-			if (atomic_image_vars.count(var.self))
+			if (atomic_image_vars_emulated.count(var.self))
 			{
 				ep_args += ", device atomic_" + type_to_glsl(get<SPIRType>(basetype.image.type), 0);
 				ep_args += "* " + r.name + "_atomic";
@@ -14512,7 +14546,7 @@ string CompilerMSL::argument_decl(const SPIRFunction::Parameter &arg)
 
 	// Emulate texture2D atomic operations
 	auto *backing_var = maybe_get_backing_variable(name_id);
-	if (backing_var && atomic_image_vars.count(backing_var->self))
+	if (backing_var && atomic_image_vars_emulated.count(backing_var->self))
 	{
 		decl += ", device atomic_" + type_to_glsl(get<SPIRType>(var_type.image.type), 0);
 		decl += "* " + to_expression(name_id) + "_atomic";
@@ -16740,8 +16774,11 @@ bool CompilerMSL::OpCodePreprocessor::handle(Op opcode, const uint32_t *args, ui
 	// Emulate texture2D atomic operations
 	case OpImageTexelPointer:
 	{
-		auto *var = compiler.maybe_get_backing_variable(args[2]);
-		image_pointers[args[1]] = var ? var->self : ID(0);
+		if (!compiler.msl_options.supports_msl_version(3, 1))
+		{
+			auto *var = compiler.maybe_get_backing_variable(args[2]);
+			image_pointers_emulated[args[1]] = var ? var->self : ID(0);
+		}
 		break;
 	}
 
@@ -16771,11 +16808,11 @@ bool CompilerMSL::OpCodePreprocessor::handle(Op opcode, const uint32_t *args, ui
 	case OpAtomicXor:
 	{
 		uses_atomics = true;
-		auto it = image_pointers.find(args[2]);
-		if (it != image_pointers.end())
+		auto it = image_pointers_emulated.find(args[2]);
+		if (it != image_pointers_emulated.end())
 		{
 			uses_image_write = true;
-			compiler.atomic_image_vars.insert(it->second);
+			compiler.atomic_image_vars_emulated.insert(it->second);
 		}
 		else
 			check_resource_write(args[2]);
@@ -16785,10 +16822,10 @@ bool CompilerMSL::OpCodePreprocessor::handle(Op opcode, const uint32_t *args, ui
 	case OpAtomicStore:
 	{
 		uses_atomics = true;
-		auto it = image_pointers.find(args[0]);
-		if (it != image_pointers.end())
+		auto it = image_pointers_emulated.find(args[0]);
+		if (it != image_pointers_emulated.end())
 		{
-			compiler.atomic_image_vars.insert(it->second);
+			compiler.atomic_image_vars_emulated.insert(it->second);
 			uses_image_write = true;
 		}
 		else
@@ -16799,10 +16836,10 @@ bool CompilerMSL::OpCodePreprocessor::handle(Op opcode, const uint32_t *args, ui
 	case OpAtomicLoad:
 	{
 		uses_atomics = true;
-		auto it = image_pointers.find(args[2]);
-		if (it != image_pointers.end())
+		auto it = image_pointers_emulated.find(args[2]);
+		if (it != image_pointers_emulated.end())
 		{
-			compiler.atomic_image_vars.insert(it->second);
+			compiler.atomic_image_vars_emulated.insert(it->second);
 		}
 		break;
 	}
@@ -16982,8 +17019,8 @@ CompilerMSL::SPVFuncImpl CompilerMSL::OpCodePreprocessor::get_spv_func_impl(Op o
 	case OpAtomicLoad:
 	case OpAtomicStore:
 	{
-		auto it = image_pointers.find(args[opcode == OpAtomicStore ? 0 : 2]);
-		if (it != image_pointers.end())
+		auto it = image_pointers_emulated.find(args[opcode == OpAtomicStore ? 0 : 2]);
+		if (it != image_pointers_emulated.end())
 		{
 			uint32_t tid = compiler.get<SPIRVariable>(it->second).basetype;
 			if (tid && compiler.get<SPIRType>(tid).image.dim == Dim2D)
@@ -17632,7 +17669,7 @@ void CompilerMSL::analyze_argument_buffers()
 					{ &var, descriptor_alias, to_name(var_id), type.basetype, resource_index, 0 });
 
 				// Emulate texture2D atomic operations
-				if (atomic_image_vars.count(var.self))
+				if (atomic_image_vars_emulated.count(var.self))
 				{
 					uint32_t buffer_resource_index = get_metal_resource_index(var, SPIRType::AtomicCounter, 0);
 					resources_in_set[desc_set].push_back(
@@ -17871,7 +17908,7 @@ void CompilerMSL::analyze_argument_buffers()
 					buffer_type.member_types.push_back(get_variable_data_type_id(var));
 					set_qualified_name(var.self, join(to_name(buffer_variable_id), ".", mbr_name));
 				}
-				else if (atomic_image_vars.count(var.self))
+				else if (atomic_image_vars_emulated.count(var.self))
 				{
 					// Emulate texture2D atomic operations.
 					// Don't set the qualified name: it's already set for this variable,

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -1209,7 +1209,7 @@ protected:
 	std::unordered_set<uint32_t> buffers_requiring_array_length;
 	SmallVector<std::pair<uint32_t, uint32_t>> buffer_aliases_argument;
 	SmallVector<uint32_t> buffer_aliases_discrete;
-	std::unordered_set<uint32_t> atomic_image_vars; // Emulate texture2D atomic operations
+	std::unordered_set<uint32_t> atomic_image_vars_emulated; // Emulate texture2D atomic operations
 	std::unordered_set<uint32_t> pull_model_inputs;
 	std::unordered_set<uint32_t> recursive_inputs;
 
@@ -1279,7 +1279,7 @@ protected:
 
 		CompilerMSL &compiler;
 		std::unordered_map<uint32_t, uint32_t> result_types;
-		std::unordered_map<uint32_t, uint32_t> image_pointers; // Emulate texture2D atomic operations
+		std::unordered_map<uint32_t, uint32_t> image_pointers_emulated; // Emulate texture2D atomic operations
 		bool suppress_missing_prototypes = false;
 		bool uses_atomics = false;
 		bool uses_image_write = false;

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -123,10 +123,12 @@ def msl_compiler_supports_version(version):
         return False
 
 def path_to_msl_standard(shader):
-    if '.ios.' in shader:
-        if '.msl3.' in shader:
-            return '-std=metal3.0'
-        elif '.msl2.' in shader:
+    if '.msl31.' in shader:
+        return '-std=metal3.1'
+    elif '.msl3.' in shader:
+        return '-std=metal3.0'
+    elif '.ios.' in shader:
+        if '.msl2.' in shader:
             return '-std=ios-metal2.0'
         elif '.msl21.' in shader:
             return '-std=ios-metal2.1'
@@ -143,9 +145,7 @@ def path_to_msl_standard(shader):
         else:
             return '-std=ios-metal1.2'
     else:
-        if '.msl3.' in shader:
-            return '-std=metal3.0'
-        elif '.msl2.' in shader:
+        if '.msl2.' in shader:
             return '-std=macos-metal2.0'
         elif '.msl21.' in shader:
             return '-std=macos-metal2.1'
@@ -161,7 +161,9 @@ def path_to_msl_standard(shader):
             return '-std=macos-metal1.2'
 
 def path_to_msl_standard_cli(shader):
-    if '.msl3.' in shader:
+    if '.msl31.' in shader:
+        return '30100'
+    elif '.msl3.' in shader:
         return '30000'
     elif '.msl2.' in shader:
         return '20000'
@@ -1037,12 +1039,14 @@ def main():
     args.msl23 = False
     args.msl24 = False
     args.msl30 = False
+    args.msl31 = False
     if args.msl:
         print_msl_compiler_version()
         args.msl22 = msl_compiler_supports_version('-std=macos-metal2.2')
         args.msl23 = msl_compiler_supports_version('-std=macos-metal2.3')
         args.msl24 = msl_compiler_supports_version('-std=macos-metal2.4')
         args.msl30 = msl_compiler_supports_version('-std=metal3.0')
+        args.msl31 = msl_compiler_supports_version('-std=metal3.1')
 
     backend = 'glsl'
     if (args.msl or args.metal):

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -29,6 +29,7 @@ import codecs
 import json
 import multiprocessing
 import errno
+import platform
 from functools import partial
 
 class Paths():
@@ -100,8 +101,14 @@ def get_shader_stats(shader):
 
 def print_msl_compiler_version():
     try:
-        subprocess.check_call(['xcrun', '--sdk', 'iphoneos', 'metal', '--version'])
-        print('... are the Metal compiler characteristics.\n')   # display after so xcrun FNF is silent
+        if platform.system() == 'Darwin':
+            subprocess.check_call(['xcrun', '--sdk', 'iphoneos', 'metal', '--version'])
+            print('... are the Metal compiler characteristics.\n')   # display after so xcrun FNF is silent
+        else:
+            # Use Metal Windows toolkit to test on Linux (Wine) and Windows.
+            print('Running on non-macOS system.')
+            subprocess.check_call(['metal', '-x', 'metal', '--version'])
+
     except OSError as e:
         if (e.errno != errno.ENOENT):    # Ignore xcrun not found error
             raise
@@ -111,9 +118,13 @@ def print_msl_compiler_version():
 
 def msl_compiler_supports_version(version):
     try:
-        subprocess.check_call(['xcrun', '--sdk', 'macosx', 'metal', '-x', 'metal', version, '-'],
-            stdin = subprocess.DEVNULL, stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL)
-        print('Current SDK supports MSL {0}. Enabling validation for MSL {0} shaders.'.format(version))
+        if platform.system() == 'Darwin':
+            subprocess.check_call(['xcrun', '--sdk', 'macosx', 'metal', '-x', 'metal', version, '-'],
+                stdin = subprocess.DEVNULL, stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL)
+            print('Current SDK supports MSL {0}. Enabling validation for MSL {0} shaders.'.format(version))
+        else:
+            print('Running on {}, assuming {} is supported.'.format(platform.system(), version))
+        # If we're running on non-macOS system, assume it's supported.
         return True
     except OSError as e:
         print('Failed to check if MSL {} is not supported. It probably is not.'.format(version))
@@ -180,18 +191,30 @@ def path_to_msl_standard_cli(shader):
     else:
         return '10200'
 
+ignore_win_metal_tool = False
 def validate_shader_msl(shader, opt):
     msl_path = reference_path(shader[0], shader[1], opt)
+    global ignore_win_metal_tool
     try:
         if '.ios.' in msl_path:
             msl_os = 'iphoneos'
         else:
             msl_os = 'macosx'
-        subprocess.check_call(['xcrun', '--sdk', msl_os, 'metal', '-x', 'metal', path_to_msl_standard(msl_path), '-Werror', '-Wno-unused-variable', msl_path])
-        print('Compiled Metal shader: ' + msl_path)   # display after so xcrun FNF is silent
+
+        if platform.system() == 'Darwin':
+            subprocess.check_call(['xcrun', '--sdk', msl_os, 'metal', '-x', 'metal', path_to_msl_standard(msl_path), '-Werror', '-Wno-unused-variable', msl_path])
+            print('Compiled Metal shader: ' + msl_path)   # display after so xcrun FNF is silent
+        elif not ignore_win_metal_tool:
+            # Use Metal Windows toolkit to test on Linux (Wine) and Windows. Running offline tool on Linux gets weird.
+            # Normal winepath doesn't work, it must be Z:/abspath *exactly* for some bizarre reason.
+            target_path = msl_path if platform.system == 'Windows' else ('Z:' + os.path.abspath(msl_path))
+            subprocess.check_call(['metal', '-x', 'metal', path_to_msl_standard(msl_path), '-Werror', '-Wno-unused-variable', target_path])
+
     except OSError as oe:
-        if (oe.errno != errno.ENOENT):   # Ignore xcrun not found error
+        if (oe.errno != errno.ENOENT):   # Ignore xcrun or metal not found error
             raise
+        print('metal toolkit does not exist, ignoring further attempts to use it.')
+        ignore_win_metal_tool = True
     except subprocess.CalledProcessError:
         print('Error compiling Metal shader: ' + msl_path)
         raise RuntimeError('Failed to compile Metal shader')
@@ -882,10 +905,20 @@ def test_shader_msl(stats, shader, args, paths):
     # executable from Xcode using args: `--msl --entry main --output msl_path spirv_path`.
 #    print('SPRIV shader: ' + spirv)
 
-    shader_is_msl22 = 'msl22' in joined_path
-    shader_is_msl23 = 'msl23' in joined_path
-    shader_is_msl24 = 'msl24' in joined_path
-    skip_validation = (shader_is_msl22 and (not args.msl22)) or (shader_is_msl23 and (not args.msl23)) or (shader_is_msl24 and (not args.msl24))
+    shader_is_msl22 = '.msl22.' in joined_path
+    shader_is_msl23 = '.msl23.' in joined_path
+    shader_is_msl24 = '.msl24.' in joined_path
+    shader_is_msl30 = '.msl3.' in joined_path
+    shader_is_msl31 = '.msl31.' in joined_path
+    skip_validation = (shader_is_msl22 and (not args.msl22)) or \
+        (shader_is_msl23 and (not args.msl23)) or \
+        (shader_is_msl24 and (not args.msl24)) or \
+        (shader_is_msl30 and (not args.msl30)) or \
+        (shader_is_msl31 and (not args.msl31))
+
+    if skip_validation:
+        print('Skipping validation for {} due to lack of toolchain support.'.format(joined_path))
+
     if '.invalid.' in joined_path:
         skip_validation = True
 


### PR DESCRIPTION
Current CI does not have Metal 3.1 support, but I added support for testing against the Windows tooling, and it passes with that.

Fix #2212.