### PR TITLE
MSL: Allow Centroid and Sample decorations on bary coord.

### DIFF
--- a/reference/shaders-msl-no-opt/asm/frag/barycentric-centroid-noperspective.msl22.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/barycentric-centroid-noperspective.msl22.asm.frag
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float3 value [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 gl_BaryCoordNoPerspEXT [[barycentric_coord, centroid_no_perspective]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    out.value = in.gl_BaryCoordNoPerspEXT;
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/asm/frag/barycentric-centroid-perspective.msl22.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/barycentric-centroid-perspective.msl22.asm.frag
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float3 value [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 gl_BaryCoordEXT [[barycentric_coord, centroid_perspective]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    out.value = in.gl_BaryCoordEXT;
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/asm/frag/barycentric-sample-noperspective.msl22.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/barycentric-sample-noperspective.msl22.asm.frag
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float3 value [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 gl_BaryCoordNoPerspEXT [[barycentric_coord, sample_no_perspective]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    out.value = in.gl_BaryCoordNoPerspEXT;
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/asm/frag/barycentric-sample-perspective.msl22.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/barycentric-sample-perspective.msl22.asm.frag
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float3 value [[color(0)]];
+};
+
+struct main0_in
+{
+    float3 gl_BaryCoordEXT [[barycentric_coord, sample_perspective]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    out.value = in.gl_BaryCoordEXT;
+    return out;
+}
+

--- a/shaders-msl-no-opt/asm/frag/barycentric-centroid-noperspective.msl22.asm.frag
+++ b/shaders-msl-no-opt/asm/frag/barycentric-centroid-noperspective.msl22.asm.frag
@@ -1,0 +1,34 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 11
+; Bound: 13
+; Schema: 0
+               OpCapability Shader
+               OpCapability FragmentBarycentricKHR
+               OpExtension "SPV_KHR_fragment_shader_barycentric"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %value %gl_BaryCoordEXT
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_fragment_shader_barycentric"
+               OpName %main "main"
+               OpName %value "value"
+               OpName %gl_BaryCoordEXT "gl_BaryCoordEXT"
+               OpDecorate %value Location 0
+               OpDecorate %gl_BaryCoordEXT BuiltIn BaryCoordNoPerspKHR
+               OpDecorate %gl_BaryCoordEXT Centroid
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+      %value = OpVariable %_ptr_Output_v3float Output
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+%gl_BaryCoordEXT = OpVariable %_ptr_Input_v3float Input
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %12 = OpLoad %v3float %gl_BaryCoordEXT
+               OpStore %value %12
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/frag/barycentric-centroid-perspective.msl22.asm.frag
+++ b/shaders-msl-no-opt/asm/frag/barycentric-centroid-perspective.msl22.asm.frag
@@ -1,0 +1,34 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 11
+; Bound: 13
+; Schema: 0
+               OpCapability Shader
+               OpCapability FragmentBarycentricKHR
+               OpExtension "SPV_KHR_fragment_shader_barycentric"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %value %gl_BaryCoordEXT
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_fragment_shader_barycentric"
+               OpName %main "main"
+               OpName %value "value"
+               OpName %gl_BaryCoordEXT "gl_BaryCoordEXT"
+               OpDecorate %value Location 0
+               OpDecorate %gl_BaryCoordEXT BuiltIn BaryCoordKHR
+               OpDecorate %gl_BaryCoordEXT Centroid
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+      %value = OpVariable %_ptr_Output_v3float Output
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+%gl_BaryCoordEXT = OpVariable %_ptr_Input_v3float Input
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %12 = OpLoad %v3float %gl_BaryCoordEXT
+               OpStore %value %12
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/frag/barycentric-sample-noperspective.msl22.asm.frag
+++ b/shaders-msl-no-opt/asm/frag/barycentric-sample-noperspective.msl22.asm.frag
@@ -1,0 +1,35 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 11
+; Bound: 13
+; Schema: 0
+               OpCapability Shader
+               OpCapability SampleRateShading
+               OpCapability FragmentBarycentricKHR
+               OpExtension "SPV_KHR_fragment_shader_barycentric"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %value %gl_BaryCoordEXT
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_fragment_shader_barycentric"
+               OpName %main "main"
+               OpName %value "value"
+               OpName %gl_BaryCoordEXT "gl_BaryCoordEXT"
+               OpDecorate %value Location 0
+               OpDecorate %gl_BaryCoordEXT BuiltIn BaryCoordNoPerspKHR
+               OpDecorate %gl_BaryCoordEXT Sample
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+      %value = OpVariable %_ptr_Output_v3float Output
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+%gl_BaryCoordEXT = OpVariable %_ptr_Input_v3float Input
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %12 = OpLoad %v3float %gl_BaryCoordEXT
+               OpStore %value %12
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/frag/barycentric-sample-perspective.msl22.asm.frag
+++ b/shaders-msl-no-opt/asm/frag/barycentric-sample-perspective.msl22.asm.frag
@@ -1,0 +1,35 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 11
+; Bound: 13
+; Schema: 0
+               OpCapability Shader
+               OpCapability SampleRateShading
+               OpCapability FragmentBarycentricKHR
+               OpExtension "SPV_KHR_fragment_shader_barycentric"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %value %gl_BaryCoordEXT
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_fragment_shader_barycentric"
+               OpName %main "main"
+               OpName %value "value"
+               OpName %gl_BaryCoordEXT "gl_BaryCoordEXT"
+               OpDecorate %value Location 0
+               OpDecorate %gl_BaryCoordEXT BuiltIn BaryCoordKHR
+               OpDecorate %gl_BaryCoordEXT Sample
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+      %value = OpVariable %_ptr_Output_v3float Output
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+%gl_BaryCoordEXT = OpVariable %_ptr_Input_v3float Input
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %12 = OpLoad %v3float %gl_BaryCoordEXT
+               OpStore %value %12
+               OpReturn
+               OpFunctionEnd


### PR DESCRIPTION
glslang doesn't seem to support this, so need asm shaders.