### PR TITLE
MSL: Merge `vulkan-sdk-1.3.280-moltenvk` branch into `main` branch.

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -10205,7 +10205,11 @@ void CompilerMSL::emit_atomic_func_op(uint32_t result_type, uint32_t result_id, 
 				switch (res_type->image.dim)
 				{
 				case Dim1D:
-					exp += join(coord, ".x, ", coord, ".y");
+					if (msl_options.texture_1D_as_2D)
+						exp += join("uint2(", coord, ".x, 0), ", coord, ".y");
+					else
+						exp += join(coord, ".x, ", coord, ".y");
+
 					break;
 				case Dim2D:
 					exp += join(coord, ".xy, ", coord, ".z");
@@ -10214,10 +10218,10 @@ void CompilerMSL::emit_atomic_func_op(uint32_t result_type, uint32_t result_id, 
 					SPIRV_CROSS_THROW("Cannot do atomics on Cube textures.");
 				}
 			}
+			else if (ptr_type.storage == StorageClassImage && res_type->image.dim == Dim1D && msl_options.texture_1D_as_2D)
+				exp += join("uint2(", coord, ", 0)");
 			else
-			{
 				exp += coord;
-			}
 		}
 		else
 		{


### PR DESCRIPTION
MSL: `atomic_compare_exchange_weak()` support `CompilerMSL:msl_options.texture_1D_as_2D`.

- `CompilerMSL:msl_options.texture_1D_as_2D` emulates a Metal 1D texture as a 2D texture in order to expand features available for 1D textures. Support accessing such textures as 2D for `atomic_compare_exchange_weak()`.

This was originally pulled into the SPIRV-Cross `vulkan-sdk-1.3.280-moltenvk` branch in order to have it available for the Vulkan SDK release. This PR is to pull the contributions into `main`. 
