### PR TITLE
Support cases of LUTs which are not function local.

### DIFF
--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -1121,6 +1121,9 @@ struct SPIRVariable : IVariant
 	// Set to true while we're inside the for loop.
 	bool loop_variable_enable = false;
 
+	// Used to find global LUTs
+	bool is_written_to = false;
+
 	SPIRFunction::Parameter *parameter = nullptr;
 
 	SPIRV_CROSS_DECLARE_CLONE(SPIRVariable)


### PR DESCRIPTION
Prevent cases where arrays that are globally defined constants are redeclared on stack. On Intel macs, declaring a large, statically initialized spvUnsafeArray on stack may cause an internal compiler error.