### PR TITLE
Fix metal shader texture/sampler binding wrong number when Sampler2Ds in GLSL shader are not arranged in sequential order

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -13764,12 +13764,12 @@ void CompilerMSL::entry_point_args_discrete_descriptors(string &ep_args)
 				entry_point_bindings.push_back(&var);
 				for (uint32_t i = 0; i < plane_count; i++)
 					resources.push_back({&var, discrete_descriptor_alias, to_name(var_id), SPIRType::Image,
-					                     get_metal_resource_index(var, SPIRType::Image, i), i, secondary_index });
+					                     get_decoration(var_id, DecorationBinding), i, secondary_index });
 
 				if (type.image.dim != DimBuffer && !constexpr_sampler)
 				{
 					resources.push_back({&var, discrete_descriptor_alias, to_sampler_expression(var_id), SPIRType::Sampler,
-					                     get_metal_resource_index(var, SPIRType::Sampler), 0, 0 });
+					                     get_decoration(var_id, DecorationBinding), 0, 0 });
 				}
 			}
 			else if (!constexpr_sampler)


### PR DESCRIPTION
The order of sampler2D objects after conversion depends on the order in which they are used.

This is my source shader:
```glsl
#version 460

layout(set = 0, binding = 0) uniform sampler2D texUnit0;
layout(set = 0, binding = 1) uniform sampler2D texUnit1;
layout(set = 0, binding = 2) uniform sampler2D texUnit2;
layout(set = 0, binding = 3) uniform sampler2D texUnit3;

void main()
{
    lowp vec4 color3 = texture(texUnit3, texCoord_f);
    lowp vec4 color0 = texture(texUnit0, texCoord_f);
    lowp vec4 color1 = texture(texUnit1, texCoord_f);
    lowp vec4 color2 = texture(texUnit2, texCoord_f);

    outColor = vec4(1,1,1,1);
}

``` 

After transfer by glslang + spriv-cross,

the reflect json file:
```
"textures" : [
        {
            "type" : "sampler2D",
            "name" : "texUnit0",
            "set" : 0,
            "binding" : 0
        },
        {
            "type" : "sampler2D",
            "name" : "texUnit1",
            "set" : 0,
            "binding" : 1
        },
        {
            "type" : "sampler2D",
            "name" : "texUnit3",
            "set" : 0,
            "binding" : 3
        },
        {
            "type" : "sampler2D",
            "name" : "texUnit2",
            "set" : 0,
            "binding" : 2
        }
    ]
``` 

my OpenGLES shader :
```glsl
#version 300 es

uniform highp sampler2D texUnit3;
uniform highp sampler2D texUnit0;
uniform highp sampler2D texUnit1;
uniform highp sampler2D texUnit2;
``` 

my metal shader : 
```c++
fragment main0_out main0(main0_in in [[stage_in]], 
texture2d<float> texUnit3 [[texture(0)]], texture2d<float> texUnit0 [[texture(1)]], 
texture2d<float> texUnit1 [[texture(2)]], texture2d<float> texUnit2 [[texture(3)]], 
sampler texUnit3Smplr [[sampler(0)]], sampler texUnit0Smplr [[sampler(1)]], 
sampler texUnit1Smplr [[sampler(2)]], sampler texUnit2Smplr [[sampler(3)]])
``` 

The texture binding number  in metal shader is different from the original opengl shader.