### PR TITLE
Add CI/CD for Apple mobile platforms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,73 @@ jobs:
         shell: bash
         working-directory: ${{github.workspace}}/build
         run: ctest --verbose -C Release
+
+  build-mobile:
+    name: "Build ${{ matrix.sdk }}"
+    strategy:
+      matrix:
+        include:
+          - platform: iOS
+            sdk: iphoneos
+            architectures: arm64
+          - platform: iOS
+            sdk: iphonesimulator
+            architectures: x86_64;arm64
+          - platform: tvOS
+            sdk: appletvos
+            architectures: arm64
+          - platform: tvOS
+            sdk: appletvsimulator
+            architectures: x86_64;arm64
+    env:
+      PARALLEL: -j 2
+
+    runs-on: "macos-latest"
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Cache glslang / SPIRV-Tools
+        id: cache-externals
+        uses: actions/cache@v3
+        with:
+          path: external/*-build/output
+          key: ${{ matrix.platform }} externals ${{ hashFiles('checkout_glslang_spirv_tools.sh', 'build_glslang_spirv_tools.sh') }}
+
+      - name: Pull glslang / SPIRV-Tools
+        if: steps.cache-externals.outputs.cache-hit != 'true'
+        shell: bash
+        working-directory: ${{github.workspace}}
+        run: ./checkout_glslang_spirv_tools.sh
+
+      - name: Build glslang / SPIRV-Tools
+        if: steps.cache-externals.outputs.cache-hit != 'true'
+        shell: bash
+        working-directory: ${{github.workspace}}
+        run: ./build_glslang_spirv_tools.sh Release 4
+
+      - name: Configure SPIRV-Cross
+        shell: bash
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DSPIRV_CROSS_WERROR=ON -DSPIRV_CROSS_MISC_WARNINGS=ON -DSPIRV_CROSS_SHARED=ON -DCMAKE_INSTALL_PREFIX=output -DCMAKE_BUILD_TYPE=Release -DSPIRV_CROSS_ENABLE_TESTS=ON -DCMAKE_SYSTEM_NAME=${{ matrix.platform }} -DCMAKE_OSX_ARCHITECTURES="${{ matrix.architectures }}" -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 -DCMAKE_OSX_SYSROOT=`xcodebuild -version -sdk ${{ matrix.sdk }} Path` -DBUILD_SHARED_LIBS=OFF
+
+      - name: Build SPIRV-Cross
+        shell: bash
+        working-directory: ${{github.workspace}}/build
+        run: |
+          cmake --build . --config Release --parallel 4
+          cmake --build . --config Release --target install
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.sdk }}-binaries
+          path: build/output
+
   reuse:
     name: "REUSE license check"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Unsure how much interest there is in this, but since we'll be using SPIRV-Cross on several Apple platforms, I've updated the CI/CD to build for Apple's other various platforms locally, and have successfully used the results on an iPhone.