### PR TITLE
MSL: add ray-cull mask

### DIFF
--- a/reference/opt/shaders-msl/comp/ray-query.spv14.vk.ios.msl24..invalid.comp
+++ b/reference/opt/shaders-msl/comp/ray-query.spv14.vk.ios.msl24..invalid.comp
@@ -48,9 +48,9 @@ struct Params
 kernel void main0(constant Params& _18 [[buffer(1)]], raytracing::acceleration_structure<raytracing::instancing> AS0 [[buffer(0)]], raytracing::acceleration_structure<raytracing::instancing> AS1 [[buffer(2)]])
 {
     raytracing::intersection_query<raytracing::instancing, raytracing::triangle_data> q;
-    q.reset(ray(_18.origin, _18.dir, _18.tmin, _18.tmax), AS0, spvMakeIntersectionParams(_18.ray_flags));
+    q.reset(ray(_18.origin, _18.dir, _18.tmin, _18.tmax), AS0, _18.cull_mask, spvMakeIntersectionParams(_18.ray_flags));
     raytracing::intersection_query<raytracing::instancing, raytracing::triangle_data> q2[2];
-    q2[1].reset(ray(_18.origin, _18.dir, _18.tmin, _18.tmax), AS1, spvMakeIntersectionParams(_18.ray_flags));
+    q2[1].reset(ray(_18.origin, _18.dir, _18.tmin, _18.tmax), AS1, _18.cull_mask, spvMakeIntersectionParams(_18.ray_flags));
     bool _63 = q.next();
     bool res = _63;
     q2[0].abort();

--- a/reference/opt/shaders-msl/frag/ray-query-object-in-function.spv14.vk.msl24.frag
+++ b/reference/opt/shaders-msl/frag/ray-query-object-in-function.spv14.vk.msl24.frag
@@ -47,7 +47,7 @@ fragment main0_out main0(main0_in in [[stage_in]], raytracing::acceleration_stru
 {
     main0_out out = {};
     raytracing::intersection_query<raytracing::instancing, raytracing::triangle_data> rayQuery;
-    rayQuery.reset(ray(float3((in.inPos.xy * 4.0) - float2(2.0), 1.0), float3(0.0, 0.0, -1.0), 0.001000000047497451305389404296875, 2.0), topLevelAS, spvMakeIntersectionParams(4u));
+    rayQuery.reset(ray(float3((in.inPos.xy * 4.0) - float2(2.0), 1.0), float3(0.0, 0.0, -1.0), 0.001000000047497451305389404296875, 2.0), topLevelAS, 255u, spvMakeIntersectionParams(4u));
     for (;;)
     {
         bool _88 = rayQuery.next();

--- a/reference/opt/shaders-msl/frag/runtime_array_as_argument_buffer.msl3.argument-tier-1.rich-descriptor.frag
+++ b/reference/opt/shaders-msl/frag/runtime_array_as_argument_buffer.msl3.argument-tier-1.rich-descriptor.frag
@@ -139,7 +139,7 @@ fragment void main0(main0_in in [[stage_in]], const device spvBufferDescriptor<c
     {
         discard_fragment();
     }
-    rayQuery.reset(ray(float3(0.0), float3(1.0), 0.00999999977648258209228515625, 1.0), tlas[in.inputId], spvMakeIntersectionParams(0u));
+    rayQuery.reset(ray(float3(0.0), float3(1.0), 0.00999999977648258209228515625, 1.0), tlas[in.inputId], 255u, spvMakeIntersectionParams(0u));
     bool _301 = rayQuery.next();
     if (smp_textures[_231].sample(smp_texturesSmplr[_231], float2(0.0), level(0.0)).w > 0.5)
     {
@@ -153,7 +153,7 @@ fragment void main0(main0_in in [[stage_in]], const device spvBufferDescriptor<c
     {
         discard_fragment();
     }
-    rayQuery_1.reset(ray(float3(0.0), float3(1.0), 0.00999999977648258209228515625, 1.0), tlas[in.inputId], spvMakeIntersectionParams(0u));
+    rayQuery_1.reset(ray(float3(0.0), float3(1.0), 0.00999999977648258209228515625, 1.0), tlas[in.inputId], 255u, spvMakeIntersectionParams(0u));
     bool _336 = rayQuery_1.next();
 }
 

--- a/reference/shaders-msl-no-opt/frag/ray-query-mutability.spv14.vk.msl24.frag
+++ b/reference/shaders-msl-no-opt/frag/ray-query-mutability.spv14.vk.msl24.frag
@@ -39,7 +39,7 @@ void initFn(thread raytracing::intersection_query<raytracing::instancing, raytra
     float3 rayOrigin = float3(0.0, 0.0, 1.0);
     float3 rayDirection = float3(0.0, 0.0, -1.0);
     float rayDistance = 2.0;
-    rayQuery.reset(ray(rayOrigin, rayDirection, 0.001000000047497451305389404296875, rayDistance), topLevelAS, spvMakeIntersectionParams(4u));
+    rayQuery.reset(ray(rayOrigin, rayDirection, 0.001000000047497451305389404296875, rayDistance), topLevelAS, 255u, spvMakeIntersectionParams(4u));
 }
 
 static inline __attribute__((always_inline))

--- a/reference/shaders-msl/comp/ray-query.spv14.vk.ios.msl24..invalid.comp
+++ b/reference/shaders-msl/comp/ray-query.spv14.vk.ios.msl24..invalid.comp
@@ -48,9 +48,9 @@ struct Params
 kernel void main0(constant Params& _18 [[buffer(1)]], raytracing::acceleration_structure<raytracing::instancing> AS0 [[buffer(0)]], raytracing::acceleration_structure<raytracing::instancing> AS1 [[buffer(2)]])
 {
     raytracing::intersection_query<raytracing::instancing, raytracing::triangle_data> q;
-    q.reset(ray(_18.origin, _18.dir, _18.tmin, _18.tmax), AS0, spvMakeIntersectionParams(_18.ray_flags));
+    q.reset(ray(_18.origin, _18.dir, _18.tmin, _18.tmax), AS0, _18.cull_mask, spvMakeIntersectionParams(_18.ray_flags));
     raytracing::intersection_query<raytracing::instancing, raytracing::triangle_data> q2[2];
-    q2[1].reset(ray(_18.origin, _18.dir, _18.tmin, _18.tmax), AS1, spvMakeIntersectionParams(_18.ray_flags));
+    q2[1].reset(ray(_18.origin, _18.dir, _18.tmin, _18.tmax), AS1, _18.cull_mask, spvMakeIntersectionParams(_18.ray_flags));
     bool _63 = q.next();
     bool res = _63;
     q2[0].abort();

--- a/reference/shaders-msl/frag/ray-query-object-in-function.spv14.vk.msl24.frag
+++ b/reference/shaders-msl/frag/ray-query-object-in-function.spv14.vk.msl24.frag
@@ -46,7 +46,7 @@ struct main0_in
 static inline __attribute__((always_inline))
 uint doRay(thread const float3& rayOrigin, thread const float3& rayDirection, thread const float& rayDistance, thread raytracing::intersection_query<raytracing::instancing, raytracing::triangle_data>& rayQuery, const raytracing::acceleration_structure<raytracing::instancing> topLevelAS)
 {
-    rayQuery.reset(ray(rayOrigin, rayDirection, 0.001000000047497451305389404296875, rayDistance), topLevelAS, spvMakeIntersectionParams(4u));
+    rayQuery.reset(ray(rayOrigin, rayDirection, 0.001000000047497451305389404296875, rayDistance), topLevelAS, 255u, spvMakeIntersectionParams(4u));
     for (;;)
     {
         bool _36 = rayQuery.next();

--- a/reference/shaders-msl/frag/runtime_array_as_argument_buffer.msl3.argument-tier-1.rich-descriptor.frag
+++ b/reference/shaders-msl/frag/runtime_array_as_argument_buffer.msl3.argument-tier-1.rich-descriptor.frag
@@ -161,7 +161,7 @@ void implicit_image(thread uint& inputId, const spvDescriptorArray<texture2d<flo
 static inline __attribute__((always_inline))
 void implicit_tlas(thread uint& inputId, thread raytracing::intersection_query<raytracing::instancing, raytracing::triangle_data>& rayQuery, const spvDescriptorArray<raytracing::acceleration_structure<raytracing::instancing>> tlas)
 {
-    rayQuery.reset(ray(float3(0.0), float3(1.0), 0.00999999977648258209228515625, 1.0), tlas[inputId], spvMakeIntersectionParams(0u));
+    rayQuery.reset(ray(float3(0.0), float3(1.0), 0.00999999977648258209228515625, 1.0), tlas[inputId], 255u, spvMakeIntersectionParams(0u));
     bool _171 = rayQuery.next();
 }
 
@@ -198,7 +198,7 @@ void explicit_image(texture2d<float> tex)
 static inline __attribute__((always_inline))
 void explicit_tlas(const raytracing::acceleration_structure<raytracing::instancing> tlas, thread raytracing::intersection_query<raytracing::instancing, raytracing::triangle_data>& rayQuery_1)
 {
-    rayQuery_1.reset(ray(float3(0.0), float3(1.0), 0.00999999977648258209228515625, 1.0), tlas, spvMakeIntersectionParams(0u));
+    rayQuery_1.reset(ray(float3(0.0), float3(1.0), 0.00999999977648258209228515625, 1.0), tlas, 255u, spvMakeIntersectionParams(0u));
     bool _203 = rayQuery_1.next();
 }
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -9472,7 +9472,7 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		add_spv_func_and_recompile(SPVFuncImplRayQueryIntersectionParams);
 
 		statement(to_expression(ops[0]), ".reset(", "ray(", to_expression(ops[4]), ", ", to_expression(ops[6]), ", ",
-		          to_expression(ops[5]), ", ", to_expression(ops[7]), "), ", to_expression(ops[1]),
+		          to_expression(ops[5]), ", ", to_expression(ops[7]), "), ", to_expression(ops[1]), ", ", to_expression(ops[3]),
 		          ", spvMakeIntersectionParams(", to_expression(ops[2]), "));");
 		break;
 	}


### PR DESCRIPTION
Small PR. I think this is the last one for ray-query - now MSL has feature parity with spirv.