### PR TITLE
GLSL: Improve BDA handling in esoteric situations

### DIFF
--- a/reference/shaders-no-opt/asm/comp/bda-to-array-in-buffer.asm.spv16.nocompat.vk.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/bda-to-array-in-buffer.asm.spv16.nocompat.vk.comp.vk
@@ -11,7 +11,7 @@ layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 
 layout(buffer_reference) buffer uintPointer;
 layout(buffer_reference) buffer uint8_tPointer;
-layout(buffer_reference) buffer uint8_t12_Pointer;
+layout(buffer_reference) buffer uint8_t12_stride_1Pointer;
 layout(buffer_reference) buffer uint8_tPointer
 {
     uint8_t value;
@@ -22,7 +22,7 @@ layout(buffer_reference, buffer_reference_align = 4) buffer uintPointer
     uint value;
 };
 
-layout(buffer_reference, buffer_reference_align = 1) buffer uint8_t12_Pointer
+layout(std430, buffer_reference, buffer_reference_align = 1) buffer uint8_t12_stride_1Pointer
 {
     uint8_t value[12];
 };
@@ -30,12 +30,12 @@ layout(buffer_reference, buffer_reference_align = 1) buffer uint8_t12_Pointer
 layout(set = 0, binding = 0, std430) buffer _7_2
 {
     uint8_tPointer _m0;
-    uint8_t12_Pointer _m1;
+    uint8_t12_stride_1Pointer _m1;
 } _2;
 
 uintPointer _23()
 {
-    uint8_t12_Pointer _26 = _2._m1;
+    uint8_t12_stride_1Pointer _26 = _2._m1;
     uintPointer _29 = uintPointer(uint64_t(_26) + 16ul);
     _29.value = 1u;
     return _29;

--- a/reference/shaders-no-opt/asm/comp/bda-to-array-in-buffer.asm.spv16.nocompat.vk.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/bda-to-array-in-buffer.asm.spv16.nocompat.vk.comp.vk
@@ -9,6 +9,9 @@
 #extension GL_EXT_buffer_reference2 : require
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 
+layout(buffer_reference) buffer uintPointer;
+layout(buffer_reference) buffer uint8_tPointer;
+layout(buffer_reference) buffer uint8_t12_Pointer;
 layout(buffer_reference) buffer uint8_tPointer
 {
     uint8_t value;

--- a/reference/shaders-no-opt/asm/comp/buffer-reference-chained-access.spv16.asm.nocompat.vk.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/buffer-reference-chained-access.spv16.asm.nocompat.vk.comp.vk
@@ -1,0 +1,20 @@
+#version 450
+#extension GL_EXT_buffer_reference2 : require
+layout(local_size_x = 4, local_size_y = 1, local_size_z = 1) in;
+
+layout(buffer_reference) buffer S;
+layout(buffer_reference, buffer_reference_align = 4, std430) buffer S
+{
+    vec4 data[];
+};
+
+layout(push_constant, std430) uniform Registers
+{
+    S s;
+} registers;
+
+void main()
+{
+    registers.s.data[gl_GlobalInvocationID.x][gl_LocalInvocationIndex] = 40.0;
+}
+

--- a/reference/shaders-no-opt/asm/comp/buffer-reference-pointer-to-plain-struct.asm.nocompat.vk.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/buffer-reference-pointer-to-plain-struct.asm.nocompat.vk.comp.vk
@@ -1,0 +1,27 @@
+#version 450
+#extension GL_EXT_buffer_reference2 : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+struct Foo
+{
+    uint a;
+    uint b;
+};
+
+layout(std430, buffer_reference, buffer_reference_align = 16) buffer FooPointer
+{
+    Foo value;
+};
+
+layout(set = 0, binding = 0, std430) buffer SSBO
+{
+    Foo foos[4];
+    FooPointer ptrfoo;
+} _7;
+
+void main()
+{
+    _7.foos[0].a = 0u;
+    _7.ptrfoo.value.a = 1u;
+}
+

--- a/reference/shaders-no-opt/asm/comp/buffer-reference-pointer-to-plain-struct.asm.nocompat.vk.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/buffer-reference-pointer-to-plain-struct.asm.nocompat.vk.comp.vk
@@ -8,7 +8,8 @@ struct Foo
     uint b;
 };
 
-layout(std430, buffer_reference, buffer_reference_align = 16) buffer FooPointer
+layout(buffer_reference) buffer FooPointer;
+layout(std430, buffer_reference, buffer_reference_align = 8) buffer FooPointer
 {
     Foo value;
 };

--- a/reference/shaders-no-opt/asm/comp/buffer-reference-pointer-to-pod-in-buffer.asm.nocompat.vk.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/buffer-reference-pointer-to-pod-in-buffer.asm.nocompat.vk.comp.vk
@@ -2,6 +2,7 @@
 #extension GL_EXT_buffer_reference2 : require
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
+layout(buffer_reference) buffer uvec4Pointer;
 layout(buffer_reference, buffer_reference_align = 8) buffer uvec4Pointer
 {
     uvec4 value;

--- a/reference/shaders-no-opt/asm/comp/buffer-reference-pointer-to-std140-std430-array.asm.spv16.nocompat.vk.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/buffer-reference-pointer-to-std140-std430-array.asm.spv16.nocompat.vk.comp.vk
@@ -1,0 +1,28 @@
+#version 450
+#extension GL_EXT_buffer_reference2 : require
+#extension GL_EXT_buffer_reference_uvec2 : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(buffer_reference) buffer vec20_stride_8Pointer;
+layout(buffer_reference) buffer vec20_stride_16Pointer;
+layout(std430, buffer_reference, buffer_reference_align = 4) buffer vec20_stride_8Pointer
+{
+    vec2 value[];
+};
+
+layout(std140, buffer_reference, buffer_reference_align = 16) buffer vec20_stride_16Pointer
+{
+    vec2 value[];
+};
+
+layout(push_constant, std430) uniform Registers
+{
+    uvec2 s;
+} registers;
+
+void main()
+{
+    vec20_stride_8Pointer(registers.s).value[0u].x = 40.0;
+    vec20_stride_16Pointer(registers.s).value[0u].x = 40.0;
+}
+

--- a/reference/shaders-no-opt/asm/comp/buffer-reference-pointer-to-unused-pod-in-buffer.asm.nocompat.vk.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/buffer-reference-pointer-to-unused-pod-in-buffer.asm.nocompat.vk.comp.vk
@@ -2,6 +2,7 @@
 #extension GL_EXT_buffer_reference2 : require
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
+layout(buffer_reference) buffer uvec4Pointer;
 layout(buffer_reference) buffer uvec4Pointer
 {
     uvec4 value;

--- a/reference/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer-2.asm.nocompat.vk.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer-2.asm.nocompat.vk.comp.vk
@@ -7,6 +7,7 @@
 #extension GL_EXT_buffer_reference2 : require
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
+layout(buffer_reference) buffer uintPointer;
 layout(buffer_reference, buffer_reference_align = 4) buffer uintPointer
 {
     uint value;

--- a/reference/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer-to-pointer.asm.nocompat.vk.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer-to-pointer.asm.nocompat.vk.comp.vk
@@ -1,0 +1,32 @@
+#version 450
+#if defined(GL_ARB_gpu_shader_int64)
+#extension GL_ARB_gpu_shader_int64 : require
+#else
+#error No extension available for 64-bit integers.
+#endif
+#extension GL_EXT_buffer_reference2 : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(buffer_reference) buffer uintPointer;
+layout(buffer_reference) buffer uintPointerPointer;
+layout(buffer_reference, buffer_reference_align = 4) buffer uintPointer
+{
+    uint value;
+};
+
+layout(buffer_reference, buffer_reference_align = 8) buffer uintPointerPointer
+{
+    uintPointer value;
+};
+
+layout(push_constant, std430) uniform _6_14
+{
+    uint64_t _m0;
+} _14;
+
+void main()
+{
+    uintPointer _4 = uintPointerPointer(_14._m0).value;
+    _4.value = 20u;
+}
+

--- a/reference/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer.asm.nocompat.vk.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer.asm.nocompat.vk.comp.vk
@@ -7,8 +7,8 @@
 #extension GL_EXT_buffer_reference2 : require
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
-layout(buffer_reference) buffer uint0_Pointer;
-layout(buffer_reference, buffer_reference_align = 4) buffer uint0_Pointer
+layout(buffer_reference) buffer uint0_stride_4Pointer;
+layout(std430, buffer_reference, buffer_reference_align = 4) buffer uint0_stride_4Pointer
 {
     uint value[];
 };
@@ -20,7 +20,7 @@ layout(push_constant, std430) uniform _8_15
 
 void main()
 {
-    uint0_Pointer _7 = uint0_Pointer(_15._m0);
+    uint0_stride_4Pointer _7 = uint0_stride_4Pointer(_15._m0);
     _7.value[10] = 20u;
 }
 

--- a/reference/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer.asm.nocompat.vk.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer.asm.nocompat.vk.comp.vk
@@ -7,6 +7,7 @@
 #extension GL_EXT_buffer_reference2 : require
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
+layout(buffer_reference) buffer uint0_Pointer;
 layout(buffer_reference, buffer_reference_align = 4) buffer uint0_Pointer
 {
     uint value[];

--- a/shaders-no-opt/asm/comp/buffer-reference-chained-access.spv16.asm.nocompat.vk.comp
+++ b/shaders-no-opt/asm/comp/buffer-reference-chained-access.spv16.asm.nocompat.vk.comp
@@ -1,0 +1,67 @@
+; SPIR-V
+; Version: 1.6
+; Generator: Khronos Glslang Reference Front End; 11
+; Bound: 35
+; Schema: 0
+               OpCapability Shader
+               OpCapability PhysicalStorageBufferAddresses
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel PhysicalStorageBuffer64 GLSL450
+               OpEntryPoint GLCompute %main "main" %registers %gl_GlobalInvocationID %gl_LocalInvocationIndex
+               OpExecutionMode %main LocalSize 4 1 1
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_buffer_reference"
+               OpName %main "main"
+               OpName %Registers "Registers"
+               OpMemberName %Registers 0 "s"
+               OpName %S "S"
+               OpMemberName %S 0 "data"
+               OpName %registers "registers"
+               OpName %gl_GlobalInvocationID "gl_GlobalInvocationID"
+               OpName %gl_LocalInvocationIndex "gl_LocalInvocationIndex"
+               OpMemberDecorate %Registers 0 Offset 0
+               OpDecorate %Registers Block
+               OpDecorate %_runtimearr_v4float ArrayStride 16
+               OpMemberDecorate %S 0 Offset 0
+               OpDecorate %S Block
+               OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
+               OpDecorate %gl_LocalInvocationIndex BuiltIn LocalInvocationIndex
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+               OpTypeForwardPointer %_ptr_PhysicalStorageBuffer_S PhysicalStorageBuffer
+  %Registers = OpTypeStruct %_ptr_PhysicalStorageBuffer_S
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_runtimearr_v4float = OpTypeRuntimeArray %v4float
+          %S = OpTypeStruct %_runtimearr_v4float
+%_ptr_PhysicalStorageBuffer_S = OpTypePointer PhysicalStorageBuffer %S
+%_ptr_PushConstant_Registers = OpTypePointer PushConstant %Registers
+  %registers = OpVariable %_ptr_PushConstant_Registers PushConstant
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_PushConstant__ptr_PhysicalStorageBuffer_S = OpTypePointer PushConstant %_ptr_PhysicalStorageBuffer_S
+       %uint = OpTypeInt 32 0
+     %v3uint = OpTypeVector %uint 3
+%_ptr_Input_v3uint = OpTypePointer Input %v3uint
+%gl_GlobalInvocationID = OpVariable %_ptr_Input_v3uint Input
+     %uint_0 = OpConstant %uint 0
+%_ptr_Input_uint = OpTypePointer Input %uint
+%gl_LocalInvocationIndex = OpVariable %_ptr_Input_uint Input
+   %float_40 = OpConstant %float 40
+%_ptr_PhysicalStorageBuffer_v4float = OpTypePointer PhysicalStorageBuffer %v4float
+%_ptr_PhysicalStorageBuffer_float = OpTypePointer PhysicalStorageBuffer %float
+     %uint_4 = OpConstant %uint 4
+     %uint_1 = OpConstant %uint 1
+         %34 = OpConstantComposite %v3uint %uint_4 %uint_1 %uint_1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %17 = OpAccessChain %_ptr_PushConstant__ptr_PhysicalStorageBuffer_S %registers %int_0
+         %18 = OpLoad %_ptr_PhysicalStorageBuffer_S %17
+         %25 = OpAccessChain %_ptr_Input_uint %gl_GlobalInvocationID %uint_0
+         %26 = OpLoad %uint %25
+         %28 = OpLoad %uint %gl_LocalInvocationIndex
+         %31 = OpAccessChain %_ptr_PhysicalStorageBuffer_v4float %18 %int_0 %26
+		 %32 = OpAccessChain %_ptr_PhysicalStorageBuffer_float %31 %28
+               OpStore %32 %float_40 Aligned 4
+               OpReturn
+               OpFunctionEnd

--- a/shaders-no-opt/asm/comp/buffer-reference-pointer-to-plain-struct.asm.nocompat.vk.comp
+++ b/shaders-no-opt/asm/comp/buffer-reference-pointer-to-plain-struct.asm.nocompat.vk.comp
@@ -54,6 +54,6 @@
          %22 = OpAccessChain %_ptr_StorageBuffer__ptr_PhysicalStorageBuffer_Foo %_ %int_1
          %23 = OpLoad %_ptr_PhysicalStorageBuffer_Foo %22
          %26 = OpAccessChain %_ptr_PhysicalStorageBuffer_uint %23 %int_0
-               OpStore %26 %uint_1 Aligned 16
+               OpStore %26 %uint_1 Aligned 8
                OpReturn
                OpFunctionEnd

--- a/shaders-no-opt/asm/comp/buffer-reference-pointer-to-plain-struct.asm.nocompat.vk.comp
+++ b/shaders-no-opt/asm/comp/buffer-reference-pointer-to-plain-struct.asm.nocompat.vk.comp
@@ -1,0 +1,59 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 11
+; Bound: 27
+; Schema: 0
+               OpCapability Shader
+               OpCapability PhysicalStorageBufferAddresses
+               OpExtension "SPV_KHR_physical_storage_buffer"
+               OpExtension "SPV_KHR_storage_buffer_storage_class"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel PhysicalStorageBuffer64 GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_buffer_reference"
+               OpName %main "main"
+               OpName %Foo "Foo"
+               OpMemberName %Foo 0 "a"
+               OpMemberName %Foo 1 "b"
+               OpName %SSBO "SSBO"
+               OpMemberName %SSBO 0 "foos"
+               OpMemberName %SSBO 1 "ptrfoo"
+               OpName %_ ""
+               OpMemberDecorate %Foo 0 Offset 0
+               OpMemberDecorate %Foo 1 Offset 4
+               OpDecorate %_arr_Foo_uint_4 ArrayStride 8
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpMemberDecorate %SSBO 1 Offset 32
+               OpDecorate %SSBO Block
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+        %Foo = OpTypeStruct %uint %uint
+     %uint_4 = OpConstant %uint 4
+%_arr_Foo_uint_4 = OpTypeArray %Foo %uint_4
+%_ptr_PhysicalStorageBuffer_Foo = OpTypePointer PhysicalStorageBuffer %Foo
+       %SSBO = OpTypeStruct %_arr_Foo_uint_4 %_ptr_PhysicalStorageBuffer_Foo
+%_ptr_StorageBuffer_SSBO = OpTypePointer StorageBuffer %SSBO
+          %_ = OpVariable %_ptr_StorageBuffer_SSBO StorageBuffer
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %uint_0 = OpConstant %uint 0
+%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
+      %int_1 = OpConstant %int 1
+%_ptr_StorageBuffer__ptr_PhysicalStorageBuffer_Foo = OpTypePointer StorageBuffer %_ptr_PhysicalStorageBuffer_Foo
+     %uint_1 = OpConstant %uint 1
+%_ptr_PhysicalStorageBuffer_uint = OpTypePointer PhysicalStorageBuffer %uint
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %19 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0 %int_0 %int_0
+               OpStore %19 %uint_0
+         %22 = OpAccessChain %_ptr_StorageBuffer__ptr_PhysicalStorageBuffer_Foo %_ %int_1
+         %23 = OpLoad %_ptr_PhysicalStorageBuffer_Foo %22
+         %26 = OpAccessChain %_ptr_PhysicalStorageBuffer_uint %23 %int_0
+               OpStore %26 %uint_1 Aligned 16
+               OpReturn
+               OpFunctionEnd

--- a/shaders-no-opt/asm/comp/buffer-reference-pointer-to-std140-std430-array.asm.spv16.nocompat.vk.comp
+++ b/shaders-no-opt/asm/comp/buffer-reference-pointer-to-std140-std430-array.asm.spv16.nocompat.vk.comp
@@ -1,0 +1,54 @@
+; SPIR-V
+; Version: 1.6
+; Generator: Khronos Glslang Reference Front End; 11
+; Bound: 35
+; Schema: 0
+               OpCapability Shader
+               OpCapability PhysicalStorageBufferAddresses
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel PhysicalStorageBuffer64 GLSL450
+               OpEntryPoint GLCompute %main "main" %registers
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_buffer_reference"
+               OpName %main "main"
+               OpName %Registers "Registers"
+               OpMemberName %Registers 0 "s"
+               OpName %registers "registers"
+               OpMemberDecorate %Registers 0 Offset 0
+               OpDecorate %Registers Block
+               OpDecorate %std430array_v2float ArrayStride 8
+               OpDecorate %std140array_v2float ArrayStride 16
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v2float = OpTypeVector %float 2
+       %uint = OpTypeInt 32 0
+       %v2uint = OpTypeVector %uint 2
+  %Registers = OpTypeStruct %v2uint
+%std430array_v2float = OpTypeRuntimeArray %v2float
+%std140array_v2float = OpTypeRuntimeArray %v2float
+%_ptr_PhysicalStorageBuffer_std430array_v2float = OpTypePointer PhysicalStorageBuffer %std430array_v2float
+%_ptr_PhysicalStorageBuffer_std140array_v2float = OpTypePointer PhysicalStorageBuffer %std140array_v2float
+%_ptr_PushConstant_Registers = OpTypePointer PushConstant %Registers
+%_ptr_PushConstant_v2uint = OpTypePointer PushConstant %v2uint
+  %registers = OpVariable %_ptr_PushConstant_Registers PushConstant
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %v3uint = OpTypeVector %uint 3
+     %uint_0 = OpConstant %uint 0
+   %float_40 = OpConstant %float 40
+%_ptr_PhysicalStorageBuffer_v2float = OpTypePointer PhysicalStorageBuffer %v2float
+%_ptr_PhysicalStorageBuffer_float = OpTypePointer PhysicalStorageBuffer %float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %ptr_bda = OpAccessChain %_ptr_PushConstant_v2uint %registers %int_0
+         %bda = OpLoad %v2uint %ptr_bda
+		 %std430_ptr = OpBitcast %_ptr_PhysicalStorageBuffer_std430array_v2float %bda
+		 %std140_ptr = OpBitcast %_ptr_PhysicalStorageBuffer_std140array_v2float %bda
+		 %ptr0 = OpAccessChain %_ptr_PhysicalStorageBuffer_float %std430_ptr %uint_0 %uint_0
+		 %ptr1 = OpAccessChain %_ptr_PhysicalStorageBuffer_float %std140_ptr %uint_0 %uint_0
+               OpStore %ptr0 %float_40 Aligned 4
+               OpStore %ptr1 %float_40 Aligned 16
+               OpReturn
+               OpFunctionEnd

--- a/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer-to-pointer.asm.nocompat.vk.comp
+++ b/shaders-no-opt/asm/comp/buffer-reference-synthesized-pointer-to-pointer.asm.nocompat.vk.comp
@@ -1,0 +1,46 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 27
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int64
+               OpCapability PhysicalStorageBufferAddressesEXT
+               OpExtension "SPV_EXT_physical_storage_buffer"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel PhysicalStorageBuffer64EXT GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_gpu_shader_int64"
+               OpSourceExtension "GL_EXT_buffer_reference"
+               OpDecorate %ptr AliasedPointerEXT
+               OpMemberDecorate %Registers 0 Offset 0
+               OpDecorate %Registers Block
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%_ptr_PhysicalStorageBufferEXT_uint = OpTypePointer PhysicalStorageBufferEXT %uint
+%_ptr_ptr_PhysicalStorageBufferEXT_uint = OpTypePointer PhysicalStorageBufferEXT %_ptr_PhysicalStorageBufferEXT_uint
+%_ptr_Function__ptr_PhysicalStorageBufferEXT_uint = OpTypePointer Function %_ptr_PhysicalStorageBufferEXT_uint
+      %ulong = OpTypeInt 64 0
+  %Registers = OpTypeStruct %ulong
+%_ptr_PushConstant_Registers = OpTypePointer PushConstant %Registers
+  %registers = OpVariable %_ptr_PushConstant_Registers PushConstant
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_PushConstant_ulong = OpTypePointer PushConstant %ulong
+     %int_10 = OpConstant %int 10
+    %uint_20 = OpConstant %uint 20
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+        %ptr = OpVariable %_ptr_Function__ptr_PhysicalStorageBufferEXT_uint Function
+         %19 = OpAccessChain %_ptr_PushConstant_ulong %registers %int_0
+         %20 = OpLoad %ulong %19
+         %21 = OpConvertUToPtr %_ptr_ptr_PhysicalStorageBufferEXT_uint %20
+		 %loaded_ptr = OpLoad %_ptr_PhysicalStorageBufferEXT_uint %21 Aligned 8
+               OpStore %ptr %loaded_ptr
+         %22 = OpLoad %_ptr_PhysicalStorageBufferEXT_uint %ptr
+               OpStore %22 %uint_20 Aligned 4
+               OpReturn
+               OpFunctionEnd

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -640,6 +640,13 @@ bool Compiler::is_physical_pointer(const SPIRType &type) const
 	return type.op == OpTypePointer && type.storage == StorageClassPhysicalStorageBuffer;
 }
 
+bool Compiler::is_physical_pointer_to_buffer_block(const SPIRType &type) const
+{
+	return is_physical_pointer(type) && get_pointee_type(type).self == type.parent_type &&
+	       (has_decoration(type.self, DecorationBlock) ||
+	        has_decoration(type.self, DecorationBufferBlock));
+}
+
 bool Compiler::is_runtime_size_array(const SPIRType &type)
 {
 	return type.op == OpTypeRuntimeArray;
@@ -5024,8 +5031,7 @@ void Compiler::PhysicalStorageBufferPointerHandler::mark_aligned_access(uint32_t
 bool Compiler::PhysicalStorageBufferPointerHandler::type_is_bda_block_entry(uint32_t type_id) const
 {
 	auto &type = compiler.get<SPIRType>(type_id);
-	return type.storage == StorageClassPhysicalStorageBufferEXT && type.pointer &&
-	       type.pointer_depth == 1 && !compiler.type_is_array_of_pointers(type);
+	return compiler.is_physical_pointer(type) && type.pointer_depth == 1;
 }
 
 uint32_t Compiler::PhysicalStorageBufferPointerHandler::get_minimum_scalar_alignment(const SPIRType &type) const
@@ -5055,7 +5061,8 @@ void Compiler::PhysicalStorageBufferPointerHandler::setup_meta_chain(uint32_t ty
 		access_chain_to_physical_block[var_id] = &meta;
 
 		auto &type = compiler.get<SPIRType>(type_id);
-		if (type.basetype != SPIRType::Struct)
+
+		if (!compiler.is_physical_pointer_to_buffer_block(type))
 			non_block_types.insert(type_id);
 
 		if (meta.alignment == 0)
@@ -5114,9 +5121,7 @@ bool Compiler::PhysicalStorageBufferPointerHandler::handle(Op op, const uint32_t
 uint32_t Compiler::PhysicalStorageBufferPointerHandler::get_base_non_block_type_id(uint32_t type_id) const
 {
 	auto *type = &compiler.get<SPIRType>(type_id);
-	while (type->pointer &&
-	       type->storage == StorageClassPhysicalStorageBufferEXT &&
-	       !type_is_bda_block_entry(type_id))
+	while (compiler.is_physical_pointer(*type) && !type_is_bda_block_entry(type_id))
 	{
 		type_id = type->parent_type;
 		type = &compiler.get<SPIRType>(type_id);
@@ -5131,12 +5136,10 @@ void Compiler::PhysicalStorageBufferPointerHandler::analyze_non_block_types_from
 	for (auto &member : type.member_types)
 	{
 		auto &subtype = compiler.get<SPIRType>(member);
-		if (subtype.basetype != SPIRType::Struct && subtype.pointer &&
-		    subtype.storage == spv::StorageClassPhysicalStorageBufferEXT)
-		{
+
+		if (compiler.is_physical_pointer(subtype) && !compiler.is_physical_pointer_to_buffer_block(subtype))
 			non_block_types.insert(get_base_non_block_type_id(member));
-		}
-		else if (subtype.basetype == SPIRType::Struct && !subtype.pointer)
+		else if (subtype.basetype == SPIRType::Struct && !compiler.is_pointer(subtype))
 			analyze_non_block_types_from_block(subtype);
 	}
 }
@@ -5149,9 +5152,14 @@ void Compiler::analyze_non_block_pointer_types()
 	// Analyze any block declaration we have to make. It might contain
 	// physical pointers to POD types which we never used, and thus never added to the list.
 	// We'll need to add those pointer types to the set of types we declare.
-	ir.for_each_typed_id<SPIRType>([&](uint32_t, SPIRType &type) {
-		if (has_decoration(type.self, DecorationBlock) || has_decoration(type.self, DecorationBufferBlock))
+	ir.for_each_typed_id<SPIRType>([&](uint32_t id, SPIRType &type) {
+		// Only analyze the raw block struct, not any pointer-to-struct, since that's just redundant.
+		if (type.self == id &&
+		    (has_decoration(type.self, DecorationBlock) ||
+		     has_decoration(type.self, DecorationBufferBlock)))
+		{
 			handler.analyze_non_block_types_from_block(type);
+		}
 	});
 
 	physical_storage_non_block_pointer_types.reserve(handler.non_block_types.size());

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -5031,7 +5031,7 @@ void Compiler::PhysicalStorageBufferPointerHandler::mark_aligned_access(uint32_t
 bool Compiler::PhysicalStorageBufferPointerHandler::type_is_bda_block_entry(uint32_t type_id) const
 {
 	auto &type = compiler.get<SPIRType>(type_id);
-	return compiler.is_physical_pointer(type) && type.pointer_depth == 1;
+	return compiler.is_physical_pointer(type);
 }
 
 uint32_t Compiler::PhysicalStorageBufferPointerHandler::get_minimum_scalar_alignment(const SPIRType &type) const

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -685,6 +685,7 @@ protected:
 	bool is_array(const SPIRType &type) const;
 	bool is_pointer(const SPIRType &type) const;
 	bool is_physical_pointer(const SPIRType &type) const;
+	bool is_physical_pointer_to_buffer_block(const SPIRType &type) const;
 	static bool is_runtime_size_array(const SPIRType &type);
 	uint32_t expression_type_id(uint32_t id) const;
 	const SPIRType &expression_type(uint32_t id) const;

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -2145,11 +2145,11 @@ string CompilerGLSL::layout_for_variable(const SPIRVariable &var)
 	// If SPIR-V does not comply with either layout, we cannot really work around it.
 	if (can_use_buffer_blocks && (ubo_block || emulated_ubo))
 	{
-		attr.push_back(buffer_to_packing_standard(type, false));
+		attr.push_back(buffer_to_packing_standard(type, false, true));
 	}
 	else if (can_use_buffer_blocks && (push_constant_block || ssbo_block))
 	{
-		attr.push_back(buffer_to_packing_standard(type, true));
+		attr.push_back(buffer_to_packing_standard(type, true, true));
 	}
 
 	// For images, the type itself adds a layout qualifer.
@@ -2170,7 +2170,9 @@ string CompilerGLSL::layout_for_variable(const SPIRVariable &var)
 	return res;
 }
 
-string CompilerGLSL::buffer_to_packing_standard(const SPIRType &type, bool support_std430_without_scalar_layout)
+string CompilerGLSL::buffer_to_packing_standard(const SPIRType &type,
+                                                bool support_std430_without_scalar_layout,
+                                                bool support_enhanced_layouts)
 {
 	if (support_std430_without_scalar_layout && buffer_is_packing_standard(type, BufferPackingStd430))
 		return "std430";
@@ -2182,6 +2184,7 @@ string CompilerGLSL::buffer_to_packing_standard(const SPIRType &type, bool suppo
 		return "scalar";
 	}
 	else if (support_std430_without_scalar_layout &&
+	         support_enhanced_layouts &&
 	         buffer_is_packing_standard(type, BufferPackingStd430EnhancedLayout))
 	{
 		if (options.es && !options.vulkan_semantics)
@@ -2193,7 +2196,8 @@ string CompilerGLSL::buffer_to_packing_standard(const SPIRType &type, bool suppo
 		set_extended_decoration(type.self, SPIRVCrossDecorationExplicitOffset);
 		return "std430";
 	}
-	else if (buffer_is_packing_standard(type, BufferPackingStd140EnhancedLayout))
+	else if (support_enhanced_layouts &&
+	         buffer_is_packing_standard(type, BufferPackingStd140EnhancedLayout))
 	{
 		// Fallback time. We might be able to use the ARB_enhanced_layouts to deal with this difference,
 		// however, we can only use layout(offset) on the block itself, not any substructs, so the substructs better be the appropriate layout.
@@ -2207,7 +2211,9 @@ string CompilerGLSL::buffer_to_packing_standard(const SPIRType &type, bool suppo
 		set_extended_decoration(type.self, SPIRVCrossDecorationExplicitOffset);
 		return "std140";
 	}
-	else if (options.vulkan_semantics && buffer_is_packing_standard(type, BufferPackingScalarEnhancedLayout))
+	else if (options.vulkan_semantics &&
+	         support_enhanced_layouts &&
+	         buffer_is_packing_standard(type, BufferPackingScalarEnhancedLayout))
 	{
 		set_extended_decoration(type.self, SPIRVCrossDecorationExplicitOffset);
 		require_extension_internal("GL_EXT_scalar_block_layout");
@@ -2221,6 +2227,7 @@ string CompilerGLSL::buffer_to_packing_standard(const SPIRType &type, bool suppo
 		return "std430";
 	}
 	else if (!support_std430_without_scalar_layout && options.vulkan_semantics &&
+	         support_enhanced_layouts &&
 	         buffer_is_packing_standard(type, BufferPackingStd430EnhancedLayout))
 	{
 		// UBOs can support std430 with GL_EXT_scalar_block_layout.
@@ -2352,10 +2359,10 @@ void CompilerGLSL::emit_buffer_reference_block(uint32_t type_id, bool forward_de
 		// Ensure we emit the correct name when emitting non-forward pointer type.
 		ir.meta[type.self].decoration.alias = buffer_name;
 	}
-	else if (type.basetype != SPIRType::Struct)
-		buffer_name = type_to_glsl(type);
 	else
-		buffer_name = to_name(type.self, false);
+	{
+		buffer_name = type_to_glsl(type);
+	}
 
 	if (!forward_declaration)
 	{
@@ -2364,13 +2371,13 @@ void CompilerGLSL::emit_buffer_reference_block(uint32_t type_id, bool forward_de
 		if (itr != physical_storage_type_to_alignment.end())
 			alignment = itr->second.alignment;
 
-		if (type.basetype == SPIRType::Struct)
+		if (is_physical_pointer_to_buffer_block(type))
 		{
 			SmallVector<std::string> attributes;
 			attributes.push_back("buffer_reference");
 			if (alignment)
 				attributes.push_back(join("buffer_reference_align = ", alignment));
-			attributes.push_back(buffer_to_packing_standard(type, true));
+			attributes.push_back(buffer_to_packing_standard(type, true, true));
 
 			auto flags = ir.get_buffer_block_type_flags(type);
 			string decorations;
@@ -2385,14 +2392,24 @@ void CompilerGLSL::emit_buffer_reference_block(uint32_t type_id, bool forward_de
 
 			statement("layout(", merge(attributes), ")", decorations, " buffer ", buffer_name);
 		}
-		else if (alignment)
-			statement("layout(buffer_reference, buffer_reference_align = ", alignment, ") buffer ", buffer_name);
 		else
-			statement("layout(buffer_reference) buffer ", buffer_name);
+		{
+			string packing_standard;
+			if (type.basetype == SPIRType::Struct)
+			{
+				// The non-block type is embedded in a block, so we cannot use enhanced layouts :(
+				packing_standard = buffer_to_packing_standard(type, true, false) + ", ";
+			}
+
+			if (alignment)
+				statement("layout(", packing_standard, "buffer_reference, buffer_reference_align = ", alignment, ") buffer ", buffer_name);
+			else
+				statement("layout(", packing_standard, "buffer_reference) buffer ", buffer_name);
+		}
 
 		begin_scope();
 
-		if (type.basetype == SPIRType::Struct)
+		if (is_physical_pointer_to_buffer_block(type))
 		{
 			type.member_name_cache.clear();
 
@@ -3706,30 +3723,20 @@ void CompilerGLSL::emit_resources()
 	if (ir.addressing_model == AddressingModelPhysicalStorageBuffer64EXT)
 	{
 		for (auto type : physical_storage_non_block_pointer_types)
-		{
 			emit_buffer_reference_block(type, false);
-		}
 
 		// Output buffer reference blocks.
 		// Do this in two stages, one with forward declaration,
 		// and one without. Buffer reference blocks can reference themselves
 		// to support things like linked lists.
-		ir.for_each_typed_id<SPIRType>([&](uint32_t self, SPIRType &type) {
-			if (type.basetype == SPIRType::Struct && type.pointer &&
-			    type.pointer_depth == 1 && !type_is_array_of_pointers(type) &&
-			    type.storage == StorageClassPhysicalStorageBufferEXT)
-			{
-				emit_buffer_reference_block(self, true);
-			}
+		ir.for_each_typed_id<SPIRType>([&](uint32_t id, SPIRType &type) {
+			if (is_physical_pointer_to_buffer_block(type))
+				emit_buffer_reference_block(id, true);
 		});
 
-		ir.for_each_typed_id<SPIRType>([&](uint32_t self, SPIRType &type) {
-			if (type.basetype == SPIRType::Struct &&
-			    type.pointer && type.pointer_depth == 1 && !type_is_array_of_pointers(type) &&
-			    type.storage == StorageClassPhysicalStorageBufferEXT)
-			{
-				emit_buffer_reference_block(self, false);
-			}
+		ir.for_each_typed_id<SPIRType>([&](uint32_t id, SPIRType &type) {
+			if (is_physical_pointer_to_buffer_block(type))
+				emit_buffer_reference_block(id, false);
 		});
 	}
 
@@ -5011,11 +5018,8 @@ string CompilerGLSL::dereference_expression(const SPIRType &expr_type, const std
 		return expr.substr(1);
 	else if (backend.native_pointers)
 		return join('*', expr);
-	else if (expr_type.storage == StorageClassPhysicalStorageBufferEXT && expr_type.basetype != SPIRType::Struct &&
-	         expr_type.pointer_depth == 1)
-	{
+	else if (is_physical_pointer(expr_type) && !is_physical_pointer_to_buffer_block(expr_type))
 		return join(enclose_expression(expr), ".value");
-	}
 	else
 		return expr;
 }
@@ -15695,17 +15699,22 @@ string CompilerGLSL::type_to_glsl_constructor(const SPIRType &type)
 // depend on a specific object's use of that type.
 string CompilerGLSL::type_to_glsl(const SPIRType &type, uint32_t id)
 {
-	if (type.pointer && type.storage == StorageClassPhysicalStorageBufferEXT && type.basetype != SPIRType::Struct)
+	if (is_physical_pointer(type) && !is_physical_pointer_to_buffer_block(type))
 	{
 		// Need to create a magic type name which compacts the entire type information.
-		string name = type_to_glsl(get_pointee_type(type));
-		for (size_t i = 0; i < type.array.size(); i++)
+		auto *parent = &get_pointee_type(type);
+		string name = type_to_glsl(*parent);
+
+		while (is_array(*parent))
 		{
-			if (type.array_size_literal[i])
-				name += join(type.array[i], "_");
+			if (parent->array_size_literal.back())
+				name += join(type.array.back(), "_");
 			else
-				name += join("id", type.array[i], "_");
+				name += join("id", type.array.back(), "_");
+
+			parent = &get<SPIRType>(parent->parent_type);
 		}
+
 		name += "Pointer";
 		return name;
 	}

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -833,7 +833,9 @@ protected:
 	bool buffer_is_packing_standard(const SPIRType &type, BufferPackingStandard packing,
 	                                uint32_t *failed_index = nullptr, uint32_t start_offset = 0,
 	                                uint32_t end_offset = ~(0u));
-	std::string buffer_to_packing_standard(const SPIRType &type, bool support_std430_without_scalar_layout);
+	std::string buffer_to_packing_standard(const SPIRType &type,
+	                                       bool support_std430_without_scalar_layout,
+	                                       bool support_enhanced_layouts);
 
 	uint32_t type_to_packed_base_size(const SPIRType &type, BufferPackingStandard packing);
 	uint32_t type_to_packed_alignment(const SPIRType &type, const Bitset &flags, BufferPackingStandard packing);


### PR DESCRIPTION
- Handle pointer to non-Block-decorated OpTypeStruct.
- Be more careful about types we forward.
- Handle non-block pointer-to-pointer.
- Handle casts to ptr-to-array types with different ArrayStride.