### PR TITLE
MSL: Fix patch vertex count with raw buffer tese input.

### DIFF
--- a/reference/opt/shaders-msl/tese/read-patch-vertices-in-func.raw-tess-in.tese
+++ b/reference/opt/shaders-msl/tese/read-patch-vertices-in-func.raw-tess-in.tese
@@ -1,0 +1,18 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+[[ patch(quad, 0) ]] vertex main0_out main0(uint gl_PrimitiveID [[patch_id]])
+{
+    main0_out out = {};
+    uint gl_PatchVerticesIn = 0;
+    out.gl_Position = float4(float(gl_PatchVerticesIn), 0.0, 0.0, 1.0);
+    return out;
+}
+

--- a/reference/opt/shaders/tese/read-patch-vertices-in-func.tese
+++ b/reference/opt/shaders/tese/read-patch-vertices-in-func.tese
@@ -1,0 +1,8 @@
+#version 450
+layout(quads, ccw, equal_spacing) in;
+
+void main()
+{
+    gl_Position = vec4(float(gl_PatchVerticesIn), 0.0, 0.0, 1.0);
+}
+

--- a/reference/shaders-msl/tese/read-patch-vertices-in-func.raw-tess-in.tese
+++ b/reference/shaders-msl/tese/read-patch-vertices-in-func.raw-tess-in.tese
@@ -1,0 +1,26 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+static inline __attribute__((always_inline))
+float4 read_patch_vertices(thread uint& gl_PatchVerticesIn)
+{
+    return float4(float(gl_PatchVerticesIn), 0.0, 0.0, 1.0);
+}
+
+[[ patch(quad, 0) ]] vertex main0_out main0(uint gl_PrimitiveID [[patch_id]])
+{
+    main0_out out = {};
+    uint gl_PatchVerticesIn = 0;
+    out.gl_Position = read_patch_vertices(gl_PatchVerticesIn);
+    return out;
+}
+

--- a/reference/shaders/tese/read-patch-vertices-in-func.tese
+++ b/reference/shaders/tese/read-patch-vertices-in-func.tese
@@ -1,0 +1,13 @@
+#version 450
+layout(quads, ccw, equal_spacing) in;
+
+vec4 read_patch_vertices()
+{
+    return vec4(float(gl_PatchVerticesIn), 0.0, 0.0, 1.0);
+}
+
+void main()
+{
+    gl_Position = read_patch_vertices();
+}
+

--- a/shaders-msl/tese/read-patch-vertices-in-func.raw-tess-in.tese
+++ b/shaders-msl/tese/read-patch-vertices-in-func.raw-tess-in.tese
@@ -1,0 +1,12 @@
+#version 450
+layout(quads) in;
+
+vec4 read_patch_vertices()
+{
+	return vec4(gl_PatchVerticesIn, 0, 0, 1);
+}
+
+void main()
+{
+	gl_Position = read_patch_vertices();
+}

--- a/shaders/tese/read-patch-vertices-in-func.tese
+++ b/shaders/tese/read-patch-vertices-in-func.tese
@@ -1,0 +1,12 @@
+#version 450
+layout(quads) in;
+
+vec4 read_patch_vertices()
+{
+	return vec4(gl_PatchVerticesIn, 0, 0, 1);
+}
+
+void main()
+{
+	gl_Position = read_patch_vertices();
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -9610,6 +9610,8 @@ string CompilerGLSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 		return "gl_TessLevelInner";
 	case BuiltInTessCoord:
 		return "gl_TessCoord";
+	case BuiltInPatchVertices:
+		return "gl_PatchVerticesIn";
 	case BuiltInFragCoord:
 		return "gl_FragCoord";
 	case BuiltInPointCoord:

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -13679,14 +13679,31 @@ void CompilerMSL::fix_up_shader_inputs_outputs()
 				break;
 			case BuiltInPatchVertices:
 				if (is_tese_shader())
-					entry_func.fixup_hooks_in.push_back([=]() {
-						statement(builtin_type_decl(bi_type), " ", to_expression(var_id), " = ",
-						          to_expression(patch_stage_in_var_id), ".gl_in.size();");
-					});
+				{
+					if (msl_options.raw_buffer_tese_input)
+					{
+						entry_func.fixup_hooks_in.push_back(
+						    [=]() {
+							    statement(builtin_type_decl(bi_type), " ", to_expression(var_id), " = ",
+							              get_entry_point().output_vertices, ";");
+						    });
+					}
+					else
+					{
+						entry_func.fixup_hooks_in.push_back(
+						    [=]()
+						    {
+							    statement(builtin_type_decl(bi_type), " ", to_expression(var_id), " = ",
+							              to_expression(patch_stage_in_var_id), ".gl_in.size();");
+						    });
+					}
+				}
 				else
+				{
 					entry_func.fixup_hooks_in.push_back([=]() {
 						statement(builtin_type_decl(bi_type), " ", to_expression(var_id), " = spvIndirectParams[0];");
 					});
+				}
 				break;
 			case BuiltInTessCoord:
 				if (get_entry_point().flags.get(ExecutionModeQuads))


### PR DESCRIPTION
We can no longer rely on the `patch_control_point<>` array being present, so the best we can do is use the value given us at compile time.

This was an oversight on my part when I initially implemented the raw-buffer tessellation evaluation input mode. The lack of tests for the `PatchVertices` built-in almost certainly contributed, so I fixed that in this patch.

Fixes the test
`dEQP-VK.tessellation.shader_input_output.patch_vertices_in_tes`. This is the last failing test under `dEQP-VK.tessellation`.