### PR TITLE
MSL: Work around internal compiler error from mulhi.

### DIFF
--- a/reference/opt/shaders-msl/asm/comp/uint_smulextended.asm.comp
+++ b/reference/opt/shaders-msl/asm/comp/uint_smulextended.asm.comp
@@ -1,7 +1,15 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
 #include <metal_stdlib>
 #include <simd/simd.h>
 
 using namespace metal;
+
+template<typename T, typename U, typename V>
+[[clang::optnone]] T spvMulExtended(V l, V r)
+{
+    return T{U(l * r), U(mulhi(l, r))};
+}
 
 struct _4
 {
@@ -16,9 +24,7 @@ struct _20
 
 kernel void main0(device _4& _5 [[buffer(0)]], device _4& _6 [[buffer(1)]], device _4& _7 [[buffer(2)]], device _4& _8 [[buffer(3)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
-    _20 _28;
-    _28._m0 = int(_5._m0[gl_GlobalInvocationID.x]) * int(_6._m0[gl_GlobalInvocationID.x]);
-    _28._m1 = mulhi(int(_5._m0[gl_GlobalInvocationID.x]), int(_6._m0[gl_GlobalInvocationID.x]));
+    _20 _28 = spvMulExtended<_20, uint>(int(_5._m0[gl_GlobalInvocationID.x]), int(_6._m0[gl_GlobalInvocationID.x]));
     _7._m0[gl_GlobalInvocationID.x] = _28._m0;
     _8._m0[gl_GlobalInvocationID.x] = _28._m1;
 }

--- a/reference/opt/shaders-msl/asm/comp/ulong_smulextended.asm.msl23.comp
+++ b/reference/opt/shaders-msl/asm/comp/ulong_smulextended.asm.msl23.comp
@@ -1,7 +1,15 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
 #include <metal_stdlib>
 #include <simd/simd.h>
 
 using namespace metal;
+
+template<typename T, typename U, typename V>
+[[clang::optnone]] T spvMulExtended(V l, V r)
+{
+    return T{U(l * r), U(mulhi(l, r))};
+}
 
 struct _4
 {
@@ -16,9 +24,7 @@ struct _21
 
 kernel void main0(device _4& _5 [[buffer(0)]], device _4& _6 [[buffer(1)]], device _4& _7 [[buffer(2)]], device _4& _8 [[buffer(3)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
-    _21 _29;
-    _29._m0 = long(_5._m0[gl_GlobalInvocationID.x]) * long(_6._m0[gl_GlobalInvocationID.x]);
-    _29._m1 = mulhi(long(_5._m0[gl_GlobalInvocationID.x]), long(_6._m0[gl_GlobalInvocationID.x]));
+    _21 _29 = spvMulExtended<_21, ulong>(long(_5._m0[gl_GlobalInvocationID.x]), long(_6._m0[gl_GlobalInvocationID.x]));
     _7._m0[gl_GlobalInvocationID.x] = _29._m0;
     _8._m0[gl_GlobalInvocationID.x] = _29._m1;
 }

--- a/reference/opt/shaders-msl/desktop-only/comp/extended-arithmetic.desktop.comp
+++ b/reference/opt/shaders-msl/desktop-only/comp/extended-arithmetic.desktop.comp
@@ -1,7 +1,15 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
 #include <metal_stdlib>
 #include <simd/simd.h>
 
 using namespace metal;
+
+template<typename T, typename U, typename V>
+[[clang::optnone]] T spvMulExtended(V l, V r)
+{
+    return T{U(l * r), U(mulhi(l, r))};
+}
 
 struct SSBOUint
 {
@@ -135,44 +143,28 @@ kernel void main0(device SSBOUint& u [[buffer(0)]], device SSBOInt& i [[buffer(1
     _106._m1 = select(uint4(1), uint4(0), u.a4 >= u.b4);
     u.d4 = _106._m1;
     u.c4 = _106._m0;
-    ResType _116;
-    _116._m0 = u.a * u.b;
-    _116._m1 = mulhi(u.a, u.b);
+    ResType _116 = spvMulExtended<ResType, uint>(u.a, u.b);
     u.d = _116._m0;
     u.c = _116._m1;
-    ResType_1 _125;
-    _125._m0 = u.a2 * u.b2;
-    _125._m1 = mulhi(u.a2, u.b2);
+    ResType_1 _125 = spvMulExtended<ResType_1, uint2>(u.a2, u.b2);
     u.d2 = _125._m0;
     u.c2 = _125._m1;
-    ResType_2 _134;
-    _134._m0 = u.a3 * u.b3;
-    _134._m1 = mulhi(u.a3, u.b3);
+    ResType_2 _134 = spvMulExtended<ResType_2, uint3>(u.a3, u.b3);
     u.d3 = _134._m0;
     u.c3 = _134._m1;
-    ResType_3 _143;
-    _143._m0 = u.a4 * u.b4;
-    _143._m1 = mulhi(u.a4, u.b4);
+    ResType_3 _143 = spvMulExtended<ResType_3, uint4>(u.a4, u.b4);
     u.d4 = _143._m0;
     u.c4 = _143._m1;
-    ResType_4 _160;
-    _160._m0 = i.a * i.b;
-    _160._m1 = mulhi(i.a, i.b);
+    ResType_4 _160 = spvMulExtended<ResType_4, int>(i.a, i.b);
     i.d = _160._m0;
     i.c = _160._m1;
-    ResType_5 _171;
-    _171._m0 = i.a2 * i.b2;
-    _171._m1 = mulhi(i.a2, i.b2);
+    ResType_5 _171 = spvMulExtended<ResType_5, int2>(i.a2, i.b2);
     i.d2 = _171._m0;
     i.c2 = _171._m1;
-    ResType_6 _182;
-    _182._m0 = i.a3 * i.b3;
-    _182._m1 = mulhi(i.a3, i.b3);
+    ResType_6 _182 = spvMulExtended<ResType_6, int3>(i.a3, i.b3);
     i.d3 = _182._m0;
     i.c3 = _182._m1;
-    ResType_7 _193;
-    _193._m0 = i.a4 * i.b4;
-    _193._m1 = mulhi(i.a4, i.b4);
+    ResType_7 _193 = spvMulExtended<ResType_7, int4>(i.a4, i.b4);
     i.d4 = _193._m0;
     i.c4 = _193._m1;
 }

--- a/reference/shaders-msl/asm/comp/uint_smulextended.asm.comp
+++ b/reference/shaders-msl/asm/comp/uint_smulextended.asm.comp
@@ -1,7 +1,15 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
 #include <metal_stdlib>
 #include <simd/simd.h>
 
 using namespace metal;
+
+template<typename T, typename U, typename V>
+[[clang::optnone]] T spvMulExtended(V l, V r)
+{
+    return T{U(l * r), U(mulhi(l, r))};
+}
 
 struct _4
 {
@@ -16,9 +24,7 @@ struct _20
 
 kernel void main0(device _4& _5 [[buffer(0)]], device _4& _6 [[buffer(1)]], device _4& _7 [[buffer(2)]], device _4& _8 [[buffer(3)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
-    _20 _28;
-    _28._m0 = int(_5._m0[gl_GlobalInvocationID.x]) * int(_6._m0[gl_GlobalInvocationID.x]);
-    _28._m1 = mulhi(int(_5._m0[gl_GlobalInvocationID.x]), int(_6._m0[gl_GlobalInvocationID.x]));
+    _20 _28 = spvMulExtended<_20, uint>(int(_5._m0[gl_GlobalInvocationID.x]), int(_6._m0[gl_GlobalInvocationID.x]));
     _7._m0[gl_GlobalInvocationID.x] = _28._m0;
     _8._m0[gl_GlobalInvocationID.x] = _28._m1;
 }

--- a/reference/shaders-msl/asm/comp/ulong_smulextended.asm.msl23.comp
+++ b/reference/shaders-msl/asm/comp/ulong_smulextended.asm.msl23.comp
@@ -1,7 +1,15 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
 #include <metal_stdlib>
 #include <simd/simd.h>
 
 using namespace metal;
+
+template<typename T, typename U, typename V>
+[[clang::optnone]] T spvMulExtended(V l, V r)
+{
+    return T{U(l * r), U(mulhi(l, r))};
+}
 
 struct _4
 {
@@ -16,9 +24,7 @@ struct _21
 
 kernel void main0(device _4& _5 [[buffer(0)]], device _4& _6 [[buffer(1)]], device _4& _7 [[buffer(2)]], device _4& _8 [[buffer(3)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
-    _21 _29;
-    _29._m0 = long(_5._m0[gl_GlobalInvocationID.x]) * long(_6._m0[gl_GlobalInvocationID.x]);
-    _29._m1 = mulhi(long(_5._m0[gl_GlobalInvocationID.x]), long(_6._m0[gl_GlobalInvocationID.x]));
+    _21 _29 = spvMulExtended<_21, ulong>(long(_5._m0[gl_GlobalInvocationID.x]), long(_6._m0[gl_GlobalInvocationID.x]));
     _7._m0[gl_GlobalInvocationID.x] = _29._m0;
     _8._m0[gl_GlobalInvocationID.x] = _29._m1;
 }

--- a/reference/shaders-msl/desktop-only/comp/extended-arithmetic.desktop.comp
+++ b/reference/shaders-msl/desktop-only/comp/extended-arithmetic.desktop.comp
@@ -1,7 +1,15 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
 #include <metal_stdlib>
 #include <simd/simd.h>
 
 using namespace metal;
+
+template<typename T, typename U, typename V>
+[[clang::optnone]] T spvMulExtended(V l, V r)
+{
+    return T{U(l * r), U(mulhi(l, r))};
+}
 
 struct SSBOUint
 {
@@ -135,44 +143,28 @@ kernel void main0(device SSBOUint& u [[buffer(0)]], device SSBOInt& i [[buffer(1
     _106._m1 = select(uint4(1), uint4(0), u.a4 >= u.b4);
     u.d4 = _106._m1;
     u.c4 = _106._m0;
-    ResType _116;
-    _116._m0 = u.a * u.b;
-    _116._m1 = mulhi(u.a, u.b);
+    ResType _116 = spvMulExtended<ResType, uint>(u.a, u.b);
     u.d = _116._m0;
     u.c = _116._m1;
-    ResType_1 _125;
-    _125._m0 = u.a2 * u.b2;
-    _125._m1 = mulhi(u.a2, u.b2);
+    ResType_1 _125 = spvMulExtended<ResType_1, uint2>(u.a2, u.b2);
     u.d2 = _125._m0;
     u.c2 = _125._m1;
-    ResType_2 _134;
-    _134._m0 = u.a3 * u.b3;
-    _134._m1 = mulhi(u.a3, u.b3);
+    ResType_2 _134 = spvMulExtended<ResType_2, uint3>(u.a3, u.b3);
     u.d3 = _134._m0;
     u.c3 = _134._m1;
-    ResType_3 _143;
-    _143._m0 = u.a4 * u.b4;
-    _143._m1 = mulhi(u.a4, u.b4);
+    ResType_3 _143 = spvMulExtended<ResType_3, uint4>(u.a4, u.b4);
     u.d4 = _143._m0;
     u.c4 = _143._m1;
-    ResType_4 _160;
-    _160._m0 = i.a * i.b;
-    _160._m1 = mulhi(i.a, i.b);
+    ResType_4 _160 = spvMulExtended<ResType_4, int>(i.a, i.b);
     i.d = _160._m0;
     i.c = _160._m1;
-    ResType_5 _171;
-    _171._m0 = i.a2 * i.b2;
-    _171._m1 = mulhi(i.a2, i.b2);
+    ResType_5 _171 = spvMulExtended<ResType_5, int2>(i.a2, i.b2);
     i.d2 = _171._m0;
     i.c2 = _171._m1;
-    ResType_6 _182;
-    _182._m0 = i.a3 * i.b3;
-    _182._m1 = mulhi(i.a3, i.b3);
+    ResType_6 _182 = spvMulExtended<ResType_6, int3>(i.a3, i.b3);
     i.d3 = _182._m0;
     i.c3 = _182._m1;
-    ResType_7 _193;
-    _193._m0 = i.a4 * i.b4;
-    _193._m1 = mulhi(i.a4, i.b4);
+    ResType_7 _193 = spvMulExtended<ResType_7, int4>(i.a4, i.b4);
     i.d4 = _193._m0;
     i.c4 = _193._m1;
 }

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -838,7 +838,8 @@ protected:
 		SPVFuncImplPaddedStd140,
 		SPVFuncImplReduceAdd,
 		SPVFuncImplImageFence,
-		SPVFuncImplTextureCast
+		SPVFuncImplTextureCast,
+		SPVFuncImplMulExtended,
 	};
 
 	// If the underlying resource has been used for comparison then duplicate loads of that resource must be too


### PR DESCRIPTION
Proposed fix for https://github.com/KhronosGroup/SPIRV-Cross/issues/2385

This introduces a helper function to perform `Op*MulExtended` instructions. The helper takes the following template parameters:
* The type of the result container.
* The type of the operands and result container fields. This is needed because `OpSMulExtended` can be used with unsigned types but will perform signed multiplication. The inputs are cast to signed to perform correct multiplication, and the results need to be cast back to unsigned afterwards in order to satisfy Metal/C++ rules for initializer list types.
* The type the function will use to multiply arguments, based on the instruction.

Updated the tests for these changes, and the shader in the linked issue now compiles without error.