### PR TITLE
HLSL: Fix issue with vec4 straddle rules in substructs.

### DIFF
--- a/reference/shaders-hlsl-no-opt/comp/substruct-cbuffer-packing-straddle-top-level.comp
+++ b/reference/shaders-hlsl-no-opt/comp/substruct-cbuffer-packing-straddle-top-level.comp
@@ -1,0 +1,16 @@
+cbuffer UboData : register(b0)
+{
+    float3 _12_data0 : packoffset(c0);
+    int2 _12_data1 : packoffset(c1);
+};
+
+
+void comp_main()
+{
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    comp_main();
+}

--- a/reference/shaders-hlsl-no-opt/comp/substruct-cbuffer-packing-straddle.comp
+++ b/reference/shaders-hlsl-no-opt/comp/substruct-cbuffer-packing-straddle.comp
@@ -1,0 +1,21 @@
+struct Data
+{
+    float3 data0;
+    int2 data1;
+};
+
+cbuffer UboData : register(b0)
+{
+    Data _13_scene : packoffset(c0);
+};
+
+
+void comp_main()
+{
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    comp_main();
+}

--- a/shaders-hlsl-no-opt/comp/substruct-cbuffer-packing-straddle-top-level.comp
+++ b/shaders-hlsl-no-opt/comp/substruct-cbuffer-packing-straddle-top-level.comp
@@ -1,0 +1,12 @@
+#version 450
+
+layout(set = 0, binding = 0, std140) uniform UboData
+{
+    vec3 data0;
+    // uint padding0; // 4 bytes of padding here
+    ivec2 data1;
+};
+
+void main()
+{
+}

--- a/shaders-hlsl-no-opt/comp/substruct-cbuffer-packing-straddle.comp
+++ b/shaders-hlsl-no-opt/comp/substruct-cbuffer-packing-straddle.comp
@@ -1,0 +1,17 @@
+#version 450
+
+struct Data
+{
+    vec3 data0;
+    // uint padding0; // 4 bytes of padding here
+    ivec2 data1;
+};
+
+layout(set = 0, binding = 0, std140) uniform UboData
+{
+    Data scene;
+};
+
+void main()
+{
+}


### PR DESCRIPTION
Supersedes #2247.