### PR TITLE
Fix CMake failing with Android NDK 27+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,9 @@ if (${CMAKE_VERSION} VERSION_GREATER "3.0.1")
 	cmake_policy(SET CMP0048 NEW)
 endif()
 
+# Avoid error on Android NDK 27+'s CMake files
+cmake_policy(SET CMP0057 NEW)
+
 project(SPIRV-Cross LANGUAGES CXX C)
 enable_testing()
 


### PR DESCRIPTION
I'm not well versed with the project so I'm not sure how to describe this any further, but we've encountered this error in one of our [tools](https://github.com/ppy/veldrid-spirv/pull) which relies on this repo:
```
CMake Warning (dev) at C:/Android/android-sdk/ndk/27.0.12077973/build/cmake/flags.cmake:46 (if):
  Policy CMP0057 is not set: Support new IN_LIST if() operator.  Run "cmake
  --help-policy CMP0057" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  IN_LIST will be interpreted as an operator when the policy is set to NEW.
  Since the policy is not set the OLD behavior will be used.
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.30/Modules/Platform/Android-Clang.cmake:23 (include)
  C:/Program Files/CMake/share/cmake-3.30/Modules/Platform/Android-Clang-CXX.cmake:1 (include)
  C:/Program Files/CMake/share/cmake-3.30/Modules/CMakeCXXInformation.cmake:48 (include)
  ext/SPIRV-Cross/CMakeLists.txt:31 (project)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Error at C:/Android/android-sdk/ndk/27.0.12077973/build/cmake/flags.cmake:46 (if):
  if given arguments:

    "hwaddress" "IN_LIST" "ANDROID_SANITIZE"

  Unknown arguments specified
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.30/Modules/Platform/Android-Clang.cmake:23 (include)
  C:/Program Files/CMake/share/cmake-3.30/Modules/Platform/Android-Clang-CXX.cmake:1 (include)
  C:/Program Files/CMake/share/cmake-3.30/Modules/CMakeCXXInformation.cmake:48 (include)
  ext/SPIRV-Cross/CMakeLists.txt:31 (project)
```

It appears that since Android NDK 27, the cmake files in there require the `CMP0057` policy to be set at this repo's `CMakeLists` file.