### PR TITLE
Add CompilerError constructor that accepts const char* as a parameter (Fixes #2273)

### DIFF
--- a/spirv_cross_error_handling.hpp
+++ b/spirv_cross_error_handling.hpp
@@ -66,6 +66,11 @@ public:
 	    : std::runtime_error(str)
 	{
 	}
+
+	explicit CompilerError(const char *str)
+	    : std::runtime_error(str)
+	{
+	}
 };
 
 #define SPIRV_CROSS_THROW(x) throw CompilerError(x)


### PR DESCRIPTION
No temporary `std::string` is created when `const char*` is passed to `SPIRV_CROSS_THROW` (like this: `SPIRV_CROSS_THROW("Cannot resolve expression type.");`).
This helps to bypass the issue #2273 where using `_HAS_EXCEPTIONS=0` can lead to invalid error messages when compiled with MSVC.