### PR TITLE
MSL: Handle volatile properly for emulated image atomics.

### DIFF
--- a/reference/opt/shaders-msl/comp/coherent-image-atomic.comp
+++ b/reference/opt/shaders-msl/comp/coherent-image-atomic.comp
@@ -1,0 +1,22 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+// The required alignment of a linear texture of R32Uint format.
+constant uint spvLinearTextureAlignmentOverride [[function_constant(65535)]];
+constant uint spvLinearTextureAlignment = is_function_constant_defined(spvLinearTextureAlignmentOverride) ? spvLinearTextureAlignmentOverride : 4;
+// Returns buffer coords corresponding to 2D texture coords for emulating 2D texture atomics
+#define spvImage2DAtomicCoord(tc, tex) (((((tex).get_width() +  spvLinearTextureAlignment / 4 - 1) & ~( spvLinearTextureAlignment / 4 - 1)) * (tc).y) + (tc).x)
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(256u, 1u, 1u);
+
+kernel void main0(texture2d<uint> rw_spd_global_atomic [[texture(0)]], volatile device atomic_uint* rw_spd_global_atomic_atomic [[buffer(0)]])
+{
+    uint _43 = atomic_fetch_add_explicit((volatile device atomic_uint*)&rw_spd_global_atomic_atomic[spvImage2DAtomicCoord(int2(0), rw_spd_global_atomic)], 1u, memory_order_relaxed);
+}
+

--- a/reference/opt/shaders-msl/comp/coherent-image-atomic.msl2.argument.comp
+++ b/reference/opt/shaders-msl/comp/coherent-image-atomic.msl2.argument.comp
@@ -1,0 +1,28 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+// The required alignment of a linear texture of R32Uint format.
+constant uint spvLinearTextureAlignmentOverride [[function_constant(65535)]];
+constant uint spvLinearTextureAlignment = is_function_constant_defined(spvLinearTextureAlignmentOverride) ? spvLinearTextureAlignmentOverride : 4;
+// Returns buffer coords corresponding to 2D texture coords for emulating 2D texture atomics
+#define spvImage2DAtomicCoord(tc, tex) (((((tex).get_width() +  spvLinearTextureAlignment / 4 - 1) & ~( spvLinearTextureAlignment / 4 - 1)) * (tc).y) + (tc).x)
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(256u, 1u, 1u);
+
+struct spvDescriptorSetBuffer1
+{
+    texture2d<uint> rw_spd_global_atomic [[id(0)]];
+    volatile device atomic_uint* rw_spd_global_atomic_atomic [[id(1)]];
+};
+
+kernel void main0(constant spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]])
+{
+    uint _43 = atomic_fetch_add_explicit((volatile device atomic_uint*)&spvDescriptorSet1.rw_spd_global_atomic_atomic[spvImage2DAtomicCoord(int2(0), spvDescriptorSet1.rw_spd_global_atomic)], 1u, memory_order_relaxed);
+}
+

--- a/reference/opt/shaders-msl/comp/coherent-image-atomic.msl2.comp
+++ b/reference/opt/shaders-msl/comp/coherent-image-atomic.msl2.comp
@@ -1,0 +1,22 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+// The required alignment of a linear texture of R32Uint format.
+constant uint spvLinearTextureAlignmentOverride [[function_constant(65535)]];
+constant uint spvLinearTextureAlignment = is_function_constant_defined(spvLinearTextureAlignmentOverride) ? spvLinearTextureAlignmentOverride : 4;
+// Returns buffer coords corresponding to 2D texture coords for emulating 2D texture atomics
+#define spvImage2DAtomicCoord(tc, tex) (((((tex).get_width() +  spvLinearTextureAlignment / 4 - 1) & ~( spvLinearTextureAlignment / 4 - 1)) * (tc).y) + (tc).x)
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(256u, 1u, 1u);
+
+kernel void main0(texture2d<uint> rw_spd_global_atomic [[texture(0)]], volatile device atomic_uint* rw_spd_global_atomic_atomic [[buffer(0)]])
+{
+    uint _43 = atomic_fetch_add_explicit((volatile device atomic_uint*)&rw_spd_global_atomic_atomic[spvImage2DAtomicCoord(int2(0), rw_spd_global_atomic)], 1u, memory_order_relaxed);
+}
+

--- a/reference/opt/shaders-msl/comp/coherent-image-atomic.msl31.argument.comp
+++ b/reference/opt/shaders-msl/comp/coherent-image-atomic.msl31.argument.comp
@@ -1,0 +1,20 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(256u, 1u, 1u);
+
+struct spvDescriptorSetBuffer1
+{
+    texture2d<uint, access::read_write> rw_spd_global_atomic [[id(0)]];
+};
+
+kernel void main0(constant spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]])
+{
+    uint _43 = spvDescriptorSet1.rw_spd_global_atomic.atomic_fetch_add(uint2(int2(0)), 1u).x;
+}
+

--- a/reference/opt/shaders-msl/comp/coherent-image-atomic.msl31.comp
+++ b/reference/opt/shaders-msl/comp/coherent-image-atomic.msl31.comp
@@ -1,0 +1,15 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(256u, 1u, 1u);
+
+kernel void main0(texture2d<uint, access::read_write> rw_spd_global_atomic [[texture(0)]])
+{
+    uint _43 = rw_spd_global_atomic.atomic_fetch_add(uint2(int2(0)), 1u).x;
+}
+

--- a/reference/shaders-msl/comp/coherent-image-atomic.comp
+++ b/reference/shaders-msl/comp/coherent-image-atomic.comp
@@ -1,0 +1,38 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+// The required alignment of a linear texture of R32Uint format.
+constant uint spvLinearTextureAlignmentOverride [[function_constant(65535)]];
+constant uint spvLinearTextureAlignment = is_function_constant_defined(spvLinearTextureAlignmentOverride) ? spvLinearTextureAlignmentOverride : 4;
+// Returns buffer coords corresponding to 2D texture coords for emulating 2D texture atomics
+#define spvImage2DAtomicCoord(tc, tex) (((((tex).get_width() +  spvLinearTextureAlignment / 4 - 1) & ~( spvLinearTextureAlignment / 4 - 1)) * (tc).y) + (tc).x)
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(256u, 1u, 1u);
+
+static inline __attribute__((always_inline))
+void SPD_IncreaseAtomicCounter(thread uint& spdCounter, texture2d<uint> rw_spd_global_atomic, volatile device atomic_uint* rw_spd_global_atomic_atomic)
+{
+    uint _25 = atomic_fetch_add_explicit((volatile device atomic_uint*)&rw_spd_global_atomic_atomic[spvImage2DAtomicCoord(int2(0), rw_spd_global_atomic)], 1u, memory_order_relaxed);
+    spdCounter = _25;
+}
+
+static inline __attribute__((always_inline))
+void ComputeAutoExposure(texture2d<uint> rw_spd_global_atomic, volatile device atomic_uint* rw_spd_global_atomic_atomic)
+{
+    uint v = 0u;
+    uint param = v;
+    SPD_IncreaseAtomicCounter(param, rw_spd_global_atomic, rw_spd_global_atomic_atomic);
+    v = param;
+}
+
+kernel void main0(texture2d<uint> rw_spd_global_atomic [[texture(0)]], volatile device atomic_uint* rw_spd_global_atomic_atomic [[buffer(0)]])
+{
+    ComputeAutoExposure(rw_spd_global_atomic, rw_spd_global_atomic_atomic);
+}
+

--- a/reference/shaders-msl/comp/coherent-image-atomic.msl2.argument.comp
+++ b/reference/shaders-msl/comp/coherent-image-atomic.msl2.argument.comp
@@ -1,0 +1,44 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+// The required alignment of a linear texture of R32Uint format.
+constant uint spvLinearTextureAlignmentOverride [[function_constant(65535)]];
+constant uint spvLinearTextureAlignment = is_function_constant_defined(spvLinearTextureAlignmentOverride) ? spvLinearTextureAlignmentOverride : 4;
+// Returns buffer coords corresponding to 2D texture coords for emulating 2D texture atomics
+#define spvImage2DAtomicCoord(tc, tex) (((((tex).get_width() +  spvLinearTextureAlignment / 4 - 1) & ~( spvLinearTextureAlignment / 4 - 1)) * (tc).y) + (tc).x)
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(256u, 1u, 1u);
+
+struct spvDescriptorSetBuffer1
+{
+    texture2d<uint> rw_spd_global_atomic [[id(0)]];
+    volatile device atomic_uint* rw_spd_global_atomic_atomic [[id(1)]];
+};
+
+static inline __attribute__((always_inline))
+void SPD_IncreaseAtomicCounter(thread uint& spdCounter, texture2d<uint> rw_spd_global_atomic, volatile device atomic_uint* rw_spd_global_atomic_atomic)
+{
+    uint _25 = atomic_fetch_add_explicit((volatile device atomic_uint*)&rw_spd_global_atomic_atomic[spvImage2DAtomicCoord(int2(0), rw_spd_global_atomic)], 1u, memory_order_relaxed);
+    spdCounter = _25;
+}
+
+static inline __attribute__((always_inline))
+void ComputeAutoExposure(texture2d<uint> rw_spd_global_atomic, volatile device atomic_uint* rw_spd_global_atomic_atomic)
+{
+    uint v = 0u;
+    uint param = v;
+    SPD_IncreaseAtomicCounter(param, rw_spd_global_atomic, rw_spd_global_atomic_atomic);
+    v = param;
+}
+
+kernel void main0(constant spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]])
+{
+    ComputeAutoExposure(spvDescriptorSet1.rw_spd_global_atomic, spvDescriptorSet1.rw_spd_global_atomic_atomic);
+}
+

--- a/reference/shaders-msl/comp/coherent-image-atomic.msl2.comp
+++ b/reference/shaders-msl/comp/coherent-image-atomic.msl2.comp
@@ -1,0 +1,38 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+// The required alignment of a linear texture of R32Uint format.
+constant uint spvLinearTextureAlignmentOverride [[function_constant(65535)]];
+constant uint spvLinearTextureAlignment = is_function_constant_defined(spvLinearTextureAlignmentOverride) ? spvLinearTextureAlignmentOverride : 4;
+// Returns buffer coords corresponding to 2D texture coords for emulating 2D texture atomics
+#define spvImage2DAtomicCoord(tc, tex) (((((tex).get_width() +  spvLinearTextureAlignment / 4 - 1) & ~( spvLinearTextureAlignment / 4 - 1)) * (tc).y) + (tc).x)
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(256u, 1u, 1u);
+
+static inline __attribute__((always_inline))
+void SPD_IncreaseAtomicCounter(thread uint& spdCounter, texture2d<uint> rw_spd_global_atomic, volatile device atomic_uint* rw_spd_global_atomic_atomic)
+{
+    uint _25 = atomic_fetch_add_explicit((volatile device atomic_uint*)&rw_spd_global_atomic_atomic[spvImage2DAtomicCoord(int2(0), rw_spd_global_atomic)], 1u, memory_order_relaxed);
+    spdCounter = _25;
+}
+
+static inline __attribute__((always_inline))
+void ComputeAutoExposure(texture2d<uint> rw_spd_global_atomic, volatile device atomic_uint* rw_spd_global_atomic_atomic)
+{
+    uint v = 0u;
+    uint param = v;
+    SPD_IncreaseAtomicCounter(param, rw_spd_global_atomic, rw_spd_global_atomic_atomic);
+    v = param;
+}
+
+kernel void main0(texture2d<uint> rw_spd_global_atomic [[texture(0)]], volatile device atomic_uint* rw_spd_global_atomic_atomic [[buffer(0)]])
+{
+    ComputeAutoExposure(rw_spd_global_atomic, rw_spd_global_atomic_atomic);
+}
+

--- a/reference/shaders-msl/comp/coherent-image-atomic.msl31.argument.comp
+++ b/reference/shaders-msl/comp/coherent-image-atomic.msl31.argument.comp
@@ -1,0 +1,37 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(256u, 1u, 1u);
+
+struct spvDescriptorSetBuffer1
+{
+    texture2d<uint, access::read_write> rw_spd_global_atomic [[id(0)]];
+};
+
+static inline __attribute__((always_inline))
+void SPD_IncreaseAtomicCounter(thread uint& spdCounter, texture2d<uint, access::read_write> rw_spd_global_atomic)
+{
+    uint _25 = rw_spd_global_atomic.atomic_fetch_add(uint2(int2(0)), 1u).x;
+    spdCounter = _25;
+}
+
+static inline __attribute__((always_inline))
+void ComputeAutoExposure(texture2d<uint, access::read_write> rw_spd_global_atomic)
+{
+    uint v = 0u;
+    uint param = v;
+    SPD_IncreaseAtomicCounter(param, rw_spd_global_atomic);
+    v = param;
+}
+
+kernel void main0(constant spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]])
+{
+    ComputeAutoExposure(spvDescriptorSet1.rw_spd_global_atomic);
+}
+

--- a/reference/shaders-msl/comp/coherent-image-atomic.msl31.comp
+++ b/reference/shaders-msl/comp/coherent-image-atomic.msl31.comp
@@ -1,0 +1,32 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(256u, 1u, 1u);
+
+static inline __attribute__((always_inline))
+void SPD_IncreaseAtomicCounter(thread uint& spdCounter, texture2d<uint, access::read_write> rw_spd_global_atomic)
+{
+    uint _25 = rw_spd_global_atomic.atomic_fetch_add(uint2(int2(0)), 1u).x;
+    spdCounter = _25;
+}
+
+static inline __attribute__((always_inline))
+void ComputeAutoExposure(texture2d<uint, access::read_write> rw_spd_global_atomic)
+{
+    uint v = 0u;
+    uint param = v;
+    SPD_IncreaseAtomicCounter(param, rw_spd_global_atomic);
+    v = param;
+}
+
+kernel void main0(texture2d<uint, access::read_write> rw_spd_global_atomic [[texture(0)]])
+{
+    ComputeAutoExposure(rw_spd_global_atomic);
+}
+

--- a/shaders-msl/comp/coherent-image-atomic.comp
+++ b/shaders-msl/comp/coherent-image-atomic.comp
@@ -1,0 +1,20 @@
+#version 450
+
+layout (set = 1, binding = 0, r32ui) coherent uniform uimage2D   rw_spd_global_atomic;
+
+void SPD_IncreaseAtomicCounter(inout uint spdCounter)
+{
+    spdCounter = imageAtomicAdd(rw_spd_global_atomic, ivec2(0,0), 1);
+}
+
+void ComputeAutoExposure() {
+    uint v = 0;
+    SPD_IncreaseAtomicCounter(v);
+}
+
+layout (local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+void main()
+{
+    ComputeAutoExposure();
+}

--- a/shaders-msl/comp/coherent-image-atomic.msl2.argument.comp
+++ b/shaders-msl/comp/coherent-image-atomic.msl2.argument.comp
@@ -1,0 +1,20 @@
+#version 450
+
+layout (set = 1, binding = 0, r32ui) coherent uniform uimage2D   rw_spd_global_atomic;
+
+void SPD_IncreaseAtomicCounter(inout uint spdCounter)
+{
+    spdCounter = imageAtomicAdd(rw_spd_global_atomic, ivec2(0,0), 1);
+}
+
+void ComputeAutoExposure() {
+    uint v = 0;
+    SPD_IncreaseAtomicCounter(v);
+}
+
+layout (local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+void main()
+{
+    ComputeAutoExposure();
+}

--- a/shaders-msl/comp/coherent-image-atomic.msl2.comp
+++ b/shaders-msl/comp/coherent-image-atomic.msl2.comp
@@ -1,0 +1,20 @@
+#version 450
+
+layout (set = 1, binding = 0, r32ui) coherent uniform uimage2D   rw_spd_global_atomic;
+
+void SPD_IncreaseAtomicCounter(inout uint spdCounter)
+{
+    spdCounter = imageAtomicAdd(rw_spd_global_atomic, ivec2(0,0), 1);
+}
+
+void ComputeAutoExposure() {
+    uint v = 0;
+    SPD_IncreaseAtomicCounter(v);
+}
+
+layout (local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+void main()
+{
+    ComputeAutoExposure();
+}

--- a/shaders-msl/comp/coherent-image-atomic.msl31.argument.comp
+++ b/shaders-msl/comp/coherent-image-atomic.msl31.argument.comp
@@ -1,0 +1,20 @@
+#version 450
+
+layout (set = 1, binding = 0, r32ui) coherent uniform uimage2D   rw_spd_global_atomic;
+
+void SPD_IncreaseAtomicCounter(inout uint spdCounter)
+{
+    spdCounter = imageAtomicAdd(rw_spd_global_atomic, ivec2(0,0), 1);
+}
+
+void ComputeAutoExposure() {
+    uint v = 0;
+    SPD_IncreaseAtomicCounter(v);
+}
+
+layout (local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+void main()
+{
+    ComputeAutoExposure();
+}

--- a/shaders-msl/comp/coherent-image-atomic.msl31.comp
+++ b/shaders-msl/comp/coherent-image-atomic.msl31.comp
@@ -1,0 +1,20 @@
+#version 450
+
+layout (set = 1, binding = 0, r32ui) coherent uniform uimage2D   rw_spd_global_atomic;
+
+void SPD_IncreaseAtomicCounter(inout uint spdCounter)
+{
+    spdCounter = imageAtomicAdd(rw_spd_global_atomic, ivec2(0,0), 1);
+}
+
+void ComputeAutoExposure() {
+    uint v = 0;
+    SPD_IncreaseAtomicCounter(v);
+}
+
+layout (local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+void main()
+{
+    ComputeAutoExposure();
+}

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -1045,6 +1045,7 @@ protected:
 	bool validate_member_packing_rules_msl(const SPIRType &type, uint32_t index) const;
 	std::string get_argument_address_space(const SPIRVariable &argument);
 	std::string get_type_address_space(const SPIRType &type, uint32_t id, bool argument = false);
+	static bool decoration_flags_signal_volatile(const Bitset &flags);
 	const char *to_restrict(uint32_t id, bool space);
 	SPIRType &get_stage_in_struct_type();
 	SPIRType &get_stage_out_struct_type();


### PR DESCRIPTION
Fix #2264.