### PR TITLE
SPIRV emitter backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,6 +459,10 @@ if (SPIRV_CROSS_CLI)
 		message(FATAL_ERROR "Must enable MSL if building CLI.")
 	endif()
 
+	if (NOT SPIRV_CROSS_ENABLE_SPIRV)
+		message(FATAL_ERROR "Must enable SPIRV if building CLI.")
+	endif()
+
 	if (NOT SPIRV_CROSS_ENABLE_CPP)
 		message(FATAL_ERROR "Must enable C++ if building CLI.")
 	endif()
@@ -487,6 +491,7 @@ if (SPIRV_CROSS_CLI)
 			spirv-cross-hlsl
 			spirv-cross-cpp
 			spirv-cross-reflect
+			spirv-cross-spirv
 			spirv-cross-msl
 			spirv-cross-util
 			spirv-cross-core)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ option(SPIRV_CROSS_ENABLE_GLSL "Enable GLSL support." ON)
 option(SPIRV_CROSS_ENABLE_HLSL "Enable HLSL target support." ON)
 option(SPIRV_CROSS_ENABLE_MSL "Enable MSL target support." ON)
 option(SPIRV_CROSS_ENABLE_CPP "Enable C++ target support." ON)
+option(SPIRV_CROSS_ENABLE_SPIRV "Enable SPIRV target support." ON)
 option(SPIRV_CROSS_ENABLE_REFLECT "Enable JSON reflection target support." ON)
 option(SPIRV_CROSS_ENABLE_C_API "Enable C API wrapper support in static library." ON)
 option(SPIRV_CROSS_ENABLE_UTIL "Enable util module support." ON)
@@ -237,6 +238,10 @@ set(spirv-cross-hlsl-sources
 		${CMAKE_CURRENT_SOURCE_DIR}/spirv_hlsl.cpp
 		${CMAKE_CURRENT_SOURCE_DIR}/spirv_hlsl.hpp)
 
+set(spirv-cross-spirv-sources
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_spirv.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/spirv_spirv.hpp)
+
 set(spirv-cross-reflect-sources
 		${CMAKE_CURRENT_SOURCE_DIR}/spirv_reflect.cpp
 		${CMAKE_CURRENT_SOURCE_DIR}/spirv_reflect.hpp)
@@ -307,6 +312,16 @@ if (SPIRV_CROSS_STATIC)
 		endif()
 	endif()
 
+	if (SPIRV_CROSS_ENABLE_SPIRV)
+		spirv_cross_add_library(spirv-cross-spirv spirv_cross_spirv STATIC
+				${spirv-cross-spirv-sources})
+		if (SPIRV_CROSS_ENABLE_GLSL)
+			target_link_libraries(spirv-cross-hlsl PRIVATE spirv-cross-glsl)
+		else()
+			message(FATAL_ERROR "Must enable GLSL support to enable SPIRV support.")
+		endif()
+	endif()
+
 	if (SPIRV_CROSS_ENABLE_UTIL)
 		spirv_cross_add_library(spirv-cross-util spirv_cross_util STATIC
 				${spirv-cross-util-sources})
@@ -337,6 +352,11 @@ if (SPIRV_CROSS_STATIC)
 		if (SPIRV_CROSS_ENABLE_CPP)
 			target_link_libraries(spirv-cross-c PRIVATE spirv-cross-cpp)
 			target_compile_definitions(spirv-cross-c PRIVATE SPIRV_CROSS_C_API_CPP=1)
+		endif()
+
+		if (SPIRV_CROSS_ENABLE_SPIRV)
+			target_link_libraries(spirv-cross-c PRIVATE spirv-cross-cpp)
+			target_compile_definitions(spirv-cross-c PRIVATE SPIRV_CROSS_C_API_SPIRV=1)
 		endif()
 
 		if (SPIRV_CROSS_ENABLE_REFLECT)
@@ -391,6 +411,15 @@ if (SPIRV_CROSS_SHARED)
 			message(FATAL_ERROR "Must enable GLSL support to enable C++ support.")
 		endif()
 		target_compile_definitions(spirv-cross-c-shared PRIVATE SPIRV_CROSS_C_API_CPP=1)
+	endif()
+
+	if (SPIRV_CROSS_ENABLE_SPIRV)
+		if (SPIRV_CROSS_ENABLE_GLSL)
+			target_sources(spirv-cross-c-shared PRIVATE ${spirv-cross-spirv-sources})
+		else()
+			message(FATAL_ERROR "Must enable GLSL support to enable SPIRV support.")
+		endif()
+		target_compile_definitions(spirv-cross-c-shared PRIVATE SPIRV_CROSS_C_API_SPIRV=1)
 	endif()
 
 	if (SPIRV_CROSS_ENABLE_REFLECT)

--- a/main.cpp
+++ b/main.cpp
@@ -26,24 +26,24 @@
 #include "spirv_glsl.hpp"
 #include "spirv_hlsl.hpp"
 #include "spirv_msl.hpp"
-#include "spirv_spirv.hpp"
 #include "spirv_parser.hpp"
 #include "spirv_reflect.hpp"
+#include "spirv_spirv.hpp"
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
+#include <fstream>
 #include <functional>
+#include <iostream>
 #include <limits>
 #include <memory>
 #include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
-#include <iostream>
-#include <fstream>
 
 #ifdef _WIN32
-#include <io.h>
 #include <fcntl.h>
+#include <io.h>
 #endif
 
 #ifdef HAVE_SPIRV_CROSS_GIT_VERSION
@@ -299,10 +299,17 @@ static void print_resources(const Compiler &compiler, spv::StorageClass storage,
 		auto &type = compiler.get_type(res.value_type_id);
 		switch (type.basetype)
 		{
-		case SPIRType::Float: basetype = "float"; break;
-		case SPIRType::Int: basetype = "int"; break;
-		case SPIRType::UInt: basetype = "uint"; break;
-		default: break;
+		case SPIRType::Float:
+			basetype = "float";
+			break;
+		case SPIRType::Int:
+			basetype = "int";
+			break;
+		case SPIRType::UInt:
+			basetype = "uint";
+			break;
+		default:
+			break;
 		}
 
 		uint32_t array_size = 0;
@@ -328,16 +335,30 @@ static void print_resources(const Compiler &compiler, spv::StorageClass storage,
 		string builtin_str;
 		switch (res.builtin)
 		{
-		case spv::BuiltInPosition: builtin_str = "Position"; break;
-		case spv::BuiltInPointSize: builtin_str = "PointSize"; break;
-		case spv::BuiltInCullDistance: builtin_str = "CullDistance"; break;
-		case spv::BuiltInClipDistance: builtin_str = "ClipDistance"; break;
-		case spv::BuiltInTessLevelInner: builtin_str = "TessLevelInner"; break;
-		case spv::BuiltInTessLevelOuter: builtin_str = "TessLevelOuter"; break;
-		default: builtin_str = string("builtin #") + to_string(res.builtin);
+		case spv::BuiltInPosition:
+			builtin_str = "Position";
+			break;
+		case spv::BuiltInPointSize:
+			builtin_str = "PointSize";
+			break;
+		case spv::BuiltInCullDistance:
+			builtin_str = "CullDistance";
+			break;
+		case spv::BuiltInClipDistance:
+			builtin_str = "ClipDistance";
+			break;
+		case spv::BuiltInTessLevelInner:
+			builtin_str = "TessLevelInner";
+			break;
+		case spv::BuiltInTessLevelOuter:
+			builtin_str = "TessLevelOuter";
+			break;
+		default:
+			builtin_str = string("builtin #") + to_string(res.builtin);
 		}
 
-		fprintf(stderr, "Builtin %s (%s) (active: %s).\n", builtin_str.c_str(), type_str.c_str(), active ? "yes" : "no");
+		fprintf(stderr, "Builtin %s (%s) (active: %s).\n", builtin_str.c_str(), type_str.c_str(),
+		        active ? "yes" : "no");
 	}
 	fprintf(stderr, "=============\n\n");
 }
@@ -467,63 +488,65 @@ static void print_resources(const Compiler &compiler, const ShaderResources &res
 	fprintf(stderr, "\n");
 
 	fprintf(stderr, "Execution modes:\n");
-	modes.for_each_bit([&](uint32_t i) {
-		auto mode = static_cast<ExecutionMode>(i);
-		uint32_t arg0 = compiler.get_execution_mode_argument(mode, 0);
-		uint32_t arg1 = compiler.get_execution_mode_argument(mode, 1);
-		uint32_t arg2 = compiler.get_execution_mode_argument(mode, 2);
+	modes.for_each_bit(
+	    [&](uint32_t i)
+	    {
+		    auto mode = static_cast<ExecutionMode>(i);
+		    uint32_t arg0 = compiler.get_execution_mode_argument(mode, 0);
+		    uint32_t arg1 = compiler.get_execution_mode_argument(mode, 1);
+		    uint32_t arg2 = compiler.get_execution_mode_argument(mode, 2);
 
-		switch (static_cast<ExecutionMode>(i))
-		{
-		case ExecutionModeInvocations:
-			fprintf(stderr, "  Invocations: %u\n", arg0);
-			break;
+		    switch (static_cast<ExecutionMode>(i))
+		    {
+		    case ExecutionModeInvocations:
+			    fprintf(stderr, "  Invocations: %u\n", arg0);
+			    break;
 
-		case ExecutionModeLocalSize:
-			fprintf(stderr, "  LocalSize: (%u, %u, %u)\n", arg0, arg1, arg2);
-			break;
+		    case ExecutionModeLocalSize:
+			    fprintf(stderr, "  LocalSize: (%u, %u, %u)\n", arg0, arg1, arg2);
+			    break;
 
-		case ExecutionModeOutputVertices:
-			fprintf(stderr, "  OutputVertices: %u\n", arg0);
-			break;
+		    case ExecutionModeOutputVertices:
+			    fprintf(stderr, "  OutputVertices: %u\n", arg0);
+			    break;
 
 #define CHECK_MODE(m)                  \
 	case ExecutionMode##m:             \
 		fprintf(stderr, "  %s\n", #m); \
 		break
-			CHECK_MODE(SpacingEqual);
-			CHECK_MODE(SpacingFractionalEven);
-			CHECK_MODE(SpacingFractionalOdd);
-			CHECK_MODE(VertexOrderCw);
-			CHECK_MODE(VertexOrderCcw);
-			CHECK_MODE(PixelCenterInteger);
-			CHECK_MODE(OriginUpperLeft);
-			CHECK_MODE(OriginLowerLeft);
-			CHECK_MODE(EarlyFragmentTests);
-			CHECK_MODE(PointMode);
-			CHECK_MODE(Xfb);
-			CHECK_MODE(DepthReplacing);
-			CHECK_MODE(DepthGreater);
-			CHECK_MODE(DepthLess);
-			CHECK_MODE(DepthUnchanged);
-			CHECK_MODE(LocalSizeHint);
-			CHECK_MODE(InputPoints);
-			CHECK_MODE(InputLines);
-			CHECK_MODE(InputLinesAdjacency);
-			CHECK_MODE(Triangles);
-			CHECK_MODE(InputTrianglesAdjacency);
-			CHECK_MODE(Quads);
-			CHECK_MODE(Isolines);
-			CHECK_MODE(OutputPoints);
-			CHECK_MODE(OutputLineStrip);
-			CHECK_MODE(OutputTriangleStrip);
-			CHECK_MODE(VecTypeHint);
-			CHECK_MODE(ContractionOff);
+			    CHECK_MODE(SpacingEqual);
+			    CHECK_MODE(SpacingFractionalEven);
+			    CHECK_MODE(SpacingFractionalOdd);
+			    CHECK_MODE(VertexOrderCw);
+			    CHECK_MODE(VertexOrderCcw);
+			    CHECK_MODE(PixelCenterInteger);
+			    CHECK_MODE(OriginUpperLeft);
+			    CHECK_MODE(OriginLowerLeft);
+			    CHECK_MODE(EarlyFragmentTests);
+			    CHECK_MODE(PointMode);
+			    CHECK_MODE(Xfb);
+			    CHECK_MODE(DepthReplacing);
+			    CHECK_MODE(DepthGreater);
+			    CHECK_MODE(DepthLess);
+			    CHECK_MODE(DepthUnchanged);
+			    CHECK_MODE(LocalSizeHint);
+			    CHECK_MODE(InputPoints);
+			    CHECK_MODE(InputLines);
+			    CHECK_MODE(InputLinesAdjacency);
+			    CHECK_MODE(Triangles);
+			    CHECK_MODE(InputTrianglesAdjacency);
+			    CHECK_MODE(Quads);
+			    CHECK_MODE(Isolines);
+			    CHECK_MODE(OutputPoints);
+			    CHECK_MODE(OutputLineStrip);
+			    CHECK_MODE(OutputTriangleStrip);
+			    CHECK_MODE(VecTypeHint);
+			    CHECK_MODE(ContractionOff);
 
-		default:
-			break;
-		}
-	});
+		    default:
+			    break;
+		    }
+	    });
 	fprintf(stderr, "\n");
 
 	print_resources(compiler, "subpass inputs", res.subpass_inputs);
@@ -647,7 +670,7 @@ struct CLIArguments
 	bool msl_pad_fragment_output = false;
 	bool msl_domain_lower_left = false;
 	bool msl_argument_buffers = false;
-	uint32_t msl_argument_buffers_tier = 0;		// Tier 1
+	uint32_t msl_argument_buffers_tier = 0; // Tier 1
 	bool msl_texture_buffer_native = false;
 	bool msl_framebuffer_fetch = false;
 	bool msl_invariant_float_math = false;
@@ -1234,7 +1257,8 @@ static string compile_iteration(const CLIArguments &args, std::vector<uint32_t> 
 		msl_opts.pad_fragment_output_components = args.msl_pad_fragment_output;
 		msl_opts.tess_domain_origin_lower_left = args.msl_domain_lower_left;
 		msl_opts.argument_buffers = args.msl_argument_buffers;
-		msl_opts.argument_buffers_tier = static_cast<CompilerMSL::Options::ArgumentBuffersTier>(args.msl_argument_buffers_tier);
+		msl_opts.argument_buffers_tier =
+		    static_cast<CompilerMSL::Options::ArgumentBuffersTier>(args.msl_argument_buffers_tier);
 		msl_opts.texture_buffer_native = args.msl_texture_buffer_native;
 		msl_opts.multiview = args.msl_multiview;
 		msl_opts.multiview_layered_rendering = args.msl_multiview_layered_rendering;
@@ -1302,7 +1326,8 @@ static string compile_iteration(const CLIArguments &args, std::vector<uint32_t> 
 
 	if (!args.variable_type_remaps.empty())
 	{
-		auto remap_cb = [&](const SPIRType &, const string &name, string &out) -> void {
+		auto remap_cb = [&](const SPIRType &, const string &name, string &out) -> void
+		{
 			for (const VariableTypeRemap &remap : args.variable_type_remaps)
 				if (name == remap.variable_name)
 					out = remap.new_variable_type;
@@ -1565,9 +1590,8 @@ static string compile_iteration(const CLIArguments &args, std::vector<uint32_t> 
 
 		for (auto &named_remap : args.hlsl_attr_remap_named)
 		{
-			auto itr = std::find_if(res.stage_inputs.begin(), res.stage_inputs.end(), [&](const Resource &input_res) {
-				return input_res.name == named_remap.name;
-			});
+			auto itr = std::find_if(res.stage_inputs.begin(), res.stage_inputs.end(),
+			                        [&](const Resource &input_res) { return input_res.name == named_remap.name; });
 
 			if (itr != res.stage_inputs.end())
 			{
@@ -1599,27 +1623,37 @@ static int main_inner(int argc, char *argv[])
 	CLIArguments args;
 	CLICallbacks cbs;
 
-	cbs.add("--help", [](CLIParser &parser) {
-		print_help();
-		parser.end();
-	});
-	cbs.add("--revision", [](CLIParser &parser) {
-		print_version();
-		parser.end();
-	});
+	cbs.add("--help",
+	        [](CLIParser &parser)
+	        {
+		        print_help();
+		        parser.end();
+	        });
+	cbs.add("--revision",
+	        [](CLIParser &parser)
+	        {
+		        print_version();
+		        parser.end();
+	        });
 	cbs.add("--output", [&args](CLIParser &parser) { args.output = parser.next_string(); });
-	cbs.add("--es", [&args](CLIParser &) {
-		args.es = true;
-		args.set_es = true;
-	});
-	cbs.add("--no-es", [&args](CLIParser &) {
-		args.es = false;
-		args.set_es = true;
-	});
-	cbs.add("--version", [&args](CLIParser &parser) {
-		args.version = parser.next_uint();
-		args.set_version = true;
-	});
+	cbs.add("--es",
+	        [&args](CLIParser &)
+	        {
+		        args.es = true;
+		        args.set_es = true;
+	        });
+	cbs.add("--no-es",
+	        [&args](CLIParser &)
+	        {
+		        args.es = false;
+		        args.set_es = true;
+	        });
+	cbs.add("--version",
+	        [&args](CLIParser &parser)
+	        {
+		        args.version = parser.next_uint();
+		        args.set_version = true;
+	        });
 	cbs.add("--dump-resources", [&args](CLIParser &) { args.dump_resources = true; });
 	cbs.add("--force-temporary", [&args](CLIParser &) { args.force_temporary = true; });
 	cbs.add("--flatten-ubo", [&args](CLIParser &) { args.flatten_ubo = true; });
@@ -1634,15 +1668,17 @@ static int main_inner(int argc, char *argv[])
 	cbs.add("--glsl-emit-push-constant-as-ubo", [&args](CLIParser &) { args.glsl_emit_push_constant_as_ubo = true; });
 	cbs.add("--glsl-emit-ubo-as-plain-uniforms", [&args](CLIParser &) { args.glsl_emit_ubo_as_plain_uniforms = true; });
 	cbs.add("--glsl-force-flattened-io-blocks", [&args](CLIParser &) { args.glsl_force_flattened_io_blocks = true; });
-	cbs.add("--glsl-ovr-multiview-view-count", [&args](CLIParser &parser) { args.glsl_ovr_multiview_view_count = parser.next_uint(); });
-	cbs.add("--glsl-remap-ext-framebuffer-fetch", [&args](CLIParser &parser) {
-		uint32_t input_index = parser.next_uint();
-		uint32_t color_attachment = parser.next_uint();
-		args.glsl_ext_framebuffer_fetch.push_back({ input_index, color_attachment });
-	});
-	cbs.add("--glsl-ext-framebuffer-fetch-noncoherent", [&args](CLIParser &) {
-		args.glsl_ext_framebuffer_fetch_noncoherent = true;
-	});
+	cbs.add("--glsl-ovr-multiview-view-count",
+	        [&args](CLIParser &parser) { args.glsl_ovr_multiview_view_count = parser.next_uint(); });
+	cbs.add("--glsl-remap-ext-framebuffer-fetch",
+	        [&args](CLIParser &parser)
+	        {
+		        uint32_t input_index = parser.next_uint();
+		        uint32_t color_attachment = parser.next_uint();
+		        args.glsl_ext_framebuffer_fetch.push_back({ input_index, color_attachment });
+	        });
+	cbs.add("--glsl-ext-framebuffer-fetch-noncoherent",
+	        [&args](CLIParser &) { args.glsl_ext_framebuffer_fetch_noncoherent = true; });
 	cbs.add("--vulkan-glsl-disable-ext-samplerless-texture-functions",
 	        [&args](CLIParser &) { args.vulkan_glsl_disable_ext_samplerless_texture_functions = true; });
 	cbs.add("--disable-storage-image-qualifier-deduction",
@@ -1654,14 +1690,15 @@ static int main_inner(int argc, char *argv[])
 	cbs.add("--hlsl-enable-compat", [&args](CLIParser &) { args.hlsl_compat = true; });
 	cbs.add("--hlsl-support-nonzero-basevertex-baseinstance",
 	        [&args](CLIParser &) { args.hlsl_support_nonzero_base = true; });
-	cbs.add("--hlsl-basevertex-baseinstance-binding", [&args](CLIParser &parser) {
-		args.hlsl_base_vertex_index_explicit_binding = true;
-		args.hlsl_base_vertex_index_register_index = parser.next_uint();
-		args.hlsl_base_vertex_index_register_space = parser.next_uint();
-	});
-	cbs.add("--hlsl-auto-binding", [&args](CLIParser &parser) {
-		args.hlsl_binding_flags |= hlsl_resource_type_to_flag(parser.next_string());
-	});
+	cbs.add("--hlsl-basevertex-baseinstance-binding",
+	        [&args](CLIParser &parser)
+	        {
+		        args.hlsl_base_vertex_index_explicit_binding = true;
+		        args.hlsl_base_vertex_index_register_index = parser.next_uint();
+		        args.hlsl_base_vertex_index_register_space = parser.next_uint();
+	        });
+	cbs.add("--hlsl-auto-binding", [&args](CLIParser &parser)
+	        { args.hlsl_binding_flags |= hlsl_resource_type_to_flag(parser.next_string()); });
 	cbs.add("--hlsl-force-storage-buffer-as-uav",
 	        [&args](CLIParser &) { args.hlsl_force_storage_buffer_as_uav = true; });
 	cbs.add("--hlsl-nonwritable-uav-texture-as-srv",
@@ -1669,7 +1706,8 @@ static int main_inner(int argc, char *argv[])
 	cbs.add("--hlsl-enable-16bit-types", [&args](CLIParser &) { args.hlsl_enable_16bit_types = true; });
 	cbs.add("--hlsl-flatten-matrix-vertex-input-semantics",
 	        [&args](CLIParser &) { args.hlsl_flatten_matrix_vertex_input_semantics = true; });
-	cbs.add("--hlsl-preserve-structured-buffers", [&args](CLIParser &) { args.hlsl_preserve_structured_buffers = true; });
+	cbs.add("--hlsl-preserve-structured-buffers",
+	        [&args](CLIParser &) { args.hlsl_preserve_structured_buffers = true; });
 	cbs.add("--vulkan-semantics", [&args](CLIParser &) { args.vulkan_semantics = true; });
 	cbs.add("-V", [&args](CLIParser &) { args.vulkan_semantics = true; });
 	cbs.add("--flatten-multidimensional-arrays", [&args](CLIParser &) { args.flatten_multidimensional_arrays = true; });
@@ -1696,23 +1734,27 @@ static int main_inner(int argc, char *argv[])
 	cbs.add("--msl-view-index-from-device-index",
 	        [&args](CLIParser &) { args.msl_view_index_from_device_index = true; });
 	cbs.add("--msl-dispatch-base", [&args](CLIParser &) { args.msl_dispatch_base = true; });
-	cbs.add("--msl-dynamic-buffer", [&args](CLIParser &parser) {
-		args.msl_argument_buffers = true;
-		// Make sure next_uint() is called in-order.
-		uint32_t desc_set = parser.next_uint();
-		uint32_t binding = parser.next_uint();
-		args.msl_dynamic_buffers.push_back(make_pair(desc_set, binding));
-	});
+	cbs.add("--msl-dynamic-buffer",
+	        [&args](CLIParser &parser)
+	        {
+		        args.msl_argument_buffers = true;
+		        // Make sure next_uint() is called in-order.
+		        uint32_t desc_set = parser.next_uint();
+		        uint32_t binding = parser.next_uint();
+		        args.msl_dynamic_buffers.push_back(make_pair(desc_set, binding));
+	        });
 	cbs.add("--msl-decoration-binding", [&args](CLIParser &) { args.msl_decoration_binding = true; });
 	cbs.add("--msl-force-active-argument-buffer-resources",
 	        [&args](CLIParser &) { args.msl_force_active_argument_buffer_resources = true; });
-	cbs.add("--msl-inline-uniform-block", [&args](CLIParser &parser) {
-		args.msl_argument_buffers = true;
-		// Make sure next_uint() is called in-order.
-		uint32_t desc_set = parser.next_uint();
-		uint32_t binding = parser.next_uint();
-		args.msl_inline_uniform_blocks.push_back(make_pair(desc_set, binding));
-	});
+	cbs.add("--msl-inline-uniform-block",
+	        [&args](CLIParser &parser)
+	        {
+		        args.msl_argument_buffers = true;
+		        // Make sure next_uint() is called in-order.
+		        uint32_t desc_set = parser.next_uint();
+		        uint32_t binding = parser.next_uint();
+		        args.msl_inline_uniform_blocks.push_back(make_pair(desc_set, binding));
+	        });
 	cbs.add("--msl-force-native-arrays", [&args](CLIParser &) { args.msl_force_native_arrays = true; });
 	cbs.add("--msl-disable-frag-depth-builtin", [&args](CLIParser &) { args.msl_enable_frag_depth_builtin = false; });
 	cbs.add("--msl-disable-frag-stencil-ref-builtin",
@@ -1721,92 +1763,100 @@ static int main_inner(int argc, char *argv[])
 	        [&args](CLIParser &parser) { args.msl_enable_frag_output_mask = parser.next_hex_uint(); });
 	cbs.add("--msl-no-clip-distance-user-varying",
 	        [&args](CLIParser &) { args.msl_enable_clip_distance_user_varying = false; });
-	cbs.add("--msl-add-shader-input", [&args](CLIParser &parser) {
-		MSLShaderInterfaceVariable input;
-		// Make sure next_uint() is called in-order.
-		input.location = parser.next_uint();
-		const char *format = parser.next_value_string("other");
-		if (strcmp(format, "any32") == 0)
-			input.format = MSL_SHADER_VARIABLE_FORMAT_ANY32;
-		else if (strcmp(format, "any16") == 0)
-			input.format = MSL_SHADER_VARIABLE_FORMAT_ANY16;
-		else if (strcmp(format, "u16") == 0)
-			input.format = MSL_SHADER_VARIABLE_FORMAT_UINT16;
-		else if (strcmp(format, "u8") == 0)
-			input.format = MSL_SHADER_VARIABLE_FORMAT_UINT8;
-		else
-			input.format = MSL_SHADER_VARIABLE_FORMAT_OTHER;
-		input.vecsize = parser.next_uint();
-		const char *rate = parser.next_value_string("vertex");
-		if (strcmp(rate, "primitive") == 0)
-			input.rate = MSL_SHADER_VARIABLE_RATE_PER_PRIMITIVE;
-		else if (strcmp(rate, "patch") == 0)
-			input.rate = MSL_SHADER_VARIABLE_RATE_PER_PATCH;
-		else
-			input.rate = MSL_SHADER_VARIABLE_RATE_PER_VERTEX;
-		args.msl_shader_inputs.push_back(input);
-	});
-	cbs.add("--msl-add-shader-output", [&args](CLIParser &parser) {
-		MSLShaderInterfaceVariable output;
-		// Make sure next_uint() is called in-order.
-		output.location = parser.next_uint();
-		const char *format = parser.next_value_string("other");
-		if (strcmp(format, "any32") == 0)
-			output.format = MSL_SHADER_VARIABLE_FORMAT_ANY32;
-		else if (strcmp(format, "any16") == 0)
-			output.format = MSL_SHADER_VARIABLE_FORMAT_ANY16;
-		else if (strcmp(format, "u16") == 0)
-			output.format = MSL_SHADER_VARIABLE_FORMAT_UINT16;
-		else if (strcmp(format, "u8") == 0)
-			output.format = MSL_SHADER_VARIABLE_FORMAT_UINT8;
-		else
-			output.format = MSL_SHADER_VARIABLE_FORMAT_OTHER;
-		output.vecsize = parser.next_uint();
-		const char *rate = parser.next_value_string("vertex");
-		if (strcmp(rate, "primitive") == 0)
-			output.rate = MSL_SHADER_VARIABLE_RATE_PER_PRIMITIVE;
-		else if (strcmp(rate, "patch") == 0)
-			output.rate = MSL_SHADER_VARIABLE_RATE_PER_PATCH;
-		else
-			output.rate = MSL_SHADER_VARIABLE_RATE_PER_VERTEX;
-		args.msl_shader_outputs.push_back(output);
-	});
-	cbs.add("--msl-shader-input", [&args](CLIParser &parser) {
-		MSLShaderInterfaceVariable input;
-		// Make sure next_uint() is called in-order.
-		input.location = parser.next_uint();
-		const char *format = parser.next_value_string("other");
-		if (strcmp(format, "any32") == 0)
-			input.format = MSL_SHADER_VARIABLE_FORMAT_ANY32;
-		else if (strcmp(format, "any16") == 0)
-			input.format = MSL_SHADER_VARIABLE_FORMAT_ANY16;
-		else if (strcmp(format, "u16") == 0)
-			input.format = MSL_SHADER_VARIABLE_FORMAT_UINT16;
-		else if (strcmp(format, "u8") == 0)
-			input.format = MSL_SHADER_VARIABLE_FORMAT_UINT8;
-		else
-			input.format = MSL_SHADER_VARIABLE_FORMAT_OTHER;
-		input.vecsize = parser.next_uint();
-		args.msl_shader_inputs.push_back(input);
-	});
-	cbs.add("--msl-shader-output", [&args](CLIParser &parser) {
-		MSLShaderInterfaceVariable output;
-		// Make sure next_uint() is called in-order.
-		output.location = parser.next_uint();
-		const char *format = parser.next_value_string("other");
-		if (strcmp(format, "any32") == 0)
-			output.format = MSL_SHADER_VARIABLE_FORMAT_ANY32;
-		else if (strcmp(format, "any16") == 0)
-			output.format = MSL_SHADER_VARIABLE_FORMAT_ANY16;
-		else if (strcmp(format, "u16") == 0)
-			output.format = MSL_SHADER_VARIABLE_FORMAT_UINT16;
-		else if (strcmp(format, "u8") == 0)
-			output.format = MSL_SHADER_VARIABLE_FORMAT_UINT8;
-		else
-			output.format = MSL_SHADER_VARIABLE_FORMAT_OTHER;
-		output.vecsize = parser.next_uint();
-		args.msl_shader_outputs.push_back(output);
-	});
+	cbs.add("--msl-add-shader-input",
+	        [&args](CLIParser &parser)
+	        {
+		        MSLShaderInterfaceVariable input;
+		        // Make sure next_uint() is called in-order.
+		        input.location = parser.next_uint();
+		        const char *format = parser.next_value_string("other");
+		        if (strcmp(format, "any32") == 0)
+			        input.format = MSL_SHADER_VARIABLE_FORMAT_ANY32;
+		        else if (strcmp(format, "any16") == 0)
+			        input.format = MSL_SHADER_VARIABLE_FORMAT_ANY16;
+		        else if (strcmp(format, "u16") == 0)
+			        input.format = MSL_SHADER_VARIABLE_FORMAT_UINT16;
+		        else if (strcmp(format, "u8") == 0)
+			        input.format = MSL_SHADER_VARIABLE_FORMAT_UINT8;
+		        else
+			        input.format = MSL_SHADER_VARIABLE_FORMAT_OTHER;
+		        input.vecsize = parser.next_uint();
+		        const char *rate = parser.next_value_string("vertex");
+		        if (strcmp(rate, "primitive") == 0)
+			        input.rate = MSL_SHADER_VARIABLE_RATE_PER_PRIMITIVE;
+		        else if (strcmp(rate, "patch") == 0)
+			        input.rate = MSL_SHADER_VARIABLE_RATE_PER_PATCH;
+		        else
+			        input.rate = MSL_SHADER_VARIABLE_RATE_PER_VERTEX;
+		        args.msl_shader_inputs.push_back(input);
+	        });
+	cbs.add("--msl-add-shader-output",
+	        [&args](CLIParser &parser)
+	        {
+		        MSLShaderInterfaceVariable output;
+		        // Make sure next_uint() is called in-order.
+		        output.location = parser.next_uint();
+		        const char *format = parser.next_value_string("other");
+		        if (strcmp(format, "any32") == 0)
+			        output.format = MSL_SHADER_VARIABLE_FORMAT_ANY32;
+		        else if (strcmp(format, "any16") == 0)
+			        output.format = MSL_SHADER_VARIABLE_FORMAT_ANY16;
+		        else if (strcmp(format, "u16") == 0)
+			        output.format = MSL_SHADER_VARIABLE_FORMAT_UINT16;
+		        else if (strcmp(format, "u8") == 0)
+			        output.format = MSL_SHADER_VARIABLE_FORMAT_UINT8;
+		        else
+			        output.format = MSL_SHADER_VARIABLE_FORMAT_OTHER;
+		        output.vecsize = parser.next_uint();
+		        const char *rate = parser.next_value_string("vertex");
+		        if (strcmp(rate, "primitive") == 0)
+			        output.rate = MSL_SHADER_VARIABLE_RATE_PER_PRIMITIVE;
+		        else if (strcmp(rate, "patch") == 0)
+			        output.rate = MSL_SHADER_VARIABLE_RATE_PER_PATCH;
+		        else
+			        output.rate = MSL_SHADER_VARIABLE_RATE_PER_VERTEX;
+		        args.msl_shader_outputs.push_back(output);
+	        });
+	cbs.add("--msl-shader-input",
+	        [&args](CLIParser &parser)
+	        {
+		        MSLShaderInterfaceVariable input;
+		        // Make sure next_uint() is called in-order.
+		        input.location = parser.next_uint();
+		        const char *format = parser.next_value_string("other");
+		        if (strcmp(format, "any32") == 0)
+			        input.format = MSL_SHADER_VARIABLE_FORMAT_ANY32;
+		        else if (strcmp(format, "any16") == 0)
+			        input.format = MSL_SHADER_VARIABLE_FORMAT_ANY16;
+		        else if (strcmp(format, "u16") == 0)
+			        input.format = MSL_SHADER_VARIABLE_FORMAT_UINT16;
+		        else if (strcmp(format, "u8") == 0)
+			        input.format = MSL_SHADER_VARIABLE_FORMAT_UINT8;
+		        else
+			        input.format = MSL_SHADER_VARIABLE_FORMAT_OTHER;
+		        input.vecsize = parser.next_uint();
+		        args.msl_shader_inputs.push_back(input);
+	        });
+	cbs.add("--msl-shader-output",
+	        [&args](CLIParser &parser)
+	        {
+		        MSLShaderInterfaceVariable output;
+		        // Make sure next_uint() is called in-order.
+		        output.location = parser.next_uint();
+		        const char *format = parser.next_value_string("other");
+		        if (strcmp(format, "any32") == 0)
+			        output.format = MSL_SHADER_VARIABLE_FORMAT_ANY32;
+		        else if (strcmp(format, "any16") == 0)
+			        output.format = MSL_SHADER_VARIABLE_FORMAT_ANY16;
+		        else if (strcmp(format, "u16") == 0)
+			        output.format = MSL_SHADER_VARIABLE_FORMAT_UINT16;
+		        else if (strcmp(format, "u8") == 0)
+			        output.format = MSL_SHADER_VARIABLE_FORMAT_UINT8;
+		        else
+			        output.format = MSL_SHADER_VARIABLE_FORMAT_OTHER;
+		        output.vecsize = parser.next_uint();
+		        args.msl_shader_outputs.push_back(output);
+	        });
 	cbs.add("--msl-raw-buffer-tese-input", [&args](CLIParser &) { args.msl_raw_buffer_tese_input = true; });
 	cbs.add("--msl-multi-patch-workgroup", [&args](CLIParser &) { args.msl_multi_patch_workgroup = true; });
 	cbs.add("--msl-vertex-for-tessellation", [&args](CLIParser &) { args.msl_vertex_for_tessellation = true; });
@@ -1826,86 +1876,106 @@ static int main_inner(int argc, char *argv[])
 	cbs.add("--msl-no-manual-helper-invocation-updates",
 	        [&args](CLIParser &) { args.msl_manual_helper_invocation_updates = false; });
 	cbs.add("--msl-check-discarded-frag-stores", [&args](CLIParser &) { args.msl_check_discarded_frag_stores = true; });
-	cbs.add("--msl-force-frag-with-side-effects-execution", [&args](CLIParser &) { args.msl_force_fragment_with_side_effects_execution = true; });
+	cbs.add("--msl-force-frag-with-side-effects-execution",
+	        [&args](CLIParser &) { args.msl_force_fragment_with_side_effects_execution = true; });
 	cbs.add("--msl-sample-dref-lod-array-as-grad",
 	        [&args](CLIParser &) { args.msl_sample_dref_lod_array_as_grad = true; });
 	cbs.add("--msl-no-readwrite-texture-fences", [&args](CLIParser &) { args.msl_readwrite_texture_fences = false; });
 	cbs.add("--msl-agx-manual-cube-grad-fixup", [&args](CLIParser &) { args.msl_agx_manual_cube_grad_fixup = true; });
-	cbs.add("--msl-combined-sampler-suffix", [&args](CLIParser &parser) {
-		args.msl_combined_sampler_suffix = parser.next_string();
-	});
+	cbs.add("--msl-combined-sampler-suffix",
+	        [&args](CLIParser &parser) { args.msl_combined_sampler_suffix = parser.next_string(); });
 	cbs.add("--msl-runtime-array-rich-descriptor",
 	        [&args](CLIParser &) { args.msl_runtime_array_rich_descriptor = true; });
-	cbs.add("--msl-replace-recursive-inputs",
-	        [&args](CLIParser &) { args.msl_replace_recursive_inputs = true; });
-	cbs.add("--msl-input-attachment-is-ds-attachment", [&args](CLIParser &) { args.msl_input_attachment_is_ds_attachment = true; });
+	cbs.add("--msl-replace-recursive-inputs", [&args](CLIParser &) { args.msl_replace_recursive_inputs = true; });
+	cbs.add("--msl-input-attachment-is-ds-attachment",
+	        [&args](CLIParser &) { args.msl_input_attachment_is_ds_attachment = true; });
 	cbs.add("--extension", [&args](CLIParser &parser) { args.extensions.push_back(parser.next_string()); });
-	cbs.add("--rename-entry-point", [&args](CLIParser &parser) {
-		auto old_name = parser.next_string();
-		auto new_name = parser.next_string();
-		auto model = stage_to_execution_model(parser.next_string());
-		args.entry_point_rename.push_back({ old_name, new_name, std::move(model) });
-	});
+	cbs.add("--rename-entry-point",
+	        [&args](CLIParser &parser)
+	        {
+		        auto old_name = parser.next_string();
+		        auto new_name = parser.next_string();
+		        auto model = stage_to_execution_model(parser.next_string());
+		        args.entry_point_rename.push_back({ old_name, new_name, std::move(model) });
+	        });
 	cbs.add("--entry", [&args](CLIParser &parser) { args.entry = parser.next_string(); });
 	cbs.add("--stage", [&args](CLIParser &parser) { args.entry_stage = parser.next_string(); });
 	cbs.add("--separate-shader-objects", [&args](CLIParser &) { args.sso = true; });
-	cbs.add("--set-hlsl-vertex-input-semantic", [&args](CLIParser &parser) {
-		HLSLVertexAttributeRemap remap;
-		remap.location = parser.next_uint();
-		remap.semantic = parser.next_string();
-		args.hlsl_attr_remap.push_back(std::move(remap));
-	});
-	cbs.add("--set-hlsl-named-vertex-input-semantic", [&args](CLIParser &parser) {
-		HLSLVertexAttributeRemapNamed remap;
-		remap.name = parser.next_string();
-		remap.semantic = parser.next_string();
-		args.hlsl_attr_remap_named.push_back(std::move(remap));
-	});
+	cbs.add("--set-hlsl-vertex-input-semantic",
+	        [&args](CLIParser &parser)
+	        {
+		        HLSLVertexAttributeRemap remap;
+		        remap.location = parser.next_uint();
+		        remap.semantic = parser.next_string();
+		        args.hlsl_attr_remap.push_back(std::move(remap));
+	        });
+	cbs.add("--set-hlsl-named-vertex-input-semantic",
+	        [&args](CLIParser &parser)
+	        {
+		        HLSLVertexAttributeRemapNamed remap;
+		        remap.name = parser.next_string();
+		        remap.semantic = parser.next_string();
+		        args.hlsl_attr_remap_named.push_back(std::move(remap));
+	        });
 
-	cbs.add("--remap", [&args](CLIParser &parser) {
-		string src = parser.next_string();
-		string dst = parser.next_string();
-		uint32_t components = parser.next_uint();
-		args.remaps.push_back({ std::move(src), std::move(dst), components });
-	});
+	cbs.add("--remap",
+	        [&args](CLIParser &parser)
+	        {
+		        string src = parser.next_string();
+		        string dst = parser.next_string();
+		        uint32_t components = parser.next_uint();
+		        args.remaps.push_back({ std::move(src), std::move(dst), components });
+	        });
 
-	cbs.add("--remap-variable-type", [&args](CLIParser &parser) {
-		string var_name = parser.next_string();
-		string new_type = parser.next_string();
-		args.variable_type_remaps.push_back({ std::move(var_name), std::move(new_type) });
-	});
+	cbs.add("--remap-variable-type",
+	        [&args](CLIParser &parser)
+	        {
+		        string var_name = parser.next_string();
+		        string new_type = parser.next_string();
+		        args.variable_type_remaps.push_back({ std::move(var_name), std::move(new_type) });
+	        });
 
-	cbs.add("--rename-interface-variable", [&args](CLIParser &parser) {
-		StorageClass cls = StorageClassMax;
-		string clsStr = parser.next_string();
-		if (clsStr == "in")
-			cls = StorageClassInput;
-		else if (clsStr == "out")
-			cls = StorageClassOutput;
+	cbs.add("--rename-interface-variable",
+	        [&args](CLIParser &parser)
+	        {
+		        StorageClass cls = StorageClassMax;
+		        string clsStr = parser.next_string();
+		        if (clsStr == "in")
+			        cls = StorageClassInput;
+		        else if (clsStr == "out")
+			        cls = StorageClassOutput;
 
-		uint32_t loc = parser.next_uint();
-		string var_name = parser.next_string();
-		args.interface_variable_renames.push_back({ cls, loc, std::move(var_name) });
-	});
+		        uint32_t loc = parser.next_uint();
+		        string var_name = parser.next_string();
+		        args.interface_variable_renames.push_back({ cls, loc, std::move(var_name) });
+	        });
 
-	cbs.add("--pls-in", [&args](CLIParser &parser) {
-		auto fmt = pls_format(parser.next_string());
-		auto name = parser.next_string();
-		args.pls_in.push_back({ std::move(fmt), std::move(name) });
-	});
-	cbs.add("--pls-out", [&args](CLIParser &parser) {
-		auto fmt = pls_format(parser.next_string());
-		auto name = parser.next_string();
-		args.pls_out.push_back({ std::move(fmt), std::move(name) });
-	});
-	cbs.add("--shader-model", [&args](CLIParser &parser) {
-		args.shader_model = parser.next_uint();
-		args.set_shader_model = true;
-	});
-	cbs.add("--msl-version", [&args](CLIParser &parser) {
-		args.msl_version = parser.next_uint();
-		args.set_msl_version = true;
-	});
+	cbs.add("--pls-in",
+	        [&args](CLIParser &parser)
+	        {
+		        auto fmt = pls_format(parser.next_string());
+		        auto name = parser.next_string();
+		        args.pls_in.push_back({ std::move(fmt), std::move(name) });
+	        });
+	cbs.add("--pls-out",
+	        [&args](CLIParser &parser)
+	        {
+		        auto fmt = pls_format(parser.next_string());
+		        auto name = parser.next_string();
+		        args.pls_out.push_back({ std::move(fmt), std::move(name) });
+	        });
+	cbs.add("--shader-model",
+	        [&args](CLIParser &parser)
+	        {
+		        args.shader_model = parser.next_uint();
+		        args.set_shader_model = true;
+	        });
+	cbs.add("--msl-version",
+	        [&args](CLIParser &parser)
+	        {
+		        args.msl_version = parser.next_uint();
+		        args.set_msl_version = true;
+	        });
 
 	cbs.add("--remove-unused-variables", [&args](CLIParser &) { args.remove_unused = true; });
 	cbs.add("--combined-samplers-inherit-bindings",
@@ -1914,34 +1984,37 @@ static int main_inner(int argc, char *argv[])
 	cbs.add("--no-support-nonzero-baseinstance", [&](CLIParser &) { args.support_nonzero_baseinstance = false; });
 	cbs.add("--emit-line-directives", [&args](CLIParser &) { args.emit_line_directives = true; });
 
-	cbs.add("--mask-stage-output-location", [&](CLIParser &parser) {
-		uint32_t location = parser.next_uint();
-		uint32_t component = parser.next_uint();
-		args.masked_stage_outputs.push_back({ location, component });
-	});
+	cbs.add("--mask-stage-output-location",
+	        [&](CLIParser &parser)
+	        {
+		        uint32_t location = parser.next_uint();
+		        uint32_t component = parser.next_uint();
+		        args.masked_stage_outputs.push_back({ location, component });
+	        });
 
-	cbs.add("--mask-stage-output-builtin", [&](CLIParser &parser) {
-		BuiltIn masked_builtin = BuiltInMax;
-		std::string builtin = parser.next_string();
-		if (builtin == "Position")
-			masked_builtin = BuiltInPosition;
-		else if (builtin == "PointSize")
-			masked_builtin = BuiltInPointSize;
-		else if (builtin == "CullDistance")
-			masked_builtin = BuiltInCullDistance;
-		else if (builtin == "ClipDistance")
-			masked_builtin = BuiltInClipDistance;
-		else
-		{
-			print_help();
-			exit(EXIT_FAILURE);
-		}
-		args.masked_stage_builtins.push_back(masked_builtin);
-	});
+	cbs.add("--mask-stage-output-builtin",
+	        [&](CLIParser &parser)
+	        {
+		        BuiltIn masked_builtin = BuiltInMax;
+		        std::string builtin = parser.next_string();
+		        if (builtin == "Position")
+			        masked_builtin = BuiltInPosition;
+		        else if (builtin == "PointSize")
+			        masked_builtin = BuiltInPointSize;
+		        else if (builtin == "CullDistance")
+			        masked_builtin = BuiltInCullDistance;
+		        else if (builtin == "ClipDistance")
+			        masked_builtin = BuiltInClipDistance;
+		        else
+		        {
+			        print_help();
+			        exit(EXIT_FAILURE);
+		        }
+		        args.masked_stage_builtins.push_back(masked_builtin);
+	        });
 
-	cbs.add("--force-recompile-max-debug-iterations", [&](CLIParser &parser) {
-		args.force_recompile_max_debug_iterations = parser.next_uint();
-	});
+	cbs.add("--force-recompile-max-debug-iterations",
+	        [&](CLIParser &parser) { args.force_recompile_max_debug_iterations = parser.next_uint(); });
 
 	cbs.add("--relax-nan-checks", [&](CLIParser &) { args.relax_nan_checks = true; });
 

--- a/spirv_cfg.cpp
+++ b/spirv_cfg.cpp
@@ -218,7 +218,8 @@ void CFG::build_post_order_visit_order()
 
 void CFG::add_branch(uint32_t from, uint32_t to)
 {
-	const auto add_unique = [](SmallVector<uint32_t> &l, uint32_t value) {
+	const auto add_unique = [](SmallVector<uint32_t> &l, uint32_t value)
+	{
 		auto itr = find(begin(l), end(l), value);
 		if (itr == end(l))
 			l.push_back(value);

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -60,7 +60,7 @@ void join_helper(StringStream<> &stream, T &&t)
 }
 
 template <typename T, typename... Ts>
-void join_helper(StringStream<> &stream, T &&t, Ts &&... ts)
+void join_helper(StringStream<> &stream, T &&t, Ts &&...ts)
 {
 	stream << std::forward<T>(t);
 	join_helper(stream, std::forward<Ts>(ts)...);
@@ -188,7 +188,7 @@ private:
 
 // Helper template to avoid lots of nasty string temporary munging.
 template <typename... Ts>
-std::string join(Ts &&... ts)
+std::string join(Ts &&...ts)
 {
 	StringStream<> stream;
 	inner::join_helper(stream, std::forward<Ts>(ts)...);
@@ -454,8 +454,8 @@ struct IVariant
 
 protected:
 	IVariant() = default;
-	IVariant(const IVariant&) = default;
-	IVariant &operator=(const IVariant&) = default;
+	IVariant(const IVariant &) = default;
+	IVariant &operator=(const IVariant &) = default;
 };
 
 #define SPIRV_CROSS_DECLARE_CLONE(T)                                \
@@ -549,7 +549,10 @@ struct SPIRType : IVariant
 	};
 
 	spv::Op op = spv::Op::OpNop;
-	explicit SPIRType(spv::Op op_) : op(op_) {}
+	explicit SPIRType(spv::Op op_)
+	    : op(op_)
+	{
+	}
 
 	enum BaseType
 	{
@@ -1508,7 +1511,7 @@ public:
 	}
 
 	template <typename T, typename... Ts>
-	T *allocate_and_set(Types new_type, Ts &&... ts)
+	T *allocate_and_set(Types new_type, Ts &&...ts)
 	{
 		T *val = static_cast<ObjectPool<T> &>(*group->pools[new_type]).allocate(std::forward<Ts>(ts)...);
 		set(val, new_type);
@@ -1583,7 +1586,7 @@ const T &variant_get(const Variant &var)
 }
 
 template <typename T, typename... P>
-T &variant_set(Variant &var, P &&... args)
+T &variant_set(Variant &var, P &&...args)
 {
 	auto *ptr = var.allocate_and_set<T>(static_cast<Types>(T::type), std::forward<P>(args)...);
 	return *ptr;

--- a/spirv_cpp.cpp
+++ b/spirv_cpp.cpp
@@ -107,7 +107,8 @@ void CompilerCPP::emit_uniform(const SPIRVariable &var)
 	}
 	else
 	{
-		statement("internal::UniformConstant<", type_name, type_to_array_glsl(type, var.self), "> ", instance_name, "__;");
+		statement("internal::UniformConstant<", type_name, type_to_array_glsl(type, var.self), "> ", instance_name,
+		          "__;");
 		statement_no_indent("#define ", instance_name, " __res->", instance_name, "__.get()");
 		resource_registrations.push_back(
 		    join("s.register_uniform_constant(", instance_name, "__", ", ", location, ");"));

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -595,7 +595,7 @@ protected:
 	// If our IDs are out of range here as part of opcodes, throw instead of
 	// undefined behavior.
 	template <typename T, typename... P>
-	T &set(uint32_t id, P &&... args)
+	T &set(uint32_t id, P &&...args)
 	{
 		ir.add_typed_id(static_cast<Types>(T::type), id);
 		auto &var = variant_set<T>(ir.ids[id], std::forward<P>(args)...);

--- a/spirv_cross_containers.hpp
+++ b/spirv_cross_containers.hpp
@@ -326,7 +326,7 @@ public:
 	}
 
 	template <typename... Ts>
-	void emplace_back(Ts &&... ts) SPIRV_CROSS_NOEXCEPT
+	void emplace_back(Ts &&...ts) SPIRV_CROSS_NOEXCEPT
 	{
 		reserve(this->buffer_size + 1);
 		new (&this->ptr[this->buffer_size]) T(std::forward<Ts>(ts)...);
@@ -567,7 +567,7 @@ public:
 	}
 
 	template <typename... P>
-	T *allocate(P &&... p)
+	T *allocate(P &&...p)
 	{
 		if (vacants.empty())
 		{

--- a/spirv_cross_parsed_ir.cpp
+++ b/spirv_cross_parsed_ir.cpp
@@ -116,7 +116,6 @@ ParsedIR &ParsedIR::operator=(const ParsedIR &other)
 		addressing_model = other.addressing_model;
 		memory_model = other.memory_model;
 
-
 		meta_needing_name_fixup = other.meta_needing_name_fixup;
 		load_type_width = other.load_type_width;
 

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -25,12 +25,12 @@
 #include "GLSL.std.450.h"
 #include "spirv_common.hpp"
 #include <algorithm>
+#include <array>
 #include <assert.h>
 #include <cmath>
 #include <limits>
 #include <locale.h>
 #include <utility>
-#include <array>
 
 #ifndef _WIN32
 #include <langinfo.h>
@@ -308,7 +308,8 @@ void CompilerGLSL::reset(uint32_t iteration_count)
 	// and it is not practical with the current architecture
 	// to resolve everything up front.
 	if (iteration_count >= options.force_recompile_max_debug_iterations && !is_force_recompile_forward_progress)
-		SPIRV_CROSS_THROW("Maximum compilation loops detected and no forward progress was made. Must be a SPIRV-Cross bug!");
+		SPIRV_CROSS_THROW(
+		    "Maximum compilation loops detected and no forward progress was made. Must be a SPIRV-Cross bug!");
 
 	// We do some speculative optimizations which should pretty much always work out,
 	// but just in case the SPIR-V is rather weird, recompile until it's happy.
@@ -332,10 +333,12 @@ void CompilerGLSL::reset(uint32_t iteration_count)
 
 	reset_name_caches();
 
-	ir.for_each_typed_id<SPIRFunction>([&](uint32_t, SPIRFunction &func) {
-		func.active = false;
-		func.flush_undeclared = true;
-	});
+	ir.for_each_typed_id<SPIRFunction>(
+	    [&](uint32_t, SPIRFunction &func)
+	    {
+		    func.active = false;
+		    func.flush_undeclared = true;
+	    });
 
 	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, SPIRVariable &var) { var.dependees.clear(); });
 
@@ -383,54 +386,54 @@ void CompilerGLSL::remap_ext_framebuffer_fetch(uint32_t input_attachment_index, 
 bool CompilerGLSL::location_is_framebuffer_fetch(uint32_t location) const
 {
 	return std::find_if(begin(inout_color_attachments), end(inout_color_attachments),
-	                    [&](const std::pair<uint32_t, bool> &elem) {
-		                    return elem.first == location;
-	                    }) != end(inout_color_attachments);
+	                    [&](const std::pair<uint32_t, bool> &elem)
+	                    { return elem.first == location; }) != end(inout_color_attachments);
 }
 
 bool CompilerGLSL::location_is_non_coherent_framebuffer_fetch(uint32_t location) const
 {
 	return std::find_if(begin(inout_color_attachments), end(inout_color_attachments),
-	                    [&](const std::pair<uint32_t, bool> &elem) {
-		                    return elem.first == location && !elem.second;
-	                    }) != end(inout_color_attachments);
+	                    [&](const std::pair<uint32_t, bool> &elem)
+	                    { return elem.first == location && !elem.second; }) != end(inout_color_attachments);
 }
 
 void CompilerGLSL::find_static_extensions()
 {
-	ir.for_each_typed_id<SPIRType>([&](uint32_t, const SPIRType &type) {
-		if (type.basetype == SPIRType::Double)
-		{
-			if (options.es)
-				SPIRV_CROSS_THROW("FP64 not supported in ES profile.");
-			if (!options.es && options.version < 400)
-				require_extension_internal("GL_ARB_gpu_shader_fp64");
-		}
-		else if (type.basetype == SPIRType::Int64 || type.basetype == SPIRType::UInt64)
-		{
-			if (options.es && options.version < 310) // GL_NV_gpu_shader5 fallback requires 310.
-				SPIRV_CROSS_THROW("64-bit integers not supported in ES profile before version 310.");
-			require_extension_internal("GL_ARB_gpu_shader_int64");
-		}
-		else if (type.basetype == SPIRType::Half)
-		{
-			require_extension_internal("GL_EXT_shader_explicit_arithmetic_types_float16");
-			if (options.vulkan_semantics)
-				require_extension_internal("GL_EXT_shader_16bit_storage");
-		}
-		else if (type.basetype == SPIRType::SByte || type.basetype == SPIRType::UByte)
-		{
-			require_extension_internal("GL_EXT_shader_explicit_arithmetic_types_int8");
-			if (options.vulkan_semantics)
-				require_extension_internal("GL_EXT_shader_8bit_storage");
-		}
-		else if (type.basetype == SPIRType::Short || type.basetype == SPIRType::UShort)
-		{
-			require_extension_internal("GL_EXT_shader_explicit_arithmetic_types_int16");
-			if (options.vulkan_semantics)
-				require_extension_internal("GL_EXT_shader_16bit_storage");
-		}
-	});
+	ir.for_each_typed_id<SPIRType>(
+	    [&](uint32_t, const SPIRType &type)
+	    {
+		    if (type.basetype == SPIRType::Double)
+		    {
+			    if (options.es)
+				    SPIRV_CROSS_THROW("FP64 not supported in ES profile.");
+			    if (!options.es && options.version < 400)
+				    require_extension_internal("GL_ARB_gpu_shader_fp64");
+		    }
+		    else if (type.basetype == SPIRType::Int64 || type.basetype == SPIRType::UInt64)
+		    {
+			    if (options.es && options.version < 310) // GL_NV_gpu_shader5 fallback requires 310.
+				    SPIRV_CROSS_THROW("64-bit integers not supported in ES profile before version 310.");
+			    require_extension_internal("GL_ARB_gpu_shader_int64");
+		    }
+		    else if (type.basetype == SPIRType::Half)
+		    {
+			    require_extension_internal("GL_EXT_shader_explicit_arithmetic_types_float16");
+			    if (options.vulkan_semantics)
+				    require_extension_internal("GL_EXT_shader_16bit_storage");
+		    }
+		    else if (type.basetype == SPIRType::SByte || type.basetype == SPIRType::UByte)
+		    {
+			    require_extension_internal("GL_EXT_shader_explicit_arithmetic_types_int8");
+			    if (options.vulkan_semantics)
+				    require_extension_internal("GL_EXT_shader_8bit_storage");
+		    }
+		    else if (type.basetype == SPIRType::Short || type.basetype == SPIRType::UShort)
+		    {
+			    require_extension_internal("GL_EXT_shader_explicit_arithmetic_types_int16");
+			    if (options.vulkan_semantics)
+				    require_extension_internal("GL_EXT_shader_16bit_storage");
+		    }
+	    });
 
 	auto &execution = get_entry_point();
 	switch (execution.model)
@@ -639,8 +642,8 @@ void CompilerGLSL::find_static_extensions()
 
 void CompilerGLSL::require_polyfill(Polyfill polyfill, bool relaxed)
 {
-	uint32_t &polyfills = (relaxed && (options.es || options.vulkan_semantics)) ?
-	                      required_polyfills_relaxed : required_polyfills;
+	uint32_t &polyfills =
+	    (relaxed && (options.es || options.vulkan_semantics)) ? required_polyfills_relaxed : required_polyfills;
 
 	if ((polyfills & polyfill) == 0)
 	{
@@ -652,15 +655,17 @@ void CompilerGLSL::require_polyfill(Polyfill polyfill, bool relaxed)
 void CompilerGLSL::ray_tracing_khr_fixup_locations()
 {
 	uint32_t location = 0;
-	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, SPIRVariable &var) {
-		// Incoming payload storage can also be used for tracing.
-		if (var.storage != StorageClassRayPayloadKHR && var.storage != StorageClassCallableDataKHR &&
-		    var.storage != StorageClassIncomingRayPayloadKHR && var.storage != StorageClassIncomingCallableDataKHR)
-			return;
-		if (is_hidden_variable(var))
-			return;
-		set_decoration(var.self, DecorationLocation, location++);
-	});
+	ir.for_each_typed_id<SPIRVariable>(
+	    [&](uint32_t, SPIRVariable &var)
+	    {
+		    // Incoming payload storage can also be used for tracing.
+		    if (var.storage != StorageClassRayPayloadKHR && var.storage != StorageClassCallableDataKHR &&
+		        var.storage != StorageClassIncomingRayPayloadKHR && var.storage != StorageClassIncomingCallableDataKHR)
+			    return;
+		    if (is_hidden_variable(var))
+			    return;
+		    set_decoration(var.self, DecorationLocation, location++);
+	    });
 }
 
 string CompilerGLSL::compile()
@@ -680,7 +685,7 @@ string CompilerGLSL::compile()
 	backend.workgroup_size_is_hidden = true;
 	backend.requires_relaxed_precision_analysis = options.es || options.vulkan_semantics;
 	backend.support_precise_qualifier =
-			(!options.es && options.version >= 400) || (options.es && options.version >= 320);
+	    (!options.es && options.version >= 400) || (options.es && options.version >= 320);
 
 	if (is_legacy_es())
 		backend.support_case_fallthrough = false;
@@ -1855,9 +1860,8 @@ bool CompilerGLSL::buffer_is_packing_standard(const SPIRType &type, BufferPackin
 			}
 
 			// Verify array stride rules.
-			if (is_array(memb_type) &&
-			    type_to_packed_array_stride(memb_type, member_flags, packing) !=
-			    type_struct_member_array_stride(type, i))
+			if (is_array(memb_type) && type_to_packed_array_stride(memb_type, member_flags, packing) !=
+			                               type_struct_member_array_stride(type, i))
 			{
 				if (failed_validation_index)
 					*failed_validation_index = i;
@@ -2173,8 +2177,7 @@ string CompilerGLSL::layout_for_variable(const SPIRVariable &var)
 	return res;
 }
 
-string CompilerGLSL::buffer_to_packing_standard(const SPIRType &type,
-                                                bool support_std430_without_scalar_layout,
+string CompilerGLSL::buffer_to_packing_standard(const SPIRType &type, bool support_std430_without_scalar_layout,
                                                 bool support_enhanced_layouts)
 {
 	if (support_std430_without_scalar_layout && buffer_is_packing_standard(type, BufferPackingStd430))
@@ -2186,8 +2189,7 @@ string CompilerGLSL::buffer_to_packing_standard(const SPIRType &type,
 		require_extension_internal("GL_EXT_scalar_block_layout");
 		return "scalar";
 	}
-	else if (support_std430_without_scalar_layout &&
-	         support_enhanced_layouts &&
+	else if (support_std430_without_scalar_layout && support_enhanced_layouts &&
 	         buffer_is_packing_standard(type, BufferPackingStd430EnhancedLayout))
 	{
 		if (options.es && !options.vulkan_semantics)
@@ -2199,8 +2201,7 @@ string CompilerGLSL::buffer_to_packing_standard(const SPIRType &type,
 		set_extended_decoration(type.self, SPIRVCrossDecorationExplicitOffset);
 		return "std430";
 	}
-	else if (support_enhanced_layouts &&
-	         buffer_is_packing_standard(type, BufferPackingStd140EnhancedLayout))
+	else if (support_enhanced_layouts && buffer_is_packing_standard(type, BufferPackingStd140EnhancedLayout))
 	{
 		// Fallback time. We might be able to use the ARB_enhanced_layouts to deal with this difference,
 		// however, we can only use layout(offset) on the block itself, not any substructs, so the substructs better be the appropriate layout.
@@ -2214,8 +2215,7 @@ string CompilerGLSL::buffer_to_packing_standard(const SPIRType &type,
 		set_extended_decoration(type.self, SPIRVCrossDecorationExplicitOffset);
 		return "std140";
 	}
-	else if (options.vulkan_semantics &&
-	         support_enhanced_layouts &&
+	else if (options.vulkan_semantics && support_enhanced_layouts &&
 	         buffer_is_packing_standard(type, BufferPackingScalarEnhancedLayout))
 	{
 		set_extended_decoration(type.self, SPIRVCrossDecorationExplicitOffset);
@@ -2229,8 +2229,7 @@ string CompilerGLSL::buffer_to_packing_standard(const SPIRType &type,
 		require_extension_internal("GL_EXT_scalar_block_layout");
 		return "std430";
 	}
-	else if (!support_std430_without_scalar_layout && options.vulkan_semantics &&
-	         support_enhanced_layouts &&
+	else if (!support_std430_without_scalar_layout && options.vulkan_semantics && support_enhanced_layouts &&
 	         buffer_is_packing_standard(type, BufferPackingStd430EnhancedLayout))
 	{
 		// UBOs can support std430 with GL_EXT_scalar_block_layout.
@@ -2405,7 +2404,7 @@ void CompilerGLSL::emit_buffer_reference_block(uint32_t type_id, bool forward_de
 			}
 			else if (is_array(get_pointee_type(type)))
 			{
-				SPIRType wrap_type{OpTypeStruct};
+				SPIRType wrap_type{ OpTypeStruct };
 				wrap_type.self = ir.increase_bound_by(1);
 				wrap_type.member_types.push_back(get_pointee_type_id(type_id));
 				ir.set_member_decoration(wrap_type.self, 0, DecorationOffset, 0);
@@ -2413,7 +2412,8 @@ void CompilerGLSL::emit_buffer_reference_block(uint32_t type_id, bool forward_de
 			}
 
 			if (alignment)
-				statement("layout(", packing_standard, "buffer_reference, buffer_reference_align = ", alignment, ") buffer ", buffer_name);
+				statement("layout(", packing_standard, "buffer_reference, buffer_reference_align = ", alignment,
+				          ") buffer ", buffer_name);
 			else
 				statement("layout(", packing_standard, "buffer_reference) buffer ", buffer_name);
 		}
@@ -2529,7 +2529,7 @@ void CompilerGLSL::emit_buffer_block_flattened(const SPIRVariable &var)
 	SPIRType::BaseType basic_type;
 	if (get_common_basic_type(type, basic_type))
 	{
-		SPIRType tmp { OpTypeVector };
+		SPIRType tmp{ OpTypeVector };
 		tmp.basetype = basic_type;
 		tmp.vecsize = 4;
 		if (basic_type != SPIRType::Float && basic_type != SPIRType::Int && basic_type != SPIRType::UInt)
@@ -2704,8 +2704,7 @@ void CompilerGLSL::emit_interface_block(const SPIRVariable &var)
 {
 	auto &type = get<SPIRType>(var.basetype);
 
-	if (var.storage == StorageClassInput && type.basetype == SPIRType::Double &&
-	    !options.es && options.version < 410)
+	if (var.storage == StorageClassInput && type.basetype == SPIRType::Double && !options.es && options.version < 410)
 	{
 		require_extension_internal("GL_ARB_vertex_attrib_64bit");
 	}
@@ -2943,42 +2942,48 @@ void CompilerGLSL::emit_entry_point_declarations()
 
 void CompilerGLSL::replace_illegal_names(const unordered_set<string> &keywords)
 {
-	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, const SPIRVariable &var) {
-		if (is_hidden_variable(var))
-			return;
+	ir.for_each_typed_id<SPIRVariable>(
+	    [&](uint32_t, const SPIRVariable &var)
+	    {
+		    if (is_hidden_variable(var))
+			    return;
 
-		auto *meta = ir.find_meta(var.self);
-		if (!meta)
-			return;
+		    auto *meta = ir.find_meta(var.self);
+		    if (!meta)
+			    return;
 
-		auto &m = meta->decoration;
-		if (keywords.find(m.alias) != end(keywords))
-			m.alias = join("_", m.alias);
-	});
+		    auto &m = meta->decoration;
+		    if (keywords.find(m.alias) != end(keywords))
+			    m.alias = join("_", m.alias);
+	    });
 
-	ir.for_each_typed_id<SPIRFunction>([&](uint32_t, const SPIRFunction &func) {
-		auto *meta = ir.find_meta(func.self);
-		if (!meta)
-			return;
+	ir.for_each_typed_id<SPIRFunction>(
+	    [&](uint32_t, const SPIRFunction &func)
+	    {
+		    auto *meta = ir.find_meta(func.self);
+		    if (!meta)
+			    return;
 
-		auto &m = meta->decoration;
-		if (keywords.find(m.alias) != end(keywords))
-			m.alias = join("_", m.alias);
-	});
+		    auto &m = meta->decoration;
+		    if (keywords.find(m.alias) != end(keywords))
+			    m.alias = join("_", m.alias);
+	    });
 
-	ir.for_each_typed_id<SPIRType>([&](uint32_t, const SPIRType &type) {
-		auto *meta = ir.find_meta(type.self);
-		if (!meta)
-			return;
+	ir.for_each_typed_id<SPIRType>(
+	    [&](uint32_t, const SPIRType &type)
+	    {
+		    auto *meta = ir.find_meta(type.self);
+		    if (!meta)
+			    return;
 
-		auto &m = meta->decoration;
-		if (keywords.find(m.alias) != end(keywords))
-			m.alias = join("_", m.alias);
+		    auto &m = meta->decoration;
+		    if (keywords.find(m.alias) != end(keywords))
+			    m.alias = join("_", m.alias);
 
-		for (auto &memb : meta->members)
-			if (keywords.find(memb.alias) != end(keywords))
-				memb.alias = join("_", memb.alias);
-	});
+		    for (auto &memb : meta->members)
+			    if (keywords.find(memb.alias) != end(keywords))
+				    memb.alias = join("_", memb.alias);
+	    });
 }
 
 void CompilerGLSL::replace_illegal_names()
@@ -3078,12 +3083,15 @@ void CompilerGLSL::replace_fragment_output(SPIRVariable &var)
 
 void CompilerGLSL::replace_fragment_outputs()
 {
-	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, SPIRVariable &var) {
-		auto &type = this->get<SPIRType>(var.basetype);
+	ir.for_each_typed_id<SPIRVariable>(
+	    [&](uint32_t, SPIRVariable &var)
+	    {
+		    auto &type = this->get<SPIRType>(var.basetype);
 
-		if (!is_builtin_variable(var) && !var.remapped_variable && type.pointer && var.storage == StorageClassOutput)
-			replace_fragment_output(var);
-	});
+		    if (!is_builtin_variable(var) && !var.remapped_variable && type.pointer &&
+		        var.storage == StorageClassOutput)
+			    replace_fragment_output(var);
+	    });
 }
 
 string CompilerGLSL::remap_swizzle(const SPIRType &out_type, uint32_t input_components, const string &expr)
@@ -3145,21 +3153,23 @@ void CompilerGLSL::fixup_image_load_store_access()
 	if (!options.enable_storage_image_qualifier_deduction)
 		return;
 
-	ir.for_each_typed_id<SPIRVariable>([&](uint32_t var, const SPIRVariable &) {
-		auto &vartype = expression_type(var);
-		if (vartype.basetype == SPIRType::Image && vartype.image.sampled == 2)
-		{
-			// Very old glslangValidator and HLSL compilers do not emit required qualifiers here.
-			// Solve this by making the image access as restricted as possible and loosen up if we need to.
-			// If any no-read/no-write flags are actually set, assume that the compiler knows what it's doing.
+	ir.for_each_typed_id<SPIRVariable>(
+	    [&](uint32_t var, const SPIRVariable &)
+	    {
+		    auto &vartype = expression_type(var);
+		    if (vartype.basetype == SPIRType::Image && vartype.image.sampled == 2)
+		    {
+			    // Very old glslangValidator and HLSL compilers do not emit required qualifiers here.
+			    // Solve this by making the image access as restricted as possible and loosen up if we need to.
+			    // If any no-read/no-write flags are actually set, assume that the compiler knows what it's doing.
 
-			if (!has_decoration(var, DecorationNonWritable) && !has_decoration(var, DecorationNonReadable))
-			{
-				set_decoration(var, DecorationNonWritable);
-				set_decoration(var, DecorationNonReadable);
-			}
-		}
-	});
+			    if (!has_decoration(var, DecorationNonWritable) && !has_decoration(var, DecorationNonReadable))
+			    {
+				    set_decoration(var, DecorationNonWritable);
+				    set_decoration(var, DecorationNonReadable);
+			    }
+		    }
+	    });
 }
 
 static bool is_block_builtin(BuiltIn builtin)
@@ -3176,34 +3186,36 @@ bool CompilerGLSL::should_force_emit_builtin_block(StorageClass storage)
 		return false;
 	bool should_force = false;
 
-	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, SPIRVariable &var) {
-		if (should_force)
-			return;
+	ir.for_each_typed_id<SPIRVariable>(
+	    [&](uint32_t, SPIRVariable &var)
+	    {
+		    if (should_force)
+			    return;
 
-		auto &type = this->get<SPIRType>(var.basetype);
-		bool block = has_decoration(type.self, DecorationBlock);
-		if (var.storage == storage && block && is_builtin_variable(var))
-		{
-			uint32_t member_count = uint32_t(type.member_types.size());
-			for (uint32_t i = 0; i < member_count; i++)
-			{
-				if (has_member_decoration(type.self, i, DecorationBuiltIn) &&
-				    is_block_builtin(BuiltIn(get_member_decoration(type.self, i, DecorationBuiltIn))) &&
-				    has_member_decoration(type.self, i, DecorationOffset))
-				{
-					should_force = true;
-				}
-			}
-		}
-		else if (var.storage == storage && !block && is_builtin_variable(var))
-		{
-			if (is_block_builtin(BuiltIn(get_decoration(type.self, DecorationBuiltIn))) &&
-			    has_decoration(var.self, DecorationOffset))
-			{
-				should_force = true;
-			}
-		}
-	});
+		    auto &type = this->get<SPIRType>(var.basetype);
+		    bool block = has_decoration(type.self, DecorationBlock);
+		    if (var.storage == storage && block && is_builtin_variable(var))
+		    {
+			    uint32_t member_count = uint32_t(type.member_types.size());
+			    for (uint32_t i = 0; i < member_count; i++)
+			    {
+				    if (has_member_decoration(type.self, i, DecorationBuiltIn) &&
+				        is_block_builtin(BuiltIn(get_member_decoration(type.self, i, DecorationBuiltIn))) &&
+				        has_member_decoration(type.self, i, DecorationOffset))
+				    {
+					    should_force = true;
+				    }
+			    }
+		    }
+		    else if (var.storage == storage && !block && is_builtin_variable(var))
+		    {
+			    if (is_block_builtin(BuiltIn(get_decoration(type.self, DecorationBuiltIn))) &&
+			        has_decoration(var.self, DecorationOffset))
+			    {
+				    should_force = true;
+			    }
+		    }
+	    });
 
 	// If we're declaring clip/cull planes with control points we need to force block declaration.
 	if ((get_execution_model() == ExecutionModelTessellationControl ||
@@ -3222,51 +3234,53 @@ bool CompilerGLSL::should_force_emit_builtin_block(StorageClass storage)
 
 void CompilerGLSL::fixup_implicit_builtin_block_names(ExecutionModel model)
 {
-	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, SPIRVariable &var) {
-		auto &type = this->get<SPIRType>(var.basetype);
-		bool block = has_decoration(type.self, DecorationBlock);
-		if ((var.storage == StorageClassOutput || var.storage == StorageClassInput) && block &&
-		    is_builtin_variable(var))
-		{
-			if (model != ExecutionModelMeshEXT)
-			{
-				// Make sure the array has a supported name in the code.
-				if (var.storage == StorageClassOutput)
-					set_name(var.self, "gl_out");
-				else if (var.storage == StorageClassInput)
-					set_name(var.self, "gl_in");
-			}
-			else
-			{
-				auto flags = get_buffer_block_flags(var.self);
-				if (flags.get(DecorationPerPrimitiveEXT))
-				{
-					set_name(var.self, "gl_MeshPrimitivesEXT");
-					set_name(type.self, "gl_MeshPerPrimitiveEXT");
-				}
-				else
-				{
-					set_name(var.self, "gl_MeshVerticesEXT");
-					set_name(type.self, "gl_MeshPerVertexEXT");
-				}
-			}
-		}
+	ir.for_each_typed_id<SPIRVariable>(
+	    [&](uint32_t, SPIRVariable &var)
+	    {
+		    auto &type = this->get<SPIRType>(var.basetype);
+		    bool block = has_decoration(type.self, DecorationBlock);
+		    if ((var.storage == StorageClassOutput || var.storage == StorageClassInput) && block &&
+		        is_builtin_variable(var))
+		    {
+			    if (model != ExecutionModelMeshEXT)
+			    {
+				    // Make sure the array has a supported name in the code.
+				    if (var.storage == StorageClassOutput)
+					    set_name(var.self, "gl_out");
+				    else if (var.storage == StorageClassInput)
+					    set_name(var.self, "gl_in");
+			    }
+			    else
+			    {
+				    auto flags = get_buffer_block_flags(var.self);
+				    if (flags.get(DecorationPerPrimitiveEXT))
+				    {
+					    set_name(var.self, "gl_MeshPrimitivesEXT");
+					    set_name(type.self, "gl_MeshPerPrimitiveEXT");
+				    }
+				    else
+				    {
+					    set_name(var.self, "gl_MeshVerticesEXT");
+					    set_name(type.self, "gl_MeshPerVertexEXT");
+				    }
+			    }
+		    }
 
-		if (model == ExecutionModelMeshEXT && var.storage == StorageClassOutput && !block)
-		{
-			auto *m = ir.find_meta(var.self);
-			if (m && m->decoration.builtin)
-			{
-				auto builtin_type = m->decoration.builtin_type;
-				if (builtin_type == BuiltInPrimitivePointIndicesEXT)
-					set_name(var.self, "gl_PrimitivePointIndicesEXT");
-				else if (builtin_type == BuiltInPrimitiveLineIndicesEXT)
-					set_name(var.self, "gl_PrimitiveLineIndicesEXT");
-				else if (builtin_type == BuiltInPrimitiveTriangleIndicesEXT)
-					set_name(var.self, "gl_PrimitiveTriangleIndicesEXT");
-			}
-		}
-	});
+		    if (model == ExecutionModelMeshEXT && var.storage == StorageClassOutput && !block)
+		    {
+			    auto *m = ir.find_meta(var.self);
+			    if (m && m->decoration.builtin)
+			    {
+				    auto builtin_type = m->decoration.builtin_type;
+				    if (builtin_type == BuiltInPrimitivePointIndicesEXT)
+					    set_name(var.self, "gl_PrimitivePointIndicesEXT");
+				    else if (builtin_type == BuiltInPrimitiveLineIndicesEXT)
+					    set_name(var.self, "gl_PrimitiveLineIndicesEXT");
+				    else if (builtin_type == BuiltInPrimitiveTriangleIndicesEXT)
+					    set_name(var.self, "gl_PrimitiveTriangleIndicesEXT");
+			    }
+		    }
+	    });
 }
 
 void CompilerGLSL::emit_declared_builtin_block(StorageClass storage, ExecutionModel model)
@@ -3287,121 +3301,124 @@ void CompilerGLSL::emit_declared_builtin_block(StorageClass storage, ExecutionMo
 	uint32_t xfb_stride = 0, xfb_buffer = 0, geom_stream = 0;
 	std::unordered_map<uint32_t, uint32_t> builtin_xfb_offsets;
 
-	const auto builtin_is_per_vertex_set = [](BuiltIn builtin) -> bool {
-		return builtin == BuiltInPosition || builtin == BuiltInPointSize ||
-			builtin == BuiltInClipDistance || builtin == BuiltInCullDistance;
+	const auto builtin_is_per_vertex_set = [](BuiltIn builtin) -> bool
+	{
+		return builtin == BuiltInPosition || builtin == BuiltInPointSize || builtin == BuiltInClipDistance ||
+		       builtin == BuiltInCullDistance;
 	};
 
-	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, SPIRVariable &var) {
-		auto &type = this->get<SPIRType>(var.basetype);
-		bool block = has_decoration(type.self, DecorationBlock);
-		Bitset builtins;
+	ir.for_each_typed_id<SPIRVariable>(
+	    [&](uint32_t, SPIRVariable &var)
+	    {
+		    auto &type = this->get<SPIRType>(var.basetype);
+		    bool block = has_decoration(type.self, DecorationBlock);
+		    Bitset builtins;
 
-		if (var.storage == storage && block && is_builtin_variable(var))
-		{
-			uint32_t index = 0;
-			for (auto &m : ir.meta[type.self].members)
-			{
-				if (m.builtin && builtin_is_per_vertex_set(m.builtin_type))
-				{
-					builtins.set(m.builtin_type);
-					if (m.builtin_type == BuiltInCullDistance)
-						cull_distance_size = to_array_size_literal(this->get<SPIRType>(type.member_types[index]));
-					else if (m.builtin_type == BuiltInClipDistance)
-						clip_distance_size = to_array_size_literal(this->get<SPIRType>(type.member_types[index]));
+		    if (var.storage == storage && block && is_builtin_variable(var))
+		    {
+			    uint32_t index = 0;
+			    for (auto &m : ir.meta[type.self].members)
+			    {
+				    if (m.builtin && builtin_is_per_vertex_set(m.builtin_type))
+				    {
+					    builtins.set(m.builtin_type);
+					    if (m.builtin_type == BuiltInCullDistance)
+						    cull_distance_size = to_array_size_literal(this->get<SPIRType>(type.member_types[index]));
+					    else if (m.builtin_type == BuiltInClipDistance)
+						    clip_distance_size = to_array_size_literal(this->get<SPIRType>(type.member_types[index]));
 
-					if (is_block_builtin(m.builtin_type) && m.decoration_flags.get(DecorationOffset))
-					{
-						have_any_xfb_offset = true;
-						builtin_xfb_offsets[m.builtin_type] = m.offset;
-					}
+					    if (is_block_builtin(m.builtin_type) && m.decoration_flags.get(DecorationOffset))
+					    {
+						    have_any_xfb_offset = true;
+						    builtin_xfb_offsets[m.builtin_type] = m.offset;
+					    }
 
-					if (is_block_builtin(m.builtin_type) && m.decoration_flags.get(DecorationStream))
-					{
-						uint32_t stream = m.stream;
-						if (have_geom_stream && geom_stream != stream)
-							SPIRV_CROSS_THROW("IO block member Stream mismatch.");
-						have_geom_stream = true;
-						geom_stream = stream;
-					}
-				}
-				index++;
-			}
+					    if (is_block_builtin(m.builtin_type) && m.decoration_flags.get(DecorationStream))
+					    {
+						    uint32_t stream = m.stream;
+						    if (have_geom_stream && geom_stream != stream)
+							    SPIRV_CROSS_THROW("IO block member Stream mismatch.");
+						    have_geom_stream = true;
+						    geom_stream = stream;
+					    }
+				    }
+				    index++;
+			    }
 
-			if (storage == StorageClassOutput && has_decoration(var.self, DecorationXfbBuffer) &&
-			    has_decoration(var.self, DecorationXfbStride))
-			{
-				uint32_t buffer_index = get_decoration(var.self, DecorationXfbBuffer);
-				uint32_t stride = get_decoration(var.self, DecorationXfbStride);
-				if (have_xfb_buffer_stride && buffer_index != xfb_buffer)
-					SPIRV_CROSS_THROW("IO block member XfbBuffer mismatch.");
-				if (have_xfb_buffer_stride && stride != xfb_stride)
-					SPIRV_CROSS_THROW("IO block member XfbBuffer mismatch.");
-				have_xfb_buffer_stride = true;
-				xfb_buffer = buffer_index;
-				xfb_stride = stride;
-			}
+			    if (storage == StorageClassOutput && has_decoration(var.self, DecorationXfbBuffer) &&
+			        has_decoration(var.self, DecorationXfbStride))
+			    {
+				    uint32_t buffer_index = get_decoration(var.self, DecorationXfbBuffer);
+				    uint32_t stride = get_decoration(var.self, DecorationXfbStride);
+				    if (have_xfb_buffer_stride && buffer_index != xfb_buffer)
+					    SPIRV_CROSS_THROW("IO block member XfbBuffer mismatch.");
+				    if (have_xfb_buffer_stride && stride != xfb_stride)
+					    SPIRV_CROSS_THROW("IO block member XfbBuffer mismatch.");
+				    have_xfb_buffer_stride = true;
+				    xfb_buffer = buffer_index;
+				    xfb_stride = stride;
+			    }
 
-			if (storage == StorageClassOutput && has_decoration(var.self, DecorationStream))
-			{
-				uint32_t stream = get_decoration(var.self, DecorationStream);
-				if (have_geom_stream && geom_stream != stream)
-					SPIRV_CROSS_THROW("IO block member Stream mismatch.");
-				have_geom_stream = true;
-				geom_stream = stream;
-			}
-		}
-		else if (var.storage == storage && !block && is_builtin_variable(var))
-		{
-			// While we're at it, collect all declared global builtins (HLSL mostly ...).
-			auto &m = ir.meta[var.self].decoration;
-			if (m.builtin && builtin_is_per_vertex_set(m.builtin_type))
-			{
-				// For mesh/tesc output, Clip/Cull is an array-of-array. Look at innermost array type
-				// for correct result.
-				global_builtins.set(m.builtin_type);
-				if (m.builtin_type == BuiltInCullDistance)
-					cull_distance_size = to_array_size_literal(type, 0);
-				else if (m.builtin_type == BuiltInClipDistance)
-					clip_distance_size = to_array_size_literal(type, 0);
+			    if (storage == StorageClassOutput && has_decoration(var.self, DecorationStream))
+			    {
+				    uint32_t stream = get_decoration(var.self, DecorationStream);
+				    if (have_geom_stream && geom_stream != stream)
+					    SPIRV_CROSS_THROW("IO block member Stream mismatch.");
+				    have_geom_stream = true;
+				    geom_stream = stream;
+			    }
+		    }
+		    else if (var.storage == storage && !block && is_builtin_variable(var))
+		    {
+			    // While we're at it, collect all declared global builtins (HLSL mostly ...).
+			    auto &m = ir.meta[var.self].decoration;
+			    if (m.builtin && builtin_is_per_vertex_set(m.builtin_type))
+			    {
+				    // For mesh/tesc output, Clip/Cull is an array-of-array. Look at innermost array type
+				    // for correct result.
+				    global_builtins.set(m.builtin_type);
+				    if (m.builtin_type == BuiltInCullDistance)
+					    cull_distance_size = to_array_size_literal(type, 0);
+				    else if (m.builtin_type == BuiltInClipDistance)
+					    clip_distance_size = to_array_size_literal(type, 0);
 
-				if (is_block_builtin(m.builtin_type) && m.decoration_flags.get(DecorationXfbStride) &&
-				    m.decoration_flags.get(DecorationXfbBuffer) && m.decoration_flags.get(DecorationOffset))
-				{
-					have_any_xfb_offset = true;
-					builtin_xfb_offsets[m.builtin_type] = m.offset;
-					uint32_t buffer_index = m.xfb_buffer;
-					uint32_t stride = m.xfb_stride;
-					if (have_xfb_buffer_stride && buffer_index != xfb_buffer)
-						SPIRV_CROSS_THROW("IO block member XfbBuffer mismatch.");
-					if (have_xfb_buffer_stride && stride != xfb_stride)
-						SPIRV_CROSS_THROW("IO block member XfbBuffer mismatch.");
-					have_xfb_buffer_stride = true;
-					xfb_buffer = buffer_index;
-					xfb_stride = stride;
-				}
+				    if (is_block_builtin(m.builtin_type) && m.decoration_flags.get(DecorationXfbStride) &&
+				        m.decoration_flags.get(DecorationXfbBuffer) && m.decoration_flags.get(DecorationOffset))
+				    {
+					    have_any_xfb_offset = true;
+					    builtin_xfb_offsets[m.builtin_type] = m.offset;
+					    uint32_t buffer_index = m.xfb_buffer;
+					    uint32_t stride = m.xfb_stride;
+					    if (have_xfb_buffer_stride && buffer_index != xfb_buffer)
+						    SPIRV_CROSS_THROW("IO block member XfbBuffer mismatch.");
+					    if (have_xfb_buffer_stride && stride != xfb_stride)
+						    SPIRV_CROSS_THROW("IO block member XfbBuffer mismatch.");
+					    have_xfb_buffer_stride = true;
+					    xfb_buffer = buffer_index;
+					    xfb_stride = stride;
+				    }
 
-				if (is_block_builtin(m.builtin_type) && m.decoration_flags.get(DecorationStream))
-				{
-					uint32_t stream = get_decoration(var.self, DecorationStream);
-					if (have_geom_stream && geom_stream != stream)
-						SPIRV_CROSS_THROW("IO block member Stream mismatch.");
-					have_geom_stream = true;
-					geom_stream = stream;
-				}
-			}
-		}
+				    if (is_block_builtin(m.builtin_type) && m.decoration_flags.get(DecorationStream))
+				    {
+					    uint32_t stream = get_decoration(var.self, DecorationStream);
+					    if (have_geom_stream && geom_stream != stream)
+						    SPIRV_CROSS_THROW("IO block member Stream mismatch.");
+					    have_geom_stream = true;
+					    geom_stream = stream;
+				    }
+			    }
+		    }
 
-		if (builtins.empty())
-			return;
+		    if (builtins.empty())
+			    return;
 
-		if (emitted_block)
-			SPIRV_CROSS_THROW("Cannot use more than one builtin I/O block.");
+		    if (emitted_block)
+			    SPIRV_CROSS_THROW("Cannot use more than one builtin I/O block.");
 
-		emitted_builtins = builtins;
-		emitted_block = true;
-		block_var = &var;
-	});
+		    emitted_builtins = builtins;
+		    emitted_block = true;
+		    block_var = &var;
+	    });
 
 	global_builtins =
 	    Bitset(global_builtins.get_lower() & ((1ull << BuiltInPosition) | (1ull << BuiltInPointSize) |
@@ -3737,87 +3754,97 @@ void CompilerGLSL::emit_resources()
 		// Do this in two stages, one with forward declaration,
 		// and one without. Buffer reference blocks can reference themselves
 		// to support things like linked lists.
-		ir.for_each_typed_id<SPIRType>([&](uint32_t id, SPIRType &type) {
-			if (is_physical_pointer(type))
-			{
-				bool emit_type = true;
-				if (!is_physical_pointer_to_buffer_block(type))
-				{
-					// Only forward-declare if we intend to emit it in the non_block_pointer types.
-					// Otherwise, these are just "benign" pointer types that exist as a result of access chains.
-					emit_type = std::find(physical_storage_non_block_pointer_types.begin(),
-					                      physical_storage_non_block_pointer_types.end(),
-					                      id) != physical_storage_non_block_pointer_types.end();
-				}
+		ir.for_each_typed_id<SPIRType>(
+		    [&](uint32_t id, SPIRType &type)
+		    {
+			    if (is_physical_pointer(type))
+			    {
+				    bool emit_type = true;
+				    if (!is_physical_pointer_to_buffer_block(type))
+				    {
+					    // Only forward-declare if we intend to emit it in the non_block_pointer types.
+					    // Otherwise, these are just "benign" pointer types that exist as a result of access chains.
+					    emit_type = std::find(physical_storage_non_block_pointer_types.begin(),
+					                          physical_storage_non_block_pointer_types.end(),
+					                          id) != physical_storage_non_block_pointer_types.end();
+				    }
 
-				if (emit_type)
-					emit_buffer_reference_block(id, true);
-			}
-		});
+				    if (emit_type)
+					    emit_buffer_reference_block(id, true);
+			    }
+		    });
 
 		for (auto type : physical_storage_non_block_pointer_types)
 			emit_buffer_reference_block(type, false);
 
-		ir.for_each_typed_id<SPIRType>([&](uint32_t id, SPIRType &type) {
-			if (is_physical_pointer_to_buffer_block(type))
-				emit_buffer_reference_block(id, false);
-		});
+		ir.for_each_typed_id<SPIRType>(
+		    [&](uint32_t id, SPIRType &type)
+		    {
+			    if (is_physical_pointer_to_buffer_block(type))
+				    emit_buffer_reference_block(id, false);
+		    });
 	}
 
 	// Output UBOs and SSBOs
-	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, SPIRVariable &var) {
-		auto &type = this->get<SPIRType>(var.basetype);
+	ir.for_each_typed_id<SPIRVariable>(
+	    [&](uint32_t, SPIRVariable &var)
+	    {
+		    auto &type = this->get<SPIRType>(var.basetype);
 
-		bool is_block_storage = type.storage == StorageClassStorageBuffer || type.storage == StorageClassUniform ||
-		                        type.storage == StorageClassShaderRecordBufferKHR;
-		bool has_block_flags = ir.meta[type.self].decoration.decoration_flags.get(DecorationBlock) ||
-		                       ir.meta[type.self].decoration.decoration_flags.get(DecorationBufferBlock);
+		    bool is_block_storage = type.storage == StorageClassStorageBuffer || type.storage == StorageClassUniform ||
+		                            type.storage == StorageClassShaderRecordBufferKHR;
+		    bool has_block_flags = ir.meta[type.self].decoration.decoration_flags.get(DecorationBlock) ||
+		                           ir.meta[type.self].decoration.decoration_flags.get(DecorationBufferBlock);
 
-		if (var.storage != StorageClassFunction && type.pointer && is_block_storage && !is_hidden_variable(var) &&
-		    has_block_flags)
-		{
-			emit_buffer_block(var);
-		}
-	});
+		    if (var.storage != StorageClassFunction && type.pointer && is_block_storage && !is_hidden_variable(var) &&
+		        has_block_flags)
+		    {
+			    emit_buffer_block(var);
+		    }
+	    });
 
 	// Output push constant blocks
-	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, SPIRVariable &var) {
-		auto &type = this->get<SPIRType>(var.basetype);
-		if (var.storage != StorageClassFunction && type.pointer && type.storage == StorageClassPushConstant &&
-		    !is_hidden_variable(var))
-		{
-			emit_push_constant_block(var);
-		}
-	});
+	ir.for_each_typed_id<SPIRVariable>(
+	    [&](uint32_t, SPIRVariable &var)
+	    {
+		    auto &type = this->get<SPIRType>(var.basetype);
+		    if (var.storage != StorageClassFunction && type.pointer && type.storage == StorageClassPushConstant &&
+		        !is_hidden_variable(var))
+		    {
+			    emit_push_constant_block(var);
+		    }
+	    });
 
 	bool skip_separate_image_sampler = !combined_image_samplers.empty() || !options.vulkan_semantics;
 
 	// Output Uniform Constants (values, samplers, images, etc).
-	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, SPIRVariable &var) {
-		auto &type = this->get<SPIRType>(var.basetype);
+	ir.for_each_typed_id<SPIRVariable>(
+	    [&](uint32_t, SPIRVariable &var)
+	    {
+		    auto &type = this->get<SPIRType>(var.basetype);
 
-		// If we're remapping separate samplers and images, only emit the combined samplers.
-		if (skip_separate_image_sampler)
-		{
-			// Sampler buffers are always used without a sampler, and they will also work in regular GL.
-			bool sampler_buffer = type.basetype == SPIRType::Image && type.image.dim == DimBuffer;
-			bool separate_image = type.basetype == SPIRType::Image && type.image.sampled == 1;
-			bool separate_sampler = type.basetype == SPIRType::Sampler;
-			if (!sampler_buffer && (separate_image || separate_sampler))
-				return;
-		}
+		    // If we're remapping separate samplers and images, only emit the combined samplers.
+		    if (skip_separate_image_sampler)
+		    {
+			    // Sampler buffers are always used without a sampler, and they will also work in regular GL.
+			    bool sampler_buffer = type.basetype == SPIRType::Image && type.image.dim == DimBuffer;
+			    bool separate_image = type.basetype == SPIRType::Image && type.image.sampled == 1;
+			    bool separate_sampler = type.basetype == SPIRType::Sampler;
+			    if (!sampler_buffer && (separate_image || separate_sampler))
+				    return;
+		    }
 
-		if (var.storage != StorageClassFunction && type.pointer &&
-		    (type.storage == StorageClassUniformConstant || type.storage == StorageClassAtomicCounter ||
-		     type.storage == StorageClassRayPayloadKHR || type.storage == StorageClassIncomingRayPayloadKHR ||
-		     type.storage == StorageClassCallableDataKHR || type.storage == StorageClassIncomingCallableDataKHR ||
-		     type.storage == StorageClassHitAttributeKHR) &&
-		    !is_hidden_variable(var))
-		{
-			emit_uniform(var);
-			emitted = true;
-		}
-	});
+		    if (var.storage != StorageClassFunction && type.pointer &&
+		        (type.storage == StorageClassUniformConstant || type.storage == StorageClassAtomicCounter ||
+		         type.storage == StorageClassRayPayloadKHR || type.storage == StorageClassIncomingRayPayloadKHR ||
+		         type.storage == StorageClassCallableDataKHR || type.storage == StorageClassIncomingCallableDataKHR ||
+		         type.storage == StorageClassHitAttributeKHR) &&
+		        !is_hidden_variable(var))
+		    {
+			    emit_uniform(var);
+			    emitted = true;
+		    }
+	    });
 
 	if (emitted)
 		statement("");
@@ -3826,71 +3853,73 @@ void CompilerGLSL::emit_resources()
 	bool emitted_base_instance = false;
 
 	// Output in/out interfaces.
-	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, SPIRVariable &var) {
-		auto &type = this->get<SPIRType>(var.basetype);
+	ir.for_each_typed_id<SPIRVariable>(
+	    [&](uint32_t, SPIRVariable &var)
+	    {
+		    auto &type = this->get<SPIRType>(var.basetype);
 
-		bool is_hidden = is_hidden_variable(var);
+		    bool is_hidden = is_hidden_variable(var);
 
-		// Unused output I/O variables might still be required to implement framebuffer fetch.
-		if (var.storage == StorageClassOutput && !is_legacy() &&
-		    location_is_framebuffer_fetch(get_decoration(var.self, DecorationLocation)) != 0)
-		{
-			is_hidden = false;
-		}
+		    // Unused output I/O variables might still be required to implement framebuffer fetch.
+		    if (var.storage == StorageClassOutput && !is_legacy() &&
+		        location_is_framebuffer_fetch(get_decoration(var.self, DecorationLocation)) != 0)
+		    {
+			    is_hidden = false;
+		    }
 
-		if (var.storage != StorageClassFunction && type.pointer &&
-		    (var.storage == StorageClassInput || var.storage == StorageClassOutput) &&
-		    interface_variable_exists_in_entry_point(var.self) && !is_hidden)
-		{
-			if (options.es && get_execution_model() == ExecutionModelVertex && var.storage == StorageClassInput &&
-			    type.array.size() == 1)
-			{
-				SPIRV_CROSS_THROW("OpenGL ES doesn't support array input variables in vertex shader.");
-			}
-			emit_interface_block(var);
-			emitted = true;
-		}
-		else if (is_builtin_variable(var))
-		{
-			auto builtin = BuiltIn(get_decoration(var.self, DecorationBuiltIn));
-			// For gl_InstanceIndex emulation on GLES, the API user needs to
-			// supply this uniform.
+		    if (var.storage != StorageClassFunction && type.pointer &&
+		        (var.storage == StorageClassInput || var.storage == StorageClassOutput) &&
+		        interface_variable_exists_in_entry_point(var.self) && !is_hidden)
+		    {
+			    if (options.es && get_execution_model() == ExecutionModelVertex && var.storage == StorageClassInput &&
+			        type.array.size() == 1)
+			    {
+				    SPIRV_CROSS_THROW("OpenGL ES doesn't support array input variables in vertex shader.");
+			    }
+			    emit_interface_block(var);
+			    emitted = true;
+		    }
+		    else if (is_builtin_variable(var))
+		    {
+			    auto builtin = BuiltIn(get_decoration(var.self, DecorationBuiltIn));
+			    // For gl_InstanceIndex emulation on GLES, the API user needs to
+			    // supply this uniform.
 
-			// The draw parameter extension is soft-enabled on GL with some fallbacks.
-			if (!options.vulkan_semantics)
-			{
-				if (!emitted_base_instance &&
-				    ((options.vertex.support_nonzero_base_instance && builtin == BuiltInInstanceIndex) ||
-				     (builtin == BuiltInBaseInstance)))
-				{
-					statement("#ifdef GL_ARB_shader_draw_parameters");
-					statement("#define SPIRV_Cross_BaseInstance gl_BaseInstanceARB");
-					statement("#else");
-					// A crude, but simple workaround which should be good enough for non-indirect draws.
-					statement("uniform int SPIRV_Cross_BaseInstance;");
-					statement("#endif");
-					emitted = true;
-					emitted_base_instance = true;
-				}
-				else if (builtin == BuiltInBaseVertex)
-				{
-					statement("#ifdef GL_ARB_shader_draw_parameters");
-					statement("#define SPIRV_Cross_BaseVertex gl_BaseVertexARB");
-					statement("#else");
-					// A crude, but simple workaround which should be good enough for non-indirect draws.
-					statement("uniform int SPIRV_Cross_BaseVertex;");
-					statement("#endif");
-				}
-				else if (builtin == BuiltInDrawIndex)
-				{
-					statement("#ifndef GL_ARB_shader_draw_parameters");
-					// Cannot really be worked around.
-					statement("#error GL_ARB_shader_draw_parameters is not supported.");
-					statement("#endif");
-				}
-			}
-		}
-	});
+			    // The draw parameter extension is soft-enabled on GL with some fallbacks.
+			    if (!options.vulkan_semantics)
+			    {
+				    if (!emitted_base_instance &&
+				        ((options.vertex.support_nonzero_base_instance && builtin == BuiltInInstanceIndex) ||
+				         (builtin == BuiltInBaseInstance)))
+				    {
+					    statement("#ifdef GL_ARB_shader_draw_parameters");
+					    statement("#define SPIRV_Cross_BaseInstance gl_BaseInstanceARB");
+					    statement("#else");
+					    // A crude, but simple workaround which should be good enough for non-indirect draws.
+					    statement("uniform int SPIRV_Cross_BaseInstance;");
+					    statement("#endif");
+					    emitted = true;
+					    emitted_base_instance = true;
+				    }
+				    else if (builtin == BuiltInBaseVertex)
+				    {
+					    statement("#ifdef GL_ARB_shader_draw_parameters");
+					    statement("#define SPIRV_Cross_BaseVertex gl_BaseVertexARB");
+					    statement("#else");
+					    // A crude, but simple workaround which should be good enough for non-indirect draws.
+					    statement("uniform int SPIRV_Cross_BaseVertex;");
+					    statement("#endif");
+				    }
+				    else if (builtin == BuiltInDrawIndex)
+				    {
+					    statement("#ifndef GL_ARB_shader_draw_parameters");
+					    // Cannot really be worked around.
+					    statement("#error GL_ARB_shader_draw_parameters is not supported.");
+					    statement("#endif");
+				    }
+			    }
+		    }
+	    });
 
 	// Global variables.
 	for (auto global : global_variables)
@@ -3984,94 +4013,103 @@ void CompilerGLSL::emit_output_variable_initializer(const SPIRVariable &var)
 
 			for (uint32_t j = 0; j < iteration_count; j++)
 			{
-				entry_func.fixup_hooks_in.push_back([=, &var]() {
-					AccessChainMeta meta;
-					auto &c = this->get<SPIRConstant>(var.initializer);
+				entry_func.fixup_hooks_in.push_back(
+				    [=, &var]()
+				    {
+					    AccessChainMeta meta;
+					    auto &c = this->get<SPIRConstant>(var.initializer);
 
-					uint32_t invocation_id = 0;
-					uint32_t member_index_id = 0;
-					if (is_control_point)
-					{
-						uint32_t ids = ir.increase_bound_by(3);
-						auto &uint_type = set<SPIRType>(ids, OpTypeInt);
-						uint_type.basetype = SPIRType::UInt;
-						uint_type.width = 32;
-						set<SPIRExpression>(ids + 1, builtin_to_glsl(BuiltInInvocationId, StorageClassInput), ids, true);
-						set<SPIRConstant>(ids + 2, ids, i, false);
-						invocation_id = ids + 1;
-						member_index_id = ids + 2;
-					}
+					    uint32_t invocation_id = 0;
+					    uint32_t member_index_id = 0;
+					    if (is_control_point)
+					    {
+						    uint32_t ids = ir.increase_bound_by(3);
+						    auto &uint_type = set<SPIRType>(ids, OpTypeInt);
+						    uint_type.basetype = SPIRType::UInt;
+						    uint_type.width = 32;
+						    set<SPIRExpression>(ids + 1, builtin_to_glsl(BuiltInInvocationId, StorageClassInput), ids,
+						                        true);
+						    set<SPIRConstant>(ids + 2, ids, i, false);
+						    invocation_id = ids + 1;
+						    member_index_id = ids + 2;
+					    }
 
-					if (is_patch)
-					{
-						statement("if (gl_InvocationID == 0)");
-						begin_scope();
-					}
+					    if (is_patch)
+					    {
+						    statement("if (gl_InvocationID == 0)");
+						    begin_scope();
+					    }
 
-					if (type_is_array && !is_control_point)
-					{
-						uint32_t indices[2] = { j, i };
-						auto chain = access_chain_internal(var.self, indices, 2, ACCESS_CHAIN_INDEX_IS_LITERAL_BIT, &meta);
-						statement(chain, " = ", lut_name, "[", j, "];");
-					}
-					else if (is_control_point)
-					{
-						uint32_t indices[2] = { invocation_id, member_index_id };
-						auto chain = access_chain_internal(var.self, indices, 2, 0, &meta);
-						statement(chain, " = ", lut_name, "[", builtin_to_glsl(BuiltInInvocationId, StorageClassInput), "];");
-					}
-					else
-					{
-						auto chain =
-								access_chain_internal(var.self, &i, 1, ACCESS_CHAIN_INDEX_IS_LITERAL_BIT, &meta);
-						statement(chain, " = ", to_expression(c.subconstants[i]), ";");
-					}
+					    if (type_is_array && !is_control_point)
+					    {
+						    uint32_t indices[2] = { j, i };
+						    auto chain =
+						        access_chain_internal(var.self, indices, 2, ACCESS_CHAIN_INDEX_IS_LITERAL_BIT, &meta);
+						    statement(chain, " = ", lut_name, "[", j, "];");
+					    }
+					    else if (is_control_point)
+					    {
+						    uint32_t indices[2] = { invocation_id, member_index_id };
+						    auto chain = access_chain_internal(var.self, indices, 2, 0, &meta);
+						    statement(chain, " = ", lut_name, "[",
+						              builtin_to_glsl(BuiltInInvocationId, StorageClassInput), "];");
+					    }
+					    else
+					    {
+						    auto chain =
+						        access_chain_internal(var.self, &i, 1, ACCESS_CHAIN_INDEX_IS_LITERAL_BIT, &meta);
+						    statement(chain, " = ", to_expression(c.subconstants[i]), ";");
+					    }
 
-					if (is_patch)
-						end_scope();
-				});
+					    if (is_patch)
+						    end_scope();
+				    });
 			}
 		}
 	}
 	else if (is_control_point)
 	{
 		auto lut_name = join("_", var.self, "_init");
-		statement("const ", type_to_glsl(type), " ", lut_name, type_to_array_glsl(type, 0),
-		          " = ", to_expression(var.initializer), ";");
-		entry_func.fixup_hooks_in.push_back([&, lut_name]() {
-			statement(to_expression(var.self), "[gl_InvocationID] = ", lut_name, "[gl_InvocationID];");
-		});
+		statement("const ", type_to_glsl(type), " ", lut_name, type_to_array_glsl(type, 0), " = ",
+		          to_expression(var.initializer), ";");
+		entry_func.fixup_hooks_in.push_back(
+		    [&, lut_name]()
+		    { statement(to_expression(var.self), "[gl_InvocationID] = ", lut_name, "[gl_InvocationID];"); });
 	}
 	else if (has_decoration(var.self, DecorationBuiltIn) &&
 	         BuiltIn(get_decoration(var.self, DecorationBuiltIn)) == BuiltInSampleMask)
 	{
 		// We cannot copy the array since gl_SampleMask is unsized in GLSL. Unroll time! <_<
-		entry_func.fixup_hooks_in.push_back([&] {
-			auto &c = this->get<SPIRConstant>(var.initializer);
-			uint32_t num_constants = uint32_t(c.subconstants.size());
-			for (uint32_t i = 0; i < num_constants; i++)
-			{
-				// Don't use to_expression on constant since it might be uint, just fish out the raw int.
-				statement(to_expression(var.self), "[", i, "] = ",
-				          convert_to_string(this->get<SPIRConstant>(c.subconstants[i]).scalar_i32()), ";");
-			}
-		});
+		entry_func.fixup_hooks_in.push_back(
+		    [&]
+		    {
+			    auto &c = this->get<SPIRConstant>(var.initializer);
+			    uint32_t num_constants = uint32_t(c.subconstants.size());
+			    for (uint32_t i = 0; i < num_constants; i++)
+			    {
+				    // Don't use to_expression on constant since it might be uint, just fish out the raw int.
+				    statement(to_expression(var.self), "[", i,
+				              "] = ", convert_to_string(this->get<SPIRConstant>(c.subconstants[i]).scalar_i32()), ";");
+			    }
+		    });
 	}
 	else
 	{
 		auto lut_name = join("_", var.self, "_init");
-		statement("const ", type_to_glsl(type), " ", lut_name,
-		          type_to_array_glsl(type, var.self), " = ", to_expression(var.initializer), ";");
-		entry_func.fixup_hooks_in.push_back([&, lut_name, is_patch]() {
-			if (is_patch)
-			{
-				statement("if (gl_InvocationID == 0)");
-				begin_scope();
-			}
-			statement(to_expression(var.self), " = ", lut_name, ";");
-			if (is_patch)
-				end_scope();
-		});
+		statement("const ", type_to_glsl(type), " ", lut_name, type_to_array_glsl(type, var.self), " = ",
+		          to_expression(var.initializer), ";");
+		entry_func.fixup_hooks_in.push_back(
+		    [&, lut_name, is_patch]()
+		    {
+			    if (is_patch)
+			    {
+				    statement("if (gl_InvocationID == 0)");
+				    begin_scope();
+			    }
+			    statement(to_expression(var.self), " = ", lut_name, ";");
+			    if (is_patch)
+				    end_scope();
+		    });
 	}
 }
 
@@ -4704,8 +4742,10 @@ void CompilerGLSL::emit_extension_workarounds(spv::ExecutionModel model)
 			{
 				// Need both variants.
 				// GLSL cannot overload on precision, so need to dispatch appropriately.
-				statement("highp ", type_to_glsl(type), " spvWorkaroundRowMajor(highp ", type_to_glsl(type), " wrap) { return wrap; }");
-				statement("mediump ", type_to_glsl(type), " spvWorkaroundRowMajorMP(mediump ", type_to_glsl(type), " wrap) { return wrap; }");
+				statement("highp ", type_to_glsl(type), " spvWorkaroundRowMajor(highp ", type_to_glsl(type),
+				          " wrap) { return wrap; }");
+				statement("mediump ", type_to_glsl(type), " spvWorkaroundRowMajorMP(mediump ", type_to_glsl(type),
+				          " wrap) { return wrap; }");
 			}
 			else
 			{
@@ -4765,8 +4805,8 @@ void CompilerGLSL::emit_polyfills(uint32_t polyfills, bool relaxed)
 		statement(qual, "float spvDeterminant", suffix, "(", qual, "mat3 m)");
 		begin_scope();
 		statement("return dot(m[0], vec3(m[1][1] * m[2][2] - m[1][2] * m[2][1], "
-		                                "m[1][2] * m[2][0] - m[1][0] * m[2][2], "
-		                                "m[1][0] * m[2][1] - m[1][1] * m[2][0]));");
+		          "m[1][2] * m[2][0] - m[1][0] * m[2][2], "
+		          "m[1][0] * m[2][1] - m[1][1] * m[2][0]));");
 		end_scope();
 		statement("");
 	}
@@ -4776,10 +4816,14 @@ void CompilerGLSL::emit_polyfills(uint32_t polyfills, bool relaxed)
 		statement(qual, "float spvDeterminant", suffix, "(", qual, "mat4 m)");
 		begin_scope();
 		statement("return dot(m[0], vec4("
-		          "m[2][1] * m[3][2] * m[1][3] - m[3][1] * m[2][2] * m[1][3] + m[3][1] * m[1][2] * m[2][3] - m[1][1] * m[3][2] * m[2][3] - m[2][1] * m[1][2] * m[3][3] + m[1][1] * m[2][2] * m[3][3], "
-		          "m[3][0] * m[2][2] * m[1][3] - m[2][0] * m[3][2] * m[1][3] - m[3][0] * m[1][2] * m[2][3] + m[1][0] * m[3][2] * m[2][3] + m[2][0] * m[1][2] * m[3][3] - m[1][0] * m[2][2] * m[3][3], "
-		          "m[2][0] * m[3][1] * m[1][3] - m[3][0] * m[2][1] * m[1][3] + m[3][0] * m[1][1] * m[2][3] - m[1][0] * m[3][1] * m[2][3] - m[2][0] * m[1][1] * m[3][3] + m[1][0] * m[2][1] * m[3][3], "
-		          "m[3][0] * m[2][1] * m[1][2] - m[2][0] * m[3][1] * m[1][2] - m[3][0] * m[1][1] * m[2][2] + m[1][0] * m[3][1] * m[2][2] + m[2][0] * m[1][1] * m[3][2] - m[1][0] * m[2][1] * m[3][2]));");
+		          "m[2][1] * m[3][2] * m[1][3] - m[3][1] * m[2][2] * m[1][3] + m[3][1] * m[1][2] * m[2][3] - m[1][1] * "
+		          "m[3][2] * m[2][3] - m[2][1] * m[1][2] * m[3][3] + m[1][1] * m[2][2] * m[3][3], "
+		          "m[3][0] * m[2][2] * m[1][3] - m[2][0] * m[3][2] * m[1][3] - m[3][0] * m[1][2] * m[2][3] + m[1][0] * "
+		          "m[3][2] * m[2][3] + m[2][0] * m[1][2] * m[3][3] - m[1][0] * m[2][2] * m[3][3], "
+		          "m[2][0] * m[3][1] * m[1][3] - m[3][0] * m[2][1] * m[1][3] + m[3][0] * m[1][1] * m[2][3] - m[1][0] * "
+		          "m[3][1] * m[2][3] - m[2][0] * m[1][1] * m[3][3] + m[1][0] * m[2][1] * m[3][3], "
+		          "m[3][0] * m[2][1] * m[1][2] - m[2][0] * m[3][1] * m[1][2] - m[3][0] * m[1][1] * m[2][2] + m[1][0] * "
+		          "m[3][1] * m[2][2] + m[2][0] * m[1][1] * m[3][2] - m[1][0] * m[2][1] * m[3][2]));");
 		end_scope();
 		statement("");
 	}
@@ -4798,17 +4842,18 @@ void CompilerGLSL::emit_polyfills(uint32_t polyfills, bool relaxed)
 	{
 		statement(qual, "mat3 spvInverse", suffix, "(", qual, "mat3 m)");
 		begin_scope();
-		statement(qual, "vec3 t = vec3(m[1][1] * m[2][2] - m[1][2] * m[2][1], m[1][2] * m[2][0] - m[1][0] * m[2][2], m[1][0] * m[2][1] - m[1][1] * m[2][0]);");
+		statement(qual, "vec3 t = vec3(m[1][1] * m[2][2] - m[1][2] * m[2][1], m[1][2] * m[2][0] - m[1][0] * m[2][2], "
+		                "m[1][0] * m[2][1] - m[1][1] * m[2][0]);");
 		statement("return mat3(t[0], "
-		                      "m[0][2] * m[2][1] - m[0][1] * m[2][2], "
-		                      "m[0][1] * m[1][2] - m[0][2] * m[1][1], "
-		                      "t[1], "
-		                      "m[0][0] * m[2][2] - m[0][2] * m[2][0], "
-		                      "m[0][2] * m[1][0] - m[0][0] * m[1][2], "
-		                      "t[2], "
-		                      "m[0][1] * m[2][0] - m[0][0] * m[2][1], "
-		                      "m[0][0] * m[1][1] - m[0][1] * m[1][0]) "
-		                      "* (1.0 / dot(m[0], t));");
+		          "m[0][2] * m[2][1] - m[0][1] * m[2][2], "
+		          "m[0][1] * m[1][2] - m[0][2] * m[1][1], "
+		          "t[1], "
+		          "m[0][0] * m[2][2] - m[0][2] * m[2][0], "
+		          "m[0][2] * m[1][0] - m[0][0] * m[1][2], "
+		          "t[2], "
+		          "m[0][1] * m[2][0] - m[0][0] * m[2][1], "
+		          "m[0][0] * m[1][1] - m[0][1] * m[1][0]) "
+		          "* (1.0 / dot(m[0], t));");
 		end_scope();
 		statement("");
 	}
@@ -4818,27 +4863,43 @@ void CompilerGLSL::emit_polyfills(uint32_t polyfills, bool relaxed)
 		statement(qual, "mat4 spvInverse", suffix, "(", qual, "mat4 m)");
 		begin_scope();
 		statement(qual, "vec4 t = vec4("
-		          "m[2][1] * m[3][2] * m[1][3] - m[3][1] * m[2][2] * m[1][3] + m[3][1] * m[1][2] * m[2][3] - m[1][1] * m[3][2] * m[2][3] - m[2][1] * m[1][2] * m[3][3] + m[1][1] * m[2][2] * m[3][3], "
-		          "m[3][0] * m[2][2] * m[1][3] - m[2][0] * m[3][2] * m[1][3] - m[3][0] * m[1][2] * m[2][3] + m[1][0] * m[3][2] * m[2][3] + m[2][0] * m[1][2] * m[3][3] - m[1][0] * m[2][2] * m[3][3], "
-		          "m[2][0] * m[3][1] * m[1][3] - m[3][0] * m[2][1] * m[1][3] + m[3][0] * m[1][1] * m[2][3] - m[1][0] * m[3][1] * m[2][3] - m[2][0] * m[1][1] * m[3][3] + m[1][0] * m[2][1] * m[3][3], "
-		          "m[3][0] * m[2][1] * m[1][2] - m[2][0] * m[3][1] * m[1][2] - m[3][0] * m[1][1] * m[2][2] + m[1][0] * m[3][1] * m[2][2] + m[2][0] * m[1][1] * m[3][2] - m[1][0] * m[2][1] * m[3][2]);");
+		                "m[2][1] * m[3][2] * m[1][3] - m[3][1] * m[2][2] * m[1][3] + m[3][1] * m[1][2] * m[2][3] - "
+		                "m[1][1] * m[3][2] * m[2][3] - m[2][1] * m[1][2] * m[3][3] + m[1][1] * m[2][2] * m[3][3], "
+		                "m[3][0] * m[2][2] * m[1][3] - m[2][0] * m[3][2] * m[1][3] - m[3][0] * m[1][2] * m[2][3] + "
+		                "m[1][0] * m[3][2] * m[2][3] + m[2][0] * m[1][2] * m[3][3] - m[1][0] * m[2][2] * m[3][3], "
+		                "m[2][0] * m[3][1] * m[1][3] - m[3][0] * m[2][1] * m[1][3] + m[3][0] * m[1][1] * m[2][3] - "
+		                "m[1][0] * m[3][1] * m[2][3] - m[2][0] * m[1][1] * m[3][3] + m[1][0] * m[2][1] * m[3][3], "
+		                "m[3][0] * m[2][1] * m[1][2] - m[2][0] * m[3][1] * m[1][2] - m[3][0] * m[1][1] * m[2][2] + "
+		                "m[1][0] * m[3][1] * m[2][2] + m[2][0] * m[1][1] * m[3][2] - m[1][0] * m[2][1] * m[3][2]);");
 		statement("return mat4("
 		          "t[0], "
-		          "m[3][1] * m[2][2] * m[0][3] - m[2][1] * m[3][2] * m[0][3] - m[3][1] * m[0][2] * m[2][3] + m[0][1] * m[3][2] * m[2][3] + m[2][1] * m[0][2] * m[3][3] - m[0][1] * m[2][2] * m[3][3], "
-		          "m[1][1] * m[3][2] * m[0][3] - m[3][1] * m[1][2] * m[0][3] + m[3][1] * m[0][2] * m[1][3] - m[0][1] * m[3][2] * m[1][3] - m[1][1] * m[0][2] * m[3][3] + m[0][1] * m[1][2] * m[3][3], "
-		          "m[2][1] * m[1][2] * m[0][3] - m[1][1] * m[2][2] * m[0][3] - m[2][1] * m[0][2] * m[1][3] + m[0][1] * m[2][2] * m[1][3] + m[1][1] * m[0][2] * m[2][3] - m[0][1] * m[1][2] * m[2][3], "
+		          "m[3][1] * m[2][2] * m[0][3] - m[2][1] * m[3][2] * m[0][3] - m[3][1] * m[0][2] * m[2][3] + m[0][1] * "
+		          "m[3][2] * m[2][3] + m[2][1] * m[0][2] * m[3][3] - m[0][1] * m[2][2] * m[3][3], "
+		          "m[1][1] * m[3][2] * m[0][3] - m[3][1] * m[1][2] * m[0][3] + m[3][1] * m[0][2] * m[1][3] - m[0][1] * "
+		          "m[3][2] * m[1][3] - m[1][1] * m[0][2] * m[3][3] + m[0][1] * m[1][2] * m[3][3], "
+		          "m[2][1] * m[1][2] * m[0][3] - m[1][1] * m[2][2] * m[0][3] - m[2][1] * m[0][2] * m[1][3] + m[0][1] * "
+		          "m[2][2] * m[1][3] + m[1][1] * m[0][2] * m[2][3] - m[0][1] * m[1][2] * m[2][3], "
 		          "t[1], "
-		          "m[2][0] * m[3][2] * m[0][3] - m[3][0] * m[2][2] * m[0][3] + m[3][0] * m[0][2] * m[2][3] - m[0][0] * m[3][2] * m[2][3] - m[2][0] * m[0][2] * m[3][3] + m[0][0] * m[2][2] * m[3][3], "
-		          "m[3][0] * m[1][2] * m[0][3] - m[1][0] * m[3][2] * m[0][3] - m[3][0] * m[0][2] * m[1][3] + m[0][0] * m[3][2] * m[1][3] + m[1][0] * m[0][2] * m[3][3] - m[0][0] * m[1][2] * m[3][3], "
-		          "m[1][0] * m[2][2] * m[0][3] - m[2][0] * m[1][2] * m[0][3] + m[2][0] * m[0][2] * m[1][3] - m[0][0] * m[2][2] * m[1][3] - m[1][0] * m[0][2] * m[2][3] + m[0][0] * m[1][2] * m[2][3], "
+		          "m[2][0] * m[3][2] * m[0][3] - m[3][0] * m[2][2] * m[0][3] + m[3][0] * m[0][2] * m[2][3] - m[0][0] * "
+		          "m[3][2] * m[2][3] - m[2][0] * m[0][2] * m[3][3] + m[0][0] * m[2][2] * m[3][3], "
+		          "m[3][0] * m[1][2] * m[0][3] - m[1][0] * m[3][2] * m[0][3] - m[3][0] * m[0][2] * m[1][3] + m[0][0] * "
+		          "m[3][2] * m[1][3] + m[1][0] * m[0][2] * m[3][3] - m[0][0] * m[1][2] * m[3][3], "
+		          "m[1][0] * m[2][2] * m[0][3] - m[2][0] * m[1][2] * m[0][3] + m[2][0] * m[0][2] * m[1][3] - m[0][0] * "
+		          "m[2][2] * m[1][3] - m[1][0] * m[0][2] * m[2][3] + m[0][0] * m[1][2] * m[2][3], "
 		          "t[2], "
-		          "m[3][0] * m[2][1] * m[0][3] - m[2][0] * m[3][1] * m[0][3] - m[3][0] * m[0][1] * m[2][3] + m[0][0] * m[3][1] * m[2][3] + m[2][0] * m[0][1] * m[3][3] - m[0][0] * m[2][1] * m[3][3], "
-		          "m[1][0] * m[3][1] * m[0][3] - m[3][0] * m[1][1] * m[0][3] + m[3][0] * m[0][1] * m[1][3] - m[0][0] * m[3][1] * m[1][3] - m[1][0] * m[0][1] * m[3][3] + m[0][0] * m[1][1] * m[3][3], "
-		          "m[2][0] * m[1][1] * m[0][3] - m[1][0] * m[2][1] * m[0][3] - m[2][0] * m[0][1] * m[1][3] + m[0][0] * m[2][1] * m[1][3] + m[1][0] * m[0][1] * m[2][3] - m[0][0] * m[1][1] * m[2][3], "
+		          "m[3][0] * m[2][1] * m[0][3] - m[2][0] * m[3][1] * m[0][3] - m[3][0] * m[0][1] * m[2][3] + m[0][0] * "
+		          "m[3][1] * m[2][3] + m[2][0] * m[0][1] * m[3][3] - m[0][0] * m[2][1] * m[3][3], "
+		          "m[1][0] * m[3][1] * m[0][3] - m[3][0] * m[1][1] * m[0][3] + m[3][0] * m[0][1] * m[1][3] - m[0][0] * "
+		          "m[3][1] * m[1][3] - m[1][0] * m[0][1] * m[3][3] + m[0][0] * m[1][1] * m[3][3], "
+		          "m[2][0] * m[1][1] * m[0][3] - m[1][0] * m[2][1] * m[0][3] - m[2][0] * m[0][1] * m[1][3] + m[0][0] * "
+		          "m[2][1] * m[1][3] + m[1][0] * m[0][1] * m[2][3] - m[0][0] * m[1][1] * m[2][3], "
 		          "t[3], "
-		          "m[2][0] * m[3][1] * m[0][2] - m[3][0] * m[2][1] * m[0][2] + m[3][0] * m[0][1] * m[2][2] - m[0][0] * m[3][1] * m[2][2] - m[2][0] * m[0][1] * m[3][2] + m[0][0] * m[2][1] * m[3][2], "
-		          "m[3][0] * m[1][1] * m[0][2] - m[1][0] * m[3][1] * m[0][2] - m[3][0] * m[0][1] * m[1][2] + m[0][0] * m[3][1] * m[1][2] + m[1][0] * m[0][1] * m[3][2] - m[0][0] * m[1][1] * m[3][2], "
-		          "m[1][0] * m[2][1] * m[0][2] - m[2][0] * m[1][1] * m[0][2] + m[2][0] * m[0][1] * m[1][2] - m[0][0] * m[2][1] * m[1][2] - m[1][0] * m[0][1] * m[2][2] + m[0][0] * m[1][1] * m[2][2]) "
+		          "m[2][0] * m[3][1] * m[0][2] - m[3][0] * m[2][1] * m[0][2] + m[3][0] * m[0][1] * m[2][2] - m[0][0] * "
+		          "m[3][1] * m[2][2] - m[2][0] * m[0][1] * m[3][2] + m[0][0] * m[2][1] * m[3][2], "
+		          "m[3][0] * m[1][1] * m[0][2] - m[1][0] * m[3][1] * m[0][2] - m[3][0] * m[0][1] * m[1][2] + m[0][0] * "
+		          "m[3][1] * m[1][2] + m[1][0] * m[0][1] * m[3][2] - m[0][0] * m[1][1] * m[3][2], "
+		          "m[1][0] * m[2][1] * m[0][2] - m[2][0] * m[1][1] * m[0][2] + m[2][0] * m[0][1] * m[1][2] - m[0][0] * "
+		          "m[2][1] * m[1][2] - m[1][0] * m[0][1] * m[2][2] + m[0][0] * m[1][1] * m[2][2]) "
 		          "* (1.0 / dot(m[0], t));");
 		end_scope();
 		statement("");
@@ -4865,8 +4926,8 @@ void CompilerGLSL::emit_polyfills(uint32_t polyfills, bool relaxed)
 
 				const char *types[3][4] = {
 					{ "float16_t", "f16vec2", "f16vec3", "f16vec4" },
-					{ "float",     "vec2",    "vec3",    "vec4" },
-					{ "double",    "dvec2",   "dvec3",   "dvec4" },
+					{ "float", "vec2", "vec3", "vec4" },
+					{ "double", "dvec2", "dvec3", "dvec4" },
 				};
 
 				for (uint32_t k = 0; k < 4; k++)
@@ -4875,13 +4936,13 @@ void CompilerGLSL::emit_polyfills(uint32_t polyfills, bool relaxed)
 
 					if (i < 2)
 					{
-						statement("spirv_instruction(set = \"GLSL.std.450\", id = ", glsl_ops[i], ") ",
-						          type, " ", spv_ops[i], "(", type, ", ", type, ");");
+						statement("spirv_instruction(set = \"GLSL.std.450\", id = ", glsl_ops[i], ") ", type, " ",
+						          spv_ops[i], "(", type, ", ", type, ");");
 					}
 					else
 					{
-						statement("spirv_instruction(set = \"GLSL.std.450\", id = ", glsl_ops[i], ") ",
-						          type, " ", spv_ops[i], "(", type, ", ", type, ", ", type, ");");
+						statement("spirv_instruction(set = \"GLSL.std.450\", id = ", glsl_ops[i], ") ", type, " ",
+						          spv_ops[i], "(", type, ", ", type, ", ", type, ");");
 					}
 
 					has_poly = true;
@@ -4914,8 +4975,8 @@ void CompilerGLSL::emit_polyfills(uint32_t polyfills, bool relaxed)
 
 				const char *types[3][4] = {
 					{ "float16_t", "f16vec2", "f16vec3", "f16vec4" },
-					{ "float",     "vec2",    "vec3",    "vec4" },
-					{ "double",    "dvec2",   "dvec3",   "dvec4" },
+					{ "float", "vec2", "vec3", "vec4" },
+					{ "double", "dvec2", "dvec3", "dvec4" },
 				};
 
 				for (uint32_t k = 0; k < 4; k++)
@@ -4924,8 +4985,8 @@ void CompilerGLSL::emit_polyfills(uint32_t polyfills, bool relaxed)
 
 					if (i < 2)
 					{
-						statement("mediump ", type, " ", spv_ops[i], "Relaxed(",
-						          "mediump ", type, " a, mediump ", type, " b)");
+						statement("mediump ", type, " ", spv_ops[i], "Relaxed(", "mediump ", type, " a, mediump ", type,
+						          " b)");
 						begin_scope();
 						statement("mediump ", type, " res = ", spv_ops[i], "(a, b);");
 						statement("return res;");
@@ -4934,8 +4995,8 @@ void CompilerGLSL::emit_polyfills(uint32_t polyfills, bool relaxed)
 					}
 					else
 					{
-						statement("mediump ", type, " ", spv_ops[i], "Relaxed(",
-						          "mediump ", type, " a, mediump ", type, " b, mediump ", type, " c)");
+						statement("mediump ", type, " ", spv_ops[i], "Relaxed(", "mediump ", type, " a, mediump ", type,
+						          " b, mediump ", type, " c)");
 						begin_scope();
 						statement("mediump ", type, " res = ", spv_ops[i], "(a, b, c);");
 						statement("return res;");
@@ -4972,7 +5033,8 @@ void CompilerGLSL::force_temporary_and_recompile(uint32_t id)
 		force_recompile();
 }
 
-uint32_t CompilerGLSL::consume_temporary_in_precision_context(uint32_t type_id, uint32_t id, Options::Precision precision)
+uint32_t CompilerGLSL::consume_temporary_in_precision_context(uint32_t type_id, uint32_t id,
+                                                              Options::Precision precision)
 {
 	// Constants do not have innate precision.
 	auto handle_type = ir.ids[id].get_type();
@@ -5285,14 +5347,13 @@ string CompilerGLSL::to_extract_constant_composite_expression(uint32_t result_ty
 	return constant_expression(tmp);
 }
 
-string CompilerGLSL::to_rerolled_array_expression(const SPIRType &parent_type,
-                                                  const string &base_expr, const SPIRType &type)
+string CompilerGLSL::to_rerolled_array_expression(const SPIRType &parent_type, const string &base_expr,
+                                                  const SPIRType &type)
 {
-	bool remapped_boolean = parent_type.basetype == SPIRType::Struct &&
-	                        type.basetype == SPIRType::Boolean &&
+	bool remapped_boolean = parent_type.basetype == SPIRType::Struct && type.basetype == SPIRType::Boolean &&
 	                        backend.boolean_in_struct_remapped_type != SPIRType::Boolean;
 
-	SPIRType tmp_type { OpNop };
+	SPIRType tmp_type{ OpNop };
 	if (remapped_boolean)
 	{
 		tmp_type = get<SPIRType>(type.parent_type);
@@ -5335,14 +5396,13 @@ string CompilerGLSL::to_composite_constructor_expression(const SPIRType &parent_
 	auto &type = expression_type(id);
 
 	bool reroll_array = false;
-	bool remapped_boolean = parent_type.basetype == SPIRType::Struct &&
-	                        type.basetype == SPIRType::Boolean &&
+	bool remapped_boolean = parent_type.basetype == SPIRType::Struct && type.basetype == SPIRType::Boolean &&
 	                        backend.boolean_in_struct_remapped_type != SPIRType::Boolean;
 
 	if (is_array(type))
 	{
-		reroll_array = !backend.array_is_value_type ||
-		               (block_like_type && !backend.array_is_value_type_in_buffer_blocks);
+		reroll_array =
+		    !backend.array_is_value_type || (block_like_type && !backend.array_is_value_type_in_buffer_blocks);
 
 		if (remapped_boolean)
 		{
@@ -5431,8 +5491,8 @@ string CompilerGLSL::to_expression(uint32_t id, bool register_expression_read)
 			uint32_t physical_type_id = get_extended_decoration(id, SPIRVCrossDecorationPhysicalTypeID);
 			bool is_packed = has_extended_decoration(id, SPIRVCrossDecorationPhysicalTypePacked);
 			bool relaxed = has_decoration(id, DecorationRelaxedPrecision);
-			return convert_row_major_matrix(e.expression, get<SPIRType>(e.expression_type), physical_type_id,
-			                                is_packed, relaxed);
+			return convert_row_major_matrix(e.expression, get<SPIRType>(e.expression_type), physical_type_id, is_packed,
+			                                relaxed);
 		}
 		else if (flattened_structs.count(id))
 		{
@@ -5467,7 +5527,8 @@ string CompilerGLSL::to_expression(uint32_t id, bool register_expression_read)
 				int wg_index = get_constant_mapping_to_workgroup_component(c);
 				if (wg_index >= 0)
 				{
-					auto wg_size = join(builtin_to_glsl(BuiltInWorkgroupSize, StorageClassInput), vector_swizzle(1, wg_index));
+					auto wg_size =
+					    join(builtin_to_glsl(BuiltInWorkgroupSize, StorageClassInput), vector_swizzle(1, wg_index));
 					if (type.basetype != SPIRType::UInt)
 						wg_size = bitcast_expression(type, SPIRType::UInt, wg_size);
 					return wg_size;
@@ -5689,7 +5750,7 @@ string CompilerGLSL::constant_op_expression(const SPIRConstantOp &cop)
 		uint32_t op0 = cop.arguments[0];
 		uint32_t op1 = cop.arguments[1];
 		return join(to_enclosed_expression(op0), " - ", to_enclosed_expression(op1), " * ", "(",
-		                 to_enclosed_expression(op0), " / ", to_enclosed_expression(op1), ")");
+		            to_enclosed_expression(op0), " / ", to_enclosed_expression(op1), ")");
 	}
 
 	case OpSelect:
@@ -5886,8 +5947,7 @@ string CompilerGLSL::constant_op_expression(const SPIRConstantOp &cop)
 	}
 }
 
-string CompilerGLSL::constant_expression(const SPIRConstant &c,
-                                         bool inside_block_like_struct_scope,
+string CompilerGLSL::constant_expression(const SPIRConstant &c, bool inside_block_like_struct_scope,
                                          bool inside_struct_scope)
 {
 	auto &type = get<SPIRType>(c.constant_type);
@@ -5906,9 +5966,8 @@ string CompilerGLSL::constant_expression(const SPIRConstant &c,
 		// Should look at ArrayStride here as well, but it's possible to declare a constant struct
 		// with Offset = 0, using no ArrayStride on the enclosed array type.
 		// A particular CTS test hits this scenario.
-		bool array_type_decays = inside_block_like_struct_scope &&
-		                         is_array(type) &&
-		                         !backend.array_is_value_type_in_buffer_blocks;
+		bool array_type_decays =
+		    inside_block_like_struct_scope && is_array(type) && !backend.array_is_value_type_in_buffer_blocks;
 
 		// Allow Metal to use the array<T> template to make arrays a value type
 		bool needs_trailing_tracket = false;
@@ -5921,10 +5980,9 @@ string CompilerGLSL::constant_expression(const SPIRConstant &c,
 		         is_array(type) && !array_type_decays)
 		{
 			const auto *p_type = &type;
-			SPIRType tmp_type { OpNop };
+			SPIRType tmp_type{ OpNop };
 
-			if (inside_struct_scope &&
-			    backend.boolean_in_struct_remapped_type != SPIRType::Boolean &&
+			if (inside_struct_scope && backend.boolean_in_struct_remapped_type != SPIRType::Boolean &&
 			    type.basetype == SPIRType::Boolean)
 			{
 				tmp_type = type;
@@ -6005,8 +6063,7 @@ string CompilerGLSL::constant_expression(const SPIRConstant &c,
 	{
 		auto res = constant_expression_vector(c, 0);
 
-		if (inside_struct_scope &&
-		    backend.boolean_in_struct_remapped_type != SPIRType::Boolean &&
+		if (inside_struct_scope && backend.boolean_in_struct_remapped_type != SPIRType::Boolean &&
 		    type.basetype == SPIRType::Boolean)
 		{
 			SPIRType tmp_type = type;
@@ -6031,8 +6088,7 @@ string CompilerGLSL::constant_expression(const SPIRConstant &c,
 		}
 		res += ")";
 
-		if (inside_struct_scope &&
-		    backend.boolean_in_struct_remapped_type != SPIRType::Boolean &&
+		if (inside_struct_scope && backend.boolean_in_struct_remapped_type != SPIRType::Boolean &&
 		    type.basetype == SPIRType::Boolean)
 		{
 			SPIRType tmp_type = type;
@@ -6060,7 +6116,7 @@ string CompilerGLSL::convert_half_to_string(const SPIRConstant &c, uint32_t col,
 	// of complicated workarounds, just value-cast to the half type always.
 	if (std::isnan(float_value) || std::isinf(float_value))
 	{
-		SPIRType type { OpTypeFloat };
+		SPIRType type{ OpTypeFloat };
 		type.basetype = SPIRType::Half;
 		type.vecsize = 1;
 		type.columns = 1;
@@ -6076,7 +6132,7 @@ string CompilerGLSL::convert_half_to_string(const SPIRConstant &c, uint32_t col,
 	}
 	else
 	{
-		SPIRType type { OpTypeFloat };
+		SPIRType type{ OpTypeFloat };
 		type.basetype = SPIRType::Half;
 		type.vecsize = 1;
 		type.columns = 1;
@@ -6096,8 +6152,8 @@ string CompilerGLSL::convert_float_to_string(const SPIRConstant &c, uint32_t col
 		// Use special representation.
 		if (!is_legacy())
 		{
-			SPIRType out_type { OpTypeFloat };
-			SPIRType in_type { OpTypeInt };
+			SPIRType out_type{ OpTypeFloat };
+			SPIRType in_type{ OpTypeInt };
 			out_type.basetype = SPIRType::Float;
 			in_type.basetype = SPIRType::UInt;
 			out_type.vecsize = 1;
@@ -6166,8 +6222,8 @@ std::string CompilerGLSL::convert_double_to_string(const SPIRConstant &c, uint32
 		// Use special representation.
 		if (!is_legacy())
 		{
-			SPIRType out_type { OpTypeFloat };
-			SPIRType in_type { OpTypeInt };
+			SPIRType out_type{ OpTypeFloat };
+			SPIRType in_type{ OpTypeInt };
 			out_type.basetype = SPIRType::Double;
 			in_type.basetype = SPIRType::UInt64;
 			out_type.vecsize = 1;
@@ -6651,9 +6707,8 @@ void CompilerGLSL::emit_uninitialized_temporary(uint32_t result_type, uint32_t r
 	{
 		auto &header = get<SPIRBlock>(current_continue_block->loop_dominator);
 		if (find_if(begin(header.declare_temporary), end(header.declare_temporary),
-		            [result_type, result_id](const pair<uint32_t, uint32_t> &tmp) {
-			            return tmp.first == result_type && tmp.second == result_id;
-		            }) == end(header.declare_temporary))
+		            [result_type, result_id](const pair<uint32_t, uint32_t> &tmp)
+		            { return tmp.first == result_type && tmp.second == result_id; }) == end(header.declare_temporary))
 		{
 			header.declare_temporary.emplace_back(result_type, result_id);
 			hoisted_temporaries.insert(result_id);
@@ -6686,9 +6741,8 @@ string CompilerGLSL::declare_temporary(uint32_t result_type, uint32_t result_id)
 	{
 		auto &header = get<SPIRBlock>(current_continue_block->loop_dominator);
 		if (find_if(begin(header.declare_temporary), end(header.declare_temporary),
-		            [result_type, result_id](const pair<uint32_t, uint32_t> &tmp) {
-			            return tmp.first == result_type && tmp.second == result_id;
-		            }) == end(header.declare_temporary))
+		            [result_type, result_id](const pair<uint32_t, uint32_t> &tmp)
+		            { return tmp.first == result_type && tmp.second == result_id; }) == end(header.declare_temporary))
 		{
 			header.declare_temporary.emplace_back(result_type, result_id);
 			hoisted_temporaries.insert(result_id);
@@ -6764,16 +6818,15 @@ void CompilerGLSL::emit_unary_op_cast(uint32_t result_type, uint32_t result_id, 
 {
 	auto &type = get<SPIRType>(result_type);
 	bool forward = should_forward(op0);
-	emit_op(result_type, result_id, join(type_to_glsl(type), "(", op, to_enclosed_unpacked_expression(op0), ")"), forward);
+	emit_op(result_type, result_id, join(type_to_glsl(type), "(", op, to_enclosed_unpacked_expression(op0), ")"),
+	        forward);
 	inherit_expression_dependencies(result_id, op0);
 }
 
 void CompilerGLSL::emit_mesh_tasks(SPIRBlock &block)
 {
-	statement("EmitMeshTasksEXT(",
-	          to_unpacked_expression(block.mesh.groups[0]), ", ",
-	          to_unpacked_expression(block.mesh.groups[1]), ", ",
-	          to_unpacked_expression(block.mesh.groups[2]), ");");
+	statement("EmitMeshTasksEXT(", to_unpacked_expression(block.mesh.groups[0]), ", ",
+	          to_unpacked_expression(block.mesh.groups[1]), ", ", to_unpacked_expression(block.mesh.groups[2]), ");");
 }
 
 void CompilerGLSL::emit_binary_op(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, const char *op)
@@ -6875,7 +6928,7 @@ SPIRType CompilerGLSL::binary_op_bitcast_helper(string &cast_op0, string &cast_o
 
 	// Create a fake type so we can bitcast to it.
 	// We only deal with regular arithmetic types here like int, uints and so on.
-	SPIRType expected_type{type0.op};
+	SPIRType expected_type{ type0.op };
 	expected_type.basetype = input_type;
 	expected_type.vecsize = type0.vecsize;
 	expected_type.columns = type0.columns;
@@ -6919,8 +6972,7 @@ bool CompilerGLSL::emit_complex_bitcast(uint32_t result_type, uint32_t id, uint3
 }
 
 void CompilerGLSL::emit_binary_op_cast(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1,
-                                       const char *op, SPIRType::BaseType input_type,
-                                       bool skip_cast_if_equal_type,
+                                       const char *op, SPIRType::BaseType input_type, bool skip_cast_if_equal_type,
                                        bool implicit_integer_promotion)
 {
 	string cast_op0, cast_op1;
@@ -6988,19 +7040,18 @@ void CompilerGLSL::emit_atomic_func_op(uint32_t result_type, uint32_t result_id,
 
 	forced_temporaries.insert(result_id);
 	emit_op(result_type, result_id,
-	        join(op, "(", to_non_uniform_aware_expression(op0), ", ",
-	             to_unpacked_expression(op1), ")"), false);
+	        join(op, "(", to_non_uniform_aware_expression(op0), ", ", to_unpacked_expression(op1), ")"), false);
 	flush_all_atomic_capable_variables();
 }
 
-void CompilerGLSL::emit_atomic_func_op(uint32_t result_type, uint32_t result_id,
-                                       uint32_t op0, uint32_t op1, uint32_t op2,
-                                       const char *op)
+void CompilerGLSL::emit_atomic_func_op(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1,
+                                       uint32_t op2, const char *op)
 {
 	forced_temporaries.insert(result_id);
 	emit_op(result_type, result_id,
-	        join(op, "(", to_non_uniform_aware_expression(op0), ", ",
-	             to_unpacked_expression(op1), ", ", to_unpacked_expression(op2), ")"), false);
+	        join(op, "(", to_non_uniform_aware_expression(op0), ", ", to_unpacked_expression(op1), ", ",
+	             to_unpacked_expression(op2), ")"),
+	        false);
 	flush_all_atomic_capable_variables();
 }
 
@@ -7230,7 +7281,7 @@ void CompilerGLSL::emit_bitfield_insert_op(uint32_t result_type, uint32_t result
 	auto op3_expr = to_unpacked_expression(op3);
 
 	assert(offset_count_type == SPIRType::UInt || offset_count_type == SPIRType::Int);
-	SPIRType target_type { OpTypeInt };
+	SPIRType target_type{ OpTypeInt };
 	target_type.width = 32;
 	target_type.vecsize = 1;
 	target_type.basetype = offset_count_type;
@@ -7359,7 +7410,9 @@ string CompilerGLSL::legacy_tex_op(const std::string &op, const SPIRType &imgtyp
 		return join(type_prefix, type, "LodOffset");
 	else if (op == "textureProjGrad")
 		return join(type_prefix, type,
-		            is_legacy_es() ? "ProjGradEXT" : is_legacy_desktop() ? "ProjGradARB" : "ProjGrad");
+		            is_legacy_es()      ? "ProjGradEXT" :
+		            is_legacy_desktop() ? "ProjGradARB" :
+		                                  "ProjGrad");
 	else if (op == "textureProjLodOffset")
 		return join(type_prefix, type, "ProjLodOffset");
 	else if (op == "textureSize")
@@ -7561,10 +7614,12 @@ string CompilerGLSL::to_combined_image_sampler(VariableID image_id, VariableID s
 		VariableID sid = global_sampler ? samp_id : VariableID(uint32_t(sampler_itr - begin(args)));
 
 		auto &combined = current_function->combined_parameters;
-		auto itr = find_if(begin(combined), end(combined), [=](const SPIRFunction::CombinedImageSamplerParameter &p) {
-			return p.global_image == global_image && p.global_sampler == global_sampler && p.image_id == iid &&
-			       p.sampler_id == sid;
-		});
+		auto itr = find_if(begin(combined), end(combined),
+		                   [=](const SPIRFunction::CombinedImageSamplerParameter &p)
+		                   {
+			                   return p.global_image == global_image && p.global_sampler == global_sampler &&
+			                          p.image_id == iid && p.sampler_id == sid;
+		                   });
 
 		if (itr != end(combined))
 			return to_expression(itr->id) + array_expr;
@@ -7579,9 +7634,9 @@ string CompilerGLSL::to_combined_image_sampler(VariableID image_id, VariableID s
 	{
 		// For global sampler2D, look directly at the global remapping table.
 		auto &mapping = combined_image_samplers;
-		auto itr = find_if(begin(mapping), end(mapping), [image_id, samp_id](const CombinedImageSampler &combined) {
-			return combined.image_id == image_id && combined.sampler_id == samp_id;
-		});
+		auto itr = find_if(begin(mapping), end(mapping),
+		                   [image_id, samp_id](const CombinedImageSampler &combined)
+		                   { return combined.image_id == image_id && combined.sampler_id == samp_id; });
 
 		if (itr != end(combined_image_samplers))
 			return to_expression(itr->combined_id) + array_expr;
@@ -7900,7 +7955,8 @@ std::string CompilerGLSL::to_texture_op(const Instruction &i, bool sparse, bool 
 		length--;
 	}
 
-	auto test = [&](uint32_t &v, uint32_t flag) {
+	auto test = [&](uint32_t &v, uint32_t flag)
+	{
 		if (length && (flags & flag))
 		{
 			v = *opt++;
@@ -8162,7 +8218,8 @@ string CompilerGLSL::to_function_args(const TextureFunctionArguments &args, bool
 	}
 
 	bool swizz_func = backend.swizzle_is_function;
-	auto swizzle = [swizz_func](uint32_t comps, uint32_t in_comps) -> const char * {
+	auto swizzle = [swizz_func](uint32_t comps, uint32_t in_comps) -> const char *
+	{
 		if (comps == in_comps)
 			return "";
 
@@ -8300,9 +8357,8 @@ string CompilerGLSL::to_function_args(const TextureFunctionArguments &args, bool
 			{
 				if (imgtype.image.arrayed)
 				{
-					coord_expr = join("ivec3(", enclose_expression(coord_expr),
-									  ".x, 0, ",
-									  enclose_expression(coord_expr), ".y)");
+					coord_expr = join("ivec3(", enclose_expression(coord_expr), ".x, 0, ",
+					                  enclose_expression(coord_expr), ".y)");
 				}
 				else
 					coord_expr = join("ivec2(", coord_expr, ", 0)");
@@ -8570,9 +8626,8 @@ void CompilerGLSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop,
 			auto &op1_type = expression_type(args[1]);
 			auto via_type = op1_type;
 			via_type.basetype = SPIRType::Int;
-			statement(to_expression(args[1]), " = ",
-			          type_to_glsl(op1_type), "(", type_to_glsl(via_type),
-			          "(", to_expression(args[0]), "));");
+			statement(to_expression(args[1]), " = ", type_to_glsl(op1_type), "(", type_to_glsl(via_type), "(",
+			          to_expression(args[0]), "));");
 			emit_binary_op(result_type, id, args[0], args[1], "-");
 		}
 		break;
@@ -8592,8 +8647,8 @@ void CompilerGLSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop,
 			auto &op0_type = expression_type(args[0]);
 			auto via_type = op0_type;
 			via_type.basetype = SPIRType::Int;
-			statement(to_expression(id), ".", to_member_name(type, 1), " = ", type_to_glsl(op0_type),
-			          "(", type_to_glsl(via_type), "(", to_expression(args[0]), "));");
+			statement(to_expression(id), ".", to_member_name(type, 1), " = ", type_to_glsl(op0_type), "(",
+			          type_to_glsl(via_type), "(", to_expression(args[0]), "));");
 			statement(to_expression(id), ".", to_member_name(type, 0), " = ", to_enclosed_expression(args[0]), " - ",
 			          to_expression(id), ".", to_member_name(type, 1), ";");
 		}
@@ -8704,8 +8759,10 @@ void CompilerGLSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop,
 			inherit_expression_dependencies(epos_id, args[0]);
 			inherit_expression_dependencies(eneg_id, args[0]);
 
-			auto expr = join("(", to_enclosed_expression(epos_id), " - ", to_enclosed_expression(eneg_id), ") / "
-			                 "(", to_enclosed_expression(epos_id), " + ", to_enclosed_expression(eneg_id), ")");
+			auto expr = join("(", to_enclosed_expression(epos_id), " - ", to_enclosed_expression(eneg_id),
+			                 ") / "
+			                 "(",
+			                 to_enclosed_expression(epos_id), " + ", to_enclosed_expression(eneg_id), ")");
 			emit_op(result_type, id, expr, true);
 			inherit_expression_dependencies(id, epos_id);
 			inherit_expression_dependencies(id, eneg_id);
@@ -8776,8 +8833,7 @@ void CompilerGLSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop,
 				SPIRV_CROSS_THROW("Unsupported type for matrix determinant");
 
 			bool relaxed = has_decoration(id, DecorationRelaxedPrecision);
-			require_polyfill(static_cast<Polyfill>(PolyfillDeterminant2x2 << (type.vecsize - 2)),
-			                 relaxed);
+			require_polyfill(static_cast<Polyfill>(PolyfillDeterminant2x2 << (type.vecsize - 2)), relaxed);
 			emit_unary_func_op(result_type, id, args[0],
 			                   (options.es && relaxed) ? "spvDeterminantMP" : "spvDeterminant");
 		}
@@ -8810,8 +8866,7 @@ void CompilerGLSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop,
 				SPIRV_CROSS_THROW("Unsupported type for matrix inverse");
 
 			bool relaxed = has_decoration(id, DecorationRelaxedPrecision);
-			require_polyfill(static_cast<Polyfill>(PolyfillMatrixInverse2x2 << (type.vecsize - 2)),
-			                 relaxed);
+			require_polyfill(static_cast<Polyfill>(PolyfillMatrixInverse2x2 << (type.vecsize - 2)), relaxed);
 			func = (options.es && relaxed) ? "spvInverseMP" : "spvInverse";
 		}
 
@@ -9045,7 +9100,8 @@ void CompilerGLSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop,
 			if (relaxed)
 				require_polyfill(poly, false);
 
-			emit_trinary_func_op(result_type, id, args[0], args[1], args[2], relaxed ? "spvNClampRelaxed" : "spvNClamp");
+			emit_trinary_func_op(result_type, id, args[0], args[1], args[2],
+			                     relaxed ? "spvNClampRelaxed" : "spvNClamp");
 		}
 		else
 		{
@@ -9122,20 +9178,21 @@ void CompilerGLSL::emit_emulated_ahyper_op(uint32_t result_type, uint32_t id, ui
 	switch (op)
 	{
 	case GLSLstd450Asinh:
-		expr = join("log(", to_enclosed_expression(op0), " + sqrt(",
-		            to_enclosed_expression(op0), " * ", to_enclosed_expression(op0), " + ", one, "))");
+		expr = join("log(", to_enclosed_expression(op0), " + sqrt(", to_enclosed_expression(op0), " * ",
+		            to_enclosed_expression(op0), " + ", one, "))");
 		emit_op(result_type, id, expr, forward);
 		break;
 
 	case GLSLstd450Acosh:
-		expr = join("log(", to_enclosed_expression(op0), " + sqrt(",
-		            to_enclosed_expression(op0), " * ", to_enclosed_expression(op0), " - ", one, "))");
+		expr = join("log(", to_enclosed_expression(op0), " + sqrt(", to_enclosed_expression(op0), " * ",
+		            to_enclosed_expression(op0), " - ", one, "))");
 		break;
 
 	case GLSLstd450Atanh:
-		expr = join("log((", one, " + ", to_enclosed_expression(op0), ") / "
-		            "(", one, " - ", to_enclosed_expression(op0), ")) * 0.5",
-		            backend.float_literal_suffix ? "f" : "");
+		expr = join("log((", one, " + ", to_enclosed_expression(op0),
+		            ") / "
+		            "(",
+		            one, " - ", to_enclosed_expression(op0), ")) * 0.5", backend.float_literal_suffix ? "f" : "");
 		break;
 
 	default:
@@ -9392,7 +9449,7 @@ void CompilerGLSL::emit_subgroup_op(const Instruction &i)
 	GLSL_GROUP_OP(FMul)
 
 #undef GLSL_GROUP_OP
-	// clang-format on
+		// clang-format on
 
 	case OpGroupNonUniformFMin:
 	case OpGroupNonUniformFMax:
@@ -10115,7 +10172,7 @@ const char *CompilerGLSL::index_to_swizzle(uint32_t index)
 	case 3:
 		return "w";
 	default:
-		return "x";		// Don't crash, but engage the "undefined behavior" described for out-of-bounds logical addressing in spec.
+		return "x"; // Don't crash, but engage the "undefined behavior" described for out-of-bounds logical addressing in spec.
 	}
 }
 
@@ -10127,7 +10184,8 @@ void CompilerGLSL::access_chain_internal_append_index(std::string &expr, uint32_
 	bool ptr_chain = (flags & ACCESS_CHAIN_PTR_CHAIN_BIT) != 0;
 	bool register_expression_read = (flags & ACCESS_CHAIN_SKIP_REGISTER_EXPRESSION_READ_BIT) == 0;
 
-	string idx_expr = index_is_literal ? convert_to_string(index) : to_unpacked_expression(index, register_expression_read);
+	string idx_expr =
+	    index_is_literal ? convert_to_string(index) : to_unpacked_expression(index, register_expression_read);
 
 	// For the case where the base of an OpPtrAccessChain already ends in [n],
 	// we need to use the index as an offset to the existing index, otherwise,
@@ -10217,7 +10275,8 @@ string CompilerGLSL::access_chain_internal(uint32_t base, const uint32_t *indice
 	// If we are translating access to a structured buffer, the first subscript '._m0' must be hidden
 	bool hide_first_subscript = count > 1 && is_user_type_structured(base);
 
-	const auto append_index = [&](uint32_t index, bool is_literal, bool is_ptr_chain = false) {
+	const auto append_index = [&](uint32_t index, bool is_literal, bool is_ptr_chain = false)
+	{
 		AccessChainFlags mod_flags = flags;
 		if (!is_literal)
 			mod_flags &= ~ACCESS_CHAIN_INDEX_IS_LITERAL_BIT;
@@ -10311,8 +10370,8 @@ string CompilerGLSL::access_chain_internal(uint32_t base, const uint32_t *indice
 					if (flags & ACCESS_CHAIN_PTR_CHAIN_CAST_TO_SCALAR_BIT)
 					{
 						is_packed = true;
-						expr = join("*reinterpret_cast<device packed_", type_to_glsl(pointee_type),
-						            " *>(", intptr_expr, ")");
+						expr = join("*reinterpret_cast<device packed_", type_to_glsl(pointee_type), " *>(", intptr_expr,
+						            ")");
 					}
 					else
 					{
@@ -10393,7 +10452,8 @@ string CompilerGLSL::access_chain_internal(uint32_t base, const uint32_t *indice
 				case BuiltInCullPrimitiveEXT:
 				case BuiltInPrimitiveShadingRateKHR:
 					if (mesh_shader)
-						expr = join("gl_MeshPrimitivesEXT[", to_expression(index, register_expression_read), "].", expr);
+						expr =
+						    join("gl_MeshPrimitivesEXT[", to_expression(index, register_expression_read), "].", expr);
 					else
 						append_index(index, is_literal);
 					break;
@@ -10403,8 +10463,8 @@ string CompilerGLSL::access_chain_internal(uint32_t base, const uint32_t *indice
 					break;
 				}
 			}
-			else if (backend.force_merged_mesh_block && i == 0 && var &&
-			         !is_builtin_variable(*var) && var->storage == StorageClassOutput)
+			else if (backend.force_merged_mesh_block && i == 0 && var && !is_builtin_variable(*var) &&
+			         var->storage == StorageClassOutput)
 			{
 				if (is_per_primitive_variable(*var))
 					expr = join("gl_MeshPrimitivesEXT[", to_expression(index, register_expression_read), "].", expr);
@@ -10435,7 +10495,8 @@ string CompilerGLSL::access_chain_internal(uint32_t base, const uint32_t *indice
 				if (!pending_array_enclose)
 					expr += "]";
 			}
-			else if (index_is_literal || !builtin_translates_to_nonarray(BuiltIn(get_decoration(base, DecorationBuiltIn))))
+			else if (index_is_literal ||
+			         !builtin_translates_to_nonarray(BuiltIn(get_decoration(base, DecorationBuiltIn))))
 			{
 				// Some builtins are arrays in SPIR-V but not in other languages, e.g. gl_SampleMask[] is an array in SPIR-V but not in Metal.
 				// By throwing away the index, we imply the index was 0, which it must be for gl_SampleMask.
@@ -10580,8 +10641,8 @@ string CompilerGLSL::access_chain_internal(uint32_t base, const uint32_t *indice
 						// E.g. [0].data followed by [1] would be shuffled to [1][0].data which is wrong,
 						// and needs to be [1].data[0] instead.
 						end_deferred_index++;
-						deferred_index = deferred_index.substr(end_deferred_index) +
-						                 deferred_index.substr(0, end_deferred_index);
+						deferred_index =
+						    deferred_index.substr(end_deferred_index) + deferred_index.substr(0, end_deferred_index);
 					}
 
 					expr.resize(column_index);
@@ -11292,9 +11353,8 @@ bool CompilerGLSL::should_forward(uint32_t id) const
 	if (expr && expr->expression_dependencies.size() >= max_expression_dependencies)
 		return false;
 
-	if (expr && expr->loaded_from
-		&& has_decoration(expr->loaded_from, DecorationBuiltIn)
-		&& has_decoration(expr->loaded_from, DecorationVolatile))
+	if (expr && expr->loaded_from && has_decoration(expr->loaded_from, DecorationBuiltIn) &&
+	    has_decoration(expr->loaded_from, DecorationVolatile))
 	{
 		// Never forward volatile builtin variables, e.g. SPIR-V 1.6 HelperInvocation.
 		return false;
@@ -12127,9 +12187,9 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 	uint32_t length = instruction.length;
 
 #define GLSL_BOP(op) emit_binary_op(ops[0], ops[1], ops[2], ops[3], #op)
-#define GLSL_BOP_CAST(op, type) \
-	emit_binary_op_cast(ops[0], ops[1], ops[2], ops[3], #op, type, \
-	                    opcode_is_sign_invariant(opcode), implicit_integer_promotion)
+#define GLSL_BOP_CAST(op, type)                                                                      \
+	emit_binary_op_cast(ops[0], ops[1], ops[2], ops[3], #op, type, opcode_is_sign_invariant(opcode), \
+	                    implicit_integer_promotion)
 #define GLSL_UOP(op) emit_unary_op(ops[0], ops[1], ops[2], #op)
 #define GLSL_UOP_CAST(op) emit_unary_op_cast(ops[0], ops[1], ops[2], #op)
 #define GLSL_QFOP(op) emit_quaternary_func_op(ops[0], ops[1], ops[2], ops[3], ops[4], ops[5], #op)
@@ -12313,9 +12373,8 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		if (flattened_buffer_blocks.count(ops[2]) && target_type.basetype == SPIRType::Struct)
 			requires_temporary = !backend.can_declare_struct_inline;
 
-		auto &expr = requires_temporary ?
-                         emit_op(ops[0], ops[1], std::move(e), false) :
-                         set<SPIRExpression>(ops[1], std::move(e), ops[0], should_forward(ops[2]));
+		auto &expr = requires_temporary ? emit_op(ops[0], ops[1], std::move(e), false) :
+		                                  set<SPIRExpression>(ops[1], std::move(e), ops[0], should_forward(ops[2]));
 
 		auto *backing_variable = maybe_get_backing_variable(ops[2]);
 		expr.loaded_from = backing_variable ? backing_variable->self : ID(ops[2]);
@@ -12680,7 +12739,8 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 			auto expr = to_extract_constant_composite_expression(result_type, *c, ops + 3, length);
 			e = &emit_op(result_type, id, expr, true, true);
 		}
-		else if (allow_base_expression && should_forward(ops[2]) && type.vecsize == 1 && type.columns == 1 && length == 1)
+		else if (allow_base_expression && should_forward(ops[2]) && type.vecsize == 1 && type.columns == 1 &&
+		         length == 1)
 		{
 			// Only apply this optimization if result is scalar.
 
@@ -12698,7 +12758,8 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 			// from expression causing it to be forced to an actual temporary in GLSL.
 			auto expr = access_chain_internal(ops[2], &ops[3], length,
 			                                  ACCESS_CHAIN_INDEX_IS_LITERAL_BIT | ACCESS_CHAIN_CHAIN_ONLY_BIT |
-			                                  ACCESS_CHAIN_FORCE_COMPOSITE_BIT, &meta);
+			                                      ACCESS_CHAIN_FORCE_COMPOSITE_BIT,
+			                                  &meta);
 			e = &emit_op(result_type, id, expr, true, should_suppress_usage_tracking(ops[2]));
 			inherit_expression_dependencies(id, ops[2]);
 			e->base_expression = ops[2];
@@ -12708,8 +12769,8 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		}
 		else
 		{
-			auto expr = access_chain_internal(ops[2], &ops[3], length,
-			                                  ACCESS_CHAIN_INDEX_IS_LITERAL_BIT | ACCESS_CHAIN_FORCE_COMPOSITE_BIT, &meta);
+			auto expr = access_chain_internal(
+			    ops[2], &ops[3], length, ACCESS_CHAIN_INDEX_IS_LITERAL_BIT | ACCESS_CHAIN_FORCE_COMPOSITE_BIT, &meta);
 			e = &emit_op(result_type, id, expr, should_forward(ops[2]), should_suppress_usage_tracking(ops[2]));
 			inherit_expression_dependencies(id, ops[2]);
 		}
@@ -12753,8 +12814,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		// that loop variable, since we won't be able to override the expression after the fact.
 		// If the composite is hoisted, we might never be able to properly invalidate any usage
 		// of that composite in a subsequent loop iteration.
-		if (invalid_expressions.count(composite) ||
-		    block_composite_insert_overwrite.count(composite) ||
+		if (invalid_expressions.count(composite) || block_composite_insert_overwrite.count(composite) ||
 		    hoisted_temporaries.count(id) || hoisted_temporaries.count(composite) ||
 		    maybe_get<SPIRExpression>(composite) == nullptr)
 		{
@@ -12762,7 +12822,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		}
 		else if (backend.requires_relaxed_precision_analysis &&
 		         has_decoration(composite, DecorationRelaxedPrecision) !=
-		         has_decoration(id, DecorationRelaxedPrecision) &&
+		             has_decoration(id, DecorationRelaxedPrecision) &&
 		         get<SPIRType>(result_type).basetype != SPIRType::Struct)
 		{
 			// Similarly, if precision does not match for input and output,
@@ -13371,9 +13431,9 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 			auto &op0_type = expression_type(op0);
 			auto via_type = op0_type;
 			via_type.basetype = SPIRType::Int;
-			expr = join(to_enclosed_expression(op0), " - ", to_enclosed_expression(op1), " * ",
-			            type_to_glsl(op0_type), "(", type_to_glsl(via_type),  "(",
-			            to_enclosed_expression(op0), " / ", to_enclosed_expression(op1), "))");
+			expr = join(to_enclosed_expression(op0), " - ", to_enclosed_expression(op1), " * ", type_to_glsl(op0_type),
+			            "(", type_to_glsl(via_type), "(", to_enclosed_expression(op0), " / ",
+			            to_enclosed_expression(op1), "))");
 		}
 
 		emit_op(result_type, result_id, expr, forward);
@@ -13816,9 +13876,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		                     (atomic_image && get<SPIRType>(type.image.type).basetype == SPIRType::UInt);
 		const char *op = atomic_image ? "imageAtomicAdd" : "atomicAdd";
 		const char *increment = unsigned_type ? "0u" : "0";
-		emit_op(ops[0], ops[1],
-		        join(op, "(",
-		             to_non_uniform_aware_expression(ops[2]), ", ", increment, ")"), false);
+		emit_op(ops[0], ops[1], join(op, "(", to_non_uniform_aware_expression(ops[2]), ", ", increment, ")"), false);
 		flush_all_atomic_capable_variables();
 		break;
 	}
@@ -13866,8 +13924,8 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 			else
 				increment = "-1";
 
-			emit_op(ops[0], ops[1],
-			        join(op, "(", to_non_uniform_aware_expression(ops[2]), ", ", increment, ")"), false);
+			emit_op(ops[0], ops[1], join(op, "(", to_non_uniform_aware_expression(ops[2]), ", ", increment, ")"),
+			        false);
 		}
 
 		flush_all_atomic_capable_variables();
@@ -14047,9 +14105,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		}
 
 		bool forward = should_forward(ops[3]);
-		emit_op(ops[0], ops[1],
-		        join(op, "(", sampler_expr, ", ", to_unpacked_expression(ops[3]), ")"),
-		        forward);
+		emit_op(ops[0], ops[1], join(op, "(", sampler_expr, ", ", to_unpacked_expression(ops[3]), ")"), forward);
 		inherit_expression_dependencies(ops[1], ops[2]);
 		inherit_expression_dependencies(ops[1], ops[3]);
 		register_control_dependent_expression(ops[1]);
@@ -14202,7 +14258,8 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 						                  "operand mask was used.");
 
 					uint32_t samples = ops[5];
-					imgexpr = join("subpassLoad(", to_non_uniform_aware_expression(ops[2]), ", ", to_expression(samples), ")");
+					imgexpr = join("subpassLoad(", to_non_uniform_aware_expression(ops[2]), ", ",
+					               to_expression(samples), ")");
 				}
 				else
 					imgexpr = join("subpassLoad(", to_non_uniform_aware_expression(ops[2]), ")");
@@ -14223,7 +14280,8 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 				else
 				{
 					// Implement subpass loads via texture barrier style sampling.
-					imgexpr = join("texelFetch(", to_non_uniform_aware_expression(ops[2]), ", ivec2(gl_FragCoord.xy), 0)");
+					imgexpr =
+					    join("texelFetch(", to_non_uniform_aware_expression(ops[2]), ", ivec2(gl_FragCoord.xy), 0)");
 				}
 			}
 			imgexpr = remap_swizzle(get<SPIRType>(result_type), 4, imgexpr);
@@ -14258,13 +14316,15 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 						                  "operand mask was used.");
 
 					uint32_t samples = ops[5];
-					statement(to_expression(sparse_code_id), " = sparseImageLoadARB(", to_non_uniform_aware_expression(ops[2]), ", ",
-					          coord_expr, ", ", to_expression(samples), ", ", to_expression(sparse_texel_id), ");");
+					statement(to_expression(sparse_code_id), " = sparseImageLoadARB(",
+					          to_non_uniform_aware_expression(ops[2]), ", ", coord_expr, ", ", to_expression(samples),
+					          ", ", to_expression(sparse_texel_id), ");");
 				}
 				else
 				{
-					statement(to_expression(sparse_code_id), " = sparseImageLoadARB(", to_non_uniform_aware_expression(ops[2]), ", ",
-					          coord_expr, ", ", to_expression(sparse_texel_id), ");");
+					statement(to_expression(sparse_code_id), " = sparseImageLoadARB(",
+					          to_non_uniform_aware_expression(ops[2]), ", ", coord_expr, ", ",
+					          to_expression(sparse_texel_id), ");");
 				}
 				imgexpr = join(type_to_glsl(get<SPIRType>(result_type)), "(", to_expression(sparse_code_id), ", ",
 				               to_expression(sparse_texel_id), ")");
@@ -14279,8 +14339,8 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 						                  "operand mask was used.");
 
 					uint32_t samples = ops[5];
-					imgexpr =
-					    join("imageLoad(", to_non_uniform_aware_expression(ops[2]), ", ", coord_expr, ", ", to_expression(samples), ")");
+					imgexpr = join("imageLoad(", to_non_uniform_aware_expression(ops[2]), ", ", coord_expr, ", ",
+					               to_expression(samples), ")");
 				}
 				else
 					imgexpr = join("imageLoad(", to_non_uniform_aware_expression(ops[2]), ", ", coord_expr, ")");
@@ -14369,7 +14429,8 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 			if (operands != ImageOperandsSampleMask || length != 5)
 				SPIRV_CROSS_THROW("Multisampled image used in OpImageWrite, but unexpected operand mask was used.");
 			uint32_t samples = ops[4];
-			statement("imageStore(", to_non_uniform_aware_expression(ops[0]), ", ", coord_expr, ", ", to_expression(samples), ", ",
+			statement("imageStore(", to_non_uniform_aware_expression(ops[0]), ", ", coord_expr, ", ",
+			          to_expression(samples), ", ",
 			          remap_swizzle(store_type, value_type.vecsize, to_expression(ops[2])), ");");
 		}
 		else
@@ -14673,8 +14734,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		{
 			emit_spv_amd_gcn_shader_op(ops[0], ops[1], ops[3], &ops[4], length - 4);
 		}
-		else if (ext == SPIRExtension::SPV_debug_info ||
-		         ext == SPIRExtension::NonSemanticShaderDebugInfo ||
+		else if (ext == SPIRExtension::SPV_debug_info || ext == SPIRExtension::NonSemanticShaderDebugInfo ||
 		         ext == SPIRExtension::NonSemanticGeneric)
 		{
 			break; // Ignore SPIR-V debug information extended instructions.
@@ -14995,19 +15055,20 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		flush_control_dependent_expressions(current_emitting_block->self);
 		break;
 	case OpTraceNV:
-		statement("traceNV(", to_non_uniform_aware_expression(ops[0]), ", ", to_expression(ops[1]), ", ", to_expression(ops[2]), ", ",
-		          to_expression(ops[3]), ", ", to_expression(ops[4]), ", ", to_expression(ops[5]), ", ",
-		          to_expression(ops[6]), ", ", to_expression(ops[7]), ", ", to_expression(ops[8]), ", ",
-		          to_expression(ops[9]), ", ", to_expression(ops[10]), ");");
+		statement("traceNV(", to_non_uniform_aware_expression(ops[0]), ", ", to_expression(ops[1]), ", ",
+		          to_expression(ops[2]), ", ", to_expression(ops[3]), ", ", to_expression(ops[4]), ", ",
+		          to_expression(ops[5]), ", ", to_expression(ops[6]), ", ", to_expression(ops[7]), ", ",
+		          to_expression(ops[8]), ", ", to_expression(ops[9]), ", ", to_expression(ops[10]), ");");
 		flush_control_dependent_expressions(current_emitting_block->self);
 		break;
 	case OpTraceRayKHR:
 		if (!has_decoration(ops[10], DecorationLocation))
 			SPIRV_CROSS_THROW("A memory declaration object must be used in TraceRayKHR.");
-		statement("traceRayEXT(", to_non_uniform_aware_expression(ops[0]), ", ", to_expression(ops[1]), ", ", to_expression(ops[2]), ", ",
-		          to_expression(ops[3]), ", ", to_expression(ops[4]), ", ", to_expression(ops[5]), ", ",
-		          to_expression(ops[6]), ", ", to_expression(ops[7]), ", ", to_expression(ops[8]), ", ",
-		          to_expression(ops[9]), ", ", get_decoration(ops[10], DecorationLocation), ");");
+		statement("traceRayEXT(", to_non_uniform_aware_expression(ops[0]), ", ", to_expression(ops[1]), ", ",
+		          to_expression(ops[2]), ", ", to_expression(ops[3]), ", ", to_expression(ops[4]), ", ",
+		          to_expression(ops[5]), ", ", to_expression(ops[6]), ", ", to_expression(ops[7]), ", ",
+		          to_expression(ops[8]), ", ", to_expression(ops[9]), ", ", get_decoration(ops[10], DecorationLocation),
+		          ");");
 		flush_control_dependent_expressions(current_emitting_block->self);
 		break;
 	case OpExecuteCallableNV:
@@ -15024,11 +15085,9 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		// Don't bother forwarding temporaries. Avoids having to test expression invalidation with ray query objects.
 	case OpRayQueryInitializeKHR:
 		flush_variable_declaration(ops[0]);
-		statement("rayQueryInitializeEXT(",
-		          to_expression(ops[0]), ", ", to_expression(ops[1]), ", ",
-		          to_expression(ops[2]), ", ", to_expression(ops[3]), ", ",
-		          to_expression(ops[4]), ", ", to_expression(ops[5]), ", ",
-		          to_expression(ops[6]), ", ", to_expression(ops[7]), ");");
+		statement("rayQueryInitializeEXT(", to_expression(ops[0]), ", ", to_expression(ops[1]), ", ",
+		          to_expression(ops[2]), ", ", to_expression(ops[3]), ", ", to_expression(ops[4]), ", ",
+		          to_expression(ops[5]), ", ", to_expression(ops[6]), ", ", to_expression(ops[7]), ");");
 		break;
 	case OpRayQueryProceedKHR:
 		flush_variable_declaration(ops[0]);
@@ -15046,34 +15105,36 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		flush_variable_declaration(ops[0]);
 		statement("rayQueryConfirmIntersectionEXT(", to_expression(ops[0]), ");");
 		break;
-#define GLSL_RAY_QUERY_GET_OP(op) \
-	case OpRayQueryGet##op##KHR: \
-		flush_variable_declaration(ops[2]); \
+#define GLSL_RAY_QUERY_GET_OP(op)                                                                   \
+	case OpRayQueryGet##op##KHR:                                                                    \
+		flush_variable_declaration(ops[2]);                                                         \
 		emit_op(ops[0], ops[1], join("rayQueryGet" #op "EXT(", to_expression(ops[2]), ")"), false); \
 		break
-#define GLSL_RAY_QUERY_GET_OP2(op) \
-	case OpRayQueryGet##op##KHR: \
-		flush_variable_declaration(ops[2]); \
-		emit_op(ops[0], ops[1], join("rayQueryGet" #op "EXT(", to_expression(ops[2]), ", ", "bool(", to_expression(ops[3]), "))"), false); \
+#define GLSL_RAY_QUERY_GET_OP2(op)                                                                                 \
+	case OpRayQueryGet##op##KHR:                                                                                   \
+		flush_variable_declaration(ops[2]);                                                                        \
+		emit_op(ops[0], ops[1],                                                                                    \
+		        join("rayQueryGet" #op "EXT(", to_expression(ops[2]), ", ", "bool(", to_expression(ops[3]), "))"), \
+		        false);                                                                                            \
 		break
-	GLSL_RAY_QUERY_GET_OP(RayTMin);
-	GLSL_RAY_QUERY_GET_OP(RayFlags);
-	GLSL_RAY_QUERY_GET_OP(WorldRayOrigin);
-	GLSL_RAY_QUERY_GET_OP(WorldRayDirection);
-	GLSL_RAY_QUERY_GET_OP(IntersectionCandidateAABBOpaque);
-	GLSL_RAY_QUERY_GET_OP2(IntersectionType);
-	GLSL_RAY_QUERY_GET_OP2(IntersectionT);
-	GLSL_RAY_QUERY_GET_OP2(IntersectionInstanceCustomIndex);
-	GLSL_RAY_QUERY_GET_OP2(IntersectionInstanceId);
-	GLSL_RAY_QUERY_GET_OP2(IntersectionInstanceShaderBindingTableRecordOffset);
-	GLSL_RAY_QUERY_GET_OP2(IntersectionGeometryIndex);
-	GLSL_RAY_QUERY_GET_OP2(IntersectionPrimitiveIndex);
-	GLSL_RAY_QUERY_GET_OP2(IntersectionBarycentrics);
-	GLSL_RAY_QUERY_GET_OP2(IntersectionFrontFace);
-	GLSL_RAY_QUERY_GET_OP2(IntersectionObjectRayDirection);
-	GLSL_RAY_QUERY_GET_OP2(IntersectionObjectRayOrigin);
-	GLSL_RAY_QUERY_GET_OP2(IntersectionObjectToWorld);
-	GLSL_RAY_QUERY_GET_OP2(IntersectionWorldToObject);
+		GLSL_RAY_QUERY_GET_OP(RayTMin);
+		GLSL_RAY_QUERY_GET_OP(RayFlags);
+		GLSL_RAY_QUERY_GET_OP(WorldRayOrigin);
+		GLSL_RAY_QUERY_GET_OP(WorldRayDirection);
+		GLSL_RAY_QUERY_GET_OP(IntersectionCandidateAABBOpaque);
+		GLSL_RAY_QUERY_GET_OP2(IntersectionType);
+		GLSL_RAY_QUERY_GET_OP2(IntersectionT);
+		GLSL_RAY_QUERY_GET_OP2(IntersectionInstanceCustomIndex);
+		GLSL_RAY_QUERY_GET_OP2(IntersectionInstanceId);
+		GLSL_RAY_QUERY_GET_OP2(IntersectionInstanceShaderBindingTableRecordOffset);
+		GLSL_RAY_QUERY_GET_OP2(IntersectionGeometryIndex);
+		GLSL_RAY_QUERY_GET_OP2(IntersectionPrimitiveIndex);
+		GLSL_RAY_QUERY_GET_OP2(IntersectionBarycentrics);
+		GLSL_RAY_QUERY_GET_OP2(IntersectionFrontFace);
+		GLSL_RAY_QUERY_GET_OP2(IntersectionObjectRayDirection);
+		GLSL_RAY_QUERY_GET_OP2(IntersectionObjectRayOrigin);
+		GLSL_RAY_QUERY_GET_OP2(IntersectionObjectToWorld);
+		GLSL_RAY_QUERY_GET_OP2(IntersectionWorldToObject);
 #undef GLSL_RAY_QUERY_GET_OP
 #undef GLSL_RAY_QUERY_GET_OP2
 
@@ -15081,8 +15142,8 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 	{
 		require_extension_internal("GL_EXT_ray_tracing");
 
-		bool elide_temporary = should_forward(ops[2]) && forced_temporaries.count(ops[1]) == 0 &&
-		                       !hoisted_temporaries.count(ops[1]);
+		bool elide_temporary =
+		    should_forward(ops[2]) && forced_temporaries.count(ops[1]) == 0 && !hoisted_temporaries.count(ops[1]);
 
 		if (elide_temporary)
 		{
@@ -15373,8 +15434,7 @@ string CompilerGLSL::convert_row_major_matrix(string exp_str, const SPIRType &ex
 			// E.g. [0].data followed by [1] would be shuffled to [1][0].data which is wrong,
 			// and needs to be [1].data[0] instead.
 			end_deferred_index++;
-			column_expr = column_expr.substr(end_deferred_index) +
-			              column_expr.substr(0, end_deferred_index);
+			column_expr = column_expr.substr(end_deferred_index) + column_expr.substr(0, end_deferred_index);
 		}
 
 		auto transposed_expr = type_to_glsl_constructor(exp_type) + "(";
@@ -15459,10 +15519,9 @@ string CompilerGLSL::flags_to_qualifiers_glsl(const SPIRType &type, const Bitset
 		qual = "precise ";
 
 	// Structs do not have precision qualifiers, neither do doubles (desktop only anyways, so no mediump/highp).
-	bool type_supports_precision =
-			type.basetype == SPIRType::Float || type.basetype == SPIRType::Int || type.basetype == SPIRType::UInt ||
-			type.basetype == SPIRType::Image || type.basetype == SPIRType::SampledImage ||
-			type.basetype == SPIRType::Sampler;
+	bool type_supports_precision = type.basetype == SPIRType::Float || type.basetype == SPIRType::Int ||
+	                               type.basetype == SPIRType::UInt || type.basetype == SPIRType::Image ||
+	                               type.basetype == SPIRType::SampledImage || type.basetype == SPIRType::Sampler;
 
 	if (!type_supports_precision)
 		return qual;
@@ -15712,7 +15771,7 @@ string CompilerGLSL::pls_decl(const PlsRemap &var)
 
 	auto op_and_basetype = pls_format_to_basetype(var.format);
 
-	SPIRType type { op_and_basetype.first };
+	SPIRType type{ op_and_basetype.first };
 	type.basetype = op_and_basetype.second;
 	auto vecsize = pls_format_to_components(var.format);
 	if (vecsize > 1)
@@ -15921,8 +15980,7 @@ string CompilerGLSL::image_type_glsl(const SPIRType &type, uint32_t id, bool /*m
 	}
 
 	// "Shadow" state in GLSL only exists for samplers and combined image samplers.
-	if (((type.basetype == SPIRType::SampledImage) || (type.basetype == SPIRType::Sampler)) &&
-	    is_depth_image(type, id))
+	if (((type.basetype == SPIRType::SampledImage) || (type.basetype == SPIRType::Sampler)) && is_depth_image(type, id))
 	{
 		res += "Shadow";
 
@@ -16583,10 +16641,11 @@ void CompilerGLSL::flush_phi(BlockID from, BlockID to)
 				// as part of another Phi node in our target block.
 				// For this case, we will need to copy phi.function_variable to a temporary, and use that for future reads.
 				// This is judged to be extremely rare, so deal with it here using a simple, but suboptimal algorithm.
-				bool need_saved_temporary =
-				    find_if(itr + 1, end(child.phi_variables), [&](const SPIRBlock::Phi &future_phi) -> bool {
-					    return future_phi.local_variable == ID(phi.function_variable) && future_phi.parent == from;
-				    }) != end(child.phi_variables);
+				bool need_saved_temporary = find_if(itr + 1, end(child.phi_variables),
+				                                    [&](const SPIRBlock::Phi &future_phi) -> bool {
+					                                    return future_phi.local_variable == ID(phi.function_variable) &&
+					                                           future_phi.parent == from;
+				                                    }) != end(child.phi_variables);
 
 				if (need_saved_temporary)
 				{
@@ -16993,8 +17052,8 @@ bool CompilerGLSL::attempt_emit_loop_header(SPIRBlock &block, SPIRBlock::Method 
 
 		bool condition_is_temporary = forced_temporaries.find(block.condition) == end(forced_temporaries);
 
-		bool flushes_phi = flush_phi_required(block.self, block.true_block) ||
-		                   flush_phi_required(block.self, block.false_block);
+		bool flushes_phi =
+		    flush_phi_required(block.self, block.true_block) || flush_phi_required(block.self, block.false_block);
 
 		// This can work! We only did trivial things which could be forwarded in block body!
 		if (!flushes_phi && current_count == statement_count && condition_is_temporary)
@@ -17076,8 +17135,8 @@ bool CompilerGLSL::attempt_emit_loop_header(SPIRBlock &block, SPIRBlock::Method 
 
 		bool condition_is_temporary = forced_temporaries.find(child.condition) == end(forced_temporaries);
 
-		bool flushes_phi = flush_phi_required(child.self, child.true_block) ||
-		                   flush_phi_required(child.self, child.false_block);
+		bool flushes_phi =
+		    flush_phi_required(child.self, child.true_block) || flush_phi_required(child.self, child.false_block);
 
 		if (!flushes_phi && current_count == statement_count && condition_is_temporary)
 		{
@@ -17191,8 +17250,7 @@ void CompilerGLSL::emit_hoisted_temporaries(SmallVector<pair<TypeID, ID>> &tempo
 		{
 			uint32_t mirror_id = mirrored_precision_itr->second;
 			auto &mirror_flags = get_decoration_bitset(mirror_id);
-			statement(flags_to_qualifiers_glsl(type, mirror_flags),
-			          variable_decl(type, to_name(mirror_id)),
+			statement(flags_to_qualifiers_glsl(type, mirror_flags), variable_decl(type, to_name(mirror_id)),
 			          initializer, ";");
 			// The temporary might be read from before it's assigned, set up the expression now.
 			set<SPIRExpression>(mirror_id, to_name(mirror_id), tmp.first, true);
@@ -17222,9 +17280,8 @@ void CompilerGLSL::emit_block_chain(SPIRBlock &block)
 			auto mirrored_precision_itr = temporary_to_mirror_precision_alias.find(var_id);
 			if (mirrored_precision_itr != temporary_to_mirror_precision_alias.end() &&
 			    find_if(block.declare_temporary.begin(), block.declare_temporary.end(),
-			            [mirrored_precision_itr](const std::pair<TypeID, VariableID> &p) {
-			              return p.second == mirrored_precision_itr->second;
-			            }) == block.declare_temporary.end())
+			            [mirrored_precision_itr](const std::pair<TypeID, VariableID> &p)
+			            { return p.second == mirrored_precision_itr->second; }) == block.declare_temporary.end())
 			{
 				block.declare_temporary.push_back({ var.basetype, mirrored_precision_itr->second });
 			}
@@ -17531,7 +17588,8 @@ void CompilerGLSL::emit_block_chain(SPIRBlock &block)
 		};
 
 		const auto to_legacy_case_label = [&](uint32_t condition, const SmallVector<uint64_t> &labels,
-		                                      const char *suffix) -> string {
+		                                      const char *suffix) -> string
+		{
 			string ret;
 			size_t count = labels.size();
 			for (size_t i = 0; i < count; i++)
@@ -17800,11 +17858,10 @@ void CompilerGLSL::emit_block_chain(SPIRBlock &block)
 		while (id)
 		{
 			auto &iter_block = get<SPIRBlock>(id);
-			if (iter_block.terminator == SPIRBlock::MultiSelect ||
-			    iter_block.merge == SPIRBlock::MergeLoop)
+			if (iter_block.terminator == SPIRBlock::MultiSelect || iter_block.merge == SPIRBlock::MergeLoop)
 			{
-				ID next_block = iter_block.merge == SPIRBlock::MergeLoop ?
-				                iter_block.merge_block : iter_block.next_block;
+				ID next_block =
+				    iter_block.merge == SPIRBlock::MergeLoop ? iter_block.merge_block : iter_block.next_block;
 				bool outside_construct = next_block && cfg.find_common_dominator(next_block, block.self) == next_block;
 				if (!outside_construct)
 				{
@@ -18048,14 +18105,13 @@ bool CompilerGLSL::unroll_array_to_complex_store(uint32_t target_id, uint32_t so
 	else
 		array_expr = to_expression(type.array.back());
 
-	SPIRType target_type { OpTypeInt };
+	SPIRType target_type{ OpTypeInt };
 	target_type.basetype = SPIRType::Int;
 
 	statement("for (int i = 0; i < int(", array_expr, "); i++)");
 	begin_scope();
-	statement(to_expression(target_id), "[i] = ",
-	          bitcast_expression(target_type, type.basetype, join(to_expression(source_id), "[i]")),
-	          ";");
+	statement(to_expression(target_id),
+	          "[i] = ", bitcast_expression(target_type, type.basetype, join(to_expression(source_id), "[i]")), ";");
 	end_scope();
 
 	return true;
@@ -18080,9 +18136,7 @@ void CompilerGLSL::unroll_array_from_complex_load(uint32_t target_id, uint32_t s
 
 	auto builtin = BuiltIn(get_decoration(var->self, DecorationBuiltIn));
 	bool is_builtin = is_builtin_variable(*var) &&
-	                  (builtin == BuiltInPointSize ||
-	                   builtin == BuiltInPosition ||
-	                   builtin == BuiltInSampleMask);
+	                  (builtin == BuiltInPointSize || builtin == BuiltInPosition || builtin == BuiltInSampleMask);
 	bool is_tess = is_tessellation_shader();
 	bool is_patch = has_decoration(var->self, DecorationPatch);
 	bool is_sample_mask = is_builtin && builtin == BuiltInSampleMask;
@@ -18113,7 +18167,7 @@ void CompilerGLSL::unroll_array_from_complex_load(uint32_t target_id, uint32_t s
 			statement(new_expr, "[i] = gl_in[i].", expr, ";");
 		else if (is_sample_mask)
 		{
-			SPIRType target_type { OpTypeInt };
+			SPIRType target_type{ OpTypeInt };
 			target_type.basetype = SPIRType::Int;
 			statement(new_expr, "[i] = ", bitcast_expression(target_type, type.basetype, join(expr, "[i]")), ";");
 		}
@@ -18241,8 +18295,7 @@ void CompilerGLSL::convert_non_uniform_expression(string &expr, uint32_t ptr_id)
 	if (!var)
 		return;
 
-	if (var->storage != StorageClassUniformConstant &&
-	    var->storage != StorageClassStorageBuffer &&
+	if (var->storage != StorageClassUniformConstant && var->storage != StorageClassStorageBuffer &&
 	    var->storage != StorageClassUniform)
 		return;
 
@@ -18374,45 +18427,50 @@ void CompilerGLSL::fixup_anonymous_struct_names()
 	// Breaks exponential explosion with weird type trees.
 	std::unordered_set<uint32_t> visited;
 
-	ir.for_each_typed_id<SPIRType>([&](uint32_t, SPIRType &type) {
-		if (type.basetype == SPIRType::Struct &&
-		    (has_decoration(type.self, DecorationBlock) ||
-		     has_decoration(type.self, DecorationBufferBlock)))
-		{
-			fixup_anonymous_struct_names(visited, type);
-		}
-	});
+	ir.for_each_typed_id<SPIRType>(
+	    [&](uint32_t, SPIRType &type)
+	    {
+		    if (type.basetype == SPIRType::Struct &&
+		        (has_decoration(type.self, DecorationBlock) || has_decoration(type.self, DecorationBufferBlock)))
+		    {
+			    fixup_anonymous_struct_names(visited, type);
+		    }
+	    });
 }
 
 void CompilerGLSL::fixup_type_alias()
 {
 	// Due to how some backends work, the "master" type of type_alias must be a block-like type if it exists.
-	ir.for_each_typed_id<SPIRType>([&](uint32_t self, SPIRType &type) {
-		if (!type.type_alias)
-			return;
+	ir.for_each_typed_id<SPIRType>(
+	    [&](uint32_t self, SPIRType &type)
+	    {
+		    if (!type.type_alias)
+			    return;
 
-		if (has_decoration(type.self, DecorationBlock) || has_decoration(type.self, DecorationBufferBlock))
-		{
-			// Top-level block types should never alias anything else.
-			type.type_alias = 0;
-		}
-		else if (type_is_block_like(type) && type.self == ID(self))
-		{
-			// A block-like type is any type which contains Offset decoration, but not top-level blocks,
-			// i.e. blocks which are placed inside buffers.
-			// Become the master.
-			ir.for_each_typed_id<SPIRType>([&](uint32_t other_id, SPIRType &other_type) {
-				if (other_id == self)
-					return;
+		    if (has_decoration(type.self, DecorationBlock) || has_decoration(type.self, DecorationBufferBlock))
+		    {
+			    // Top-level block types should never alias anything else.
+			    type.type_alias = 0;
+		    }
+		    else if (type_is_block_like(type) && type.self == ID(self))
+		    {
+			    // A block-like type is any type which contains Offset decoration, but not top-level blocks,
+			    // i.e. blocks which are placed inside buffers.
+			    // Become the master.
+			    ir.for_each_typed_id<SPIRType>(
+			        [&](uint32_t other_id, SPIRType &other_type)
+			        {
+				        if (other_id == self)
+					        return;
 
-				if (other_type.type_alias == type.type_alias)
-					other_type.type_alias = self;
-			});
+				        if (other_type.type_alias == type.type_alias)
+					        other_type.type_alias = self;
+			        });
 
-			this->get<SPIRType>(type.type_alias).type_alias = self;
-			type.type_alias = 0;
-		}
-	});
+			    this->get<SPIRType>(type.type_alias).type_alias = self;
+			    type.type_alias = 0;
+		    }
+	    });
 }
 
 void CompilerGLSL::reorder_type_alias()
@@ -18562,23 +18620,27 @@ bool CompilerGLSL::subpass_input_is_framebuffer_fetch(uint32_t id) const
 const SPIRVariable *CompilerGLSL::find_subpass_input_by_attachment_index(uint32_t index) const
 {
 	const SPIRVariable *ret = nullptr;
-	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, const SPIRVariable &var) {
-		if (has_decoration(var.self, DecorationInputAttachmentIndex) &&
-		    get_decoration(var.self, DecorationInputAttachmentIndex) == index)
-		{
-			ret = &var;
-		}
-	});
+	ir.for_each_typed_id<SPIRVariable>(
+	    [&](uint32_t, const SPIRVariable &var)
+	    {
+		    if (has_decoration(var.self, DecorationInputAttachmentIndex) &&
+		        get_decoration(var.self, DecorationInputAttachmentIndex) == index)
+		    {
+			    ret = &var;
+		    }
+	    });
 	return ret;
 }
 
 const SPIRVariable *CompilerGLSL::find_color_output_by_location(uint32_t location) const
 {
 	const SPIRVariable *ret = nullptr;
-	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, const SPIRVariable &var) {
-		if (var.storage == StorageClassOutput && get_decoration(var.self, DecorationLocation) == location)
-			ret = &var;
-	});
+	ir.for_each_typed_id<SPIRVariable>(
+	    [&](uint32_t, const SPIRVariable &var)
+	    {
+		    if (var.storage == StorageClassOutput && get_decoration(var.self, DecorationLocation) == location)
+			    ret = &var;
+	    });
 	return ret;
 }
 
@@ -18597,19 +18659,21 @@ void CompilerGLSL::emit_inout_fragment_outputs_copy_to_subpass_inputs()
 			SPIRV_CROSS_THROW("Cannot use GL_EXT_shader_framebuffer_fetch with arrays of color outputs.");
 
 		auto &func = get<SPIRFunction>(get_entry_point().self);
-		func.fixup_hooks_in.push_back([=]() {
-			if (is_legacy())
-			{
-				statement(to_expression(subpass_var->self), " = ", "gl_LastFragData[",
-				          get_decoration(output_var->self, DecorationLocation), "];");
-			}
-			else
-			{
-				uint32_t num_rt_components = this->get<SPIRType>(output_var->basetype).vecsize;
-				statement(to_expression(subpass_var->self), vector_swizzle(num_rt_components, 0), " = ",
-				          to_expression(output_var->self), ";");
-			}
-		});
+		func.fixup_hooks_in.push_back(
+		    [=]()
+		    {
+			    if (is_legacy())
+			    {
+				    statement(to_expression(subpass_var->self), " = ", "gl_LastFragData[",
+				              get_decoration(output_var->self, DecorationLocation), "];");
+			    }
+			    else
+			    {
+				    uint32_t num_rt_components = this->get<SPIRType>(output_var->basetype).vecsize;
+				    statement(to_expression(subpass_var->self), vector_swizzle(num_rt_components, 0), " = ",
+				              to_expression(output_var->self), ";");
+			    }
+		    });
 	}
 }
 
@@ -18705,8 +18769,7 @@ bool CompilerGLSL::ShaderSubgroupSupportHelper::can_feature_be_implemented_witho
 		true, // SubgroupBalloFindLSB_MSB
 		false, false, false, false,
 		true, // SubgroupMemBarrier - replaced with workgroup memory barriers
-		false, false, true, false,
-		false, false, false, false, false, false, // iadd, fadd
+		false, false, true,  false, false, false, false, false, false, false, // iadd, fadd
 		false, false, false, false, false, false, // imul , fmul
 	};
 
@@ -18717,14 +18780,16 @@ CompilerGLSL::ShaderSubgroupSupportHelper::Candidate CompilerGLSL::ShaderSubgrou
     get_KHR_extension_for_feature(Feature feature)
 {
 	static const Candidate extensions[FeatureCount] = {
-		KHR_shader_subgroup_ballot, KHR_shader_subgroup_basic,  KHR_shader_subgroup_basic,  KHR_shader_subgroup_basic,
-		KHR_shader_subgroup_basic,  KHR_shader_subgroup_ballot, KHR_shader_subgroup_ballot, KHR_shader_subgroup_vote,
-		KHR_shader_subgroup_vote,   KHR_shader_subgroup_basic,  KHR_shader_subgroup_basic, KHR_shader_subgroup_basic,
-		KHR_shader_subgroup_ballot, KHR_shader_subgroup_ballot, KHR_shader_subgroup_ballot, KHR_shader_subgroup_ballot,
+		KHR_shader_subgroup_ballot,     KHR_shader_subgroup_basic,      KHR_shader_subgroup_basic,
+		KHR_shader_subgroup_basic,      KHR_shader_subgroup_basic,      KHR_shader_subgroup_ballot,
+		KHR_shader_subgroup_ballot,     KHR_shader_subgroup_vote,       KHR_shader_subgroup_vote,
+		KHR_shader_subgroup_basic,      KHR_shader_subgroup_basic,      KHR_shader_subgroup_basic,
+		KHR_shader_subgroup_ballot,     KHR_shader_subgroup_ballot,     KHR_shader_subgroup_ballot,
+		KHR_shader_subgroup_ballot,     KHR_shader_subgroup_arithmetic, KHR_shader_subgroup_arithmetic,
 		KHR_shader_subgroup_arithmetic, KHR_shader_subgroup_arithmetic, KHR_shader_subgroup_arithmetic,
 		KHR_shader_subgroup_arithmetic, KHR_shader_subgroup_arithmetic, KHR_shader_subgroup_arithmetic,
 		KHR_shader_subgroup_arithmetic, KHR_shader_subgroup_arithmetic, KHR_shader_subgroup_arithmetic,
-		KHR_shader_subgroup_arithmetic, KHR_shader_subgroup_arithmetic, KHR_shader_subgroup_arithmetic,
+		KHR_shader_subgroup_arithmetic,
 	};
 
 	return extensions[feature];
@@ -18774,7 +18839,8 @@ CompilerGLSL::ShaderSubgroupSupportHelper::CandidateVector CompilerGLSL::ShaderS
     get_candidates_for_feature(Feature ft, const Result &r)
 {
 	auto c = get_candidates_for_feature(ft);
-	auto cmp = [&r](Candidate a, Candidate b) {
+	auto cmp = [&r](Candidate a, Candidate b)
+	{
 		if (r.weights[a] == r.weights[b])
 			return a < b; // Prefer candidates with lower enum value
 		return r.weights[a] > r.weights[b];
@@ -18956,9 +19022,8 @@ bool CompilerGLSL::is_stage_output_variable_masked(const SPIRVariable &var) cons
 		if (!has_decoration(var.self, DecorationLocation))
 			return false;
 
-		return is_stage_output_location_masked(
-				get_decoration(var.self, DecorationLocation),
-				get_decoration(var.self, DecorationComponent));
+		return is_stage_output_location_masked(get_decoration(var.self, DecorationLocation),
+		                                       get_decoration(var.self, DecorationComponent));
 	}
 }
 
@@ -19017,7 +19082,8 @@ uint32_t CompilerGLSL::get_declared_member_location(const SPIRVariable &var, uin
 		return get_accumulated_member_location(var, mbr_idx, strip_array);
 }
 
-uint32_t CompilerGLSL::get_accumulated_member_location(const SPIRVariable &var, uint32_t mbr_idx, bool strip_array) const
+uint32_t CompilerGLSL::get_accumulated_member_location(const SPIRVariable &var, uint32_t mbr_idx,
+                                                       bool strip_array) const
 {
 	auto &type = strip_array ? get_variable_element_type(var) : get_variable_data_type(var);
 	uint32_t location = get_decoration(var.self, DecorationLocation);
@@ -19106,4 +19172,3 @@ std::string CompilerGLSL::format_double(double value) const
 	// default behavior
 	return convert_to_string(value, current_locale_radix_character);
 }
-

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -260,7 +260,7 @@ public:
 	// require_extension("GL_KHR_my_extension");
 	void require_extension(const std::string &ext);
 
-	// Returns the list of required extensions. After compilation this will contains any other 
+	// Returns the list of required extensions. After compilation this will contains any other
 	// extensions that the compiler used automatically, in addition to the user specified ones.
 	const SmallVector<std::string> &get_required_extensions() const;
 
@@ -441,8 +441,7 @@ protected:
 	                                const std::string &qualifier = "", uint32_t base_offset = 0);
 	virtual void emit_struct_padding_target(const SPIRType &type);
 	virtual std::string image_type_glsl(const SPIRType &type, uint32_t id = 0, bool member = false);
-	std::string constant_expression(const SPIRConstant &c,
-	                                bool inside_block_like_struct_scope = false,
+	std::string constant_expression(const SPIRConstant &c, bool inside_block_like_struct_scope = false,
 	                                bool inside_struct_scope = false);
 	virtual std::string constant_op_expression(const SPIRConstantOp &cop);
 	virtual std::string constant_expression_vector(const SPIRConstant &c, uint32_t vector);
@@ -509,7 +508,7 @@ protected:
 	}
 
 	template <typename T, typename... Ts>
-	inline void statement_inner(T &&t, Ts &&... ts)
+	inline void statement_inner(T &&t, Ts &&...ts)
 	{
 		buffer << std::forward<T>(t);
 		statement_count++;
@@ -517,7 +516,7 @@ protected:
 	}
 
 	template <typename... Ts>
-	inline void statement(Ts &&... ts)
+	inline void statement(Ts &&...ts)
 	{
 		if (is_forcing_recompilation())
 		{
@@ -542,7 +541,7 @@ protected:
 	}
 
 	template <typename... Ts>
-	inline void statement_no_indent(Ts &&... ts)
+	inline void statement_no_indent(Ts &&...ts)
 	{
 		auto old_indent = indent;
 		indent = 0;
@@ -584,8 +583,7 @@ protected:
 	bool member_is_remapped_physical_type(const SPIRType &type, uint32_t index) const;
 	bool member_is_packed_physical_type(const SPIRType &type, uint32_t index) const;
 	virtual std::string convert_row_major_matrix(std::string exp_str, const SPIRType &exp_type,
-	                                             uint32_t physical_type_id, bool is_packed,
-	                                             bool relaxed = false);
+	                                             uint32_t physical_type_id, bool is_packed, bool relaxed = false);
 
 	std::unordered_set<std::string> local_variable_names;
 	std::unordered_set<std::string> resource_names;
@@ -707,7 +705,8 @@ protected:
 	                          const char *op);
 	void emit_binary_func_op(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, const char *op);
 	void emit_atomic_func_op(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, const char *op);
-	void emit_atomic_func_op(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, uint32_t op2, const char *op);
+	void emit_atomic_func_op(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, uint32_t op2,
+	                         const char *op);
 
 	void emit_unary_func_op_cast(uint32_t result_type, uint32_t result_id, uint32_t op0, const char *op,
 	                             SPIRType::BaseType input_type, SPIRType::BaseType expected_result_type);
@@ -730,7 +729,8 @@ protected:
 	void emit_unrolled_binary_op(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, const char *op,
 	                             bool negate, SPIRType::BaseType expected_type);
 	void emit_binary_op_cast(uint32_t result_type, uint32_t result_id, uint32_t op0, uint32_t op1, const char *op,
-	                         SPIRType::BaseType input_type, bool skip_cast_if_equal_type, bool implicit_integer_promotion);
+	                         SPIRType::BaseType input_type, bool skip_cast_if_equal_type,
+	                         bool implicit_integer_promotion);
 
 	SPIRType binary_op_bitcast_helper(std::string &cast_op0, std::string &cast_op1, SPIRType::BaseType &input_type,
 	                                  uint32_t op0, uint32_t op1, bool skip_cast_if_equal_type);
@@ -796,7 +796,8 @@ protected:
 	std::string to_non_uniform_aware_expression(uint32_t id);
 	std::string to_expression(uint32_t id, bool register_expression_read = true);
 	std::string to_composite_constructor_expression(const SPIRType &parent_type, uint32_t id, bool block_like_type);
-	std::string to_rerolled_array_expression(const SPIRType &parent_type, const std::string &expr, const SPIRType &type);
+	std::string to_rerolled_array_expression(const SPIRType &parent_type, const std::string &expr,
+	                                         const SPIRType &type);
 	std::string to_enclosed_expression(uint32_t id, bool register_expression_read = true);
 	std::string to_unpacked_expression(uint32_t id, bool register_expression_read = true);
 	std::string to_unpacked_row_major_matrix_expression(uint32_t id);
@@ -813,7 +814,8 @@ protected:
 	std::string address_of_expression(const std::string &expr);
 	void strip_enclosed_expression(std::string &expr);
 	std::string to_member_name(const SPIRType &type, uint32_t index);
-	virtual std::string to_member_reference(uint32_t base, const SPIRType &type, uint32_t index, bool ptr_chain_is_resolved);
+	virtual std::string to_member_reference(uint32_t base, const SPIRType &type, uint32_t index,
+	                                        bool ptr_chain_is_resolved);
 	std::string to_multi_member_reference(const SPIRType &type, const SmallVector<uint32_t> &indices);
 	std::string type_to_glsl_constructor(const SPIRType &type);
 	std::string argument_decl(const SPIRFunction::Parameter &arg);
@@ -829,8 +831,8 @@ protected:
 	std::string layout_for_variable(const SPIRVariable &variable);
 	std::string to_combined_image_sampler(VariableID image_id, VariableID samp_id);
 	virtual bool skip_argument(uint32_t id) const;
-	virtual bool emit_array_copy(const char *expr, uint32_t lhs_id, uint32_t rhs_id,
-	                             spv::StorageClass lhs_storage, spv::StorageClass rhs_storage);
+	virtual bool emit_array_copy(const char *expr, uint32_t lhs_id, uint32_t rhs_id, spv::StorageClass lhs_storage,
+	                             spv::StorageClass rhs_storage);
 	virtual void emit_block_hints(const SPIRBlock &block);
 	virtual std::string to_initializer_expression(const SPIRVariable &var);
 	virtual std::string to_zero_initialized_expression(uint32_t type_id);
@@ -839,8 +841,7 @@ protected:
 	bool buffer_is_packing_standard(const SPIRType &type, BufferPackingStandard packing,
 	                                uint32_t *failed_index = nullptr, uint32_t start_offset = 0,
 	                                uint32_t end_offset = ~(0u));
-	std::string buffer_to_packing_standard(const SPIRType &type,
-	                                       bool support_std430_without_scalar_layout,
+	std::string buffer_to_packing_standard(const SPIRType &type, bool support_std430_without_scalar_layout,
 	                                       bool support_enhanced_layouts);
 
 	uint32_t type_to_packed_base_size(const SPIRType &type, BufferPackingStandard packing);

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -126,7 +126,7 @@ public:
 		// By default, a readonly storage buffer will be declared as ByteAddressBuffer (SRV) instead.
 		// Alternatively, use set_hlsl_force_storage_buffer_as_uav to specify individually.
 		bool force_storage_buffer_as_uav = false;
-	
+
 		// Forces any storage image type marked as NonWritable to be considered an SRV instead.
 		// For this to work with function call parameters, NonWritable must be considered to be part of the type system
 		// so that NonWritable image arguments are also translated to Texture rather than RWTexture.

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -502,7 +502,7 @@ public:
 		// Note: Only Apple's GPU compiler takes advantage of the lack of coherency, so make sure to test on Apple GPUs if you disable this.
 		bool readwrite_texture_fences = true;
 
-		// Metal 3.1 introduced a Metal regression bug which causes infinite recursion during 
+		// Metal 3.1 introduced a Metal regression bug which causes infinite recursion during
 		// Metal's analysis of an entry point input structure that is itself recursive. Enabling
 		// this option will replace the recursive input declaration with a alternate variable of
 		// type void*, and then cast to the correct type at the top of the entry point function.
@@ -896,7 +896,8 @@ protected:
 	std::string bitcast_glsl_op(const SPIRType &result_type, const SPIRType &argument_type) override;
 	bool emit_complex_bitcast(uint32_t result_id, uint32_t id, uint32_t op0) override;
 	bool skip_argument(uint32_t id) const override;
-	std::string to_member_reference(uint32_t base, const SPIRType &type, uint32_t index, bool ptr_chain_is_resolved) override;
+	std::string to_member_reference(uint32_t base, const SPIRType &type, uint32_t index,
+	                                bool ptr_chain_is_resolved) override;
 	std::string to_qualifiers_glsl(uint32_t id) override;
 	void replace_illegal_names() override;
 	void declare_constant_arrays();
@@ -958,33 +959,29 @@ protected:
 	void add_plain_variable_to_interface_block(spv::StorageClass storage, const std::string &ib_var_ref,
 	                                           SPIRType &ib_type, SPIRVariable &var, InterfaceBlockMeta &meta);
 	bool add_component_variable_to_interface_block(spv::StorageClass storage, const std::string &ib_var_ref,
-	                                               SPIRVariable &var, const SPIRType &type,
-	                                               InterfaceBlockMeta &meta);
-	void add_plain_member_variable_to_interface_block(spv::StorageClass storage,
-	                                                  const std::string &ib_var_ref, SPIRType &ib_type,
-	                                                  SPIRVariable &var, SPIRType &var_type,
+	                                               SPIRVariable &var, const SPIRType &type, InterfaceBlockMeta &meta);
+	void add_plain_member_variable_to_interface_block(spv::StorageClass storage, const std::string &ib_var_ref,
+	                                                  SPIRType &ib_type, SPIRVariable &var, SPIRType &var_type,
 	                                                  uint32_t mbr_idx, InterfaceBlockMeta &meta,
 	                                                  const std::string &mbr_name_qual,
-	                                                  const std::string &var_chain_qual,
-	                                                  uint32_t &location, uint32_t &var_mbr_idx);
-	void add_composite_member_variable_to_interface_block(spv::StorageClass storage,
-	                                                      const std::string &ib_var_ref, SPIRType &ib_type,
-	                                                      SPIRVariable &var, SPIRType &var_type,
+	                                                  const std::string &var_chain_qual, uint32_t &location,
+	                                                  uint32_t &var_mbr_idx);
+	void add_composite_member_variable_to_interface_block(spv::StorageClass storage, const std::string &ib_var_ref,
+	                                                      SPIRType &ib_type, SPIRVariable &var, SPIRType &var_type,
 	                                                      uint32_t mbr_idx, InterfaceBlockMeta &meta,
 	                                                      const std::string &mbr_name_qual,
-	                                                      const std::string &var_chain_qual,
-	                                                      uint32_t &location, uint32_t &var_mbr_idx,
-	                                                      const Bitset &interpolation_qual);
+	                                                      const std::string &var_chain_qual, uint32_t &location,
+	                                                      uint32_t &var_mbr_idx, const Bitset &interpolation_qual);
 	void add_tess_level_input_to_interface_block(const std::string &ib_var_ref, SPIRType &ib_type, SPIRVariable &var);
 	void add_tess_level_input(const std::string &base_ref, const std::string &mbr_name, SPIRVariable &var);
 
 	void fix_up_interface_member_indices(spv::StorageClass storage, uint32_t ib_type_id);
 
-	void mark_location_as_used_by_shader(uint32_t location, const SPIRType &type,
-	                                     spv::StorageClass storage, bool fallback = false);
+	void mark_location_as_used_by_shader(uint32_t location, const SPIRType &type, spv::StorageClass storage,
+	                                     bool fallback = false);
 	uint32_t ensure_correct_builtin_type(uint32_t type_id, spv::BuiltIn builtin);
-	uint32_t ensure_correct_input_type(uint32_t type_id, uint32_t location, uint32_t component,
-	                                   uint32_t num_components, bool strip_array);
+	uint32_t ensure_correct_input_type(uint32_t type_id, uint32_t location, uint32_t component, uint32_t num_components,
+	                                   bool strip_array);
 
 	void emit_custom_templates();
 	void emit_custom_functions();
@@ -1021,10 +1018,10 @@ protected:
 	std::string round_fp_tex_coords(std::string tex_coords, bool coord_is_fp);
 	uint32_t get_metal_resource_index(SPIRVariable &var, SPIRType::BaseType basetype, uint32_t plane = 0);
 	uint32_t get_member_location(uint32_t type_id, uint32_t index, uint32_t *comp = nullptr) const;
-	uint32_t get_or_allocate_builtin_input_member_location(spv::BuiltIn builtin,
-	                                                       uint32_t type_id, uint32_t index, uint32_t *comp = nullptr);
-	uint32_t get_or_allocate_builtin_output_member_location(spv::BuiltIn builtin,
-	                                                        uint32_t type_id, uint32_t index, uint32_t *comp = nullptr);
+	uint32_t get_or_allocate_builtin_input_member_location(spv::BuiltIn builtin, uint32_t type_id, uint32_t index,
+	                                                       uint32_t *comp = nullptr);
+	uint32_t get_or_allocate_builtin_output_member_location(spv::BuiltIn builtin, uint32_t type_id, uint32_t index,
+	                                                        uint32_t *comp = nullptr);
 
 	uint32_t get_physical_tess_level_array_size(spv::BuiltIn builtin) const;
 
@@ -1072,14 +1069,15 @@ protected:
 	SPIRType &get_uint_type();
 	uint32_t get_uint_type_id();
 	void emit_atomic_func_op(uint32_t result_type, uint32_t result_id, const char *op, spv::Op opcode,
-	                         uint32_t mem_order_1, uint32_t mem_order_2, bool has_mem_order_2, uint32_t op0, uint32_t op1 = 0,
-	                         bool op1_is_pointer = false, bool op1_is_literal = false, uint32_t op2 = 0);
+	                         uint32_t mem_order_1, uint32_t mem_order_2, bool has_mem_order_2, uint32_t op0,
+	                         uint32_t op1 = 0, bool op1_is_pointer = false, bool op1_is_literal = false,
+	                         uint32_t op2 = 0);
 	const char *get_memory_order(uint32_t spv_mem_sem);
 	void add_pragma_line(const std::string &line);
 	void add_typedef_line(const std::string &line);
 	void emit_barrier(uint32_t id_exe_scope, uint32_t id_mem_scope, uint32_t id_mem_sem);
-	bool emit_array_copy(const char *expr, uint32_t lhs_id, uint32_t rhs_id,
-	                     spv::StorageClass lhs_storage, spv::StorageClass rhs_storage) override;
+	bool emit_array_copy(const char *expr, uint32_t lhs_id, uint32_t rhs_id, spv::StorageClass lhs_storage,
+	                     spv::StorageClass rhs_storage) override;
 	void build_implicit_builtins();
 	uint32_t build_constant_uint_array_pointer();
 	void emit_entry_point_declarations() override;
@@ -1244,16 +1242,19 @@ protected:
 	uint32_t argument_buffer_discrete_mask = 0;
 	uint32_t argument_buffer_device_storage_mask = 0;
 
-	void emit_argument_buffer_aliased_descriptor(const SPIRVariable &aliased_var,
-	                                             const SPIRVariable &base_var);
+	void emit_argument_buffer_aliased_descriptor(const SPIRVariable &aliased_var, const SPIRVariable &base_var);
 
 	void analyze_argument_buffers();
 	bool descriptor_set_is_argument_buffer(uint32_t desc_set) const;
 	const MSLResourceBinding &get_argument_buffer_resource(uint32_t desc_set, uint32_t arg_idx) const;
-	void add_argument_buffer_padding_buffer_type(SPIRType &struct_type, uint32_t &mbr_idx, uint32_t &arg_buff_index, MSLResourceBinding &rez_bind);
-	void add_argument_buffer_padding_image_type(SPIRType &struct_type, uint32_t &mbr_idx, uint32_t &arg_buff_index, MSLResourceBinding &rez_bind);
-	void add_argument_buffer_padding_sampler_type(SPIRType &struct_type, uint32_t &mbr_idx, uint32_t &arg_buff_index, MSLResourceBinding &rez_bind);
-	void add_argument_buffer_padding_type(uint32_t mbr_type_id, SPIRType &struct_type, uint32_t &mbr_idx, uint32_t &arg_buff_index, uint32_t count);
+	void add_argument_buffer_padding_buffer_type(SPIRType &struct_type, uint32_t &mbr_idx, uint32_t &arg_buff_index,
+	                                             MSLResourceBinding &rez_bind);
+	void add_argument_buffer_padding_image_type(SPIRType &struct_type, uint32_t &mbr_idx, uint32_t &arg_buff_index,
+	                                            MSLResourceBinding &rez_bind);
+	void add_argument_buffer_padding_sampler_type(SPIRType &struct_type, uint32_t &mbr_idx, uint32_t &arg_buff_index,
+	                                              MSLResourceBinding &rez_bind);
+	void add_argument_buffer_padding_type(uint32_t mbr_type_id, SPIRType &struct_type, uint32_t &mbr_idx,
+	                                      uint32_t &arg_buff_index, uint32_t count);
 
 	uint32_t get_target_components_for_fragment_location(uint32_t location) const;
 	uint32_t build_extended_vector_type(uint32_t type_id, uint32_t components,
@@ -1282,7 +1283,10 @@ protected:
 		       msl_options.check_discarded_frag_stores && frag_shader_needs_discard_checks;
 	}
 
-	bool has_additional_fixed_sample_mask() const { return msl_options.additional_fixed_sample_mask != 0xffffffff; }
+	bool has_additional_fixed_sample_mask() const
+	{
+		return msl_options.additional_fixed_sample_mask != 0xffffffff;
+	}
 	std::string additional_fixed_sample_mask_str() const;
 
 	// OpcodeHandler that handles several MSL preprocessing operations.

--- a/spirv_parser.cpp
+++ b/spirv_parser.cpp
@@ -423,20 +423,22 @@ void Parser::parse(const Instruction &instruction)
 		for (uint32_t i = 1; i < length; i++)
 		{
 			uint32_t target = ops[i];
-			flags.for_each_bit([&](uint32_t bit) {
-				auto decoration = static_cast<Decoration>(bit);
+			flags.for_each_bit(
+			    [&](uint32_t bit)
+			    {
+				    auto decoration = static_cast<Decoration>(bit);
 
-				if (decoration_is_string(decoration))
-				{
-					ir.set_decoration_string(target, decoration, ir.get_decoration_string(group_id, decoration));
-				}
-				else
-				{
-					ir.meta[target].decoration_word_offset[decoration] =
-					    ir.meta[group_id].decoration_word_offset[decoration];
-					ir.set_decoration(target, decoration, ir.get_decoration(group_id, decoration));
-				}
-			});
+				    if (decoration_is_string(decoration))
+				    {
+					    ir.set_decoration_string(target, decoration, ir.get_decoration_string(group_id, decoration));
+				    }
+				    else
+				    {
+					    ir.meta[target].decoration_word_offset[decoration] =
+					        ir.meta[group_id].decoration_word_offset[decoration];
+					    ir.set_decoration(target, decoration, ir.get_decoration(group_id, decoration));
+				    }
+			    });
 		}
 		break;
 	}
@@ -452,15 +454,17 @@ void Parser::parse(const Instruction &instruction)
 		{
 			uint32_t target = ops[i + 0];
 			uint32_t index = ops[i + 1];
-			flags.for_each_bit([&](uint32_t bit) {
-				auto decoration = static_cast<Decoration>(bit);
+			flags.for_each_bit(
+			    [&](uint32_t bit)
+			    {
+				    auto decoration = static_cast<Decoration>(bit);
 
-				if (decoration_is_string(decoration))
-					ir.set_member_decoration_string(target, index, decoration,
-					                                ir.get_decoration_string(group_id, decoration));
-				else
-					ir.set_member_decoration(target, index, decoration, ir.get_decoration(group_id, decoration));
-			});
+				    if (decoration_is_string(decoration))
+					    ir.set_member_decoration_string(target, index, decoration,
+					                                    ir.get_decoration_string(group_id, decoration));
+				    else
+					    ir.set_member_decoration(target, index, decoration, ir.get_decoration(group_id, decoration));
+			    });
 		}
 		break;
 	}

--- a/spirv_parser.hpp
+++ b/spirv_parser.hpp
@@ -53,7 +53,7 @@ private:
 	const uint32_t *stream(const Instruction &instr) const;
 
 	template <typename T, typename... P>
-	T &set(uint32_t id, P &&... args)
+	T &set(uint32_t id, P &&...args)
 	{
 		ir.add_typed_id(static_cast<Types>(T::type), id);
 		auto &var = variant_set<T>(ir.ids[id], std::forward<P>(args)...);

--- a/spirv_reflect.cpp
+++ b/spirv_reflect.cpp
@@ -89,14 +89,14 @@ private:
 	}
 
 	template <typename T, typename... Ts>
-	inline void statement_inner(T &&t, Ts &&... ts)
+	inline void statement_inner(T &&t, Ts &&...ts)
 	{
 		buffer << std::forward<T>(t);
 		statement_inner(std::forward<Ts>(ts)...);
 	}
 
 	template <typename... Ts>
-	inline void statement(Ts &&... ts)
+	inline void statement(Ts &&...ts)
 	{
 		statement_indent();
 		statement_inner(std::forward<Ts>(ts)...);
@@ -104,7 +104,7 @@ private:
 	}
 
 	template <typename... Ts>
-	void statement_no_return(Ts &&... ts)
+	void statement_no_return(Ts &&...ts)
 	{
 		statement_indent();
 		statement_inner(std::forward<Ts>(ts)...);
@@ -303,21 +303,23 @@ void CompilerReflection::emit_types()
 
 	// If we have physical pointers or arrays of physical pointers, it's also helpful to emit the pointee type
 	// and chain the type hierarchy. For POD, arrays can emit the entire type in-place.
-	ir.for_each_typed_id<SPIRType>([&](uint32_t self, SPIRType &type) {
-		if (naturally_emit_type(type))
-		{
-			emit_type(self, emitted_open_tag);
-		}
-		else if (type_is_reference(type))
-		{
-			if (!naturally_emit_type(this->get<SPIRType>(type.parent_type)) &&
-			    find(physical_pointee_types.begin(), physical_pointee_types.end(), type.parent_type) ==
-			        physical_pointee_types.end())
-			{
-				physical_pointee_types.push_back(type.parent_type);
-			}
-		}
-	});
+	ir.for_each_typed_id<SPIRType>(
+	    [&](uint32_t self, SPIRType &type)
+	    {
+		    if (naturally_emit_type(type))
+		    {
+			    emit_type(self, emitted_open_tag);
+		    }
+		    else if (type_is_reference(type))
+		    {
+			    if (!naturally_emit_type(this->get<SPIRType>(type.parent_type)) &&
+			        find(physical_pointee_types.begin(), physical_pointee_types.end(), type.parent_type) ==
+			            physical_pointee_types.end())
+			    {
+				    physical_pointee_types.push_back(type.parent_type);
+			    }
+		    }
+	    });
 
 	for (uint32_t pointee_type : physical_pointee_types)
 		emit_type(pointee_type, emitted_open_tag);
@@ -489,14 +491,16 @@ void CompilerReflection::emit_entry_points()
 	if (!entries.empty())
 	{
 		// Needed to make output deterministic.
-		sort(begin(entries), end(entries), [](const EntryPoint &a, const EntryPoint &b) -> bool {
-			if (a.execution_model < b.execution_model)
-				return true;
-			else if (a.execution_model > b.execution_model)
-				return false;
-			else
-				return a.name < b.name;
-		});
+		sort(begin(entries), end(entries),
+		     [](const EntryPoint &a, const EntryPoint &b) -> bool
+		     {
+			     if (a.execution_model < b.execution_model)
+				     return true;
+			     else if (a.execution_model > b.execution_model)
+				     return false;
+			     else
+				     return a.name < b.name;
+		     });
 
 		json_stream->emit_json_key_array("entryPoints");
 		for (auto &e : entries)
@@ -636,7 +640,8 @@ void CompilerReflection::emit_resources(const char *tag, const SmallVector<Resou
 		if (mask.get(DecorationWeightTextureQCOM))
 			json_stream->emit_json_key_value("WeightTextureQCOM", get_decoration(res.id, DecorationWeightTextureQCOM));
 		if (mask.get(DecorationBlockMatchTextureQCOM))
-			json_stream->emit_json_key_value("BlockMatchTextureQCOM", get_decoration(res.id, DecorationBlockMatchTextureQCOM));
+			json_stream->emit_json_key_value("BlockMatchTextureQCOM",
+			                                 get_decoration(res.id, DecorationBlockMatchTextureQCOM));
 
 		// For images, the type itself adds a layout qualifer.
 		// Only emit the format for storage images.

--- a/spirv_spirv.cpp
+++ b/spirv_spirv.cpp
@@ -50,7 +50,7 @@ string CompilerSPIRV::compile()
 {
 	buffer.clear();
 	ir.fixup_reserved_names();
-	
+
 	this->emit_header();
 	this->emit_capabilities();
 	this->emit_ext_inst_imports();
@@ -58,7 +58,7 @@ string CompilerSPIRV::compile()
 	this->emit_annotations();
 	this->emit_types();
 
-	return string(reinterpret_cast<const char *>(buffer.data()), buffer.size()*sizeof(uint32_t));
+	return string(reinterpret_cast<const char *>(buffer.data()), buffer.size() * sizeof(uint32_t));
 }
 
 void CompilerSPIRV::emit_header()
@@ -82,8 +82,8 @@ void CompilerSPIRV::emit_capabilities()
 
 void CompilerSPIRV::emit_extensions()
 {
-	
-	for (string& ext: ir.declared_extensions)
+
+	for (string &ext : ir.declared_extensions)
 	{
 		auto str = this->get_spirv_string(ext);
 		this->emit_opcode(Op::OpExtension, str.size());
@@ -93,54 +93,56 @@ void CompilerSPIRV::emit_extensions()
 
 void CompilerSPIRV::emit_ext_inst_imports()
 {
-	ir.for_each_typed_id<SPIRExtension>([this](ID id, SPIRExtension ext) {
-		if (ext.ext != SPIRExtension::Unsupported && ext.ext != SPIRExtension::NonSemanticGeneric)
-		{
-			vector<uint32_t> ext_name;
+	ir.for_each_typed_id<SPIRExtension>(
+	    [this](ID id, SPIRExtension ext)
+	    {
+		    if (ext.ext != SPIRExtension::Unsupported && ext.ext != SPIRExtension::NonSemanticGeneric)
+		    {
+			    vector<uint32_t> ext_name;
 
-			switch (ext.ext)
-			{
-			default:
-				break;
+			    switch (ext.ext)
+			    {
+			    default:
+				    break;
 
-			case SPIRExtension::GLSL:
-				ext_name = this->get_spirv_string("GLSL.std.450");
-				break;
+			    case SPIRExtension::GLSL:
+				    ext_name = this->get_spirv_string("GLSL.std.450");
+				    break;
 
-			case SPIRExtension::SPV_debug_info:
-				ext_name = this->get_spirv_string("DebugInfo");
-				break;
+			    case SPIRExtension::SPV_debug_info:
+				    ext_name = this->get_spirv_string("DebugInfo");
+				    break;
 
-			case SPIRExtension::SPV_AMD_shader_ballot:
-				ext_name = this->get_spirv_string("SPV_AMD_shader_ballot");
-				break;
+			    case SPIRExtension::SPV_AMD_shader_ballot:
+				    ext_name = this->get_spirv_string("SPV_AMD_shader_ballot");
+				    break;
 
-			case SPIRExtension::SPV_AMD_shader_explicit_vertex_parameter:
-				ext_name = this->get_spirv_string("SPV_AMD_shader_explicit_vertex_parameter");
-				break;
+			    case SPIRExtension::SPV_AMD_shader_explicit_vertex_parameter:
+				    ext_name = this->get_spirv_string("SPV_AMD_shader_explicit_vertex_parameter");
+				    break;
 
-			case SPIRExtension::SPV_AMD_shader_trinary_minmax:
-				ext_name = this->get_spirv_string("SPV_AMD_shader_trinary_minmax");
-				break;
+			    case SPIRExtension::SPV_AMD_shader_trinary_minmax:
+				    ext_name = this->get_spirv_string("SPV_AMD_shader_trinary_minmax");
+				    break;
 
-			case SPIRExtension::SPV_AMD_gcn_shader:
-				ext_name = this->get_spirv_string("SPV_AMD_gcn_shader");
-				break;
+			    case SPIRExtension::SPV_AMD_gcn_shader:
+				    ext_name = this->get_spirv_string("SPV_AMD_gcn_shader");
+				    break;
 
-			case SPIRExtension::NonSemanticDebugPrintf:
-				ext_name = this->get_spirv_string("NonSemantic.DebugPrintf");
-				break;
+			    case SPIRExtension::NonSemanticDebugPrintf:
+				    ext_name = this->get_spirv_string("NonSemantic.DebugPrintf");
+				    break;
 
-			case SPIRExtension::NonSemanticShaderDebugInfo:
-				ext_name = this->get_spirv_string("NonSemantic.Shader.DebugInfo.100");
-				break;
-			}
+			    case SPIRExtension::NonSemanticShaderDebugInfo:
+				    ext_name = this->get_spirv_string("NonSemantic.Shader.DebugInfo.100");
+				    break;
+			    }
 
-			this->emit_opcode(Op::OpExtInstImport, 1+ext_name.size());
-			this->emit_id(id);
-			this->emit_string(ext_name);
-		}
-	});
+			    this->emit_opcode(Op::OpExtInstImport, 1 + ext_name.size());
+			    this->emit_id(id);
+			    this->emit_string(ext_name);
+		    }
+	    });
 }
 
 void CompilerSPIRV::emit_exec_info()
@@ -386,10 +388,10 @@ void CompilerSPIRV::emit_types()
 		    uint32_t signed_ = 0;
 		    switch (type.op)
 		    {
-			default:
+		    default:
 			    break;
 
-			case Op::OpTypeSampler:
+		    case Op::OpTypeSampler:
 		    case Op::OpTypeVoid:
 			    this->emit_opcode(type.op, 1);
 			    this->emit_id(id);
@@ -397,7 +399,7 @@ void CompilerSPIRV::emit_types()
 
 		    case Op::OpTypeInt:
 			    signed_ = (type.basetype == SPIRType::SByte || type.basetype == SPIRType::Short ||
-			                        type.basetype == SPIRType::Int || type.basetype == SPIRType::Int64);
+			               type.basetype == SPIRType::Int || type.basetype == SPIRType::Int64);
 			    this->emit_opcode(type.op, 3);
 			    this->emit_id(id);
 			    this->emit_id(type.width);
@@ -424,7 +426,7 @@ void CompilerSPIRV::emit_types()
 			    this->emit_id(type.columns);
 			    break;
 
-			case Op::OpTypeImage:
+		    case Op::OpTypeImage:
 			    this->emit_opcode(type.op, 9);
 			    this->emit_id(id);
 			    this->emit_id(type.image.sampled);
@@ -435,20 +437,20 @@ void CompilerSPIRV::emit_types()
 			    this->emit_id(type.image.sampled);
 			    this->emit_id(type.image.format);
 			    this->emit_id(type.image.access);
-				break;
+			    break;
 
-			case Op::OpTypeSampledImage:
+		    case Op::OpTypeSampledImage:
 			    this->emit_opcode(type.op, 2);
 			    this->emit_id(id);
 			    this->emit_id(type.parent_type);
 			    break;
 
-			case Op::OpTypeArray:
+		    case Op::OpTypeArray:
 			    if (type.array_size_literal[0])
 			    {
-					this->emit_opcode(type.op, 3);
-					this->emit_id(id);
-					this->emit_id(type.parent_type);
+				    this->emit_opcode(type.op, 3);
+				    this->emit_id(id);
+				    this->emit_id(type.parent_type);
 				    this->emit_id(type.array[0]);
 			    }
 			    else
@@ -460,49 +462,44 @@ void CompilerSPIRV::emit_types()
 			    break;
 
 		    case Op::OpTypeStruct:
-			    this->emit_opcode(type.op, 1+type.member_types.size());
+			    this->emit_opcode(type.op, 1 + type.member_types.size());
 			    this->emit_id(id);
 			    for (auto member_id : type.member_types)
 			    {
 				    this->emit_id(member_id);
-				}
+			    }
 			    break;
 
-
-			case Op::OpTypePointer:
+		    case Op::OpTypePointer:
 			    this->emit_opcode(type.op, 3);
 			    this->emit_id(id);
 			    this->emit_id(type.storage);
 			    this->emit_id(type.parent_type);
 			    break;
-			}
-	    }
-	);
+		    }
+	    });
 
 	ir.for_each_typed_id<SPIRConstant>(
-		[this](ID id, SPIRConstant const_) 
-		{ 
-			Op opcode;
+	    [this](ID id, SPIRConstant const_)
+	    {
+		    Op opcode;
 		    auto type = this->get_type(const_.constant_type);
 
-			// SPIRConstant does itself not fully know what type it is.
-			// So we'll go looking.
-			// Additionally, we don't care what kind of float
-			// or integer scalar types are, so we use the op as the switch key.
+		    // SPIRConstant does itself not fully know what type it is.
+		    // So we'll go looking.
+		    // Additionally, we don't care what kind of float
+		    // or integer scalar types are, so we use the op as the switch key.
 		    switch (type.op)
 		    {
 		    case Op::OpTypeBool:
-				
-			    opcode = const_.scalar_u8() == 1 ? 
-					Op::OpConstantTrue :
-					Op::OpConstantFalse;
+
+			    opcode = const_.scalar_u8() == 1 ? Op::OpConstantTrue : Op::OpConstantFalse;
 
 			    this->emit_opcode(opcode, 2);
 			    this->emit_id(const_.constant_type);
 			    this->emit_id(id);
 			    break;
 
-			
 		    case Op::OpTypeInt:
 		    case Op::OpTypeFloat:
 			    this->emit_opcode(type.op, 3);
@@ -510,38 +507,33 @@ void CompilerSPIRV::emit_types()
 			    this->emit_id(id);
 			    this->emit_id(const_.scalar());
 			    break;
-
-
-			}
-		}
-	);
+		    }
+	    });
 
 	ir.for_each_typed_id<SPIRFunction>(
-		[this] (ID id, SPIRFunction func) { 
-			this->emit_opcode(Op::OpTypeFunction, 2 + func.arguments.size());
+	    [this](ID id, SPIRFunction func)
+	    {
+		    this->emit_opcode(Op::OpTypeFunction, 2 + func.arguments.size());
 		    this->emit_id(func.function_type);
 		    this->emit_id(func.return_type);
 		    for (auto &param : func.arguments)
 		    {
 			    this->emit_id(param.type);
-			}
-		}
-	);
+		    }
+	    });
 }
 
 void CompilerSPIRV::emit_function_defs()
 {
-
 }
 
 void CompilerSPIRV::emit_functions()
 {
-
 }
 
 void CompilerSPIRV::emit_opcode(Op opcode, uint32_t arglength)
 {
-	buffer.push_back(opcode + ((arglength+1) << 16));
+	buffer.push_back(opcode + ((arglength + 1) << 16));
 }
 
 void CompilerSPIRV::emit_id(uint32_t id)

--- a/spirv_spirv.cpp
+++ b/spirv_spirv.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2016-2021 The Brenwill Workshop Ltd.
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * At your option, you may choose to accept this material under either:
+ *  1. The Apache License, Version 2.0, found at <http://www.apache.org/licenses/LICENSE-2.0>, or
+ *  2. The MIT License, found at <http://opensource.org/licenses/MIT>.
+ */
+#include "spirv_spirv.hpp"
+
+using namespace spv;
+using namespace SPIRV_CROSS_NAMESPACE;
+using namespace std;
+
+CompilerSPIRV::CompilerSPIRV(std::vector<uint32_t> spirv_)
+    : Compiler(std::move(spirv_))
+{
+}
+
+CompilerSPIRV::CompilerSPIRV(const uint32_t *ir_, size_t word_count)
+    : Compiler(ir_, word_count)
+{
+}
+
+CompilerSPIRV::CompilerSPIRV(const ParsedIR &ir_)
+    : Compiler(ir_)
+{
+}
+
+CompilerSPIRV::CompilerSPIRV(ParsedIR &&ir_)
+    : Compiler(std::move(ir_))
+{
+}
+
+string CompilerSPIRV::compile()
+{
+	ir.fixup_reserved_names();
+	
+	this->emit_header();
+	this->emit_capabilities();
+	this->emit_ext_inst_imports();
+	this->emit_exec_info();
+}
+
+void CompilerSPIRV::emit_header()
+{
+	// Push header info to buffer
+	buffer.push_back(spv::MagicNumber);
+	buffer.push_back(ir.get_spirv_version());
+	buffer.push_back(0);
+	buffer.push_back(ir.ids.size());
+	buffer.push_back(0);
+}
+
+void CompilerSPIRV::emit_capabilities()
+{
+	for (spv::Capability cap : ir.declared_capabilities)
+	{
+		this->emit_opcode(Op::OpCapability);
+		this->emit_id(cap);
+	}
+}
+
+void CompilerSPIRV::emit_extensions()
+{
+	
+	for (string& ext: ir.declared_extensions)
+	{
+		this->emit_opcode(Op::OpExtension);
+		this->emit_string(ext);
+	}
+}
+
+void CompilerSPIRV::emit_ext_inst_imports()
+{
+	ir.for_each_typed_id<SPIRExtension>([this](ID id, SPIRExtension ext) {
+		if (ext.ext != SPIRExtension::Unsupported && ext.ext != SPIRExtension::NonSemanticGeneric)
+		{
+			this->emit_opcode(Op::OpExtInstImport);
+
+			switch (ext.ext)
+			{
+			default:
+				break;
+
+			case SPIRExtension::GLSL:
+				this->emit_string("GLSL.std.450");
+				break;
+
+			case SPIRExtension::SPV_debug_info:
+				this->emit_string("DebugInfo");
+				break;
+
+			case SPIRExtension::SPV_AMD_shader_ballot:
+				this->emit_string("SPV_AMD_shader_ballot");
+				break;
+
+			case SPIRExtension::SPV_AMD_shader_explicit_vertex_parameter:
+				this->emit_string("SPV_AMD_shader_explicit_vertex_parameter");
+				break;
+
+			case SPIRExtension::SPV_AMD_shader_trinary_minmax:
+				this->emit_string("SPV_AMD_shader_trinary_minmax");
+				break;
+
+			case SPIRExtension::SPV_AMD_gcn_shader:
+				this->emit_string("SPV_AMD_gcn_shader");
+				break;
+
+			case SPIRExtension::NonSemanticDebugPrintf:
+				this->emit_string("NonSemantic.DebugPrintf");
+				break;
+
+			case SPIRExtension::NonSemanticShaderDebugInfo:
+				this->emit_string("NonSemantic.Shader.DebugInfo.100");
+				break;
+
+			}
+		    
+		}
+	});
+}
+
+void CompilerSPIRV::emit_exec_info()
+{
+	// OpMemoryModel
+	this->emit_opcode(Op::OpMemoryModel, 2);
+	this->emit_id(ir.addressing_model);
+	this->emit_id(ir.memory_model);
+
+	// Emit entrypoints
+	for (auto& entrypoint : ir.entry_points)
+	{
+		auto functionId = entrypoint.first;
+		auto functionInfo = entrypoint.second;
+
+		this->emit_opcode(Op::OpEntryPoint, 3 + functionInfo.interface_variables.size());
+		this->emit_id(functionInfo.model);
+		this->emit_id(functionId);
+		this->emit_string(functionInfo.name);
+		for (auto &ifaceId : functionInfo.interface_variables)
+		{
+			this->emit_id(ifaceId);
+		}
+	}
+}
+
+void CompilerSPIRV::emit_opcode(Op opcode, uint32_t arglength = 0)
+{
+	buffer.push_back(opcode | ((arglength+1) << 16));
+}
+
+void CompilerSPIRV::emit_id(uint32_t id)
+{
+	buffer.push_back(id);
+}
+
+void CompilerSPIRV::emit_string(string str)
+{
+	// TODO implement
+}

--- a/spirv_spirv.cpp
+++ b/spirv_spirv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 The Brenwill Workshop Ltd.
+ * Copyright 2024 Kitsunebi Games
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/spirv_spirv.hpp
+++ b/spirv_spirv.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 Kitsunebi Games
+ * Copyright 2024 Kitsunebi Games
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,7 @@
 #ifndef SPIRV_CROSS_SPIRV_HPP
 #define SPIRV_CROSS_SPIRV_HPP
 
-#include "spirv_cross.hpp"
+#include "spirv_glsl.hpp"
 #include <vector>
 #include <map>
 #include <set>
@@ -32,7 +32,7 @@
 
 namespace SPIRV_CROSS_NAMESPACE
 {
-class CompilerSPIRV : public Compiler
+class CompilerSPIRV : public CompilerGLSL
 {
 public:
 	explicit CompilerSPIRV(std::vector<uint32_t> spirv);
@@ -45,12 +45,17 @@ public:
 private:
 	std::vector<uint32_t> buffer;
 
+	// The different stages of emitting SPIRV.
 	void emit_header();
 	void emit_capabilities();
 	void emit_extensions();
 	void emit_ext_inst_imports();
 	void emit_exec_info();
+	void emit_types();
+	void emit_function_defs();
+	void emit_functions();
 
+	// Helper functions
 	void emit_opcode(spv::Op opcode, uint32_t arglength = 0);
 	void emit_id(uint32_t id);
 	void emit_string(std::vector<uint32_t> str);

--- a/spirv_spirv.hpp
+++ b/spirv_spirv.hpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015-2021 Arm Limited
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * At your option, you may choose to accept this material under either:
+ *  1. The Apache License, Version 2.0, found at <http://www.apache.org/licenses/LICENSE-2.0>, or
+ *  2. The MIT License, found at <http://opensource.org/licenses/MIT>.
+ */
+
+#ifndef SPIRV_CROSS_SPIRV_HPP
+#define SPIRV_CROSS_SPIRV_HPP
+
+#include "spirv_cross.hpp"
+#include <vector>
+#include <map>
+#include <set>
+#include <stddef.h>
+
+namespace SPIRV_CROSS_NAMESPACE
+{
+class CompilerSPIRV : public Compiler
+{
+public:
+	explicit CompilerSPIRV(std::vector<uint32_t> spirv);
+	CompilerSPIRV(const uint32_t *ir, size_t word_count);
+	explicit CompilerSPIRV(const ParsedIR &ir);
+	explicit CompilerSPIRV(ParsedIR &&ir);
+
+	std::string compile() override;
+
+private:
+	std::vector<uint32_t> buffer;
+
+	void emit_header();
+	void emit_capabilities();
+	void emit_extensions();
+	void emit_ext_inst_imports();
+	void emit_exec_info();
+
+	void emit_opcode(spv::Op opcode, uint32_t arglength = 0);
+	void emit_id(uint32_t id);
+	void emit_string(std::string str);
+};
+} // namespace SPIRV_CROSS_NAMESPACE
+
+#endif

--- a/spirv_spirv.hpp
+++ b/spirv_spirv.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 Arm Limited
+ * Copyright 2015-2021 Kitsunebi Games
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/spirv_spirv.hpp
+++ b/spirv_spirv.hpp
@@ -51,6 +51,7 @@ private:
 	void emit_extensions();
 	void emit_ext_inst_imports();
 	void emit_exec_info();
+	void emit_annotations();
 	void emit_types();
 	void emit_function_defs();
 	void emit_functions();
@@ -60,6 +61,13 @@ private:
 	void emit_id(uint32_t id);
 	void emit_string(std::vector<uint32_t> str);
 	std::vector<uint32_t> get_spirv_string(std::string str);
+
+	// Decoration helpers
+	std::vector<spv::Decoration> get_decoration_list(Meta::Decoration decoration);
+	void emit_decorations(ID id, Meta::Decoration decoration);
+	void emit_decorations_member(uint32_t offset, ID id, Meta::Decoration decoration);
+	void emit_decorations_operand(spv::Decoration decoration, Meta::Decoration meta);
+	bool has_decorations(Meta::Decoration decoration);
 };
 } // namespace SPIRV_CROSS_NAMESPACE
 

--- a/spirv_spirv.hpp
+++ b/spirv_spirv.hpp
@@ -53,7 +53,8 @@ private:
 
 	void emit_opcode(spv::Op opcode, uint32_t arglength = 0);
 	void emit_id(uint32_t id);
-	void emit_string(std::string str);
+	void emit_string(std::vector<uint32_t> str);
+	std::vector<uint32_t> get_spirv_string(std::string str);
 };
 } // namespace SPIRV_CROSS_NAMESPACE
 

--- a/spirv_spirv.hpp
+++ b/spirv_spirv.hpp
@@ -25,10 +25,10 @@
 #define SPIRV_CROSS_SPIRV_HPP
 
 #include "spirv_glsl.hpp"
-#include <vector>
 #include <map>
 #include <set>
 #include <stddef.h>
+#include <vector>
 
 namespace SPIRV_CROSS_NAMESPACE
 {


### PR DESCRIPTION
As stated in issue #2387, I am working on a `CompilerSPIRV` to allow emitting SPIRV after reflection.
My plan is to only support simple modifications to the SPIRV, such as decorator changes.