### PR TITLE
MSL: Add option to force depth write in fragment shaders

### DIFF
--- a/reference/opt/shaders-msl/frag/force-depth-write-early-tests.input-attachment-is-ds-attachment.frag
+++ b/reference/opt/shaders-msl/frag/force-depth-write-early-tests.input-attachment-is-ds-attachment.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 color [[color(0)]];
+};
+
+[[ early_fragment_tests ]] fragment main0_out main0(texture2d<float> inputDepth [[texture(0)]], float4 gl_FragCoord [[position]])
+{
+    main0_out out = {};
+    out.color = inputDepth.read(uint2(gl_FragCoord.xy));
+    return out;
+}
+

--- a/reference/opt/shaders-msl/frag/force-depth-write-false.input-attachment-is-ds-attachment.frag
+++ b/reference/opt/shaders-msl/frag/force-depth-write-false.input-attachment-is-ds-attachment.frag
@@ -1,0 +1,19 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 color [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
+
+fragment main0_out main0(texture2d<float> inputDepth [[texture(0)]], float4 gl_FragCoord [[position]])
+{
+    main0_out out = {};
+    out.color = inputDepth.read(uint2(gl_FragCoord.xy));
+    out.gl_FragDepth = 1.0;
+    return out;
+}
+

--- a/reference/opt/shaders-msl/frag/force-depth-write.input-attachment-is-ds-attachment.frag
+++ b/reference/opt/shaders-msl/frag/force-depth-write.input-attachment-is-ds-attachment.frag
@@ -1,0 +1,19 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 color [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
+
+fragment main0_out main0(texture2d<float> inputDepth [[texture(0)]], float4 gl_FragCoord [[position]])
+{
+    main0_out out = {};
+    out.color = inputDepth.read(uint2(gl_FragCoord.xy));
+    out.gl_FragDepth = gl_FragCoord.z;
+    return out;
+}
+

--- a/reference/shaders-msl/frag/force-depth-write-early-tests.input-attachment-is-ds-attachment.frag
+++ b/reference/shaders-msl/frag/force-depth-write-early-tests.input-attachment-is-ds-attachment.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 color [[color(0)]];
+};
+
+[[ early_fragment_tests ]] fragment main0_out main0(texture2d<float> inputDepth [[texture(0)]], float4 gl_FragCoord [[position]])
+{
+    main0_out out = {};
+    out.color = inputDepth.read(uint2(gl_FragCoord.xy));
+    return out;
+}
+

--- a/reference/shaders-msl/frag/force-depth-write-false.input-attachment-is-ds-attachment.frag
+++ b/reference/shaders-msl/frag/force-depth-write-false.input-attachment-is-ds-attachment.frag
@@ -1,0 +1,19 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 color [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
+
+fragment main0_out main0(texture2d<float> inputDepth [[texture(0)]], float4 gl_FragCoord [[position]])
+{
+    main0_out out = {};
+    out.color = inputDepth.read(uint2(gl_FragCoord.xy));
+    out.gl_FragDepth = 1.0;
+    return out;
+}
+

--- a/reference/shaders-msl/frag/force-depth-write.input-attachment-is-ds-attachment.frag
+++ b/reference/shaders-msl/frag/force-depth-write.input-attachment-is-ds-attachment.frag
@@ -1,0 +1,19 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 color [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
+
+fragment main0_out main0(texture2d<float> inputDepth [[texture(0)]], float4 gl_FragCoord [[position]])
+{
+    main0_out out = {};
+    out.color = inputDepth.read(uint2(gl_FragCoord.xy));
+    out.gl_FragDepth = gl_FragCoord.z;
+    return out;
+}
+

--- a/shaders-msl/frag/force-depth-write-early-tests.input-attachment-is-ds-attachment.frag
+++ b/shaders-msl/frag/force-depth-write-early-tests.input-attachment-is-ds-attachment.frag
@@ -1,0 +1,12 @@
+#version 450
+
+layout(early_fragment_tests) in;
+
+layout (input_attachment_index = 0, binding = 0) uniform subpassInput inputDepth;
+
+layout (location = 0) out vec4 color;
+
+void main()
+{
+    color = subpassLoad(inputDepth);
+}

--- a/shaders-msl/frag/force-depth-write-false.input-attachment-is-ds-attachment.frag
+++ b/shaders-msl/frag/force-depth-write-false.input-attachment-is-ds-attachment.frag
@@ -1,0 +1,11 @@
+#version 450
+
+layout (input_attachment_index = 0, binding = 0) uniform subpassInput inputDepth;
+
+layout (location = 0) out vec4 color;
+
+void main()
+{
+    color = subpassLoad(inputDepth);
+    gl_FragDepth = 1.0f;
+}

--- a/shaders-msl/frag/force-depth-write.input-attachment-is-ds-attachment.frag
+++ b/shaders-msl/frag/force-depth-write.input-attachment-is-ds-attachment.frag
@@ -1,0 +1,10 @@
+#version 450
+
+layout (input_attachment_index = 0, binding = 0) uniform subpassInput inputDepth;
+
+layout (location = 0) out vec4 color;
+
+void main()
+{
+    color = subpassLoad(inputDepth);
+}

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -529,6 +529,13 @@ public:
 		// with side effects. Provided as an option hoping Metal will fix this issue in the future.
 		bool force_fragment_with_side_effects_execution = false;
 
+		// If set, adds a depth pass through statement to circumvent the following issue:
+		// When the same depth/stencil is used as input and depth/stencil attachment, we need to
+		// force Metal to perform the depth/stencil write after fragment execution. Otherwise,
+		// Metal will write to the depth attachment before fragment execution. This happens
+		// if the fragment does not modify the depth value.
+		bool input_attachment_is_ds_attachment = false;
+
 		bool is_ios() const
 		{
 			return platform == iOS;
@@ -1094,6 +1101,7 @@ protected:
 	uint32_t builtin_stage_input_size_id = 0;
 	uint32_t builtin_local_invocation_index_id = 0;
 	uint32_t builtin_workgroup_size_id = 0;
+	uint32_t builtin_frag_depth_id = 0;
 	uint32_t swizzle_buffer_id = 0;
 	uint32_t buffer_size_buffer_id = 0;
 	uint32_t view_mask_buffer_id = 0;
@@ -1190,6 +1198,7 @@ protected:
 	bool needs_subgroup_size = false;
 	bool needs_sample_id = false;
 	bool needs_helper_invocation = false;
+	bool writes_to_depth = false;
 	std::string qual_pos_var_name;
 	std::string stage_in_var_name = "in";
 	std::string stage_out_var_name = "out";

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -388,6 +388,8 @@ def cross_compile_msl(shader, spirv, opt, iterations, paths):
         msl_args.append('--msl-runtime-array-rich-descriptor')
     if '.replace-recursive-inputs.' in shader:
         msl_args.append('--msl-replace-recursive-inputs')
+    if '.input-attachment-is-ds-attachment.' in shader:
+        msl_args.append('--msl-input-attachment-is-ds-attachment')
     if '.mask-location-0.' in shader:
         msl_args.append('--mask-stage-output-location')
         msl_args.append('0')


### PR DESCRIPTION
Metal writes to the depth/stencil attachment before fragment shader execution if the execution does not modify the depth value. However, Vulkan expects the write to happen after fragment shader execution. To circumvent the issue we add a simple depth passthrough if the user opts in. Only required when the depth/stencil attachment is used as input attachment at the same time. It seems Metal does not correctly detect the dependency.

Required for https://github.com/KhronosGroup/MoltenVK/issues/2232