### PR TITLE
HLSL: fix packing of structs

### DIFF
--- a/reference/opt/shaders-hlsl/comp/ubo-std140.comp
+++ b/reference/opt/shaders-hlsl/comp/ubo-std140.comp
@@ -1,0 +1,9 @@
+void comp_main()
+{
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    comp_main();
+}

--- a/reference/shaders-hlsl/comp/ubo-std140.comp
+++ b/reference/shaders-hlsl/comp/ubo-std140.comp
@@ -1,0 +1,21 @@
+struct Data
+{
+    float3 data0;
+    int2 data1;
+};
+
+cbuffer UboData : register(b0)
+{
+    Data _13_scene : packoffset(c0);
+};
+
+
+void comp_main()
+{
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    comp_main();
+}

--- a/shaders-hlsl/comp/ubo-std140.comp
+++ b/shaders-hlsl/comp/ubo-std140.comp
@@ -1,0 +1,17 @@
+#version 450
+
+struct Data
+{
+    vec3 data0;
+    // uint padding0; // 4 bytes of padding here
+    ivec2 data1;
+};
+
+layout(set = 0, binding = 0, std140) uniform UboData
+{
+    Data scene;
+};
+
+void main()
+{
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1809,6 +1809,12 @@ bool CompilerGLSL::buffer_is_packing_standard(const SPIRType &type, BufferPackin
 
 		uint32_t alignment = max(packed_alignment, pad_alignment);
 		offset = (offset + alignment - 1) & ~(alignment - 1);
+		if (offset <= (actual_offset & ~(alignment - 1)))
+		{
+			packed_size += actual_offset % alignment;
+			offset = actual_offset & ~(alignment - 1);
+			alignment = 1;
+		}
 
 		// The next member following a struct member is aligned to the base alignment of the struct that came before.
 		// GL 4.5 spec, 7.6.2.2.

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -1797,8 +1797,8 @@ bool CompilerGLSL::buffer_is_packing_standard(const SPIRType &type, BufferPackin
 		if (packing_is_hlsl(packing))
 		{
 			// If a member straddles across a vec4 boundary, alignment is actually vec4.
-			uint32_t begin_word = actual_offset / 16;
-			uint32_t end_word = (actual_offset + packed_size - 1) / 16;
+			uint32_t begin_word = offset / 16;
+			uint32_t end_word = (offset + packed_size - 1) / 16;
 			if (begin_word != end_word)
 				packed_alignment = max<uint32_t>(packed_alignment, 16u);
 		}


### PR DESCRIPTION
It seems there was a typo in calculation of `begin_word`/`end_word`, causing some shaders in opengothic not to work