### PR TITLE
Fix incorrect return value for ParsedIR::get_member_decoration(SpvDecorationMatrixStride)

### DIFF
--- a/spirv_cross_parsed_ir.cpp
+++ b/spirv_cross_parsed_ir.cpp
@@ -783,6 +783,8 @@ uint32_t ParsedIR::get_member_decoration(TypeID id, uint32_t index, Decoration d
 		return dec.stream;
 	case DecorationSpecId:
 		return dec.spec_id;
+	case DecorationMatrixStride:
+		return dec.matrix_stride;
 	case DecorationIndex:
 		return dec.index;
 	default:


### PR DESCRIPTION
Discovered through the `spvc_compiler_get_member_decoration()` C interface, it was returning 1 instead of the correct value. The JSON backend is unaffected, it seems to obtain the data some other way.