### PR TITLE
Replace assert of buffer block SPIRType with exception in `get_buffer_block_flags`

### DIFF
--- a/spirv_cross_parsed_ir.cpp
+++ b/spirv_cross_parsed_ir.cpp
@@ -564,7 +564,8 @@ Bitset ParsedIR::get_buffer_block_type_flags(const SPIRType &type) const
 Bitset ParsedIR::get_buffer_block_flags(const SPIRVariable &var) const
 {
 	auto &type = get<SPIRType>(var.basetype);
-	assert(type.basetype == SPIRType::Struct);
+	if (type.basetype != SPIRType::Struct)
+		SPIRV_CROSS_THROW("Cannot get buffer block flags for non-buffer variable.");
 
 	// Some flags like non-writable, non-readable are actually found
 	// as member decorations. If all members have a decoration set, propagate


### PR DESCRIPTION
The assert in `ParsedIR::get_buffer_block_flags` is exposed to user code if `Compiler::get_buffer_block_flags` or `spvc_compiler_get_buffer_block_decorations` is called with a non-buffer variable (handle).

Particularly since the C API has no way of getting a `SPIRType` given only a `spvc_variable_id` this should not cause an assertion fail or be ignored but throw an exception.