### PR TITLE
MSL: Support a runtime array with dynamic offset in an argument buffer.

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1361,14 +1361,14 @@ void CompilerMSL::emit_entry_point_declarations()
 
 		if (is_array(type))
 		{
-			if (!type.array[type.array.size() - 1])
-				SPIRV_CROSS_THROW("Runtime arrays with dynamic offsets are not supported yet.");
-
 			is_using_builtin_array = true;
 			statement(get_argument_address_space(var), " ", type_to_glsl(type), "* ", to_restrict(var_id, true), name,
 			          type_to_array_glsl(type, var_id), " =");
 
-			uint32_t array_size = to_array_size_literal(type);
+			uint32_t array_size = get_resource_array_size(type, var_id);
+			if (array_size == 0)
+				SPIRV_CROSS_THROW("Size of runtime array with dynamic offset could not be determined from resource bindings.");
+
 			begin_scope();
 
 			for (uint32_t i = 0; i < array_size; i++)


### PR DESCRIPTION
- Modify `get_resource_array_size()` to retrieve size of descriptors in an argument buffer from resource_bindings (reversing change made in b236352).
- Retrieve size of runtime array from `get_resource_array_size()`.

@HansKristian-Work This PR reverses the b236352 commit from PR #2329. It was not clear why the restriction from that commit is required (what is the ABI referenced there?), and it means that variables held within an argument buffer descriptor set cannot have their sizes established by the app. This is particularly troublesome for SPIR-V runtime arrays, whose size must be set by the app.

Several hundred CTS tests use a runtime array in SPIR-V to read from a fixed-size array defined in a Vulkan descriptor set.

If the restriction in b236352 is still required, perhaps this PR could add a parameter to `msl_options` to control when is it required.