### PR TITLE
MSL: add fmod to reserved function names

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -15254,6 +15254,7 @@ const std::unordered_set<std::string> &CompilerMSL::get_illegal_func_names()
 		"fmin3",
 		"fmax3",
 		"divide",
+		"fmod",
 		"median3",
 		"VARIABLE_TRACEPOINT",
 		"STATIC_DATA_TRACEPOINT",


### PR DESCRIPTION
Fix https://github.com/KhronosGroup/SPIRV-Cross/issues/2381

Found the similar ticket as I was writing up the bug report, the fix is so trivial I might as well just do it.