### PR TITLE
MSL: Add support for overlapping bindings.

### DIFF
--- a/reference/opt/shaders-msl/comp/overlapping-bindings.msl31.argument.argument-tier-1.decoration-binding.device-argument-buffer.texture-buffer-native.comp
+++ b/reference/opt/shaders-msl/comp/overlapping-bindings.msl31.argument.argument-tier-1.decoration-binding.device-argument-buffer.texture-buffer-native.comp
@@ -1,0 +1,35 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
+
+struct spvDescriptorSetBuffer0
+{
+    array<texture_buffer<uint, access::write>, 8> u0 [[id(0)]];
+};
+
+struct spvDescriptorSetBuffer1
+{
+    array<texture_buffer<uint, access::write>, 1> u3 [[id(0)]];
+};
+
+struct spvDescriptorSetBuffer2
+{
+    array<texture_buffer<uint, access::write>, 8> u2 [[id(0)]];
+};
+
+struct spvDescriptorSetBuffer3
+{
+    array<texture_buffer<uint, access::write>, 8> u1 [[id(0)]];
+};
+
+kernel void main0(const device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], const device spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], constant spvDescriptorSetBuffer2& spvDescriptorSet2 [[buffer(2)]], constant spvDescriptorSetBuffer3& spvDescriptorSet3 [[buffer(3)]])
+{
+    spvDescriptorSet0.u0[0].write(uint4(0u), uint(0));
+    spvDescriptorSet3.u1[0].write(uint4(0u), uint(0));
+    spvDescriptorSet2.u2[0].write(uint4(0u), uint(0));
+    spvDescriptorSet1.u3[0].write(uint4(0u), uint(0));
+}
+

--- a/reference/shaders-msl/comp/overlapping-bindings.msl31.argument.argument-tier-1.decoration-binding.device-argument-buffer.texture-buffer-native.comp
+++ b/reference/shaders-msl/comp/overlapping-bindings.msl31.argument.argument-tier-1.decoration-binding.device-argument-buffer.texture-buffer-native.comp
@@ -1,0 +1,130 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+template<typename T>
+struct spvDescriptor
+{
+    T value;
+};
+
+template<typename T>
+struct spvDescriptorArray
+{
+    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(ptr)
+    {
+    }
+    const device T& operator [] (size_t i) const
+    {
+        return ptr[i].value;
+    }
+    const device spvDescriptor<T>* ptr;
+};
+
+struct B10
+{
+    float v;
+};
+
+struct B11
+{
+    float v;
+};
+
+struct B20
+{
+    float v;
+};
+
+struct B21
+{
+    float v;
+};
+
+struct B30
+{
+    uint i;
+};
+
+struct B31
+{
+    float v;
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
+
+struct spvDescriptorSetBuffer0
+{
+    array<texture2d<float>, 8> t00 [[id(0)]];
+    // Overlapping binding: array<texture2d<uint>, 8> t01 [[id(0)]];
+    // Overlapping binding: array<texture2d<int>, 8> t02 [[id(0)]];
+    // Overlapping binding: array<texture_buffer<uint, access::read_write>, 8> u0 [[id(0)]];
+    // Overlapping binding: array<sampler, 8> s00 [[id(0)]];
+};
+
+struct spvDescriptorSetBuffer1
+{
+    device B30* b30 [[id(0)]][1];
+    // Overlapping binding: spvDescriptor<texture2d<float>> t30 [[id(0)]][1] /* unsized array hack */;
+    // Overlapping binding: spvDescriptor<texture2d<uint>> t31 [[id(0)]][1] /* unsized array hack */;
+    // Overlapping binding: spvDescriptor<texture2d<int>> t32 [[id(0)]][1] /* unsized array hack */;
+    // Overlapping binding: array<texture_buffer<uint, access::write>, 1> u3 [[id(0)]];
+    // Overlapping binding: spvDescriptor<sampler> s30 [[id(0)]][1] /* unsized array hack */;
+};
+
+struct spvDescriptorSetBuffer2
+{
+    device B20* b20 [[id(0)]][8];
+    // Overlapping binding: array<texture2d<float>, 8> t20 [[id(0)]];
+    // Overlapping binding: array<texture2d<uint>, 8> t21 [[id(0)]];
+    // Overlapping binding: array<texture2d<int>, 8> t22 [[id(0)]];
+    // Overlapping binding: array<texture_buffer<uint, access::read_write>, 8> u2 [[id(0)]];
+    // Overlapping binding: array<sampler, 8> s20 [[id(0)]];
+};
+
+struct spvDescriptorSetBuffer3
+{
+    device B10* b10 [[id(0)]][8];
+    // Overlapping binding: array<texture_buffer<uint, access::read_write>, 8> u1 [[id(0)]];
+};
+
+kernel void main0(const device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], const device spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], constant spvDescriptorSetBuffer2& spvDescriptorSet2 [[buffer(2)]], constant spvDescriptorSetBuffer3& spvDescriptorSet3 [[buffer(3)]])
+{
+    spvDescriptorArray<texture2d<float>> t30 {(*(const device spvDescriptor<texture2d<float>>* device *)&spvDescriptorSet1.b30)};
+    spvDescriptorArray<sampler> s30 {(*(const device spvDescriptor<sampler>* device *)&spvDescriptorSet1.b30)};
+    spvDescriptorArray<texture2d<uint>> t31 {(*(const device spvDescriptor<texture2d<uint>>* device *)&spvDescriptorSet1.b30)};
+    spvDescriptorArray<texture2d<int>> t32 {(*(const device spvDescriptor<texture2d<int>>* device *)&spvDescriptorSet1.b30)};
+
+    const device auto& b31 = (constant B31* const device (&)[1])spvDescriptorSet1.b30;
+    constant auto& b21 = (constant B21* constant (&)[8])spvDescriptorSet2.b20;
+    constant auto& b11 = (constant B11* constant (&)[8])spvDescriptorSet3.b10;
+    float4 r0 = spvDescriptorSet0.t00[0].sample((*(device array<sampler, 8>*)&spvDescriptorSet0.t00)[3], float2(0.0), level(0.0));
+    r0.x = as_type<float>((*(device array<texture2d<uint>, 8>*)&spvDescriptorSet0.t00)[1].read(uint2(int2(0)), 0).x);
+    r0.y = as_type<float>((*(device array<texture2d<int>, 8>*)&spvDescriptorSet0.t00)[2].read(uint2(int2(0)), 0).x);
+    (*(device array<texture_buffer<uint, access::read_write>, 8>*)&spvDescriptorSet0.t00)[2].fence();
+    r0.z = as_type<float>((*(device array<texture_buffer<uint, access::read_write>, 8>*)&spvDescriptorSet0.t00)[2].read(uint(0)).x);
+    float4 r1;
+    r1.x = spvDescriptorSet3.b10[3]->v;
+    r1.y = b11[4]->v;
+    (*(constant array<texture_buffer<uint, access::read_write>, 8>*)&spvDescriptorSet3.b10)[2].fence();
+    r1.z = as_type<float>((*(constant array<texture_buffer<uint, access::read_write>, 8>*)&spvDescriptorSet3.b10)[2].read(uint(0)).x);
+    float4 r2 = (*(constant array<texture2d<float>, 8>*)&spvDescriptorSet2.b20)[0].sample((*(constant array<sampler, 8>*)&spvDescriptorSet2.b20)[3], float2(0.0), level(0.0));
+    r2.x = as_type<float>((*(constant array<texture2d<uint>, 8>*)&spvDescriptorSet2.b20)[1].read(uint2(int2(0)), 0).x);
+    r2.y = as_type<float>((*(constant array<texture2d<int>, 8>*)&spvDescriptorSet2.b20)[2].read(uint2(int2(0)), 0).x);
+    (*(constant array<texture_buffer<uint, access::read_write>, 8>*)&spvDescriptorSet2.b20)[2].fence();
+    r2.z = spvDescriptorSet2.b20[3]->v + as_type<float>((*(constant array<texture_buffer<uint, access::read_write>, 8>*)&spvDescriptorSet2.b20)[2].read(uint(0)).x);
+    r2.w = b21[4]->v;
+    uint i = spvDescriptorSet1.b30[0]->i;
+    float4 r3 = t30[i].sample(s30[i + 1u], float2(0.0), level(0.0));
+    r3.x = as_type<float>(t31[i + 2u].read(uint2(int2(0)), 0).x);
+    r3.y = as_type<float>(t32[i + 3u].read(uint2(int2(0)), 0).x);
+    r3.z = b31[i + 5u]->v;
+    (*(device array<texture_buffer<uint, access::read_write>, 8>*)&spvDescriptorSet0.t00)[0].write(uint4(0u), uint(0));
+    (*(constant array<texture_buffer<uint, access::read_write>, 8>*)&spvDescriptorSet3.b10)[0].write(uint4(0u), uint(0));
+    (*(constant array<texture_buffer<uint, access::read_write>, 8>*)&spvDescriptorSet2.b20)[0].write(uint4(0u), uint(0));
+    (*(device array<texture_buffer<uint, access::write>, 1>*)&spvDescriptorSet1.b30)[0].write(uint4(0u), uint(0));
+}
+

--- a/shaders-msl/comp/overlapping-bindings.msl31.argument.argument-tier-1.decoration-binding.device-argument-buffer.texture-buffer-native.comp
+++ b/shaders-msl/comp/overlapping-bindings.msl31.argument.argument-tier-1.decoration-binding.device-argument-buffer.texture-buffer-native.comp
@@ -1,0 +1,71 @@
+#version 450
+#extension GL_EXT_samplerless_texture_functions : require
+#extension GL_EXT_nonuniform_qualifier : require
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(set = 0, binding = 0) uniform samplerShadow s00[8];
+layout(set = 0, binding = 0) uniform texture2D t00[8];
+layout(set = 0, binding = 0) uniform utexture2D t01[8];
+layout(set = 0, binding = 0) uniform itexture2D t02[8];
+layout(set = 0, binding = 0, r32ui) uniform uimageBuffer u0[8];
+
+
+layout(set = 3, binding = 0) buffer B10 { float v; } b10[8];
+layout(set = 3, binding = 0) uniform B11 { float v; } b11[8];
+layout(set = 3, binding = 0, r32ui) uniform uimageBuffer u1[8];
+
+layout(set = 2, binding = 0) uniform samplerShadow s20[8];
+layout(set = 2, binding = 0) uniform texture2D t20[8];
+layout(set = 2, binding = 0) uniform utexture2D t21[8];
+layout(set = 2, binding = 0) uniform itexture2D t22[8];
+layout(set = 2, binding = 0) buffer B20 { float v; } b20[8];
+layout(set = 2, binding = 0) uniform B21 { float v; } b21[8];
+layout(set = 2, binding = 0, r32ui) uniform uimageBuffer u2[8];
+
+layout(set = 1, binding = 0) uniform samplerShadow s30[];
+layout(set = 1, binding = 0) uniform texture2D t30[];
+layout(set = 1, binding = 0) uniform utexture2D t31[];
+layout(set = 1, binding = 0) uniform itexture2D t32[];
+layout(set = 1, binding = 0) buffer B30 { uint i; } b30[];
+layout(set = 1, binding = 0) uniform B31 { float v; } b31[];
+layout(set = 1, binding = 0, r32ui) uniform uimageBuffer u3[];
+
+vec4 r0;
+vec4 r1;
+vec4 r2;
+vec4 r3;
+
+
+void main()
+{
+    r0 = textureLod(sampler2D(t00[0u], s00[3u]), vec4(0.0).xy, 0.0);
+    r0.x = uintBitsToFloat(texelFetch(t01[1u], ivec2(0), 0).x);
+    r0.y =  intBitsToFloat(texelFetch(t02[2u], ivec2(0), 0).x);
+    r0.z = uintBitsToFloat(imageLoad(u0[2u], 0).x);
+
+    r1.x = b10[3u].v;
+    r1.y = b11[4u].v;
+    r1.z = uintBitsToFloat(imageLoad(u1[2u], 0).x);
+
+    r2 = textureLod(sampler2D(t20[0u], s20[3u]), vec4(0.0).xy, 0.0);
+    r2.x = uintBitsToFloat(texelFetch(t21[1u], ivec2(0), 0).x);
+    r2.y =  intBitsToFloat(texelFetch(t22[2u], ivec2(0), 0).x);
+    r2.z = b20[3u].v + uintBitsToFloat(imageLoad(u2[2u], 0).x);
+    r2.w = b21[4u].v;
+
+    uint i = b30[0u].i;
+
+    r3 = textureLod(sampler2D(t30[i], s30[i+1u]), vec4(0.0).xy, 0.0);
+    r3.x = uintBitsToFloat(texelFetch(t31[i+2u], ivec2(0), 0).x);
+    r3.y =  intBitsToFloat(texelFetch(t32[i+3u], ivec2(0), 0).x);
+    r3.z = b31[i+5u].v;
+    // r3.w = uintBitsToFloat(imageLoad(u3[i+6u], 0).x); // TODO: Calls fence() on const device&, which is not supported.
+
+    imageStore(u0[0u], 0, uvec4(0));
+    imageStore(u1[0u], 0, uvec4(0));
+    imageStore(u2[0u], 0, uvec4(0));
+    imageStore(u3[0u], 0, uvec4(0));
+
+}
+

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -1671,6 +1671,8 @@ enum ExtendedDecorations
 	// lack of constructors in the 'threadgroup' address space.
 	SPIRVCrossDecorationWorkgroupStruct,
 
+	SPIRVCrossDecorationOverlappingBinding,
+
 	SPIRVCrossDecorationCount
 };
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -18259,7 +18259,11 @@ void CompilerMSL::analyze_argument_buffers()
 						auto &entry_func = get<SPIRFunction>(ir.default_entry_point);
 						entry_func.fixup_hooks_in.push_back([=]()
 						{
-							auto name = join("(*(", type_to_glsl(get<SPIRType>(var.basetype), var.self, false), "*)&", to_name(resource.overlapping_var_id, false), ")");
+							auto var_type = get<SPIRType>(var.basetype);
+							SPIRType effective_type = var_type;
+							if ((argument_buffer_device_storage_mask & (1u << desc_set)) != 0)
+								effective_type.storage = StorageClassStorageBuffer;
+							auto name = join("(*(", type_to_glsl(effective_type, var.self, false), "*)&", to_name(resource.overlapping_var_id, false), ")");
 							set_qualified_name(var.self, name);
 						});
 					}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -14557,6 +14557,12 @@ bool CompilerMSL::type_is_msl_framebuffer_fetch(const SPIRType &type) const
 
 bool CompilerMSL::type_is_pointer(const SPIRType &type) const
 {
+	if ((type.basetype == SPIRType::Image || type.basetype == SPIRType::Sampler) && !type.array.empty())
+	{
+		uint32_t array_size = get_resource_array_size(type, 0);
+		if (array_size == 0 && processing_entry_point) return true;
+	}
+
 	if (!type.pointer)
 		return false;
 	auto &parent_type = get<SPIRType>(type.parent_type);

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1405,10 +1405,10 @@ void CompilerMSL::emit_entry_point_declarations()
 			case SPIRType::Image:
 			case SPIRType::Sampler:
 			case SPIRType::AccelerationStructure:
-				statement("spvDescriptorArray<", type_to_glsl(buffer_type), "> ", name, " {", resource_name, "};");
+				statement("spvDescriptorArray<", type_to_glsl(buffer_type, var.self), "> ", name, " {", resource_name, "};");
 				break;
 			case SPIRType::SampledImage:
-				statement("spvDescriptorArray<", type_to_glsl(buffer_type), "> ", name, " {", resource_name, "};");
+				statement("spvDescriptorArray<", type_to_glsl(buffer_type, var.self), "> ", name, " {", resource_name, "};");
 				// Unsupported with argument buffer for now.
 				statement("spvDescriptorArray<sampler> ", name, "Smplr {", name, "Smplr_};");
 				break;

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1373,6 +1373,20 @@ void CompilerMSL::emit_entry_point_declarations()
 		const auto &type = get_variable_data_type(var);
 		const auto &buffer_type = get_variable_element_type(var);
 		const string name = to_name(var.self);
+
+		bool has_alias = false;
+		for (auto &pair: buffer_aliases_argument)
+		{
+			if (var.self == pair.first)
+			{
+				has_alias = true;
+				break;
+			}
+		}
+
+		if (has_alias)
+			continue;
+
 		if (is_var_runtime_size_array(var))
 		{
 			if (msl_options.argument_buffers_tier < Options::ArgumentBuffersTier::Tier2)

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -12293,8 +12293,17 @@ string CompilerMSL::to_struct_member(const SPIRType &type, uint32_t member_type_
 	else
 		decl_type = type_to_glsl(*declared_type, orig_id, true);
 
-	auto result = join(pack_pfx, decl_type, " ", qualifier,
-	                   to_member_name(type, index), member_attribute_qualifier(type, index), array_type, ";");
+	string result;
+	if (!has_extended_member_decoration(type.self, index, SPIRVCrossDecorationOverlappingBinding))
+	{
+		result = join(pack_pfx, decl_type, " ", qualifier,
+		               to_member_name(type, index), member_attribute_qualifier(type, index), array_type, ";");
+	}
+	else
+	{
+		result = join("// Overlapping binding: ", pack_pfx, decl_type, " ", qualifier,
+		               to_member_name(type, index), member_attribute_qualifier(type, index), array_type, ";");
+	}
 
 	is_using_builtin_array = false;
 	return result;
@@ -17890,6 +17899,7 @@ void CompilerMSL::analyze_argument_buffers()
 		SPIRType::BaseType basetype;
 		uint32_t index;
 		uint32_t plane;
+		uint32_t overlapping_var_id;
 	};
 	SmallVector<Resource> resources_in_set[kMaxArgumentBuffers];
 	SmallVector<uint32_t> inline_block_vars;
@@ -17964,14 +17974,14 @@ void CompilerMSL::analyze_argument_buffers()
 				{
 					uint32_t image_resource_index = get_metal_resource_index(var, SPIRType::Image, i);
 					resources_in_set[desc_set].push_back(
-					    { &var, descriptor_alias, to_name(var_id), SPIRType::Image, image_resource_index, i });
+					    { &var, descriptor_alias, to_name(var_id), SPIRType::Image, image_resource_index, i, 0 });
 				}
 
 				if (type.image.dim != DimBuffer && !constexpr_sampler)
 				{
 					uint32_t sampler_resource_index = get_metal_resource_index(var, SPIRType::Sampler);
 					resources_in_set[desc_set].push_back(
-					    { &var, descriptor_alias, to_sampler_expression(var_id), SPIRType::Sampler, sampler_resource_index, 0 });
+					    { &var, descriptor_alias, to_sampler_expression(var_id), SPIRType::Sampler, sampler_resource_index, 0, 0 });
 				}
 			}
 			else if (inline_uniform_blocks.count(SetBindingPair{ desc_set, binding }))
@@ -17989,14 +17999,14 @@ void CompilerMSL::analyze_argument_buffers()
 					resource_index = get_metal_resource_index(var, type.basetype);
 
 				resources_in_set[desc_set].push_back(
-					{ &var, descriptor_alias, to_name(var_id), type.basetype, resource_index, 0 });
+					{ &var, descriptor_alias, to_name(var_id), type.basetype, resource_index, 0, 0 });
 
 				// Emulate texture2D atomic operations
 				if (atomic_image_vars_emulated.count(var.self))
 				{
 					uint32_t buffer_resource_index = get_metal_resource_index(var, SPIRType::AtomicCounter, 0);
 					resources_in_set[desc_set].push_back(
-						{ &var, descriptor_alias, to_name(var_id) + "_atomic", SPIRType::Struct, buffer_resource_index, 0 });
+						{ &var, descriptor_alias, to_name(var_id) + "_atomic", SPIRType::Struct, buffer_resource_index, 0, 0 });
 				}
 			}
 
@@ -18044,7 +18054,7 @@ void CompilerMSL::analyze_argument_buffers()
 				set_decoration(var_id, DecorationDescriptorSet, desc_set);
 				set_decoration(var_id, DecorationBinding, kSwizzleBufferBinding);
 				resources_in_set[desc_set].push_back(
-				    { &var, nullptr, to_name(var_id), SPIRType::UInt, get_metal_resource_index(var, SPIRType::UInt), 0 });
+				    { &var, nullptr, to_name(var_id), SPIRType::UInt, get_metal_resource_index(var, SPIRType::UInt), 0, 0 });
 			}
 
 			if (set_needs_buffer_sizes[desc_set])
@@ -18055,7 +18065,7 @@ void CompilerMSL::analyze_argument_buffers()
 				set_decoration(var_id, DecorationDescriptorSet, desc_set);
 				set_decoration(var_id, DecorationBinding, kBufferSizeBufferBinding);
 				resources_in_set[desc_set].push_back(
-				    { &var, nullptr, to_name(var_id), SPIRType::UInt, get_metal_resource_index(var, SPIRType::UInt), 0 });
+				    { &var, nullptr, to_name(var_id), SPIRType::UInt, get_metal_resource_index(var, SPIRType::UInt), 0, 0 });
 			}
 		}
 	}
@@ -18067,7 +18077,7 @@ void CompilerMSL::analyze_argument_buffers()
 		uint32_t desc_set = get_decoration(var_id, DecorationDescriptorSet);
 		add_resource_name(var_id);
 		resources_in_set[desc_set].push_back(
-		    { &var, nullptr, to_name(var_id), SPIRType::Struct, get_metal_resource_index(var, SPIRType::Struct), 0 });
+		    { &var, nullptr, to_name(var_id), SPIRType::Struct, get_metal_resource_index(var, SPIRType::Struct), 0, 0 });
 	}
 
 	for (uint32_t desc_set = 0; desc_set < kMaxArgumentBuffers; desc_set++)
@@ -18115,6 +18125,21 @@ void CompilerMSL::analyze_argument_buffers()
 		stable_sort(begin(resources), end(resources), [&](const Resource &lhs, const Resource &rhs) -> bool {
 			return tie(lhs.index, lhs.basetype) < tie(rhs.index, rhs.basetype);
 		});
+
+		for (size_t i = 0; i < resources.size()-1; ++i) {
+			auto &r1 = resources[i];
+			auto &r2 = resources[i+1];
+
+			if (r1.index == r2.index)
+			{
+				if (r1.overlapping_var_id)
+					r2.overlapping_var_id = r1.overlapping_var_id;
+				else
+					r2.overlapping_var_id = r1.var->self;
+
+				set_extended_decoration(r2.var->self, SPIRVCrossDecorationOverlappingBinding, r2.overlapping_var_id);
+			}
+		}
 
 		uint32_t member_index = 0;
 		uint32_t next_arg_buff_index = 0;
@@ -18215,8 +18240,19 @@ void CompilerMSL::analyze_argument_buffers()
 				{
 					// Drop pointer information when we emit the resources into a struct.
 					buffer_type.member_types.push_back(get_variable_data_type_id(var));
-					if (resource.plane == 0)
+					if (has_extended_decoration(var.self, SPIRVCrossDecorationOverlappingBinding))
+					{
+						auto &entry_func = get<SPIRFunction>(ir.default_entry_point);
+						entry_func.fixup_hooks_in.push_back([=]()
+						{
+							auto name = join("(*(", type_to_glsl(get<SPIRType>(var.basetype), var.self, false), "*)&", to_name(resource.overlapping_var_id, false), ")");
+							set_qualified_name(var.self, name);
+						});
+					}
+					else if (resource.plane == 0)
+					{
 						set_qualified_name(var.self, join(to_name(buffer_variable_id), ".", mbr_name));
+					}
 				}
 				else if (buffers_requiring_dynamic_offset.count(pair))
 				{
@@ -18280,6 +18316,8 @@ void CompilerMSL::analyze_argument_buffers()
 			                               resource.index);
 			set_extended_member_decoration(buffer_type.self, member_index, SPIRVCrossDecorationInterfaceOrigID,
 			                               var.self);
+			if (has_extended_decoration(var.self, SPIRVCrossDecorationOverlappingBinding))
+				set_extended_member_decoration(buffer_type.self, member_index, SPIRVCrossDecorationOverlappingBinding);
 			member_index++;
 		}
 	}


### PR DESCRIPTION
This adds support for bindings which share the same DescriptorSet/Binding pair.

The motivating example is vkd3d, which uses overlapping arrays of resources to emulate D3D12 descriptor tables. The generated MSL argument buffer only includes the first resource (in this example 't0'):
```
struct spvDescriptorSetBuffer2
{
    array<texture2d<float>, 499968> t0 [[id(0)]];
    // Overlapping binding: array<texture3d<float>, 499968> t2 [[id(0)]];
};
```
When t2 is referenced, we cast the instantiated member:
```
float4 r1 = spvDescriptorSet2.t0[_79].sample(...);
float4 r2 = (*(constant array<texture3d<float>, 499968>*)&spvDescriptorSet2.t0)[_97].sample(...);
```