### PR TITLE
Remove spvDescriptor wrapper in spvDescriptorArray

### DIFF
--- a/reference/opt/shaders-msl/comp/argument-buffers-runtime-array-buffer.argument.device-argument-buffer.argument-tier-1.msl2.comp
+++ b/reference/opt/shaders-msl/comp/argument-buffers-runtime-array-buffer.argument.device-argument-buffer.argument-tier-1.msl2.comp
@@ -14,14 +14,14 @@ struct spvDescriptor
 template<typename T>
 struct spvDescriptorArray
 {
-    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(ptr)
+    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(&ptr->value)
     {
     }
     const device T& operator [] (size_t i) const
     {
-        return ptr[i].value;
+        return ptr[i];
     }
-    const device spvDescriptor<T>* ptr;
+    const device T* ptr;
 };
 
 struct SSBO

--- a/reference/opt/shaders-msl/comp/argument-buffers-runtime-array-buffer.rich-descriptor.argument.device-argument-buffer.argument-tier-1.msl2.comp
+++ b/reference/opt/shaders-msl/comp/argument-buffers-runtime-array-buffer.rich-descriptor.argument.device-argument-buffer.argument-tier-1.msl2.comp
@@ -29,14 +29,14 @@ struct spvBufferDescriptor
 template<typename T>
 struct spvDescriptorArray
 {
-    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(ptr)
+    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(&ptr->value)
     {
     }
     const device T& operator [] (size_t i) const
     {
-        return ptr[i].value;
+        return ptr[i];
     }
-    const device spvDescriptor<T>* ptr;
+    const device T* ptr;
 };
 
 template<typename T>

--- a/reference/opt/shaders-msl/comp/argument-buffers-runtime-array.argument.device-argument-buffer.argument-tier-1.msl2.comp
+++ b/reference/opt/shaders-msl/comp/argument-buffers-runtime-array.argument.device-argument-buffer.argument-tier-1.msl2.comp
@@ -14,14 +14,14 @@ struct spvDescriptor
 template<typename T>
 struct spvDescriptorArray
 {
-    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(ptr)
+    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(&ptr->value)
     {
     }
     const device T& operator [] (size_t i) const
     {
-        return ptr[i].value;
+        return ptr[i];
     }
-    const device spvDescriptor<T>* ptr;
+    const device T* ptr;
 };
 
 struct SSBO

--- a/reference/opt/shaders-msl/comp/overlapping-bindings.msl31.argument.argument-tier-1.decoration-binding.device-argument-buffer.texture-buffer-native.comp
+++ b/reference/opt/shaders-msl/comp/overlapping-bindings.msl31.argument.argument-tier-1.decoration-binding.device-argument-buffer.texture-buffer-native.comp
@@ -15,14 +15,14 @@ struct spvDescriptor
 template<typename T>
 struct spvDescriptorArray
 {
-    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(ptr)
+    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(&ptr->value)
     {
     }
     const device T& operator [] (size_t i) const
     {
-        return ptr[i].value;
+        return ptr[i];
     }
-    const device spvDescriptor<T>* ptr;
+    const device T* ptr;
 };
 
 template <typename ImageT>

--- a/reference/opt/shaders-msl/frag/runtime_array_as_argument_buffer.msl3.argument-tier-1.rich-descriptor.frag
+++ b/reference/opt/shaders-msl/frag/runtime_array_as_argument_buffer.msl3.argument-tier-1.rich-descriptor.frag
@@ -57,14 +57,14 @@ struct spvBufferDescriptor
 template<typename T>
 struct spvDescriptorArray
 {
-    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(ptr)
+    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(&ptr->value)
     {
     }
     const device T& operator [] (size_t i) const
     {
-        return ptr[i].value;
+        return ptr[i];
     }
-    const device spvDescriptor<T>* ptr;
+    const device T* ptr;
 };
 
 template<typename T>

--- a/reference/shaders-msl/comp/argument-buffers-runtime-array-buffer.argument.device-argument-buffer.argument-tier-1.msl2.comp
+++ b/reference/shaders-msl/comp/argument-buffers-runtime-array-buffer.argument.device-argument-buffer.argument-tier-1.msl2.comp
@@ -14,14 +14,14 @@ struct spvDescriptor
 template<typename T>
 struct spvDescriptorArray
 {
-    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(ptr)
+    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(&ptr->value)
     {
     }
     const device T& operator [] (size_t i) const
     {
-        return ptr[i].value;
+        return ptr[i];
     }
-    const device spvDescriptor<T>* ptr;
+    const device T* ptr;
 };
 
 struct SSBO

--- a/reference/shaders-msl/comp/argument-buffers-runtime-array-buffer.rich-descriptor.argument.device-argument-buffer.argument-tier-1.msl2.comp
+++ b/reference/shaders-msl/comp/argument-buffers-runtime-array-buffer.rich-descriptor.argument.device-argument-buffer.argument-tier-1.msl2.comp
@@ -29,14 +29,14 @@ struct spvBufferDescriptor
 template<typename T>
 struct spvDescriptorArray
 {
-    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(ptr)
+    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(&ptr->value)
     {
     }
     const device T& operator [] (size_t i) const
     {
-        return ptr[i].value;
+        return ptr[i];
     }
-    const device spvDescriptor<T>* ptr;
+    const device T* ptr;
 };
 
 template<typename T>

--- a/reference/shaders-msl/comp/argument-buffers-runtime-array.argument.device-argument-buffer.argument-tier-1.msl2.comp
+++ b/reference/shaders-msl/comp/argument-buffers-runtime-array.argument.device-argument-buffer.argument-tier-1.msl2.comp
@@ -14,14 +14,14 @@ struct spvDescriptor
 template<typename T>
 struct spvDescriptorArray
 {
-    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(ptr)
+    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(&ptr->value)
     {
     }
     const device T& operator [] (size_t i) const
     {
-        return ptr[i].value;
+        return ptr[i];
     }
-    const device spvDescriptor<T>* ptr;
+    const device T* ptr;
 };
 
 struct SSBO

--- a/reference/shaders-msl/comp/overlapping-bindings.msl31.argument.argument-tier-1.decoration-binding.device-argument-buffer.texture-buffer-native.comp
+++ b/reference/shaders-msl/comp/overlapping-bindings.msl31.argument.argument-tier-1.decoration-binding.device-argument-buffer.texture-buffer-native.comp
@@ -15,14 +15,14 @@ struct spvDescriptor
 template<typename T>
 struct spvDescriptorArray
 {
-    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(ptr)
+    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(&ptr->value)
     {
     }
     const device T& operator [] (size_t i) const
     {
-        return ptr[i].value;
+        return ptr[i];
     }
-    const device spvDescriptor<T>* ptr;
+    const device T* ptr;
 };
 
 template <typename ImageT>

--- a/reference/shaders-msl/frag/runtime_array_as_argument_buffer.msl3.argument-tier-1.rich-descriptor.frag
+++ b/reference/shaders-msl/frag/runtime_array_as_argument_buffer.msl3.argument-tier-1.rich-descriptor.frag
@@ -57,14 +57,14 @@ struct spvBufferDescriptor
 template<typename T>
 struct spvDescriptorArray
 {
-    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(ptr)
+    spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(&ptr->value)
     {
     }
     const device T& operator [] (size_t i) const
     {
-        return ptr[i].value;
+        return ptr[i];
     }
-    const device spvDescriptor<T>* ptr;
+    const device T* ptr;
 };
 
 template<typename T>

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -7419,14 +7419,14 @@ void CompilerMSL::emit_custom_functions()
 				statement("template<typename T>");
 				statement("struct spvDescriptorArray");
 				begin_scope();
-				statement("spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(ptr)");
+				statement("spvDescriptorArray(const device spvDescriptor<T>* ptr) : ptr(&ptr->value)");
 				begin_scope();
 				end_scope();
 				statement("const device T& operator [] (size_t i) const");
 				begin_scope();
-				statement("return ptr[i].value;");
+				statement("return ptr[i];");
 				end_scope();
-				statement("const device spvDescriptor<T>* ptr;");
+				statement("const device T* ptr;");
 				end_scope_decl();
 				statement("");
 			}


### PR DESCRIPTION
That's a workaround for #2308. The diff between shader byte code with and without this change is only the `getelementptr` indexing order for affected variables, and looks something like this: (old above, new below)

```
<   %8 = getelementptr inbounds %struct.spvDescriptorSetBuffer1, ptr addrspace(1) %0, i64 0, i32 0, i64 %7, i32 0, i32 0
---
>   %8 = getelementptr inbounds %struct.spvDescriptorSetBuffer1, ptr addrspace(1) %0, i64 %7, i32 0, i64 0, i32 0, i32 0
```