### PR TITLE
Add out-of-bounds check

### DIFF
--- a/spirv_cross_parsed_ir.cpp
+++ b/spirv_cross_parsed_ir.cpp
@@ -928,6 +928,9 @@ void ParsedIR::reset_all_of_type(Types type)
 
 void ParsedIR::add_typed_id(Types type, ID id)
 {
+	if (id == ids.size())
+		return;
+	
 	if (loop_iteration_depth_hard != 0)
 		SPIRV_CROSS_THROW("Cannot add typed ID while looping over it.");
 
@@ -1030,6 +1033,9 @@ ParsedIR::LoopLock &ParsedIR::LoopLock::operator=(LoopLock &&other) SPIRV_CROSS_
 
 void ParsedIR::make_constant_null(uint32_t id, uint32_t type, bool add_to_typed_id_set)
 {
+	if (id == ids.size())
+		return;
+	
 	auto &constant_type = get<SPIRType>(type);
 
 	if (constant_type.pointer)


### PR DESCRIPTION
The size of the buffer from size is used as an array index. This value could be one larger than the last possible index of the array, causing a buffer overread.