### PR TITLE
Allow empty structs in legacy HLSL

### DIFF
--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -6725,6 +6725,7 @@ string CompilerHLSL::compile()
 	backend.support_case_fallthrough = false;
 	backend.force_merged_mesh_block = get_execution_model() == ExecutionModelMeshEXT;
 	backend.force_gl_in_out_block = backend.force_merged_mesh_block;
+	backend.supports_empty_struct = hlsl_options.shader_model <= 30;
 
 	// SM 4.1 does not support precise for some reason.
 	backend.support_precise_qualifier = hlsl_options.shader_model >= 50 || hlsl_options.shader_model == 40;


### PR DESCRIPTION
There's no good reason to write out a dummy member in an empty struct in legacy HLSL, and doing so can use up an extra constant register.

It may not be necessary in non-legacy HLSL either, but I am unable to test that extensively at this time.