### PR TITLE
Add support for the SPV_QCOM_image_processing extension

### DIFF
--- a/reference/opt/shaders/frag/block-match-sad.frag
+++ b/reference/opt/shaders/frag/block-match-sad.frag
@@ -1,0 +1,26 @@
+#version 450
+#extension GL_QCOM_image_processing : require
+
+layout(binding = 4) uniform sampler2D target_samp;
+layout(binding = 5) uniform sampler2D ref_samp;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src1samp;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src2samp;
+
+layout(location = 0) in vec4 v_texcoord;
+layout(location = 0) out vec4 fragColor;
+
+void main()
+{
+    uvec2 tgt_coords;
+    tgt_coords.x = uint(v_texcoord.x);
+    tgt_coords.x = uint(v_texcoord.y);
+    uvec2 ref_coords;
+    ref_coords.x = uint(v_texcoord.z);
+    ref_coords.y = uint(v_texcoord.w);
+    uvec2 blockSize = uvec2(4u);
+    vec4 _59 = textureBlockMatchSADQCOM(SPIRV_Cross_Combinedtex2D_src1samp, tgt_coords, SPIRV_Cross_Combinedtex2D_src2samp, ref_coords, uvec2(4u));
+    fragColor = _59;
+    vec4 _68 = textureBlockMatchSADQCOM(target_samp, tgt_coords, ref_samp, ref_coords, uvec2(4u));
+    fragColor = _68;
+}
+

--- a/reference/opt/shaders/frag/block-match-ssd.frag
+++ b/reference/opt/shaders/frag/block-match-ssd.frag
@@ -1,0 +1,26 @@
+#version 450
+#extension GL_QCOM_image_processing : require
+
+layout(binding = 4) uniform sampler2D target_samp;
+layout(binding = 5) uniform sampler2D ref_samp;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src1samp;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src2samp;
+
+layout(location = 0) in vec4 v_texcoord;
+layout(location = 0) out vec4 fragColor;
+
+void main()
+{
+    uvec2 tgt_coords;
+    tgt_coords.x = uint(v_texcoord.x);
+    tgt_coords.x = uint(v_texcoord.y);
+    uvec2 ref_coords;
+    ref_coords.x = uint(v_texcoord.z);
+    ref_coords.y = uint(v_texcoord.w);
+    uvec2 blockSize = uvec2(4u);
+    vec4 _59 = textureBlockMatchSSDQCOM(SPIRV_Cross_Combinedtex2D_src1samp, tgt_coords, SPIRV_Cross_Combinedtex2D_src2samp, ref_coords, uvec2(4u));
+    fragColor = _59;
+    vec4 _68 = textureBlockMatchSSDQCOM(target_samp, tgt_coords, ref_samp, ref_coords, uvec2(4u));
+    fragColor = _68;
+}
+

--- a/reference/opt/shaders/frag/box-filter.frag
+++ b/reference/opt/shaders/frag/box-filter.frag
@@ -1,0 +1,18 @@
+#version 450
+#extension GL_QCOM_image_processing : require
+
+layout(binding = 4) uniform sampler2D tex_samp;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src1samp;
+
+layout(location = 0) out vec4 fragColor;
+layout(location = 0) in vec4 v_texcoord;
+
+void main()
+{
+    vec2 boxSize = vec2(2.5, 4.5);
+    vec4 _31 = textureBoxFilterQCOM(SPIRV_Cross_Combinedtex2D_src1samp, v_texcoord.xy, vec2(2.5, 4.5));
+    fragColor = _31;
+    vec4 _38 = textureBoxFilterQCOM(tex_samp, v_texcoord.xy, vec2(2.5, 4.5));
+    fragColor = _38;
+}
+

--- a/reference/opt/shaders/frag/sample-weighted.frag
+++ b/reference/opt/shaders/frag/sample-weighted.frag
@@ -1,0 +1,19 @@
+#version 450
+#extension GL_QCOM_image_processing : require
+
+layout(binding = 4) uniform sampler2D tex_samp;
+layout(binding = 5) uniform sampler2DArray tex_samp_array;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src1samp;
+uniform sampler2DArray SPIRV_Cross_Combinedtex2DArray_weightssamp;
+
+layout(location = 0) out vec4 fragColor;
+layout(location = 0) in vec4 v_texcoord;
+
+void main()
+{
+    vec4 _32 = textureWeightedQCOM(SPIRV_Cross_Combinedtex2D_src1samp, v_texcoord.xy, SPIRV_Cross_Combinedtex2DArray_weightssamp);
+    fragColor = _32;
+    vec4 _41 = textureWeightedQCOM(tex_samp, v_texcoord.xy, tex_samp_array);
+    fragColor = _41;
+}
+

--- a/reference/opt/shaders/vulkan/frag/block-match-sad.frag
+++ b/reference/opt/shaders/vulkan/frag/block-match-sad.frag
@@ -1,0 +1,26 @@
+#version 450
+#extension GL_QCOM_image_processing : require
+
+layout(binding = 4) uniform sampler2D target_samp;
+layout(binding = 5) uniform sampler2D ref_samp;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src1samp;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src2samp;
+
+layout(location = 0) in vec4 v_texcoord;
+layout(location = 0) out vec4 fragColor;
+
+void main()
+{
+    uvec2 tgt_coords;
+    tgt_coords.x = uint(v_texcoord.x);
+    tgt_coords.x = uint(v_texcoord.y);
+    uvec2 ref_coords;
+    ref_coords.x = uint(v_texcoord.z);
+    ref_coords.y = uint(v_texcoord.w);
+    uvec2 blockSize = uvec2(4u);
+    vec4 _59 = textureBlockMatchSADQCOM(SPIRV_Cross_Combinedtex2D_src1samp, tgt_coords, SPIRV_Cross_Combinedtex2D_src2samp, ref_coords, uvec2(4u));
+    fragColor = _59;
+    vec4 _68 = textureBlockMatchSADQCOM(target_samp, tgt_coords, ref_samp, ref_coords, uvec2(4u));
+    fragColor = _68;
+}
+

--- a/reference/opt/shaders/vulkan/frag/block-match-ssd.frag
+++ b/reference/opt/shaders/vulkan/frag/block-match-ssd.frag
@@ -1,0 +1,26 @@
+#version 450
+#extension GL_QCOM_image_processing : require
+
+layout(binding = 4) uniform sampler2D target_samp;
+layout(binding = 5) uniform sampler2D ref_samp;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src1samp;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src2samp;
+
+layout(location = 0) in vec4 v_texcoord;
+layout(location = 0) out vec4 fragColor;
+
+void main()
+{
+    uvec2 tgt_coords;
+    tgt_coords.x = uint(v_texcoord.x);
+    tgt_coords.x = uint(v_texcoord.y);
+    uvec2 ref_coords;
+    ref_coords.x = uint(v_texcoord.z);
+    ref_coords.y = uint(v_texcoord.w);
+    uvec2 blockSize = uvec2(4u);
+    vec4 _59 = textureBlockMatchSSDQCOM(SPIRV_Cross_Combinedtex2D_src1samp, tgt_coords, SPIRV_Cross_Combinedtex2D_src2samp, ref_coords, uvec2(4u));
+    fragColor = _59;
+    vec4 _68 = textureBlockMatchSSDQCOM(target_samp, tgt_coords, ref_samp, ref_coords, uvec2(4u));
+    fragColor = _68;
+}
+

--- a/reference/opt/shaders/vulkan/frag/box-filter.frag
+++ b/reference/opt/shaders/vulkan/frag/box-filter.frag
@@ -1,0 +1,18 @@
+#version 450
+#extension GL_QCOM_image_processing : require
+
+layout(binding = 4) uniform sampler2D tex_samp;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src1samp;
+
+layout(location = 0) out vec4 fragColor;
+layout(location = 0) in vec4 v_texcoord;
+
+void main()
+{
+    vec2 boxSize = vec2(2.5, 4.5);
+    vec4 _31 = textureBoxFilterQCOM(SPIRV_Cross_Combinedtex2D_src1samp, v_texcoord.xy, vec2(2.5, 4.5));
+    fragColor = _31;
+    vec4 _38 = textureBoxFilterQCOM(tex_samp, v_texcoord.xy, vec2(2.5, 4.5));
+    fragColor = _38;
+}
+

--- a/reference/opt/shaders/vulkan/frag/sample-weighted.frag
+++ b/reference/opt/shaders/vulkan/frag/sample-weighted.frag
@@ -1,0 +1,19 @@
+#version 450
+#extension GL_QCOM_image_processing : require
+
+layout(binding = 4) uniform sampler2D tex_samp;
+layout(binding = 5) uniform sampler2DArray tex_samp_array;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src1samp;
+uniform sampler2DArray SPIRV_Cross_Combinedtex2DArray_weightssamp;
+
+layout(location = 0) out vec4 fragColor;
+layout(location = 0) in vec4 v_texcoord;
+
+void main()
+{
+    vec4 _32 = textureWeightedQCOM(SPIRV_Cross_Combinedtex2D_src1samp, v_texcoord.xy, SPIRV_Cross_Combinedtex2DArray_weightssamp);
+    fragColor = _32;
+    vec4 _41 = textureWeightedQCOM(tex_samp, v_texcoord.xy, tex_samp_array);
+    fragColor = _41;
+}
+

--- a/reference/shaders/frag/block-match-sad.frag
+++ b/reference/shaders/frag/block-match-sad.frag
@@ -1,0 +1,26 @@
+#version 450
+#extension GL_QCOM_image_processing : require
+
+layout(binding = 4) uniform sampler2D target_samp;
+layout(binding = 5) uniform sampler2D ref_samp;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src1samp;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src2samp;
+
+layout(location = 0) in vec4 v_texcoord;
+layout(location = 0) out vec4 fragColor;
+
+void main()
+{
+    uvec2 tgt_coords;
+    tgt_coords.x = uint(v_texcoord.x);
+    tgt_coords.x = uint(v_texcoord.y);
+    uvec2 ref_coords;
+    ref_coords.x = uint(v_texcoord.z);
+    ref_coords.y = uint(v_texcoord.w);
+    uvec2 blockSize = uvec2(4u);
+    vec4 _59 = textureBlockMatchSADQCOM(SPIRV_Cross_Combinedtex2D_src1samp, tgt_coords, SPIRV_Cross_Combinedtex2D_src2samp, ref_coords, blockSize);
+    fragColor = _59;
+    vec4 _68 = textureBlockMatchSADQCOM(target_samp, tgt_coords, ref_samp, ref_coords, blockSize);
+    fragColor = _68;
+}
+

--- a/reference/shaders/frag/block-match-ssd.frag
+++ b/reference/shaders/frag/block-match-ssd.frag
@@ -1,0 +1,26 @@
+#version 450
+#extension GL_QCOM_image_processing : require
+
+layout(binding = 4) uniform sampler2D target_samp;
+layout(binding = 5) uniform sampler2D ref_samp;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src1samp;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src2samp;
+
+layout(location = 0) in vec4 v_texcoord;
+layout(location = 0) out vec4 fragColor;
+
+void main()
+{
+    uvec2 tgt_coords;
+    tgt_coords.x = uint(v_texcoord.x);
+    tgt_coords.x = uint(v_texcoord.y);
+    uvec2 ref_coords;
+    ref_coords.x = uint(v_texcoord.z);
+    ref_coords.y = uint(v_texcoord.w);
+    uvec2 blockSize = uvec2(4u);
+    vec4 _59 = textureBlockMatchSSDQCOM(SPIRV_Cross_Combinedtex2D_src1samp, tgt_coords, SPIRV_Cross_Combinedtex2D_src2samp, ref_coords, blockSize);
+    fragColor = _59;
+    vec4 _68 = textureBlockMatchSSDQCOM(target_samp, tgt_coords, ref_samp, ref_coords, blockSize);
+    fragColor = _68;
+}
+

--- a/reference/shaders/frag/box-filter.frag
+++ b/reference/shaders/frag/box-filter.frag
@@ -1,0 +1,18 @@
+#version 450
+#extension GL_QCOM_image_processing : require
+
+layout(binding = 4) uniform sampler2D tex_samp;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src1samp;
+
+layout(location = 0) out vec4 fragColor;
+layout(location = 0) in vec4 v_texcoord;
+
+void main()
+{
+    vec2 boxSize = vec2(2.5, 4.5);
+    vec4 _31 = textureBoxFilterQCOM(SPIRV_Cross_Combinedtex2D_src1samp, v_texcoord.xy, boxSize);
+    fragColor = _31;
+    vec4 _38 = textureBoxFilterQCOM(tex_samp, v_texcoord.xy, boxSize);
+    fragColor = _38;
+}
+

--- a/reference/shaders/frag/sample-weighted.frag
+++ b/reference/shaders/frag/sample-weighted.frag
@@ -1,0 +1,19 @@
+#version 450
+#extension GL_QCOM_image_processing : require
+
+layout(binding = 4) uniform sampler2D tex_samp;
+layout(binding = 5) uniform sampler2DArray tex_samp_array;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src1samp;
+uniform sampler2DArray SPIRV_Cross_Combinedtex2DArray_weightssamp;
+
+layout(location = 0) out vec4 fragColor;
+layout(location = 0) in vec4 v_texcoord;
+
+void main()
+{
+    vec4 _32 = textureWeightedQCOM(SPIRV_Cross_Combinedtex2D_src1samp, v_texcoord.xy, SPIRV_Cross_Combinedtex2DArray_weightssamp);
+    fragColor = _32;
+    vec4 _41 = textureWeightedQCOM(tex_samp, v_texcoord.xy, tex_samp_array);
+    fragColor = _41;
+}
+

--- a/reference/shaders/vulkan/frag/block-match-sad.frag
+++ b/reference/shaders/vulkan/frag/block-match-sad.frag
@@ -1,0 +1,26 @@
+#version 450
+#extension GL_QCOM_image_processing : require
+
+layout(binding = 4) uniform sampler2D target_samp;
+layout(binding = 5) uniform sampler2D ref_samp;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src1samp;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src2samp;
+
+layout(location = 0) in vec4 v_texcoord;
+layout(location = 0) out vec4 fragColor;
+
+void main()
+{
+    uvec2 tgt_coords;
+    tgt_coords.x = uint(v_texcoord.x);
+    tgt_coords.x = uint(v_texcoord.y);
+    uvec2 ref_coords;
+    ref_coords.x = uint(v_texcoord.z);
+    ref_coords.y = uint(v_texcoord.w);
+    uvec2 blockSize = uvec2(4u);
+    vec4 _59 = textureBlockMatchSADQCOM(SPIRV_Cross_Combinedtex2D_src1samp, tgt_coords, SPIRV_Cross_Combinedtex2D_src2samp, ref_coords, blockSize);
+    fragColor = _59;
+    vec4 _68 = textureBlockMatchSADQCOM(target_samp, tgt_coords, ref_samp, ref_coords, blockSize);
+    fragColor = _68;
+}
+

--- a/reference/shaders/vulkan/frag/block-match-ssd.frag
+++ b/reference/shaders/vulkan/frag/block-match-ssd.frag
@@ -1,0 +1,26 @@
+#version 450
+#extension GL_QCOM_image_processing : require
+
+layout(binding = 4) uniform sampler2D target_samp;
+layout(binding = 5) uniform sampler2D ref_samp;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src1samp;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src2samp;
+
+layout(location = 0) in vec4 v_texcoord;
+layout(location = 0) out vec4 fragColor;
+
+void main()
+{
+    uvec2 tgt_coords;
+    tgt_coords.x = uint(v_texcoord.x);
+    tgt_coords.x = uint(v_texcoord.y);
+    uvec2 ref_coords;
+    ref_coords.x = uint(v_texcoord.z);
+    ref_coords.y = uint(v_texcoord.w);
+    uvec2 blockSize = uvec2(4u);
+    vec4 _59 = textureBlockMatchSSDQCOM(SPIRV_Cross_Combinedtex2D_src1samp, tgt_coords, SPIRV_Cross_Combinedtex2D_src2samp, ref_coords, blockSize);
+    fragColor = _59;
+    vec4 _68 = textureBlockMatchSSDQCOM(target_samp, tgt_coords, ref_samp, ref_coords, blockSize);
+    fragColor = _68;
+}
+

--- a/reference/shaders/vulkan/frag/box-filter.frag
+++ b/reference/shaders/vulkan/frag/box-filter.frag
@@ -1,0 +1,18 @@
+#version 450
+#extension GL_QCOM_image_processing : require
+
+layout(binding = 4) uniform sampler2D tex_samp;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src1samp;
+
+layout(location = 0) out vec4 fragColor;
+layout(location = 0) in vec4 v_texcoord;
+
+void main()
+{
+    vec2 boxSize = vec2(2.5, 4.5);
+    vec4 _31 = textureBoxFilterQCOM(SPIRV_Cross_Combinedtex2D_src1samp, v_texcoord.xy, boxSize);
+    fragColor = _31;
+    vec4 _38 = textureBoxFilterQCOM(tex_samp, v_texcoord.xy, boxSize);
+    fragColor = _38;
+}
+

--- a/reference/shaders/vulkan/frag/sample-weighted.frag
+++ b/reference/shaders/vulkan/frag/sample-weighted.frag
@@ -1,0 +1,19 @@
+#version 450
+#extension GL_QCOM_image_processing : require
+
+layout(binding = 4) uniform sampler2D tex_samp;
+layout(binding = 5) uniform sampler2DArray tex_samp_array;
+uniform sampler2D SPIRV_Cross_Combinedtex2D_src1samp;
+uniform sampler2DArray SPIRV_Cross_Combinedtex2DArray_weightssamp;
+
+layout(location = 0) out vec4 fragColor;
+layout(location = 0) in vec4 v_texcoord;
+
+void main()
+{
+    vec4 _32 = textureWeightedQCOM(SPIRV_Cross_Combinedtex2D_src1samp, v_texcoord.xy, SPIRV_Cross_Combinedtex2DArray_weightssamp);
+    fragColor = _32;
+    vec4 _41 = textureWeightedQCOM(tex_samp, v_texcoord.xy, tex_samp_array);
+    fragColor = _41;
+}
+

--- a/shaders/vulkan/frag/block-match-sad.frag
+++ b/shaders/vulkan/frag/block-match-sad.frag
@@ -1,0 +1,38 @@
+#version 450
+#extension GL_QCOM_image_processing : require
+
+precision highp float;
+
+// fragment shader inputs and outputs
+layout (location = 0) in vec4 v_texcoord;
+
+layout (location = 0) out vec4 fragColor;
+
+// fragment shader resources
+layout(set = 0, binding = 0) uniform texture2DArray tex2DArray_weights;
+layout(set = 0, binding = 1) uniform texture2D tex2D_src1;
+layout(set = 0, binding = 2) uniform texture2D tex2D_src2;
+layout(set = 0, binding = 3) uniform sampler samp;
+layout(set = 0, binding = 4) uniform sampler2D target_samp;
+layout(set = 0, binding = 5) uniform sampler2D ref_samp;
+
+void main()
+{
+
+    uvec2 tgt_coords; tgt_coords.x = uint(v_texcoord.x); tgt_coords.x = uint(v_texcoord.y);
+    uvec2 ref_coords; ref_coords.x = uint(v_texcoord.z); ref_coords.y = uint(v_texcoord.w);
+    uvec2 blockSize = uvec2(4, 4);
+    fragColor = textureBlockMatchSADQCOM(
+                    sampler2D(tex2D_src1, samp),                   // target texture
+                    tgt_coords,                                    // target coords
+                    sampler2D(tex2D_src2, samp),                   // reference texture
+                    ref_coords,                                    // reference coords
+                    blockSize);                                    // block size
+    fragColor = textureBlockMatchSADQCOM(
+                    target_samp,                                   // target texture
+                    tgt_coords,                                    // target coords
+                    ref_samp,                                      // reference texture
+                    ref_coords,                                    // reference coords
+                    blockSize);                                    // block size
+}
+

--- a/shaders/vulkan/frag/block-match-ssd.frag
+++ b/shaders/vulkan/frag/block-match-ssd.frag
@@ -1,0 +1,38 @@
+#version 450
+#extension GL_QCOM_image_processing : require
+
+precision highp float;
+
+// fragment shader inputs and outputs
+layout (location = 0) in vec4 v_texcoord;
+
+layout (location = 0) out vec4 fragColor;
+
+// fragment shader resources
+layout(set = 0, binding = 0) uniform texture2DArray tex2DArray_weights;
+layout(set = 0, binding = 1) uniform texture2D tex2D_src1;
+layout(set = 0, binding = 2) uniform texture2D tex2D_src2;
+layout(set = 0, binding = 3) uniform sampler samp;
+layout(set = 0, binding = 4) uniform sampler2D target_samp;
+layout(set = 0, binding = 5) uniform sampler2D ref_samp;
+
+void main()
+{
+
+    uvec2 tgt_coords; tgt_coords.x = uint(v_texcoord.x); tgt_coords.x = uint(v_texcoord.y);
+    uvec2 ref_coords; ref_coords.x = uint(v_texcoord.z); ref_coords.y = uint(v_texcoord.w);
+    uvec2 blockSize = uvec2(4, 4);
+    fragColor = textureBlockMatchSSDQCOM(
+                    sampler2D(tex2D_src1, samp),                   // target texture
+                    tgt_coords,                                    // target coords
+                    sampler2D(tex2D_src2, samp),                   // reference texture
+                    ref_coords,                                    // reference coords
+                    blockSize);                                    // block size
+    fragColor = textureBlockMatchSSDQCOM(
+                    target_samp,                                   // target texture
+                    tgt_coords,                                    // target coords
+                    ref_samp,                                      // reference texture
+                    ref_coords,                                    // reference coords
+                    blockSize);                                    // block size
+}
+

--- a/shaders/vulkan/frag/box-filter.frag
+++ b/shaders/vulkan/frag/box-filter.frag
@@ -1,0 +1,32 @@
+#version 450
+#extension GL_QCOM_image_processing : require
+
+precision highp float;
+
+// fragment shader inputs and outputs
+layout (location = 0) in vec4 v_texcoord;
+
+layout (location = 0) out vec4 fragColor;
+
+// fragment shader resources
+layout(set = 0, binding = 0) uniform texture2DArray tex2DArray_weights;
+layout(set = 0, binding = 1) uniform texture2D tex2D_src1;
+layout(set = 0, binding = 2) uniform texture2D tex2D_src2;
+layout(set = 0, binding = 3) uniform sampler samp;
+layout(set = 0, binding = 4) uniform sampler2D tex_samp;
+
+void main()
+{
+
+    vec2 boxSize = vec2(2.5, 4.5);
+    fragColor = textureBoxFilterQCOM(
+                    sampler2D(tex2D_src1, samp),                   // source texture
+                    v_texcoord.xy,                                 // tex coords
+                    boxSize);                                      // box size
+    fragColor = textureBoxFilterQCOM(
+                    tex_samp,                                      // combined source texture
+                    v_texcoord.xy,                                 // tex coords
+                    boxSize);                                      // box size
+
+}
+

--- a/shaders/vulkan/frag/sample-weighted.frag
+++ b/shaders/vulkan/frag/sample-weighted.frag
@@ -1,0 +1,32 @@
+#version 450
+#extension GL_QCOM_image_processing : require
+
+precision highp float;
+
+// fragment shader inputs and outputs
+layout (location = 0) in vec4 v_texcoord;
+
+layout (location = 0) out vec4 fragColor;
+
+// fragment shader resources
+layout(set = 0, binding = 0) uniform texture2DArray tex2DArray_weights;
+layout(set = 0, binding = 1) uniform texture2D tex2D_src1;
+layout(set = 0, binding = 2) uniform texture2D tex2D_src2;
+layout(set = 0, binding = 3) uniform sampler samp;
+layout(set = 0, binding = 4) uniform sampler2D tex_samp;
+layout(set = 0, binding = 5) uniform sampler2DArray tex_samp_array;
+
+void main()
+{
+
+    fragColor = textureWeightedQCOM(
+                    sampler2D(tex2D_src1, samp),                   // source texture
+                    v_texcoord.xy,                                 // tex coords
+                    sampler2DArray(tex2DArray_weights, samp));     // weight texture
+    fragColor = textureWeightedQCOM(
+                    tex_samp,                                      // combined source texture
+                    v_texcoord.xy,                                 // tex coords
+                    tex_samp_array);                               // combined weight texture
+
+}
+

--- a/spirv.h
+++ b/spirv.h
@@ -509,6 +509,8 @@ typedef enum SpvDecoration_ {
     SpvDecorationMaxByteOffsetId = 47,
     SpvDecorationNoSignedWrap = 4469,
     SpvDecorationNoUnsignedWrap = 4470,
+    SpvDecorationWeightTextureQCOM = 4487,
+    SpvDecorationBlockMatchTextureQCOM = 4488,
     SpvDecorationExplicitInterpAMD = 4999,
     SpvDecorationOverrideCoverageNV = 5248,
     SpvDecorationPassthroughNV = 5250,
@@ -991,6 +993,9 @@ typedef enum SpvCapability_ {
     SpvCapabilityRayQueryKHR = 4472,
     SpvCapabilityRayTraversalPrimitiveCullingKHR = 4478,
     SpvCapabilityRayTracingKHR = 4479,
+    SpvCapabilityTextureSampleWeightedQCOM = 4484,
+    SpvCapabilityTextureBoxFilterQCOM = 4485,
+    SpvCapabilityTextureBlockMatchQCOM = 4486,
     SpvCapabilityFloat16ImageAMD = 5008,
     SpvCapabilityImageGatherBiasLodAMD = 5009,
     SpvCapabilityFragmentMaskAMD = 5010,
@@ -1596,6 +1601,10 @@ typedef enum SpvOp_ {
     SpvOpRayQueryConfirmIntersectionKHR = 4476,
     SpvOpRayQueryProceedKHR = 4477,
     SpvOpRayQueryGetIntersectionTypeKHR = 4479,
+    SpvOpImageSampleWeightedQCOM = 4480,
+    SpvOpImageBoxFilterQCOM = 4481,
+    SpvOpImageBlockMatchSSDQCOM = 4482,
+    SpvOpImageBlockMatchSADQCOM = 4483,
     SpvOpGroupIAddNonUniformAMD = 5000,
     SpvOpGroupFAddNonUniformAMD = 5001,
     SpvOpGroupFMinNonUniformAMD = 5002,
@@ -2271,6 +2280,10 @@ inline void SpvHasResultAndType(SpvOp opcode, bool *hasResult, bool *hasResultTy
     case SpvOpRayQueryConfirmIntersectionKHR: *hasResult = false; *hasResultType = false; break;
     case SpvOpRayQueryProceedKHR: *hasResult = true; *hasResultType = true; break;
     case SpvOpRayQueryGetIntersectionTypeKHR: *hasResult = true; *hasResultType = true; break;
+    case SpvOpImageSampleWeightedQCOM: *hasResult = true; *hasResultType = true; break;
+    case SpvOpImageBoxFilterQCOM: *hasResult = true; *hasResultType = true; break;
+    case SpvOpImageBlockMatchSSDQCOM: *hasResult = true; *hasResultType = true; break;
+    case SpvOpImageBlockMatchSADQCOM: *hasResult = true; *hasResultType = true; break;
     case SpvOpGroupIAddNonUniformAMD: *hasResult = true; *hasResultType = true; break;
     case SpvOpGroupFAddNonUniformAMD: *hasResult = true; *hasResultType = true; break;
     case SpvOpGroupFMinNonUniformAMD: *hasResult = true; *hasResultType = true; break;

--- a/spirv.hpp
+++ b/spirv.hpp
@@ -505,6 +505,8 @@ enum Decoration {
     DecorationMaxByteOffsetId = 47,
     DecorationNoSignedWrap = 4469,
     DecorationNoUnsignedWrap = 4470,
+    DecorationWeightTextureQCOM = 4487,
+    DecorationBlockMatchTextureQCOM = 4488,
     DecorationExplicitInterpAMD = 4999,
     DecorationOverrideCoverageNV = 5248,
     DecorationPassthroughNV = 5250,
@@ -987,6 +989,9 @@ enum Capability {
     CapabilityRayQueryKHR = 4472,
     CapabilityRayTraversalPrimitiveCullingKHR = 4478,
     CapabilityRayTracingKHR = 4479,
+    CapabilityTextureSampleWeightedQCOM = 4484,
+    CapabilityTextureBoxFilterQCOM = 4485,
+    CapabilityTextureBlockMatchQCOM = 4486,
     CapabilityFloat16ImageAMD = 5008,
     CapabilityImageGatherBiasLodAMD = 5009,
     CapabilityFragmentMaskAMD = 5010,
@@ -1592,6 +1597,10 @@ enum Op {
     OpRayQueryConfirmIntersectionKHR = 4476,
     OpRayQueryProceedKHR = 4477,
     OpRayQueryGetIntersectionTypeKHR = 4479,
+    OpImageSampleWeightedQCOM = 4480,
+    OpImageBoxFilterQCOM = 4481,
+    OpImageBlockMatchSSDQCOM = 4482,
+    OpImageBlockMatchSADQCOM = 4483,
     OpGroupIAddNonUniformAMD = 5000,
     OpGroupFAddNonUniformAMD = 5001,
     OpGroupFMinNonUniformAMD = 5002,
@@ -2267,6 +2276,10 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     case OpRayQueryConfirmIntersectionKHR: *hasResult = false; *hasResultType = false; break;
     case OpRayQueryProceedKHR: *hasResult = true; *hasResultType = true; break;
     case OpRayQueryGetIntersectionTypeKHR: *hasResult = true; *hasResultType = true; break;
+    case OpImageSampleWeightedQCOM: *hasResult = true; *hasResultType = true; break;
+    case OpImageBoxFilterQCOM: *hasResult = true; *hasResultType = true; break;
+    case OpImageBlockMatchSSDQCOM: *hasResult = true; *hasResultType = true; break;
+    case OpImageBlockMatchSADQCOM: *hasResult = true; *hasResultType = true; break;
     case OpGroupIAddNonUniformAMD: *hasResult = true; *hasResultType = true; break;
     case OpGroupFAddNonUniformAMD: *hasResult = true; *hasResultType = true; break;
     case OpGroupFMinNonUniformAMD: *hasResult = true; *hasResultType = true; break;

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -14159,20 +14159,20 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		string expr;
 		switch (opcode)
 		{
-			case OpImageSampleWeightedQCOM:
-				expr = std::move("textureWeightedQCOM");
-				break;
-			case OpImageBoxFilterQCOM:
-				expr = std::move("textureBoxFilterQCOM");
-				break;
-			case OpImageBlockMatchSSDQCOM:
-				expr = std::move("textureBlockMatchSSDQCOM");
-				break;
-			case OpImageBlockMatchSADQCOM:
-				expr = std::move("textureBlockMatchSADQCOM");
-				break;
-			default:
-				SPIRV_CROSS_THROW("Invalid opcode for QCOM_image_processing.");
+		case OpImageSampleWeightedQCOM:
+			expr = "textureWeightedQCOM";
+			break;
+		case OpImageBoxFilterQCOM:
+			expr = "textureBoxFilterQCOM";
+			break;
+		case OpImageBlockMatchSSDQCOM:
+			expr = "textureBlockMatchSSDQCOM";
+			break;
+		case OpImageBlockMatchSADQCOM:
+			expr = "textureBlockMatchSADQCOM";
+			break;
+		default:
+			SPIRV_CROSS_THROW("Invalid opcode for QCOM_image_processing.");
 		}
 		expr += "(";
 
@@ -14182,27 +14182,27 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 
 		switch (opcode)
 		{
-			case OpImageSampleWeightedQCOM:
-				expr += ", " + to_non_uniform_aware_expression(ops[4]);
-				break;
-			case OpImageBoxFilterQCOM:
-				expr += ", " + to_expression(ops[4]);
-				break;
-			case OpImageBlockMatchSSDQCOM:
-			case OpImageBlockMatchSADQCOM:
-				expr += ", " + to_non_uniform_aware_expression(ops[4]);
-				expr += ", " + to_expression(ops[5]);
-				expr += ", " + to_expression(ops[6]);
-				break;
-			default:
-				SPIRV_CROSS_THROW("Invalid opcode for QCOM_image_processing.");
+		case OpImageSampleWeightedQCOM:
+			expr += ", " + to_non_uniform_aware_expression(ops[4]);
+			break;
+		case OpImageBoxFilterQCOM:
+			expr += ", " + to_expression(ops[4]);
+			break;
+		case OpImageBlockMatchSSDQCOM:
+		case OpImageBlockMatchSADQCOM:
+			expr += ", " + to_non_uniform_aware_expression(ops[4]);
+			expr += ", " + to_expression(ops[5]);
+			expr += ", " + to_expression(ops[6]);
+			break;
+		default:
+			SPIRV_CROSS_THROW("Invalid opcode for QCOM_image_processing.");
 		}
 
 		expr += ")";
 		emit_op(result_type_id, id, expr, forward);
 
 		inherit_expression_dependencies(id, ops[3]);
-		if (opcode == OpImageBlockMatchSSDQCOM || opcode == OpImageBlockMatchSADQCOM )
+		if (opcode == OpImageBlockMatchSSDQCOM || opcode == OpImageBlockMatchSADQCOM)
 			inherit_expression_dependencies(id, ops[5]);
 
 		break;

--- a/spirv_reflect.cpp
+++ b/spirv_reflect.cpp
@@ -633,6 +633,10 @@ void CompilerReflection::emit_resources(const char *tag, const SmallVector<Resou
 			                                 get_decoration(res.id, DecorationInputAttachmentIndex));
 		if (mask.get(DecorationOffset))
 			json_stream->emit_json_key_value("offset", get_decoration(res.id, DecorationOffset));
+		if (mask.get(DecorationWeightTextureQCOM))
+			json_stream->emit_json_key_value("WeightTextureQCOM", get_decoration(res.id, DecorationWeightTextureQCOM));
+		if (mask.get(DecorationBlockMatchTextureQCOM))
+			json_stream->emit_json_key_value("BlockMatchTextureQCOM", get_decoration(res.id, DecorationBlockMatchTextureQCOM));
 
 		// For images, the type itself adds a layout qualifer.
 		// Only emit the format for storage images.


### PR DESCRIPTION
1. Add support for the SPV_QCOM_image_processing extension
2. Add four unit tests
3. Fix minor issues in other unit tests

Please note that 

the following test failed with "The flag --preserve-numeric-ids was specified multiple times."

shaders-no-opt/asm/frag/opaque-id-literal-alias.preserve.asm.frag

the following test failed with "The type of Value must match the Result type"

shaders-no-opt/asm/frag/subgroup-arithmetic-cast.nocompat.vk.asm.frag
shaders-msl-no-opt/asm/frag/subgroup-arithmetic-cast.msl21.asm.frag
  %18 = OpGroupNonUniformSMin %uint %uint_3 Reduce %16

the following tests failed with "Selection must be structured"

shaders-no-opt/asm/comp/loop-variable-early-read-with-initializer.asm.comp
  OpBranchConditional %69 %12 %13

shaders-no-opt/asm/comp/loop-variable-early-read-with-undef.asm.comp
  OpBranchConditional %69 %12 %13

the following tests failed with "OpSpecConstantComposite Constituent <id> '7[%7]'s type does not match Result Type <id> '29[%v3uint]'s vector element type."

shaders-no-opt/asm/comp/local-size-id.vk.asm.comp
shaders-hlsl-no-opt/asm/comp/local-size-id.asm.comp
shaders-msl-no-opt/asm/comp/local-size-id.asm.comp
  %38 = OpSpecConstantComposite %v3uint %37 %7 %uint_2


	
	shaders-msl-no-opt/asm/comp/local-size-id.asm.comp
	shaders-msl-no-opt/asm/frag/subgroup-arithmetic-cast.msl21.asm.frag
	


	