### PR TITLE
MSL: added mesh-shader support

### DIFF
--- a/reference/opt/shaders-msl/mesh/mesh-shader-basic-lines.msl3.spv14.vk.nocompat.mesh
+++ b/reference/opt/shaders-msl/mesh/mesh-shader-basic-lines.msl3.spv14.vk.nocompat.mesh
@@ -1,0 +1,211 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wmissing-braces"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+template<typename T, size_t Num>
+struct spvUnsafeArray
+{
+    T elements[Num ? Num : 1];
+    
+    thread T& operator [] (size_t pos) thread
+    {
+        return elements[pos];
+    }
+    constexpr const thread T& operator [] (size_t pos) const thread
+    {
+        return elements[pos];
+    }
+    
+    device T& operator [] (size_t pos) device
+    {
+        return elements[pos];
+    }
+    constexpr const device T& operator [] (size_t pos) const device
+    {
+        return elements[pos];
+    }
+    
+    constexpr const constant T& operator [] (size_t pos) const constant
+    {
+        return elements[pos];
+    }
+    
+    threadgroup T& operator [] (size_t pos) threadgroup
+    {
+        return elements[pos];
+    }
+    constexpr const threadgroup T& operator [] (size_t pos) const threadgroup
+    {
+        return elements[pos];
+    }
+    
+    object_data T& operator [] (size_t pos) object_data
+    {
+        return elements[pos];
+    }
+    constexpr const object_data T& operator [] (size_t pos) const object_data
+    {
+        return elements[pos];
+    }
+};
+
+void SetMeshOutputsEXT(thread uint gl_LocalInvocationIndex, threadgroup uint2& spvMeshSizes, uint vertexCount, uint primitiveCount)
+{
+    if (gl_LocalInvocationIndex == 0)
+    {
+        spvMeshSizes.x = vertexCount;
+        spvMeshSizes.y = primitiveCount;
+    }
+}
+
+struct gl_MeshPerPrimitiveEXT
+{
+    uint gl_PrimitiveID [[primitive_id]];
+    uint gl_Layer [[render_target_array_index]];
+    uint gl_ViewportIndex [[viewport_array_index]];
+    bool gl_CullPrimitiveEXT [[primitive_culled]];
+};
+
+struct gl_MeshPerVertexEXT
+{
+    float4 gl_Position [[position]];
+    float gl_PointSize;
+    float gl_ClipDistance [[clip_distance]] [1];
+    float gl_CullDistance [[cull_distance]] [2];
+};
+
+struct BlockOut
+{
+    float4 a;
+    float4 b;
+};
+
+struct BlockOutPrim
+{
+    float4 a;
+    float4 b;
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(2u, 3u, 4u);
+
+struct TaskPayload
+{
+    float a;
+    float b;
+    int c;
+};
+
+struct spvPerVertex
+{
+    float4 gl_Position [[position]];
+    float gl_PointSize;
+    float gl_ClipDistance [[clip_distance]] [1];
+    float gl_ClipDistance_0 [[user(clip0)]];
+    float gl_CullDistance_0 [[user(cull0)]];
+    float gl_CullDistance_1 [[user(cull1)]];
+    float4 vOut [[user(locn0)]];
+    float4 outputs_a [[user(locn2)]];
+    float4 outputs_b [[user(locn3)]];
+};
+
+struct spvPerPrimitive
+{
+    int gl_PrimitiveID [[primitive_id]];
+    uint gl_Layer [[render_target_array_index]];
+    uint gl_ViewportIndex [[viewport_array_index]];
+    short gl_CullPrimitiveEXT [[primitive_culled]];
+    float4 vPrim [[user(locn1)]];
+    float4 prim_outputs_a [[user(locn4)]];
+    float4 prim_outputs_b [[user(locn5)]];
+};
+
+using spvMesh_t = mesh<spvPerVertex, spvPerPrimitive, 24, 22, topology::line>;
+
+static inline __attribute__((always_inline))
+void _4(threadgroup spvUnsafeArray<uint2, 22>& gl_PrimitiveLineIndicesEXT, thread uint& gl_LocalInvocationIndex, threadgroup spvUnsafeArray<gl_MeshPerPrimitiveEXT, 22>& gl_MeshPrimitivesEXT, thread uint3& gl_GlobalInvocationID, threadgroup spvUnsafeArray<gl_MeshPerVertexEXT, 24>& gl_MeshVerticesEXT, threadgroup spvUnsafeArray<float4, 24>& vOut, threadgroup spvUnsafeArray<BlockOut, 24>& outputs, threadgroup spvUnsafeArray<float4, 22>& vPrim, thread uint3& gl_WorkGroupID, threadgroup spvUnsafeArray<BlockOutPrim, 22>& prim_outputs, threadgroup uint2& spvMeshSizes)
+{
+    SetMeshOutputsEXT(gl_LocalInvocationIndex, spvMeshSizes, 24u, 22u);
+    float3 _163 = float3(gl_GlobalInvocationID);
+    float _164 = _163.x;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position = float4(_164, _163.yz, 1.0);
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_PointSize = 2.0;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_ClipDistance[0] = 4.0;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[0] = 6.0;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[1] = 5.0;
+    vOut[gl_LocalInvocationIndex] = float4(_164, _163.yz, 2.0);
+    outputs[gl_LocalInvocationIndex].a = float4(5.0);
+    outputs[gl_LocalInvocationIndex].b = float4(6.0);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (gl_LocalInvocationIndex < 22u)
+    {
+        vPrim[gl_LocalInvocationIndex] = float4(float3(gl_WorkGroupID), 3.0);
+        prim_outputs[gl_LocalInvocationIndex].a = float4(0.0);
+        prim_outputs[gl_LocalInvocationIndex].b = float4(1.0);
+        gl_PrimitiveLineIndicesEXT[gl_LocalInvocationIndex] = uint2(0u, 1u) + uint2(gl_LocalInvocationIndex);
+        int _215 = int(gl_GlobalInvocationID.x);
+        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_PrimitiveID = _215;
+        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_Layer = _215 + 1;
+        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_ViewportIndex = _215 + 2;
+        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_CullPrimitiveEXT = short((gl_GlobalInvocationID.x & 1u) != 0u);
+    }
+}
+
+[[mesh]] void main0(uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]], spvMesh_t spvMesh)
+{
+    threadgroup uint2 spvMeshSizes;
+    threadgroup spvUnsafeArray<uint2, 22> gl_PrimitiveLineIndicesEXT;
+    threadgroup spvUnsafeArray<gl_MeshPerPrimitiveEXT, 22> gl_MeshPrimitivesEXT;
+    threadgroup spvUnsafeArray<gl_MeshPerVertexEXT, 24> gl_MeshVerticesEXT;
+    threadgroup spvUnsafeArray<float4, 24> vOut;
+    threadgroup spvUnsafeArray<BlockOut, 24> outputs;
+    threadgroup spvUnsafeArray<float4, 22> vPrim;
+    threadgroup spvUnsafeArray<BlockOutPrim, 22> prim_outputs;
+    threadgroup spvUnsafeArray<float, 16> shared_float;
+    _4(gl_PrimitiveLineIndicesEXT, gl_LocalInvocationIndex, gl_MeshPrimitivesEXT, gl_GlobalInvocationID, gl_MeshVerticesEXT, vOut, outputs, vPrim, gl_WorkGroupID, prim_outputs, spvMeshSizes);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (spvMeshSizes.y == 0)
+    {
+        return;
+    }
+    spvMesh.set_primitive_count(spvMeshSizes.y);
+    const uint spvThreadCount = (gl_WorkGroupSize.x*gl_WorkGroupSize.y*gl_WorkGroupSize.z);
+    if (gl_LocalInvocationIndex < 22)
+    {
+        const uint spvI = gl_LocalInvocationIndex;
+        spvMesh.set_index(spvI * 2u + 0u, gl_PrimitiveLineIndicesEXT[spvI].x);
+        spvMesh.set_index(spvI * 2u + 1u, gl_PrimitiveLineIndicesEXT[spvI].y);
+    }
+    {
+        const uint spvI = gl_LocalInvocationIndex;
+        spvPerVertex spvV = {};
+        spvV.gl_Position = gl_MeshVerticesEXT[spvI].gl_Position;
+        spvV.gl_PointSize = gl_MeshVerticesEXT[spvI].gl_PointSize;
+        spvV.gl_ClipDistance[0] = gl_MeshVerticesEXT[spvI].gl_ClipDistance[0];
+        spvV.gl_ClipDistance_0 = gl_MeshVerticesEXT[spvI].gl_ClipDistance[0];
+        spvV.gl_CullDistance[0] = gl_MeshVerticesEXT[spvI].gl_CullDistance[0];
+        spvV.gl_CullDistance_0 = gl_MeshVerticesEXT[spvI].gl_CullDistance[0];
+        spvV.gl_CullDistance[1] = gl_MeshVerticesEXT[spvI].gl_CullDistance[1];
+        spvV.gl_CullDistance_1 = gl_MeshVerticesEXT[spvI].gl_CullDistance[1];
+        spvV.outputs_a = outputs[spvI].a;
+        spvV.outputs_b = outputs[spvI].b;
+        spvMesh.set_vertex(spvI, spvV);
+    }
+    if (gl_LocalInvocationIndex < 22)
+    {
+        const uint spvI = gl_LocalInvocationIndex;
+        spvPerPrimitive spvP = {};
+        spvP.gl_PrimitiveID = gl_MeshPrimitivesEXT[spvI].gl_PrimitiveID;
+        spvP.gl_Layer = gl_MeshPrimitivesEXT[spvI].gl_Layer;
+        spvP.gl_ViewportIndex = gl_MeshPrimitivesEXT[spvI].gl_ViewportIndex;
+        spvP.gl_CullPrimitiveEXT = gl_MeshPrimitivesEXT[spvI].gl_CullPrimitiveEXT;
+        spvP.vPrim = vPrim[spvI];
+        spvP.prim_outputs_a = prim_outputs[spvI].a;
+        spvP.prim_outputs_b = prim_outputs[spvI].b;
+        spvMesh.set_primitive(spvI, spvP);
+    }
+}
+

--- a/reference/opt/shaders-msl/mesh/mesh-shader-basic-lines.msl3.spv14.vk.nocompat.mesh
+++ b/reference/opt/shaders-msl/mesh/mesh-shader-basic-lines.msl3.spv14.vk.nocompat.mesh
@@ -75,7 +75,6 @@ struct gl_MeshPerVertexEXT
     float4 gl_Position [[position]];
     float gl_PointSize;
     float gl_ClipDistance [[clip_distance]] [1];
-    float gl_CullDistance [[cull_distance]] [2];
 };
 
 struct BlockOut
@@ -105,8 +104,6 @@ struct spvPerVertex
     float gl_PointSize;
     float gl_ClipDistance [[clip_distance]] [1];
     float gl_ClipDistance_0 [[user(clip0)]];
-    float gl_CullDistance_0 [[user(cull0)]];
-    float gl_CullDistance_1 [[user(cull1)]];
     float4 vOut [[user(locn0)]];
     float4 outputs_a [[user(locn2)]];
     float4 outputs_b [[user(locn3)]];
@@ -114,10 +111,10 @@ struct spvPerVertex
 
 struct spvPerPrimitive
 {
-    int gl_PrimitiveID [[primitive_id]];
+    uint gl_PrimitiveID [[primitive_id]];
     uint gl_Layer [[render_target_array_index]];
     uint gl_ViewportIndex [[viewport_array_index]];
-    short gl_CullPrimitiveEXT [[primitive_culled]];
+    bool gl_CullPrimitiveEXT [[primitive_culled]];
     float4 vPrim [[user(locn1)]];
     float4 prim_outputs_a [[user(locn4)]];
     float4 prim_outputs_b [[user(locn5)]];
@@ -129,14 +126,12 @@ static inline __attribute__((always_inline))
 void _4(threadgroup spvUnsafeArray<uint2, 22>& gl_PrimitiveLineIndicesEXT, thread uint& gl_LocalInvocationIndex, threadgroup spvUnsafeArray<gl_MeshPerPrimitiveEXT, 22>& gl_MeshPrimitivesEXT, thread uint3& gl_GlobalInvocationID, threadgroup spvUnsafeArray<gl_MeshPerVertexEXT, 24>& gl_MeshVerticesEXT, threadgroup spvUnsafeArray<float4, 24>& vOut, threadgroup spvUnsafeArray<BlockOut, 24>& outputs, threadgroup spvUnsafeArray<float4, 22>& vPrim, thread uint3& gl_WorkGroupID, threadgroup spvUnsafeArray<BlockOutPrim, 22>& prim_outputs, threadgroup uint2& spvMeshSizes)
 {
     SetMeshOutputsEXT(gl_LocalInvocationIndex, spvMeshSizes, 24u, 22u);
-    float3 _163 = float3(gl_GlobalInvocationID);
-    float _164 = _163.x;
-    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position = float4(_164, _163.yz, 1.0);
+    float3 _158 = float3(gl_GlobalInvocationID);
+    float _159 = _158.x;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position = float4(_159, _158.yz, 1.0);
     gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_PointSize = 2.0;
     gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_ClipDistance[0] = 4.0;
-    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[0] = 6.0;
-    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[1] = 5.0;
-    vOut[gl_LocalInvocationIndex] = float4(_164, _163.yz, 2.0);
+    vOut[gl_LocalInvocationIndex] = float4(_159, _158.yz, 2.0);
     outputs[gl_LocalInvocationIndex].a = float4(5.0);
     outputs[gl_LocalInvocationIndex].b = float4(6.0);
     threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -146,10 +141,10 @@ void _4(threadgroup spvUnsafeArray<uint2, 22>& gl_PrimitiveLineIndicesEXT, threa
         prim_outputs[gl_LocalInvocationIndex].a = float4(0.0);
         prim_outputs[gl_LocalInvocationIndex].b = float4(1.0);
         gl_PrimitiveLineIndicesEXT[gl_LocalInvocationIndex] = uint2(0u, 1u) + uint2(gl_LocalInvocationIndex);
-        int _215 = int(gl_GlobalInvocationID.x);
-        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_PrimitiveID = _215;
-        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_Layer = _215 + 1;
-        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_ViewportIndex = _215 + 2;
+        int _206 = int(gl_GlobalInvocationID.x);
+        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_PrimitiveID = _206;
+        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_Layer = _206 + 1;
+        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_ViewportIndex = _206 + 2;
         gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_CullPrimitiveEXT = short((gl_GlobalInvocationID.x & 1u) != 0u);
     }
 }
@@ -186,10 +181,6 @@ void _4(threadgroup spvUnsafeArray<uint2, 22>& gl_PrimitiveLineIndicesEXT, threa
         spvV.gl_PointSize = gl_MeshVerticesEXT[spvI].gl_PointSize;
         spvV.gl_ClipDistance[0] = gl_MeshVerticesEXT[spvI].gl_ClipDistance[0];
         spvV.gl_ClipDistance_0 = gl_MeshVerticesEXT[spvI].gl_ClipDistance[0];
-        spvV.gl_CullDistance[0] = gl_MeshVerticesEXT[spvI].gl_CullDistance[0];
-        spvV.gl_CullDistance_0 = gl_MeshVerticesEXT[spvI].gl_CullDistance[0];
-        spvV.gl_CullDistance[1] = gl_MeshVerticesEXT[spvI].gl_CullDistance[1];
-        spvV.gl_CullDistance_1 = gl_MeshVerticesEXT[spvI].gl_CullDistance[1];
         spvV.outputs_a = outputs[spvI].a;
         spvV.outputs_b = outputs[spvI].b;
         spvMesh.set_vertex(spvI, spvV);

--- a/reference/opt/shaders-msl/mesh/mesh-shader-basic-lines.msl3.spv14.vk.nocompat.mesh
+++ b/reference/opt/shaders-msl/mesh/mesh-shader-basic-lines.msl3.spv14.vk.nocompat.mesh
@@ -91,13 +91,6 @@ struct BlockOutPrim
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(2u, 3u, 4u);
 
-struct TaskPayload
-{
-    float a;
-    float b;
-    int c;
-};
-
 struct spvPerVertex
 {
     float4 gl_Position [[position]];

--- a/reference/opt/shaders-msl/mesh/mesh-shader-basic-triangle.msl3.spv14.vk.nocompat.mesh
+++ b/reference/opt/shaders-msl/mesh/mesh-shader-basic-triangle.msl3.spv14.vk.nocompat.mesh
@@ -67,7 +67,6 @@ struct gl_MeshPerVertexEXT
     float4 gl_Position [[position]];
     float gl_PointSize;
     float gl_ClipDistance [[clip_distance]] [1];
-    float gl_CullDistance [[cull_distance]] [2];
 };
 
 struct BlockOut
@@ -88,7 +87,6 @@ struct gl_MeshPerPrimitiveEXT
     uint gl_Layer [[render_target_array_index]];
     uint gl_ViewportIndex [[viewport_array_index]];
     bool gl_CullPrimitiveEXT [[primitive_culled]];
-    
 };
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(2u, 3u, 4u);
@@ -106,8 +104,6 @@ struct spvPerVertex
     float gl_PointSize;
     float gl_ClipDistance [[clip_distance]] [1];
     float gl_ClipDistance_0 [[user(clip0)]];
-    float gl_CullDistance_0 [[user(cull0)]];
-    float gl_CullDistance_1 [[user(cull1)]];
     float4 vOut [[user(locn0)]];
     float4 outputs_a [[user(locn2)]];
     float4 outputs_b [[user(locn3)]];
@@ -118,11 +114,10 @@ struct spvPerPrimitive
     float4 vPrim [[user(locn1)]];
     float4 prim_outputs_a [[user(locn4)]];
     float4 prim_outputs_b [[user(locn5)]];
-    int gl_PrimitiveID [[primitive_id]];
+    uint gl_PrimitiveID [[primitive_id]];
     uint gl_Layer [[render_target_array_index]];
     uint gl_ViewportIndex [[viewport_array_index]];
-    short gl_CullPrimitiveEXT [[primitive_culled]];
-    int gl_PrimitiveShadingRateEXT [[unsupported-built-in]];
+    bool gl_CullPrimitiveEXT [[primitive_culled]];
 };
 
 using spvMesh_t = mesh<spvPerVertex, spvPerPrimitive, 24, 22, topology::triangle>;
@@ -131,14 +126,12 @@ static inline __attribute__((always_inline))
 void _4(threadgroup spvUnsafeArray<gl_MeshPerVertexEXT, 24>& gl_MeshVerticesEXT, thread uint& gl_LocalInvocationIndex, thread uint3& gl_GlobalInvocationID, threadgroup spvUnsafeArray<float4, 24>& vOut, threadgroup spvUnsafeArray<BlockOut, 24>& outputs, threadgroup spvUnsafeArray<float4, 22>& vPrim, thread uint3& gl_WorkGroupID, threadgroup spvUnsafeArray<BlockOutPrim, 22>& prim_outputs, threadgroup spvUnsafeArray<uint3, 22>& gl_PrimitiveTriangleIndicesEXT, threadgroup spvUnsafeArray<gl_MeshPerPrimitiveEXT, 22>& gl_MeshPrimitivesEXT, threadgroup uint2& spvMeshSizes)
 {
     SetMeshOutputsEXT(gl_LocalInvocationIndex, spvMeshSizes, 24u, 22u);
-    float3 _29 = float3(gl_GlobalInvocationID);
-    float _31 = _29.x;
-    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position = float4(_31, _29.yz, 1.0);
+    float3 _27 = float3(gl_GlobalInvocationID);
+    float _29 = _27.x;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position = float4(_29, _27.yz, 1.0);
     gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_PointSize = 2.0;
     gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_ClipDistance[0] = 4.0;
-    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[0] = 3.0;
-    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[1] = 5.0;
-    vOut[gl_LocalInvocationIndex] = float4(_31, _29.yz, 2.0);
+    vOut[gl_LocalInvocationIndex] = float4(_29, _27.yz, 2.0);
     outputs[gl_LocalInvocationIndex].a = float4(5.0);
     outputs[gl_LocalInvocationIndex].b = float4(6.0);
     threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -148,12 +141,11 @@ void _4(threadgroup spvUnsafeArray<gl_MeshPerVertexEXT, 24>& gl_MeshVerticesEXT,
         prim_outputs[gl_LocalInvocationIndex].a = float4(0.0);
         prim_outputs[gl_LocalInvocationIndex].b = float4(1.0);
         gl_PrimitiveTriangleIndicesEXT[gl_LocalInvocationIndex] = uint3(0u, 1u, 2u) + uint3(gl_LocalInvocationIndex);
-        int _122 = int(gl_GlobalInvocationID.x);
-        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_PrimitiveID = _122;
-        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_Layer = _122 + 1;
-        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_ViewportIndex = _122 + 2;
+        int _116 = int(gl_GlobalInvocationID.x);
+        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_PrimitiveID = _116;
+        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_Layer = _116 + 1;
+        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_ViewportIndex = _116 + 2;
         gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_CullPrimitiveEXT = short((gl_GlobalInvocationID.x & 1u) != 0u);
-        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_PrimitiveShadingRateEXT = _122 + 3;
     }
 }
 
@@ -190,10 +182,6 @@ void _4(threadgroup spvUnsafeArray<gl_MeshPerVertexEXT, 24>& gl_MeshVerticesEXT,
         spvV.gl_PointSize = gl_MeshVerticesEXT[spvI].gl_PointSize;
         spvV.gl_ClipDistance[0] = gl_MeshVerticesEXT[spvI].gl_ClipDistance[0];
         spvV.gl_ClipDistance_0 = gl_MeshVerticesEXT[spvI].gl_ClipDistance[0];
-        spvV.gl_CullDistance[0] = gl_MeshVerticesEXT[spvI].gl_CullDistance[0];
-        spvV.gl_CullDistance_0 = gl_MeshVerticesEXT[spvI].gl_CullDistance[0];
-        spvV.gl_CullDistance[1] = gl_MeshVerticesEXT[spvI].gl_CullDistance[1];
-        spvV.gl_CullDistance_1 = gl_MeshVerticesEXT[spvI].gl_CullDistance[1];
         spvV.outputs_a = outputs[spvI].a;
         spvV.outputs_b = outputs[spvI].b;
         spvMesh.set_vertex(spvI, spvV);
@@ -209,7 +197,6 @@ void _4(threadgroup spvUnsafeArray<gl_MeshPerVertexEXT, 24>& gl_MeshVerticesEXT,
         spvP.gl_Layer = gl_MeshPrimitivesEXT[spvI].gl_Layer;
         spvP.gl_ViewportIndex = gl_MeshPrimitivesEXT[spvI].gl_ViewportIndex;
         spvP.gl_CullPrimitiveEXT = gl_MeshPrimitivesEXT[spvI].gl_CullPrimitiveEXT;
-        spvP.gl_PrimitiveShadingRateEXT = gl_MeshPrimitivesEXT[spvI].gl_PrimitiveShadingRateEXT;
         spvMesh.set_primitive(spvI, spvP);
     }
 }

--- a/reference/opt/shaders-msl/mesh/mesh-shader-basic-triangle.msl3.spv14.vk.nocompat.mesh
+++ b/reference/opt/shaders-msl/mesh/mesh-shader-basic-triangle.msl3.spv14.vk.nocompat.mesh
@@ -1,0 +1,216 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wmissing-braces"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+template<typename T, size_t Num>
+struct spvUnsafeArray
+{
+    T elements[Num ? Num : 1];
+    
+    thread T& operator [] (size_t pos) thread
+    {
+        return elements[pos];
+    }
+    constexpr const thread T& operator [] (size_t pos) const thread
+    {
+        return elements[pos];
+    }
+    
+    device T& operator [] (size_t pos) device
+    {
+        return elements[pos];
+    }
+    constexpr const device T& operator [] (size_t pos) const device
+    {
+        return elements[pos];
+    }
+    
+    constexpr const constant T& operator [] (size_t pos) const constant
+    {
+        return elements[pos];
+    }
+    
+    threadgroup T& operator [] (size_t pos) threadgroup
+    {
+        return elements[pos];
+    }
+    constexpr const threadgroup T& operator [] (size_t pos) const threadgroup
+    {
+        return elements[pos];
+    }
+    
+    object_data T& operator [] (size_t pos) object_data
+    {
+        return elements[pos];
+    }
+    constexpr const object_data T& operator [] (size_t pos) const object_data
+    {
+        return elements[pos];
+    }
+};
+
+void SetMeshOutputsEXT(thread uint gl_LocalInvocationIndex, threadgroup uint2& spvMeshSizes, uint vertexCount, uint primitiveCount)
+{
+    if (gl_LocalInvocationIndex == 0)
+    {
+        spvMeshSizes.x = vertexCount;
+        spvMeshSizes.y = primitiveCount;
+    }
+}
+
+struct gl_MeshPerVertexEXT
+{
+    float4 gl_Position [[position]];
+    float gl_PointSize;
+    float gl_ClipDistance [[clip_distance]] [1];
+    float gl_CullDistance [[cull_distance]] [2];
+};
+
+struct BlockOut
+{
+    float4 a;
+    float4 b;
+};
+
+struct BlockOutPrim
+{
+    float4 a;
+    float4 b;
+};
+
+struct gl_MeshPerPrimitiveEXT
+{
+    uint gl_PrimitiveID [[primitive_id]];
+    uint gl_Layer [[render_target_array_index]];
+    uint gl_ViewportIndex [[viewport_array_index]];
+    bool gl_CullPrimitiveEXT [[primitive_culled]];
+    
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(2u, 3u, 4u);
+
+struct TaskPayload
+{
+    float a;
+    float b;
+    int c;
+};
+
+struct spvPerVertex
+{
+    float4 gl_Position [[position]];
+    float gl_PointSize;
+    float gl_ClipDistance [[clip_distance]] [1];
+    float gl_ClipDistance_0 [[user(clip0)]];
+    float gl_CullDistance_0 [[user(cull0)]];
+    float gl_CullDistance_1 [[user(cull1)]];
+    float4 vOut [[user(locn0)]];
+    float4 outputs_a [[user(locn2)]];
+    float4 outputs_b [[user(locn3)]];
+};
+
+struct spvPerPrimitive
+{
+    float4 vPrim [[user(locn1)]];
+    float4 prim_outputs_a [[user(locn4)]];
+    float4 prim_outputs_b [[user(locn5)]];
+    int gl_PrimitiveID [[primitive_id]];
+    uint gl_Layer [[render_target_array_index]];
+    uint gl_ViewportIndex [[viewport_array_index]];
+    short gl_CullPrimitiveEXT [[primitive_culled]];
+    int gl_PrimitiveShadingRateEXT [[unsupported-built-in]];
+};
+
+using spvMesh_t = mesh<spvPerVertex, spvPerPrimitive, 24, 22, topology::triangle>;
+
+static inline __attribute__((always_inline))
+void _4(threadgroup spvUnsafeArray<gl_MeshPerVertexEXT, 24>& gl_MeshVerticesEXT, thread uint& gl_LocalInvocationIndex, thread uint3& gl_GlobalInvocationID, threadgroup spvUnsafeArray<float4, 24>& vOut, threadgroup spvUnsafeArray<BlockOut, 24>& outputs, threadgroup spvUnsafeArray<float4, 22>& vPrim, thread uint3& gl_WorkGroupID, threadgroup spvUnsafeArray<BlockOutPrim, 22>& prim_outputs, threadgroup spvUnsafeArray<uint3, 22>& gl_PrimitiveTriangleIndicesEXT, threadgroup spvUnsafeArray<gl_MeshPerPrimitiveEXT, 22>& gl_MeshPrimitivesEXT, threadgroup uint2& spvMeshSizes)
+{
+    SetMeshOutputsEXT(gl_LocalInvocationIndex, spvMeshSizes, 24u, 22u);
+    float3 _29 = float3(gl_GlobalInvocationID);
+    float _31 = _29.x;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position = float4(_31, _29.yz, 1.0);
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_PointSize = 2.0;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_ClipDistance[0] = 4.0;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[0] = 3.0;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[1] = 5.0;
+    vOut[gl_LocalInvocationIndex] = float4(_31, _29.yz, 2.0);
+    outputs[gl_LocalInvocationIndex].a = float4(5.0);
+    outputs[gl_LocalInvocationIndex].b = float4(6.0);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (gl_LocalInvocationIndex < 22u)
+    {
+        vPrim[gl_LocalInvocationIndex] = float4(float3(gl_WorkGroupID), 3.0);
+        prim_outputs[gl_LocalInvocationIndex].a = float4(0.0);
+        prim_outputs[gl_LocalInvocationIndex].b = float4(1.0);
+        gl_PrimitiveTriangleIndicesEXT[gl_LocalInvocationIndex] = uint3(0u, 1u, 2u) + uint3(gl_LocalInvocationIndex);
+        int _122 = int(gl_GlobalInvocationID.x);
+        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_PrimitiveID = _122;
+        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_Layer = _122 + 1;
+        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_ViewportIndex = _122 + 2;
+        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_CullPrimitiveEXT = short((gl_GlobalInvocationID.x & 1u) != 0u);
+        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_PrimitiveShadingRateEXT = _122 + 3;
+    }
+}
+
+[[mesh]] void main0(uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]], spvMesh_t spvMesh)
+{
+    threadgroup uint2 spvMeshSizes;
+    threadgroup spvUnsafeArray<gl_MeshPerVertexEXT, 24> gl_MeshVerticesEXT;
+    threadgroup spvUnsafeArray<float4, 24> vOut;
+    threadgroup spvUnsafeArray<BlockOut, 24> outputs;
+    threadgroup spvUnsafeArray<float4, 22> vPrim;
+    threadgroup spvUnsafeArray<BlockOutPrim, 22> prim_outputs;
+    threadgroup spvUnsafeArray<uint3, 22> gl_PrimitiveTriangleIndicesEXT;
+    threadgroup spvUnsafeArray<gl_MeshPerPrimitiveEXT, 22> gl_MeshPrimitivesEXT;
+    threadgroup spvUnsafeArray<float, 16> shared_float;
+    _4(gl_MeshVerticesEXT, gl_LocalInvocationIndex, gl_GlobalInvocationID, vOut, outputs, vPrim, gl_WorkGroupID, prim_outputs, gl_PrimitiveTriangleIndicesEXT, gl_MeshPrimitivesEXT, spvMeshSizes);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (spvMeshSizes.y == 0)
+    {
+        return;
+    }
+    spvMesh.set_primitive_count(spvMeshSizes.y);
+    const uint spvThreadCount = (gl_WorkGroupSize.x*gl_WorkGroupSize.y*gl_WorkGroupSize.z);
+    if (gl_LocalInvocationIndex < 22)
+    {
+        const uint spvI = gl_LocalInvocationIndex;
+        spvMesh.set_index(spvI * 3u + 0u, gl_PrimitiveTriangleIndicesEXT[spvI].x);
+        spvMesh.set_index(spvI * 3u + 1u, gl_PrimitiveTriangleIndicesEXT[spvI].y);
+        spvMesh.set_index(spvI * 3u + 2u, gl_PrimitiveTriangleIndicesEXT[spvI].z);
+    }
+    {
+        const uint spvI = gl_LocalInvocationIndex;
+        spvPerVertex spvV = {};
+        spvV.gl_Position = gl_MeshVerticesEXT[spvI].gl_Position;
+        spvV.gl_PointSize = gl_MeshVerticesEXT[spvI].gl_PointSize;
+        spvV.gl_ClipDistance[0] = gl_MeshVerticesEXT[spvI].gl_ClipDistance[0];
+        spvV.gl_ClipDistance_0 = gl_MeshVerticesEXT[spvI].gl_ClipDistance[0];
+        spvV.gl_CullDistance[0] = gl_MeshVerticesEXT[spvI].gl_CullDistance[0];
+        spvV.gl_CullDistance_0 = gl_MeshVerticesEXT[spvI].gl_CullDistance[0];
+        spvV.gl_CullDistance[1] = gl_MeshVerticesEXT[spvI].gl_CullDistance[1];
+        spvV.gl_CullDistance_1 = gl_MeshVerticesEXT[spvI].gl_CullDistance[1];
+        spvV.outputs_a = outputs[spvI].a;
+        spvV.outputs_b = outputs[spvI].b;
+        spvMesh.set_vertex(spvI, spvV);
+    }
+    if (gl_LocalInvocationIndex < 22)
+    {
+        const uint spvI = gl_LocalInvocationIndex;
+        spvPerPrimitive spvP = {};
+        spvP.vPrim = vPrim[spvI];
+        spvP.prim_outputs_a = prim_outputs[spvI].a;
+        spvP.prim_outputs_b = prim_outputs[spvI].b;
+        spvP.gl_PrimitiveID = gl_MeshPrimitivesEXT[spvI].gl_PrimitiveID;
+        spvP.gl_Layer = gl_MeshPrimitivesEXT[spvI].gl_Layer;
+        spvP.gl_ViewportIndex = gl_MeshPrimitivesEXT[spvI].gl_ViewportIndex;
+        spvP.gl_CullPrimitiveEXT = gl_MeshPrimitivesEXT[spvI].gl_CullPrimitiveEXT;
+        spvP.gl_PrimitiveShadingRateEXT = gl_MeshPrimitivesEXT[spvI].gl_PrimitiveShadingRateEXT;
+        spvMesh.set_primitive(spvI, spvP);
+    }
+}
+

--- a/reference/shaders-msl/mesh/mesh-shader-basic-lines.msl3.spv14.vk.nocompat.mesh
+++ b/reference/shaders-msl/mesh/mesh-shader-basic-lines.msl3.spv14.vk.nocompat.mesh
@@ -1,0 +1,220 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wmissing-braces"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+template<typename T, size_t Num>
+struct spvUnsafeArray
+{
+    T elements[Num ? Num : 1];
+    
+    thread T& operator [] (size_t pos) thread
+    {
+        return elements[pos];
+    }
+    constexpr const thread T& operator [] (size_t pos) const thread
+    {
+        return elements[pos];
+    }
+    
+    device T& operator [] (size_t pos) device
+    {
+        return elements[pos];
+    }
+    constexpr const device T& operator [] (size_t pos) const device
+    {
+        return elements[pos];
+    }
+    
+    constexpr const constant T& operator [] (size_t pos) const constant
+    {
+        return elements[pos];
+    }
+    
+    threadgroup T& operator [] (size_t pos) threadgroup
+    {
+        return elements[pos];
+    }
+    constexpr const threadgroup T& operator [] (size_t pos) const threadgroup
+    {
+        return elements[pos];
+    }
+    
+    object_data T& operator [] (size_t pos) object_data
+    {
+        return elements[pos];
+    }
+    constexpr const object_data T& operator [] (size_t pos) const object_data
+    {
+        return elements[pos];
+    }
+};
+
+void SetMeshOutputsEXT(thread uint gl_LocalInvocationIndex, threadgroup uint2& spvMeshSizes, uint vertexCount, uint primitiveCount)
+{
+    if (gl_LocalInvocationIndex == 0)
+    {
+        spvMeshSizes.x = vertexCount;
+        spvMeshSizes.y = primitiveCount;
+    }
+}
+
+struct gl_MeshPerPrimitiveEXT
+{
+    uint gl_PrimitiveID [[primitive_id]];
+    uint gl_Layer [[render_target_array_index]];
+    uint gl_ViewportIndex [[viewport_array_index]];
+    bool gl_CullPrimitiveEXT [[primitive_culled]];
+};
+
+struct gl_MeshPerVertexEXT
+{
+    float4 gl_Position [[position]];
+    float gl_PointSize;
+    float gl_ClipDistance [[clip_distance]] [1];
+    float gl_CullDistance [[cull_distance]] [2];
+};
+
+struct BlockOut
+{
+    float4 a;
+    float4 b;
+};
+
+struct BlockOutPrim
+{
+    float4 a;
+    float4 b;
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(2u, 3u, 4u);
+
+struct TaskPayload
+{
+    float a;
+    float b;
+    int c;
+};
+
+struct spvPerVertex
+{
+    float4 gl_Position [[position]];
+    float gl_PointSize;
+    float gl_ClipDistance [[clip_distance]] [1];
+    float gl_ClipDistance_0 [[user(clip0)]];
+    float gl_CullDistance_0 [[user(cull0)]];
+    float gl_CullDistance_1 [[user(cull1)]];
+    float4 vOut [[user(locn0)]];
+    float4 outputs_a [[user(locn2)]];
+    float4 outputs_b [[user(locn3)]];
+};
+
+struct spvPerPrimitive
+{
+    int gl_PrimitiveID [[primitive_id]];
+    uint gl_Layer [[render_target_array_index]];
+    uint gl_ViewportIndex [[viewport_array_index]];
+    short gl_CullPrimitiveEXT [[primitive_culled]];
+    float4 vPrim [[user(locn1)]];
+    float4 prim_outputs_a [[user(locn4)]];
+    float4 prim_outputs_b [[user(locn5)]];
+};
+
+using spvMesh_t = mesh<spvPerVertex, spvPerPrimitive, 24, 22, topology::line>;
+
+static inline __attribute__((always_inline))
+void main3(threadgroup spvUnsafeArray<uint2, 22>& gl_PrimitiveLineIndicesEXT, thread uint& gl_LocalInvocationIndex, threadgroup spvUnsafeArray<gl_MeshPerPrimitiveEXT, 22>& gl_MeshPrimitivesEXT, thread uint3& gl_GlobalInvocationID)
+{
+    gl_PrimitiveLineIndicesEXT[gl_LocalInvocationIndex] = uint2(0u, 1u) + uint2(gl_LocalInvocationIndex);
+    gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_PrimitiveID = int(gl_GlobalInvocationID.x);
+    gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_Layer = int(gl_GlobalInvocationID.x) + 1;
+    gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_ViewportIndex = int(gl_GlobalInvocationID.x) + 2;
+    gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_CullPrimitiveEXT = short((gl_GlobalInvocationID.x & 1u) != 0u);
+}
+
+static inline __attribute__((always_inline))
+void main2(threadgroup spvUnsafeArray<uint2, 22>& gl_PrimitiveLineIndicesEXT, thread uint& gl_LocalInvocationIndex, threadgroup spvUnsafeArray<gl_MeshPerPrimitiveEXT, 22>& gl_MeshPrimitivesEXT, thread uint3& gl_GlobalInvocationID, threadgroup spvUnsafeArray<gl_MeshPerVertexEXT, 24>& gl_MeshVerticesEXT, threadgroup spvUnsafeArray<float4, 24>& vOut, threadgroup spvUnsafeArray<BlockOut, 24>& outputs, threadgroup spvUnsafeArray<float4, 22>& vPrim, thread uint3& gl_WorkGroupID, threadgroup spvUnsafeArray<BlockOutPrim, 22>& prim_outputs, threadgroup uint2& spvMeshSizes)
+{
+    SetMeshOutputsEXT(gl_LocalInvocationIndex, spvMeshSizes, 24u, 22u);
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position = float4(float3(gl_GlobalInvocationID), 1.0);
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_PointSize = 2.0;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_ClipDistance[0] = 4.0;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[0] = 6.0;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[1] = 5.0;
+    vOut[gl_LocalInvocationIndex] = float4(float3(gl_GlobalInvocationID), 2.0);
+    outputs[gl_LocalInvocationIndex].a = float4(5.0);
+    outputs[gl_LocalInvocationIndex].b = float4(6.0);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (gl_LocalInvocationIndex < 22u)
+    {
+        vPrim[gl_LocalInvocationIndex] = float4(float3(gl_WorkGroupID), 3.0);
+        prim_outputs[gl_LocalInvocationIndex].a = float4(0.0);
+        prim_outputs[gl_LocalInvocationIndex].b = float4(1.0);
+        main3(gl_PrimitiveLineIndicesEXT, gl_LocalInvocationIndex, gl_MeshPrimitivesEXT, gl_GlobalInvocationID);
+    }
+}
+
+static inline __attribute__((always_inline))
+void _4(threadgroup spvUnsafeArray<uint2, 22>& gl_PrimitiveLineIndicesEXT, thread uint& gl_LocalInvocationIndex, threadgroup spvUnsafeArray<gl_MeshPerPrimitiveEXT, 22>& gl_MeshPrimitivesEXT, thread uint3& gl_GlobalInvocationID, threadgroup spvUnsafeArray<gl_MeshPerVertexEXT, 24>& gl_MeshVerticesEXT, threadgroup spvUnsafeArray<float4, 24>& vOut, threadgroup spvUnsafeArray<BlockOut, 24>& outputs, threadgroup spvUnsafeArray<float4, 22>& vPrim, thread uint3& gl_WorkGroupID, threadgroup spvUnsafeArray<BlockOutPrim, 22>& prim_outputs, threadgroup uint2& spvMeshSizes)
+{
+    main2(gl_PrimitiveLineIndicesEXT, gl_LocalInvocationIndex, gl_MeshPrimitivesEXT, gl_GlobalInvocationID, gl_MeshVerticesEXT, vOut, outputs, vPrim, gl_WorkGroupID, prim_outputs, spvMeshSizes);
+}
+
+[[mesh]] void main0(uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]], spvMesh_t spvMesh)
+{
+    threadgroup uint2 spvMeshSizes;
+    threadgroup spvUnsafeArray<uint2, 22> gl_PrimitiveLineIndicesEXT;
+    threadgroup spvUnsafeArray<gl_MeshPerPrimitiveEXT, 22> gl_MeshPrimitivesEXT;
+    threadgroup spvUnsafeArray<gl_MeshPerVertexEXT, 24> gl_MeshVerticesEXT;
+    threadgroup spvUnsafeArray<float4, 24> vOut;
+    threadgroup spvUnsafeArray<BlockOut, 24> outputs;
+    threadgroup spvUnsafeArray<float4, 22> vPrim;
+    threadgroup spvUnsafeArray<BlockOutPrim, 22> prim_outputs;
+    threadgroup spvUnsafeArray<float, 16> shared_float;
+    _4(gl_PrimitiveLineIndicesEXT, gl_LocalInvocationIndex, gl_MeshPrimitivesEXT, gl_GlobalInvocationID, gl_MeshVerticesEXT, vOut, outputs, vPrim, gl_WorkGroupID, prim_outputs, spvMeshSizes);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (spvMeshSizes.y == 0)
+    {
+        return;
+    }
+    spvMesh.set_primitive_count(spvMeshSizes.y);
+    const uint spvThreadCount = (gl_WorkGroupSize.x*gl_WorkGroupSize.y*gl_WorkGroupSize.z);
+    if (gl_LocalInvocationIndex < 22)
+    {
+        const uint spvI = gl_LocalInvocationIndex;
+        spvMesh.set_index(spvI * 2u + 0u, gl_PrimitiveLineIndicesEXT[spvI].x);
+        spvMesh.set_index(spvI * 2u + 1u, gl_PrimitiveLineIndicesEXT[spvI].y);
+    }
+    {
+        const uint spvI = gl_LocalInvocationIndex;
+        spvPerVertex spvV = {};
+        spvV.gl_Position = gl_MeshVerticesEXT[spvI].gl_Position;
+        spvV.gl_PointSize = gl_MeshVerticesEXT[spvI].gl_PointSize;
+        spvV.gl_ClipDistance[0] = gl_MeshVerticesEXT[spvI].gl_ClipDistance[0];
+        spvV.gl_ClipDistance_0 = gl_MeshVerticesEXT[spvI].gl_ClipDistance[0];
+        spvV.gl_CullDistance[0] = gl_MeshVerticesEXT[spvI].gl_CullDistance[0];
+        spvV.gl_CullDistance_0 = gl_MeshVerticesEXT[spvI].gl_CullDistance[0];
+        spvV.gl_CullDistance[1] = gl_MeshVerticesEXT[spvI].gl_CullDistance[1];
+        spvV.gl_CullDistance_1 = gl_MeshVerticesEXT[spvI].gl_CullDistance[1];
+        spvV.outputs_a = outputs[spvI].a;
+        spvV.outputs_b = outputs[spvI].b;
+        spvMesh.set_vertex(spvI, spvV);
+    }
+    if (gl_LocalInvocationIndex < 22)
+    {
+        const uint spvI = gl_LocalInvocationIndex;
+        spvPerPrimitive spvP = {};
+        spvP.gl_PrimitiveID = gl_MeshPrimitivesEXT[spvI].gl_PrimitiveID;
+        spvP.gl_Layer = gl_MeshPrimitivesEXT[spvI].gl_Layer;
+        spvP.gl_ViewportIndex = gl_MeshPrimitivesEXT[spvI].gl_ViewportIndex;
+        spvP.gl_CullPrimitiveEXT = gl_MeshPrimitivesEXT[spvI].gl_CullPrimitiveEXT;
+        spvP.vPrim = vPrim[spvI];
+        spvP.prim_outputs_a = prim_outputs[spvI].a;
+        spvP.prim_outputs_b = prim_outputs[spvI].b;
+        spvMesh.set_primitive(spvI, spvP);
+    }
+}
+

--- a/reference/shaders-msl/mesh/mesh-shader-basic-lines.msl3.spv14.vk.nocompat.mesh
+++ b/reference/shaders-msl/mesh/mesh-shader-basic-lines.msl3.spv14.vk.nocompat.mesh
@@ -75,7 +75,6 @@ struct gl_MeshPerVertexEXT
     float4 gl_Position [[position]];
     float gl_PointSize;
     float gl_ClipDistance [[clip_distance]] [1];
-    float gl_CullDistance [[cull_distance]] [2];
 };
 
 struct BlockOut
@@ -105,8 +104,6 @@ struct spvPerVertex
     float gl_PointSize;
     float gl_ClipDistance [[clip_distance]] [1];
     float gl_ClipDistance_0 [[user(clip0)]];
-    float gl_CullDistance_0 [[user(cull0)]];
-    float gl_CullDistance_1 [[user(cull1)]];
     float4 vOut [[user(locn0)]];
     float4 outputs_a [[user(locn2)]];
     float4 outputs_b [[user(locn3)]];
@@ -114,10 +111,10 @@ struct spvPerVertex
 
 struct spvPerPrimitive
 {
-    int gl_PrimitiveID [[primitive_id]];
+    uint gl_PrimitiveID [[primitive_id]];
     uint gl_Layer [[render_target_array_index]];
     uint gl_ViewportIndex [[viewport_array_index]];
-    short gl_CullPrimitiveEXT [[primitive_culled]];
+    bool gl_CullPrimitiveEXT [[primitive_culled]];
     float4 vPrim [[user(locn1)]];
     float4 prim_outputs_a [[user(locn4)]];
     float4 prim_outputs_b [[user(locn5)]];
@@ -142,8 +139,6 @@ void main2(threadgroup spvUnsafeArray<uint2, 22>& gl_PrimitiveLineIndicesEXT, th
     gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position = float4(float3(gl_GlobalInvocationID), 1.0);
     gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_PointSize = 2.0;
     gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_ClipDistance[0] = 4.0;
-    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[0] = 6.0;
-    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[1] = 5.0;
     vOut[gl_LocalInvocationIndex] = float4(float3(gl_GlobalInvocationID), 2.0);
     outputs[gl_LocalInvocationIndex].a = float4(5.0);
     outputs[gl_LocalInvocationIndex].b = float4(6.0);
@@ -195,10 +190,6 @@ void _4(threadgroup spvUnsafeArray<uint2, 22>& gl_PrimitiveLineIndicesEXT, threa
         spvV.gl_PointSize = gl_MeshVerticesEXT[spvI].gl_PointSize;
         spvV.gl_ClipDistance[0] = gl_MeshVerticesEXT[spvI].gl_ClipDistance[0];
         spvV.gl_ClipDistance_0 = gl_MeshVerticesEXT[spvI].gl_ClipDistance[0];
-        spvV.gl_CullDistance[0] = gl_MeshVerticesEXT[spvI].gl_CullDistance[0];
-        spvV.gl_CullDistance_0 = gl_MeshVerticesEXT[spvI].gl_CullDistance[0];
-        spvV.gl_CullDistance[1] = gl_MeshVerticesEXT[spvI].gl_CullDistance[1];
-        spvV.gl_CullDistance_1 = gl_MeshVerticesEXT[spvI].gl_CullDistance[1];
         spvV.outputs_a = outputs[spvI].a;
         spvV.outputs_b = outputs[spvI].b;
         spvMesh.set_vertex(spvI, spvV);

--- a/reference/shaders-msl/mesh/mesh-shader-basic-triangle.msl3.spv14.vk.nocompat.mesh
+++ b/reference/shaders-msl/mesh/mesh-shader-basic-triangle.msl3.spv14.vk.nocompat.mesh
@@ -67,7 +67,6 @@ struct gl_MeshPerVertexEXT
     float4 gl_Position [[position]];
     float gl_PointSize;
     float gl_ClipDistance [[clip_distance]] [1];
-    float gl_CullDistance [[cull_distance]] [2];
 };
 
 struct BlockOut
@@ -88,7 +87,6 @@ struct gl_MeshPerPrimitiveEXT
     uint gl_Layer [[render_target_array_index]];
     uint gl_ViewportIndex [[viewport_array_index]];
     bool gl_CullPrimitiveEXT [[primitive_culled]];
-    
 };
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(2u, 3u, 4u);
@@ -106,8 +104,6 @@ struct spvPerVertex
     float gl_PointSize;
     float gl_ClipDistance [[clip_distance]] [1];
     float gl_ClipDistance_0 [[user(clip0)]];
-    float gl_CullDistance_0 [[user(cull0)]];
-    float gl_CullDistance_1 [[user(cull1)]];
     float4 vOut [[user(locn0)]];
     float4 outputs_a [[user(locn2)]];
     float4 outputs_b [[user(locn3)]];
@@ -118,11 +114,10 @@ struct spvPerPrimitive
     float4 vPrim [[user(locn1)]];
     float4 prim_outputs_a [[user(locn4)]];
     float4 prim_outputs_b [[user(locn5)]];
-    int gl_PrimitiveID [[primitive_id]];
+    uint gl_PrimitiveID [[primitive_id]];
     uint gl_Layer [[render_target_array_index]];
     uint gl_ViewportIndex [[viewport_array_index]];
-    short gl_CullPrimitiveEXT [[primitive_culled]];
-    int gl_PrimitiveShadingRateEXT [[unsupported-built-in]];
+    bool gl_CullPrimitiveEXT [[primitive_culled]];
 };
 
 using spvMesh_t = mesh<spvPerVertex, spvPerPrimitive, 24, 22, topology::triangle>;
@@ -134,8 +129,6 @@ void _4(threadgroup spvUnsafeArray<gl_MeshPerVertexEXT, 24>& gl_MeshVerticesEXT,
     gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position = float4(float3(gl_GlobalInvocationID), 1.0);
     gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_PointSize = 2.0;
     gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_ClipDistance[0] = 4.0;
-    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[0] = 3.0;
-    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[1] = 5.0;
     vOut[gl_LocalInvocationIndex] = float4(float3(gl_GlobalInvocationID), 2.0);
     outputs[gl_LocalInvocationIndex].a = float4(5.0);
     outputs[gl_LocalInvocationIndex].b = float4(6.0);
@@ -150,7 +143,6 @@ void _4(threadgroup spvUnsafeArray<gl_MeshPerVertexEXT, 24>& gl_MeshVerticesEXT,
         gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_Layer = int(gl_GlobalInvocationID.x) + 1;
         gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_ViewportIndex = int(gl_GlobalInvocationID.x) + 2;
         gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_CullPrimitiveEXT = short((gl_GlobalInvocationID.x & 1u) != 0u);
-        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_PrimitiveShadingRateEXT = int(gl_GlobalInvocationID.x) + 3;
     }
 }
 
@@ -187,10 +179,6 @@ void _4(threadgroup spvUnsafeArray<gl_MeshPerVertexEXT, 24>& gl_MeshVerticesEXT,
         spvV.gl_PointSize = gl_MeshVerticesEXT[spvI].gl_PointSize;
         spvV.gl_ClipDistance[0] = gl_MeshVerticesEXT[spvI].gl_ClipDistance[0];
         spvV.gl_ClipDistance_0 = gl_MeshVerticesEXT[spvI].gl_ClipDistance[0];
-        spvV.gl_CullDistance[0] = gl_MeshVerticesEXT[spvI].gl_CullDistance[0];
-        spvV.gl_CullDistance_0 = gl_MeshVerticesEXT[spvI].gl_CullDistance[0];
-        spvV.gl_CullDistance[1] = gl_MeshVerticesEXT[spvI].gl_CullDistance[1];
-        spvV.gl_CullDistance_1 = gl_MeshVerticesEXT[spvI].gl_CullDistance[1];
         spvV.outputs_a = outputs[spvI].a;
         spvV.outputs_b = outputs[spvI].b;
         spvMesh.set_vertex(spvI, spvV);
@@ -206,7 +194,6 @@ void _4(threadgroup spvUnsafeArray<gl_MeshPerVertexEXT, 24>& gl_MeshVerticesEXT,
         spvP.gl_Layer = gl_MeshPrimitivesEXT[spvI].gl_Layer;
         spvP.gl_ViewportIndex = gl_MeshPrimitivesEXT[spvI].gl_ViewportIndex;
         spvP.gl_CullPrimitiveEXT = gl_MeshPrimitivesEXT[spvI].gl_CullPrimitiveEXT;
-        spvP.gl_PrimitiveShadingRateEXT = gl_MeshPrimitivesEXT[spvI].gl_PrimitiveShadingRateEXT;
         spvMesh.set_primitive(spvI, spvP);
     }
 }

--- a/reference/shaders-msl/mesh/mesh-shader-basic-triangle.msl3.spv14.vk.nocompat.mesh
+++ b/reference/shaders-msl/mesh/mesh-shader-basic-triangle.msl3.spv14.vk.nocompat.mesh
@@ -1,0 +1,213 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wmissing-braces"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+template<typename T, size_t Num>
+struct spvUnsafeArray
+{
+    T elements[Num ? Num : 1];
+    
+    thread T& operator [] (size_t pos) thread
+    {
+        return elements[pos];
+    }
+    constexpr const thread T& operator [] (size_t pos) const thread
+    {
+        return elements[pos];
+    }
+    
+    device T& operator [] (size_t pos) device
+    {
+        return elements[pos];
+    }
+    constexpr const device T& operator [] (size_t pos) const device
+    {
+        return elements[pos];
+    }
+    
+    constexpr const constant T& operator [] (size_t pos) const constant
+    {
+        return elements[pos];
+    }
+    
+    threadgroup T& operator [] (size_t pos) threadgroup
+    {
+        return elements[pos];
+    }
+    constexpr const threadgroup T& operator [] (size_t pos) const threadgroup
+    {
+        return elements[pos];
+    }
+    
+    object_data T& operator [] (size_t pos) object_data
+    {
+        return elements[pos];
+    }
+    constexpr const object_data T& operator [] (size_t pos) const object_data
+    {
+        return elements[pos];
+    }
+};
+
+void SetMeshOutputsEXT(thread uint gl_LocalInvocationIndex, threadgroup uint2& spvMeshSizes, uint vertexCount, uint primitiveCount)
+{
+    if (gl_LocalInvocationIndex == 0)
+    {
+        spvMeshSizes.x = vertexCount;
+        spvMeshSizes.y = primitiveCount;
+    }
+}
+
+struct gl_MeshPerVertexEXT
+{
+    float4 gl_Position [[position]];
+    float gl_PointSize;
+    float gl_ClipDistance [[clip_distance]] [1];
+    float gl_CullDistance [[cull_distance]] [2];
+};
+
+struct BlockOut
+{
+    float4 a;
+    float4 b;
+};
+
+struct BlockOutPrim
+{
+    float4 a;
+    float4 b;
+};
+
+struct gl_MeshPerPrimitiveEXT
+{
+    uint gl_PrimitiveID [[primitive_id]];
+    uint gl_Layer [[render_target_array_index]];
+    uint gl_ViewportIndex [[viewport_array_index]];
+    bool gl_CullPrimitiveEXT [[primitive_culled]];
+    
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(2u, 3u, 4u);
+
+struct TaskPayload
+{
+    float a;
+    float b;
+    int c;
+};
+
+struct spvPerVertex
+{
+    float4 gl_Position [[position]];
+    float gl_PointSize;
+    float gl_ClipDistance [[clip_distance]] [1];
+    float gl_ClipDistance_0 [[user(clip0)]];
+    float gl_CullDistance_0 [[user(cull0)]];
+    float gl_CullDistance_1 [[user(cull1)]];
+    float4 vOut [[user(locn0)]];
+    float4 outputs_a [[user(locn2)]];
+    float4 outputs_b [[user(locn3)]];
+};
+
+struct spvPerPrimitive
+{
+    float4 vPrim [[user(locn1)]];
+    float4 prim_outputs_a [[user(locn4)]];
+    float4 prim_outputs_b [[user(locn5)]];
+    int gl_PrimitiveID [[primitive_id]];
+    uint gl_Layer [[render_target_array_index]];
+    uint gl_ViewportIndex [[viewport_array_index]];
+    short gl_CullPrimitiveEXT [[primitive_culled]];
+    int gl_PrimitiveShadingRateEXT [[unsupported-built-in]];
+};
+
+using spvMesh_t = mesh<spvPerVertex, spvPerPrimitive, 24, 22, topology::triangle>;
+
+static inline __attribute__((always_inline))
+void _4(threadgroup spvUnsafeArray<gl_MeshPerVertexEXT, 24>& gl_MeshVerticesEXT, thread uint& gl_LocalInvocationIndex, thread uint3& gl_GlobalInvocationID, threadgroup spvUnsafeArray<float4, 24>& vOut, threadgroup spvUnsafeArray<BlockOut, 24>& outputs, threadgroup spvUnsafeArray<float4, 22>& vPrim, thread uint3& gl_WorkGroupID, threadgroup spvUnsafeArray<BlockOutPrim, 22>& prim_outputs, threadgroup spvUnsafeArray<uint3, 22>& gl_PrimitiveTriangleIndicesEXT, threadgroup spvUnsafeArray<gl_MeshPerPrimitiveEXT, 22>& gl_MeshPrimitivesEXT, threadgroup uint2& spvMeshSizes)
+{
+    SetMeshOutputsEXT(gl_LocalInvocationIndex, spvMeshSizes, 24u, 22u);
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position = float4(float3(gl_GlobalInvocationID), 1.0);
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_PointSize = 2.0;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_ClipDistance[0] = 4.0;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[0] = 3.0;
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[1] = 5.0;
+    vOut[gl_LocalInvocationIndex] = float4(float3(gl_GlobalInvocationID), 2.0);
+    outputs[gl_LocalInvocationIndex].a = float4(5.0);
+    outputs[gl_LocalInvocationIndex].b = float4(6.0);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (gl_LocalInvocationIndex < 22u)
+    {
+        vPrim[gl_LocalInvocationIndex] = float4(float3(gl_WorkGroupID), 3.0);
+        prim_outputs[gl_LocalInvocationIndex].a = float4(0.0);
+        prim_outputs[gl_LocalInvocationIndex].b = float4(1.0);
+        gl_PrimitiveTriangleIndicesEXT[gl_LocalInvocationIndex] = uint3(0u, 1u, 2u) + uint3(gl_LocalInvocationIndex);
+        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_PrimitiveID = int(gl_GlobalInvocationID.x);
+        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_Layer = int(gl_GlobalInvocationID.x) + 1;
+        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_ViewportIndex = int(gl_GlobalInvocationID.x) + 2;
+        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_CullPrimitiveEXT = short((gl_GlobalInvocationID.x & 1u) != 0u);
+        gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_PrimitiveShadingRateEXT = int(gl_GlobalInvocationID.x) + 3;
+    }
+}
+
+[[mesh]] void main0(uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]], spvMesh_t spvMesh)
+{
+    threadgroup uint2 spvMeshSizes;
+    threadgroup spvUnsafeArray<gl_MeshPerVertexEXT, 24> gl_MeshVerticesEXT;
+    threadgroup spvUnsafeArray<float4, 24> vOut;
+    threadgroup spvUnsafeArray<BlockOut, 24> outputs;
+    threadgroup spvUnsafeArray<float4, 22> vPrim;
+    threadgroup spvUnsafeArray<BlockOutPrim, 22> prim_outputs;
+    threadgroup spvUnsafeArray<uint3, 22> gl_PrimitiveTriangleIndicesEXT;
+    threadgroup spvUnsafeArray<gl_MeshPerPrimitiveEXT, 22> gl_MeshPrimitivesEXT;
+    threadgroup spvUnsafeArray<float, 16> shared_float;
+    _4(gl_MeshVerticesEXT, gl_LocalInvocationIndex, gl_GlobalInvocationID, vOut, outputs, vPrim, gl_WorkGroupID, prim_outputs, gl_PrimitiveTriangleIndicesEXT, gl_MeshPrimitivesEXT, spvMeshSizes);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (spvMeshSizes.y == 0)
+    {
+        return;
+    }
+    spvMesh.set_primitive_count(spvMeshSizes.y);
+    const uint spvThreadCount = (gl_WorkGroupSize.x*gl_WorkGroupSize.y*gl_WorkGroupSize.z);
+    if (gl_LocalInvocationIndex < 22)
+    {
+        const uint spvI = gl_LocalInvocationIndex;
+        spvMesh.set_index(spvI * 3u + 0u, gl_PrimitiveTriangleIndicesEXT[spvI].x);
+        spvMesh.set_index(spvI * 3u + 1u, gl_PrimitiveTriangleIndicesEXT[spvI].y);
+        spvMesh.set_index(spvI * 3u + 2u, gl_PrimitiveTriangleIndicesEXT[spvI].z);
+    }
+    {
+        const uint spvI = gl_LocalInvocationIndex;
+        spvPerVertex spvV = {};
+        spvV.gl_Position = gl_MeshVerticesEXT[spvI].gl_Position;
+        spvV.gl_PointSize = gl_MeshVerticesEXT[spvI].gl_PointSize;
+        spvV.gl_ClipDistance[0] = gl_MeshVerticesEXT[spvI].gl_ClipDistance[0];
+        spvV.gl_ClipDistance_0 = gl_MeshVerticesEXT[spvI].gl_ClipDistance[0];
+        spvV.gl_CullDistance[0] = gl_MeshVerticesEXT[spvI].gl_CullDistance[0];
+        spvV.gl_CullDistance_0 = gl_MeshVerticesEXT[spvI].gl_CullDistance[0];
+        spvV.gl_CullDistance[1] = gl_MeshVerticesEXT[spvI].gl_CullDistance[1];
+        spvV.gl_CullDistance_1 = gl_MeshVerticesEXT[spvI].gl_CullDistance[1];
+        spvV.outputs_a = outputs[spvI].a;
+        spvV.outputs_b = outputs[spvI].b;
+        spvMesh.set_vertex(spvI, spvV);
+    }
+    if (gl_LocalInvocationIndex < 22)
+    {
+        const uint spvI = gl_LocalInvocationIndex;
+        spvPerPrimitive spvP = {};
+        spvP.vPrim = vPrim[spvI];
+        spvP.prim_outputs_a = prim_outputs[spvI].a;
+        spvP.prim_outputs_b = prim_outputs[spvI].b;
+        spvP.gl_PrimitiveID = gl_MeshPrimitivesEXT[spvI].gl_PrimitiveID;
+        spvP.gl_Layer = gl_MeshPrimitivesEXT[spvI].gl_Layer;
+        spvP.gl_ViewportIndex = gl_MeshPrimitivesEXT[spvI].gl_ViewportIndex;
+        spvP.gl_CullPrimitiveEXT = gl_MeshPrimitivesEXT[spvI].gl_CullPrimitiveEXT;
+        spvP.gl_PrimitiveShadingRateEXT = gl_MeshPrimitivesEXT[spvI].gl_PrimitiveShadingRateEXT;
+        spvMesh.set_primitive(spvI, spvP);
+    }
+}
+

--- a/shaders-msl/mesh/mesh-shader-basic-lines.msl3.spv14.vk.nocompat.mesh
+++ b/shaders-msl/mesh/mesh-shader-basic-lines.msl3.spv14.vk.nocompat.mesh
@@ -1,0 +1,75 @@
+#version 450
+#extension GL_EXT_mesh_shader : require
+
+layout(local_size_x = 2, local_size_y = 3, local_size_z = 4) in;
+layout(lines, max_vertices = 24, max_primitives = 22) out;
+
+out gl_MeshPerVertexEXT
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+	float gl_ClipDistance[1];
+	float gl_CullDistance[2];
+} gl_MeshVerticesEXT[];
+
+layout(location = 0) out vec4 vOut[];
+layout(location = 1) perprimitiveEXT out vec4 vPrim[];
+
+layout(location = 2) out BlockOut
+{
+	vec4 a;
+	vec4 b;
+} outputs[];
+
+layout(location = 4) perprimitiveEXT out BlockOutPrim
+{
+	vec4 a;
+	vec4 b;
+} prim_outputs[];
+
+shared float shared_float[16];
+
+struct TaskPayload
+{
+	float a;
+	float b;
+	int c;
+};
+
+// taskPayloadSharedEXT TaskPayload payload;
+const TaskPayload payload = {0.0, 1.0, 2};
+
+void main3()
+{
+	gl_PrimitiveLineIndicesEXT[gl_LocalInvocationIndex] = uvec2(0, 1) + gl_LocalInvocationIndex;
+	gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_PrimitiveID = int(gl_GlobalInvocationID.x);
+	gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_Layer = int(gl_GlobalInvocationID.x) + 1;
+	gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_ViewportIndex = int(gl_GlobalInvocationID.x) + 2;
+	gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_CullPrimitiveEXT = bool(gl_GlobalInvocationID.x & 1);
+}
+
+void main2()
+{
+	SetMeshOutputsEXT(24, 22);
+	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position = vec4(gl_GlobalInvocationID, 1.0);
+	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_PointSize = 2.0;
+	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_ClipDistance[0] = 4.0;
+	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[0] = 6.0;
+	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[1] = 5.0;
+	vOut[gl_LocalInvocationIndex] = vec4(gl_GlobalInvocationID, 2.0);
+	outputs[gl_LocalInvocationIndex].a = vec4(5.0);
+	outputs[gl_LocalInvocationIndex].b = vec4(6.0);
+	barrier();
+	if (gl_LocalInvocationIndex < 22)
+	{
+		vPrim[gl_LocalInvocationIndex] = vec4(gl_WorkGroupID, 3.0);
+		prim_outputs[gl_LocalInvocationIndex].a = vec4(payload.a);
+		prim_outputs[gl_LocalInvocationIndex].b = vec4(payload.b);
+		main3();
+	}
+}
+
+void main()
+{
+	main2();
+}

--- a/shaders-msl/mesh/mesh-shader-basic-lines.msl3.spv14.vk.nocompat.mesh
+++ b/shaders-msl/mesh/mesh-shader-basic-lines.msl3.spv14.vk.nocompat.mesh
@@ -9,7 +9,7 @@ out gl_MeshPerVertexEXT
 	vec4 gl_Position;
 	float gl_PointSize;
 	float gl_ClipDistance[1];
-	float gl_CullDistance[2];
+	// float gl_CullDistance[2];
 } gl_MeshVerticesEXT[];
 
 layout(location = 0) out vec4 vOut[];
@@ -54,8 +54,8 @@ void main2()
 	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position = vec4(gl_GlobalInvocationID, 1.0);
 	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_PointSize = 2.0;
 	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_ClipDistance[0] = 4.0;
-	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[0] = 6.0;
-	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[1] = 5.0;
+	// gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[0] = 6.0;
+	// gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[1] = 5.0;
 	vOut[gl_LocalInvocationIndex] = vec4(gl_GlobalInvocationID, 2.0);
 	outputs[gl_LocalInvocationIndex].a = vec4(5.0);
 	outputs[gl_LocalInvocationIndex].b = vec4(6.0);

--- a/shaders-msl/mesh/mesh-shader-basic-triangle.msl3.spv14.vk.nocompat.mesh
+++ b/shaders-msl/mesh/mesh-shader-basic-triangle.msl3.spv14.vk.nocompat.mesh
@@ -1,0 +1,66 @@
+#version 450
+#extension GL_EXT_mesh_shader : require
+#extension GL_EXT_fragment_shading_rate : require
+layout(local_size_x = 2, local_size_y = 3, local_size_z = 4) in;
+layout(triangles, max_vertices = 24, max_primitives = 22) out;
+
+out gl_MeshPerVertexEXT
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+	float gl_ClipDistance[1];
+	float gl_CullDistance[2];
+} gl_MeshVerticesEXT[];
+
+layout(location = 0) out vec4 vOut[];
+layout(location = 1) perprimitiveEXT out vec4 vPrim[];
+
+layout(location = 2) out BlockOut
+{
+	vec4 a;
+	vec4 b;
+} outputs[];
+
+layout(location = 4) perprimitiveEXT out BlockOutPrim
+{
+	vec4 a;
+	vec4 b;
+} prim_outputs[];
+
+shared float shared_float[16];
+
+struct TaskPayload
+{
+	float a;
+	float b;
+	int c;
+};
+
+// taskPayloadSharedEXT TaskPayload payload;
+const TaskPayload payload = {0.0, 1.0, 2};
+
+void main()
+{
+	SetMeshOutputsEXT(24, 22);
+	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position = vec4(gl_GlobalInvocationID, 1.0);
+  gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_PointSize = 2.0;
+	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_ClipDistance[0] = 4.0;
+	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[0] = 3.0;
+	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[1] = 5.0;
+	vOut[gl_LocalInvocationIndex] = vec4(gl_GlobalInvocationID, 2.0);
+	outputs[gl_LocalInvocationIndex].a = vec4(5.0);
+	outputs[gl_LocalInvocationIndex].b = vec4(6.0);
+	barrier();
+	if (gl_LocalInvocationIndex < 22)
+	{
+		vPrim[gl_LocalInvocationIndex] = vec4(gl_WorkGroupID, 3.0);
+		prim_outputs[gl_LocalInvocationIndex].a = vec4(payload.a);
+		prim_outputs[gl_LocalInvocationIndex].b = vec4(payload.b);
+		gl_PrimitiveTriangleIndicesEXT[gl_LocalInvocationIndex] = uvec3(0, 1, 2) + gl_LocalInvocationIndex;
+		gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_PrimitiveID = int(gl_GlobalInvocationID.x);
+		gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_Layer = int(gl_GlobalInvocationID.x) + 1;
+		gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_ViewportIndex = int(gl_GlobalInvocationID.x) + 2;
+		gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_CullPrimitiveEXT = bool(gl_GlobalInvocationID.x & 1);
+		gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_PrimitiveShadingRateEXT = int(gl_GlobalInvocationID.x) + 3;
+	}
+}

--- a/shaders-msl/mesh/mesh-shader-basic-triangle.msl3.spv14.vk.nocompat.mesh
+++ b/shaders-msl/mesh/mesh-shader-basic-triangle.msl3.spv14.vk.nocompat.mesh
@@ -9,7 +9,7 @@ out gl_MeshPerVertexEXT
 	vec4 gl_Position;
 	float gl_PointSize;
 	float gl_ClipDistance[1];
-	float gl_CullDistance[2];
+	// float gl_CullDistance[2];
 } gl_MeshVerticesEXT[];
 
 layout(location = 0) out vec4 vOut[];
@@ -43,10 +43,10 @@ void main()
 {
 	SetMeshOutputsEXT(24, 22);
 	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position = vec4(gl_GlobalInvocationID, 1.0);
-  gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_PointSize = 2.0;
+	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_PointSize = 2.0;
 	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_ClipDistance[0] = 4.0;
-	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[0] = 3.0;
-	gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[1] = 5.0;
+	// gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[0] = 3.0;
+	// gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[1] = 5.0;
 	vOut[gl_LocalInvocationIndex] = vec4(gl_GlobalInvocationID, 2.0);
 	outputs[gl_LocalInvocationIndex].a = vec4(5.0);
 	outputs[gl_LocalInvocationIndex].b = vec4(6.0);
@@ -61,6 +61,6 @@ void main()
 		gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_Layer = int(gl_GlobalInvocationID.x) + 1;
 		gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_ViewportIndex = int(gl_GlobalInvocationID.x) + 2;
 		gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_CullPrimitiveEXT = bool(gl_GlobalInvocationID.x & 1);
-		gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_PrimitiveShadingRateEXT = int(gl_GlobalInvocationID.x) + 3;
+		// gl_MeshPrimitivesEXT[gl_LocalInvocationIndex].gl_PrimitiveShadingRateEXT = int(gl_GlobalInvocationID.x) + 3;
 	}
 }

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -578,7 +578,8 @@ struct SPIRType : IVariant
 		// Keep internal types at the end.
 		ControlPointArray,
 		Interpolant,
-		Char
+		Char,
+		Meshlet
 	};
 
 	// Scalar/vector/matrix support.

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -269,7 +269,7 @@ void CompilerMSL::build_implicit_builtins()
 	    (active_input_builtins.get(BuiltInVertexId) || active_input_builtins.get(BuiltInVertexIndex) ||
 	     active_input_builtins.get(BuiltInBaseVertex) || active_input_builtins.get(BuiltInInstanceId) ||
 	     active_input_builtins.get(BuiltInInstanceIndex) || active_input_builtins.get(BuiltInBaseInstance));
-	bool need_local_invocation_index = msl_options.emulate_subgroups && active_input_builtins.get(BuiltInSubgroupId);
+	bool need_local_invocation_index = (msl_options.emulate_subgroups && active_input_builtins.get(BuiltInSubgroupId)) || is_mesh_shader();
 	bool need_workgroup_size = msl_options.emulate_subgroups && active_input_builtins.get(BuiltInNumSubgroups);
 	bool force_frag_depth_passthrough =
 	    get_execution_model() == ExecutionModelFragment && !uses_explicit_early_fragment_test() && need_subpass_input &&
@@ -278,7 +278,7 @@ void CompilerMSL::build_implicit_builtins()
 	if (need_subpass_input || need_sample_pos || need_subgroup_mask || need_vertex_params || need_tesc_params ||
 	    need_tese_params || need_multiview || need_dispatch_base || need_vertex_base_params || need_grid_params ||
 	    needs_sample_id || needs_subgroup_invocation_id || needs_subgroup_size || needs_helper_invocation ||
-		has_additional_fixed_sample_mask() || need_local_invocation_index || need_workgroup_size || force_frag_depth_passthrough)
+	  has_additional_fixed_sample_mask() || need_local_invocation_index || need_workgroup_size || force_frag_depth_passthrough || is_mesh_shader())
 	{
 		bool has_frag_coord = false;
 		bool has_sample_id = false;
@@ -323,6 +323,12 @@ void CompilerMSL::build_implicit_builtins()
 					mark_implicit_builtin(StorageClassOutput, BuiltInFragDepth, var.self);
 					has_frag_depth = true;
 				}
+			}
+
+			if (builtin == BuiltInPrimitivePointIndicesEXT || builtin == BuiltInPrimitiveLineIndicesEXT ||
+			    builtin == BuiltInPrimitiveTriangleIndicesEXT)
+			{
+				builtin_mesh_primitive_indices_id = var.self;
 			}
 
 			if (var.storage != StorageClassInput)
@@ -1057,6 +1063,28 @@ void CompilerMSL::build_implicit_builtins()
 		set_decoration(var_id, DecorationBuiltIn, BuiltInPosition);
 		mark_implicit_builtin(StorageClassOutput, BuiltInPosition, var_id);
 	}
+
+	if (is_mesh_shader())
+	{
+		uint32_t offset = ir.increase_bound_by(2);
+		uint32_t type_ptr_id = offset;
+		uint32_t var_id = offset + 1;
+
+		// Create variable to store meshlet size.
+		uint32_t type_id = build_extended_vector_type(get_uint_type_id(), 2);
+		SPIRType uint_type_ptr = get<SPIRType>(type_id);
+		uint_type_ptr.op = OpTypePointer;
+		uint_type_ptr.pointer = true;
+		uint_type_ptr.pointer_depth++;
+		uint_type_ptr.parent_type = type_id;
+		uint_type_ptr.storage = StorageClassWorkgroup;
+
+		auto &ptr_type = set<SPIRType>(type_ptr_id, uint_type_ptr);
+		ptr_type.self = type_id;
+		set<SPIRVariable>(var_id, type_ptr_id, StorageClassWorkgroup);
+		set_name(var_id, "spvMeshSizes");
+		builtin_mesh_sizes_id = var_id;
+	}
 }
 
 // Checks if the specified builtin variable (e.g. gl_InstanceIndex) is marked as active.
@@ -1206,6 +1234,35 @@ uint32_t CompilerMSL::get_uint_type_id()
 	type.width = 32;
 	set<SPIRType>(uint_type_id, type);
 	return uint_type_id;
+}
+
+uint32_t CompilerMSL::get_shared_uint_type_id()
+{
+	if (shared_uint_type_id != 0)
+		return shared_uint_type_id;
+
+	shared_uint_type_id = ir.increase_bound_by(1);
+
+	SPIRType type { OpTypeInt };
+	type.basetype = SPIRType::UInt;
+	type.width = 32;
+	type.storage = spv::StorageClassWorkgroup;
+	set<SPIRType>(shared_uint_type_id, type);
+	return shared_uint_type_id;
+}
+
+uint32_t CompilerMSL::get_meshlet_type_id()
+{
+	if (meshlet_type_id != 0)
+		return meshlet_type_id;
+
+	meshlet_type_id = ir.increase_bound_by(1);
+
+	SPIRType type { OpTypeStruct };
+	type.basetype = SPIRType::Meshlet;
+	// type.storage = StorageClassWorkgroup; // threadgroup is not alowed with mesh<>
+	set<SPIRType>(meshlet_type_id, type);
+	return meshlet_type_id;
 }
 
 void CompilerMSL::emit_entry_point_declarations()
@@ -1509,6 +1566,11 @@ void CompilerMSL::emit_entry_point_declarations()
 		statement(CompilerGLSL::variable_decl(var), ";");
 		var.deferred_declaration = false;
 	}
+
+	if (processing_entry_point && is_mesh_shader())
+	{
+		statement("threadgroup uint2 spvMeshSizes;");
+	}
 }
 
 string CompilerMSL::compile()
@@ -1544,6 +1606,8 @@ string CompilerMSL::compile()
 	backend.native_pointers = true;
 	backend.nonuniform_qualifier = "";
 	backend.support_small_type_sampling_result = true;
+	backend.force_merged_mesh_block = false;
+	backend.force_gl_in_out_block = get_execution_model() == ExecutionModelMeshEXT;
 	backend.supports_empty_struct = true;
 	backend.support_64bit_switch = true;
 	backend.boolean_in_struct_remapped_type = SPIRType::Short;
@@ -1559,6 +1623,11 @@ string CompilerMSL::compile()
 	capture_output_to_buffer = msl_options.capture_output_to_buffer;
 	is_rasterization_disabled = msl_options.disable_rasterization || capture_output_to_buffer;
 
+	if(is_mesh_shader() && !get_entry_point().flags.get(ExecutionModeOutputPoints))
+	{
+		msl_options.enable_point_size_builtin = false;
+	}
+
 	// Initialize array here rather than constructor, MSVC 2013 workaround.
 	for (auto &id : next_metal_resource_ids)
 		id = 0;
@@ -1566,6 +1635,11 @@ string CompilerMSL::compile()
 	fixup_anonymous_struct_names();
 	fixup_type_alias();
 	replace_illegal_names();
+	if (get_execution_model() == ExecutionModelMeshEXT)
+	{
+		// emit proxy entry-point for the sake of copy-pass
+		emit_mesh_entry_point();
+	}
 	sync_entry_point_aliases_and_names();
 
 	build_function_control_flow_graphs_and_analyze();
@@ -1617,9 +1691,16 @@ string CompilerMSL::compile()
 	// Create structs to hold input, output and uniform variables.
 	// Do output first to ensure out. is declared at top of entry function.
 	qual_pos_var_name = "";
-	stage_out_var_id = add_interface_block(StorageClassOutput);
-	patch_stage_out_var_id = add_interface_block(StorageClassOutput, true);
-	stage_in_var_id = add_interface_block(StorageClassInput);
+	if(is_mesh_shader())
+	{
+		fixup_implicit_builtin_block_names(get_execution_model());
+	}
+	else
+	{
+		stage_out_var_id = add_interface_block(StorageClassOutput);
+		patch_stage_out_var_id = add_interface_block(StorageClassOutput, true);
+		stage_in_var_id = add_interface_block(StorageClassInput);
+	}
 	if (is_tese_shader())
 		patch_stage_in_var_id = add_interface_block(StorageClassInput, true);
 
@@ -1627,6 +1708,11 @@ string CompilerMSL::compile()
 		stage_out_ptr_var_id = add_interface_block_pointer(stage_out_var_id, StorageClassOutput);
 	if (is_tessellation_shader())
 		stage_in_ptr_var_id = add_interface_block_pointer(stage_in_var_id, StorageClassInput);
+	if (is_mesh_shader())
+	{
+		mesh_out_per_vertex = add_meshlet_block(false);
+		mesh_out_per_primitive = add_meshlet_block(true);
+	}
 
 	// Metal vertex functions that define no output must disable rasterization and return void.
 	if (!stage_out_var_id)
@@ -1766,6 +1852,11 @@ void CompilerMSL::localize_global_variables()
 		{
 			if (!variable_is_lut(var))
 				entry_func.add_local_variable(v_id);
+			iter = global_variables.erase(iter);
+		}
+		else if (var.storage == StorageClassOutput && is_mesh_shader())
+		{
+			entry_func.add_local_variable(v_id);
 			iter = global_variables.erase(iter);
 		}
 		else
@@ -2105,6 +2196,15 @@ void CompilerMSL::extract_global_variables_from_function(uint32_t func_id, std::
 				break;
 			}
 
+			case OpSetMeshOutputsEXT:
+			{
+				if (builtin_local_invocation_index_id != 0)
+					added_arg_ids.insert(builtin_local_invocation_index_id);
+				if (builtin_mesh_sizes_id != 0)
+					added_arg_ids.insert(builtin_mesh_sizes_id);
+				break;
+			}
+
 			default:
 				break;
 			}
@@ -2205,6 +2305,17 @@ void CompilerMSL::extract_global_variables_from_function(uint32_t func_id, std::
 				set_name(next_id, name);
 				if (is_tese_shader() && msl_options.raw_buffer_tese_input && var.storage == StorageClassInput)
 					set_decoration(next_id, DecorationNonWritable);
+			}
+			else if (is_builtin && is_mesh_shader())
+			{
+				uint32_t next_id = ir.increase_bound_by(1);
+				func.add_parameter(type_id, next_id, true);
+				auto &v = set<SPIRVariable>(next_id, type_id, StorageClassFunction, 0, arg_id);
+				v.storage = StorageClassWorkgroup;
+
+				// Ensure the existing variable has a valid name and the new variable has all the same meta info
+				set_name(arg_id, ensure_valid_name(to_name(arg_id), "v"));
+				ir.meta[next_id] = ir.meta[arg_id];
 			}
 			else if (is_builtin && has_decoration(p_type->self, DecorationBlock))
 			{
@@ -4490,6 +4601,43 @@ uint32_t CompilerMSL::add_interface_block_pointer(uint32_t ib_var_id, StorageCla
 	return ib_ptr_var_id;
 }
 
+uint32_t CompilerMSL::add_meshlet_block(bool per_primitive)
+{
+	// Accumulate the variables that should appear in the interface struct.
+	SmallVector<SPIRVariable *> vars;
+
+	ir.for_each_typed_id<SPIRVariable>(
+	    [&](uint32_t, SPIRVariable &var)
+		  {
+		    if (var.storage != StorageClassOutput || var.self == builtin_mesh_primitive_indices_id)
+					return;
+				if (is_per_primitive_variable(var) != per_primitive)
+					return;
+				vars.push_back(&var);
+		  });
+
+	if (vars.empty())
+		return 0;
+
+	uint32_t next_id = ir.increase_bound_by(1);
+	SPIRType &type = set<SPIRType>(next_id, SPIRType(OpTypeStruct));
+	type.basetype = SPIRType::Struct;
+
+	InterfaceBlockMeta meta;
+	for (auto *p_var : vars)
+	{
+		meta.strip_array = true;
+		meta.allow_local_declaration = false;
+		add_variable_to_interface_block(StorageClassOutput, "", type, *p_var, meta);
+	}
+
+	if (per_primitive)
+		set_name(type.self, "spvPerPrimitive");
+	else
+		set_name(type.self, "spvPerVertex");
+	return next_id;
+}
+
 // Ensure that the type is compatible with the builtin.
 // If it is, simply return the given type ID.
 // Otherwise, create a new type, and return it's ID.
@@ -5482,6 +5630,19 @@ void CompilerMSL::emit_custom_templates()
 			begin_scope();
 			statement("return elements[pos];");
 			end_scope();
+			if (get_execution_model() == spv::ExecutionModelMeshEXT ||
+			    get_execution_model() == spv::ExecutionModelTaskEXT)
+			{
+				statement("");
+				statement("object_data T& operator [] (size_t pos) object_data");
+				begin_scope();
+				statement("return elements[pos];");
+				end_scope();
+				statement("constexpr const object_data T& operator [] (size_t pos) const object_data");
+				begin_scope();
+				statement("return elements[pos];");
+				end_scope();
+			}
 			end_scope_decl();
 			statement("");
 			break;
@@ -7609,6 +7770,17 @@ void CompilerMSL::emit_custom_functions()
 			statement("");
 			break;
 
+		case SPVFuncImplSetMeshOutputsEXT:
+			statement("void SetMeshOutputsEXT(thread uint gl_LocalInvocationIndex, threadgroup uint2& spvMeshSizes, uint vertexCount, uint primitiveCount)");
+			begin_scope();
+			statement("if (gl_LocalInvocationIndex == 0)");
+			begin_scope();
+			statement("spvMeshSizes.x = vertexCount;");
+			statement("spvMeshSizes.y = primitiveCount;");
+			end_scope();
+			end_scope();
+			statement("");
+			break;
 		default:
 			break;
 		}
@@ -7710,6 +7882,23 @@ void CompilerMSL::emit_resources()
 	emit_interface_block(patch_stage_out_var_id);
 	emit_interface_block(stage_in_var_id);
 	emit_interface_block(patch_stage_in_var_id);
+
+	if (get_execution_model() == ExecutionModelMeshEXT)
+	{
+		auto &execution = get_entry_point();
+		const char *topology = "";
+		if (execution.flags.get(ExecutionModeOutputTrianglesEXT))
+			topology = "topology::triangle";
+		else if (execution.flags.get(ExecutionModeOutputLinesEXT))
+			topology = "topology::line";
+		else if (execution.flags.get(ExecutionModeOutputPoints))
+			topology = "topology::point";
+
+		const char *per_primitive = mesh_out_per_primitive ? "spvPerPrimitive" : "void";
+		statement("using spvMesh_t = mesh<", "spvPerVertex, ", per_primitive, ", ", execution.output_vertices, ", ",
+		          execution.output_primitives, ", ", topology, ">;");
+		statement("");
+	}
 }
 
 // Emit declarations for the specialization Metal function constants
@@ -7733,7 +7922,7 @@ void CompilerMSL::emit_specialization_constants_and_structs()
 			mark_scalar_layout_structs(type);
 	});
 
-	bool builtin_block_type_is_required = false;
+	bool builtin_block_type_is_required = is_mesh_shader();
 	// Very special case. If gl_PerVertex is initialized as an array (tessellation)
 	// we have to potentially emit the gl_PerVertex struct type so that we can emit a constant LUT.
 	ir.for_each_typed_id<SPIRConstant>([&](uint32_t, SPIRConstant &c) {
@@ -9924,6 +10113,13 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		inherit_expression_dependencies(id, vec2);
 		break;
 	}
+	case OpSetMeshOutputsEXT:
+	{
+		flush_variable_declaration(builtin_mesh_primitive_indices_id);
+		add_spv_func_and_recompile(SPVFuncImplSetMeshOutputsEXT);
+		statement("SetMeshOutputsEXT(gl_LocalInvocationIndex, spvMeshSizes, ", to_unpacked_expression(ops[0]), ", ", to_unpacked_expression(ops[1]), ");");
+	}
+	break;
 
 	default:
 		CompilerGLSL::emit_instruction(instruction);
@@ -9966,7 +10162,9 @@ void CompilerMSL::emit_texture_op(const Instruction &i, bool sparse)
 
 void CompilerMSL::emit_barrier(uint32_t id_exe_scope, uint32_t id_mem_scope, uint32_t id_mem_sem)
 {
-	if (get_execution_model() != ExecutionModelGLCompute && !is_tesc_shader())
+	auto model = get_execution_model();
+	if (model != ExecutionModelGLCompute && model != ExecutionModelTaskEXT && model != ExecutionModelMeshEXT &&
+	    !is_tesc_shader())
 		return;
 
 	uint32_t exe_scope = id_exe_scope ? evaluate_constant_u32(id_exe_scope) : uint32_t(ScopeInvocation);
@@ -12463,10 +12661,44 @@ string CompilerMSL::to_struct_member(const SPIRType &type, uint32_t member_type_
 				((stage_out_var_id && get_stage_out_struct_type().self == type.self &&
 				  variable_storage_requires_stage_io(StorageClassOutput)) ||
 				 (stage_in_var_id && get_stage_in_struct_type().self == type.self &&
-				  variable_storage_requires_stage_io(StorageClassInput)));
+		      variable_storage_requires_stage_io(StorageClassInput))) ||
+		    (is_mesh_shader());
 		if (is_ib_in_out && is_member_builtin(type, index, &builtin))
 			is_using_builtin_array = true;
 		array_type = type_to_array_glsl(physical_type, orig_id);
+	}
+
+	if (is_mesh_shader())
+	{
+		BuiltIn builtin = BuiltInMax;
+		bool block = has_decoration(type.self, DecorationBlock);
+		if (block && is_member_builtin(type, index, &builtin))
+		{
+			if (builtin == BuiltInPrimitiveShadingRateKHR)
+			{
+				// not supported in metal 3.0
+				is_using_builtin_array = false;
+				return "";
+			}
+
+			SPIRType metallic_type = *declared_type;
+			if (builtin == BuiltInCullPrimitiveEXT)
+			{
+				metallic_type.basetype = SPIRType::Boolean;
+			}
+			else if (builtin == BuiltInPrimitiveId || builtin == BuiltInLayer || builtin == BuiltInViewportIndex)
+			{
+				metallic_type.basetype = SPIRType::UInt;
+			}
+
+			is_using_builtin_array = true;
+			std::string result;
+			result = join(type_to_glsl(metallic_type, orig_id, false), " ", qualifier,
+			              builtin_to_glsl(builtin, StorageClassOutput), member_attribute_qualifier(type, index),
+			              array_type, ";");
+			is_using_builtin_array = false;
+			return result;
+		}
 	}
 
 	if (orig_id)
@@ -12520,6 +12752,16 @@ void CompilerMSL::emit_struct_member(const SPIRType &type, uint32_t member_type_
 	{
 		uint32_t pad_len = get_extended_member_decoration(type.self, index, SPIRVCrossDecorationPaddingTarget);
 		statement("char _m", index, "_pad", "[", pad_len, "];");
+	}
+
+	BuiltIn builtin = BuiltInMax;
+	if (is_mesh_shader() && is_member_builtin(type, index, &builtin))
+	{
+		if (!has_active_builtin(builtin, StorageClassOutput) && !has_active_builtin(builtin, StorageClassInput))
+		{
+			// Do not emit unused builtins in mesh-output blocks
+			return;
+		}
 	}
 
 	// Handle HLSL-style 0-based vertex/instance index.
@@ -12596,8 +12838,8 @@ string CompilerMSL::member_attribute_qualifier(const SPIRType &type, uint32_t in
 	}
 
 	// Vertex and tessellation evaluation function outputs
-	if (((execution.model == ExecutionModelVertex && !msl_options.vertex_for_tessellation) || is_tese_shader()) &&
-	    type.storage == StorageClassOutput)
+	if (((execution.model == ExecutionModelVertex && !msl_options.vertex_for_tessellation) || is_tese_shader() || is_mesh_shader()) &&
+	    (type.storage == StorageClassOutput || is_mesh_shader()))
 	{
 		if (is_builtin)
 		{
@@ -12616,6 +12858,9 @@ string CompilerMSL::member_attribute_qualifier(const SPIRType &type, uint32_t in
 				/* fallthrough */
 			case BuiltInPosition:
 			case BuiltInLayer:
+			case BuiltInCullPrimitiveEXT:
+			case BuiltInPrimitiveShadingRateKHR:
+			case BuiltInPrimitiveId:
 				return string(" [[") + builtin_qualifier(builtin) + "]]" + (mbr_type.array.empty() ? "" : " ");
 
 			case BuiltInClipDistance:
@@ -13078,6 +13323,9 @@ string CompilerMSL::func_type_decl(SPIRType &type)
 	case ExecutionModelKernel:
 		entry_type = "kernel";
 		break;
+	case ExecutionModelMeshEXT:
+		entry_type = "[[mesh]]";
+		break;
 	default:
 		entry_type = "unknown";
 		break;
@@ -13094,6 +13342,11 @@ bool CompilerMSL::is_tesc_shader() const
 bool CompilerMSL::is_tese_shader() const
 {
 	return get_execution_model() == ExecutionModelTessellationEvaluation;
+}
+
+bool CompilerMSL::is_mesh_shader() const
+{
+	return get_execution_model() == spv::ExecutionModelMeshEXT;
 }
 
 bool CompilerMSL::uses_explicit_early_fragment_test()
@@ -13210,6 +13463,10 @@ string CompilerMSL::get_type_address_space(const SPIRType &type, uint32_t id, bo
 
 			if (!addr_space)
 				addr_space = "device";
+		}
+		if (is_mesh_shader())
+		{
+			addr_space = "threadgroup";
 		}
 		break;
 
@@ -13611,6 +13868,13 @@ void CompilerMSL::entry_point_args_builtin(string &ep_args)
 			ep_args += join("const device ", type_to_glsl(get_stage_in_struct_type()), "* ", input_buffer_var_name,
 			                " [[buffer(", convert_to_string(msl_options.shader_input_buffer_index), ")]]");
 		}
+	}
+
+	if (is_mesh_shader())
+	{
+		if (!ep_args.empty())
+			ep_args += ", ";
+		ep_args += join("spvMesh_t spvMesh");
 	}
 }
 
@@ -14048,6 +14312,11 @@ void CompilerMSL::fix_up_shader_inputs_outputs()
 			          " >= ", to_expression(builtin_stage_input_size_id), "))");
 			statement("    return;");
 		});
+	}
+
+	if (is_mesh_shader())
+	{
+		entry_func.fixup_hooks_out.push_back([=]() { emit_mesh_outputs(); });
 	}
 
 	// Look for sampled images and buffer. Add hooks to set up the swizzle constants or array lengths.
@@ -14850,7 +15119,8 @@ string CompilerMSL::argument_decl(const SPIRFunction::Parameter &arg)
 
 	if (var.basevariable && (var.basevariable == stage_in_ptr_var_id || var.basevariable == stage_out_ptr_var_id))
 		decl = join(cv_qualifier, type_to_glsl(type, arg.id));
-	else if (builtin)
+	else if (builtin && builtin_type != spv::BuiltInPrimitiveTriangleIndicesEXT &&
+	         builtin_type != spv::BuiltInPrimitiveLineIndicesEXT && builtin_type != spv::BuiltInPrimitivePointIndicesEXT)
 	{
 		// Only use templated array for Clip/Cull distance when feasible.
 		// In other scenarios, we need need to override array length for tess levels (if used as outputs),
@@ -15785,6 +16055,11 @@ bool CompilerMSL::variable_decl_is_remapped_storage(const SPIRVariable &variable
 			return true;
 		}
 
+		if (is_mesh_shader())
+		{
+			return variable.storage == StorageClassOutput;
+		}
+
 		return variable.storage == StorageClassOutput && is_tesc_shader() && is_stage_output_variable_masked(variable);
 	}
 	else if (storage == StorageClassStorageBuffer)
@@ -16554,6 +16829,8 @@ string CompilerMSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 	case BuiltInLayer:
 		if (is_tesc_shader())
 			break;
+		if (is_mesh_shader())
+			break;
 		if (storage != StorageClassInput && current_function && (current_function->self == ir.default_entry_point) &&
 		    !is_stage_output_builtin_masked(builtin))
 			return stage_out_var_name + "." + CompilerGLSL::builtin_to_glsl(builtin, storage);
@@ -16611,6 +16888,9 @@ string CompilerMSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 		// In SPIR-V 1.6 with Volatile HelperInvocation, we cannot emit a fixup early.
 		return "simd_is_helper_thread()";
 
+	case BuiltInPrimitiveId:
+		return "gl_PrimitiveID";
+
 	default:
 		break;
 	}
@@ -16644,6 +16924,8 @@ string CompilerMSL::builtin_qualifier(BuiltIn builtin)
 	// Vertex function out
 	case BuiltInClipDistance:
 		return "clip_distance";
+	case BuiltInCullDistance:
+		return "cull_distance";
 	case BuiltInPointSize:
 		return "point_size";
 	case BuiltInPosition:
@@ -16691,6 +16973,8 @@ string CompilerMSL::builtin_qualifier(BuiltIn builtin)
 			else if (msl_options.is_macos() && !msl_options.supports_msl_version(2, 2))
 				SPIRV_CROSS_THROW("PrimitiveId on macOS requires MSL 2.2.");
 			return "primitive_id";
+		case ExecutionModelMeshEXT:
+			return "primitive_id";
 		default:
 			SPIRV_CROSS_THROW("PrimitiveId is not supported in this execution model.");
 		}
@@ -16720,7 +17004,7 @@ string CompilerMSL::builtin_qualifier(BuiltIn builtin)
 		// Shouldn't be reached.
 		SPIRV_CROSS_THROW("Sample position is retrieved by a function in MSL.");
 	case BuiltInViewIndex:
-		if (execution.model != ExecutionModelFragment)
+		if (execution.model != ExecutionModelFragment && execution.model != ExecutionModelMeshEXT)
 			SPIRV_CROSS_THROW("ViewIndex is handled specially outside fragment shaders.");
 		// The ViewIndex was implicitly used in the prior stages to set the render_target_array_index,
 		// so we can get it from there.
@@ -16824,6 +17108,9 @@ string CompilerMSL::builtin_qualifier(BuiltIn builtin)
 		else if (!msl_options.supports_msl_version(2, 2))
 			SPIRV_CROSS_THROW("Barycentrics are only supported in MSL 2.2 and above on macOS.");
 		return "barycentric_coord";
+
+	case BuiltInCullPrimitiveEXT:
+		return "primitive_culled";
 
 	default:
 		return "unsupported-built-in";
@@ -16940,6 +17227,13 @@ string CompilerMSL::builtin_type_decl(BuiltIn builtin, uint32_t id)
 
 	case BuiltInDeviceIndex:
 		return "int";
+
+	case BuiltInPrimitivePointIndicesEXT:
+		return "uint";
+	case BuiltInPrimitiveLineIndicesEXT:
+		return "uint2";
+	case BuiltInPrimitiveTriangleIndicesEXT:
+		return "uint3";
 
 	default:
 		return "unsupported-built-in-type";
@@ -18797,6 +19091,223 @@ const char *CompilerMSL::get_combined_sampler_suffix() const
 
 void CompilerMSL::emit_block_hints(const SPIRBlock &)
 {
+}
+
+void CompilerMSL::emit_mesh_entry_point()
+{
+	auto &ep = get_entry_point();
+	auto &f = get<SPIRFunction>(ir.default_entry_point);
+
+	const uint32_t func_id = ir.increase_bound_by(3);
+	const uint32_t block_id = func_id + 1;
+	const uint32_t ret_id = func_id + 2;
+	current_function = &set<SPIRFunction>(func_id, f.return_type, f.function_type);
+
+	current_function->blocks.push_back(block_id);
+	current_function->entry_block = block_id;
+
+	current_block = &set<SPIRBlock>(block_id);
+	current_block->terminator = SPIRBlock::Return;
+
+	// push call to original 'main'
+	Instruction ix = {};
+	ix.op = OpFunctionCall;
+	ix.offset = uint32_t(ir.spirv.size());
+	ix.length = 3;
+
+	ir.spirv.push_back(f.return_type);
+	ir.spirv.push_back(ret_id);
+	ir.spirv.push_back(ep.self);
+
+	current_block->ops.push_back(ix);
+
+	current_block = nullptr;
+	current_function = nullptr;
+
+	// relace entry-point for new one
+	SPIREntryPoint proxy_ep = ep;
+	proxy_ep.self = func_id;
+	ir.entry_points.insert(std::make_pair(func_id, proxy_ep));
+	ir.meta[func_id] = ir.meta[ir.default_entry_point];
+	ir.meta[ir.default_entry_point].decoration.alias.clear();
+
+	ir.default_entry_point = func_id;
+}
+
+void CompilerMSL::emit_mesh_outputs()
+{
+	auto &mode = get_entry_point();
+
+	// predefined thread count or zero, if specialization constant is in use
+	uint32_t num_invocaions = 0;
+	if (mode.workgroup_size.id_x == 0 && mode.workgroup_size.id_y == 0 && mode.workgroup_size.id_z == 0)
+	{
+		num_invocaions = mode.workgroup_size.x * mode.workgroup_size.y * mode.workgroup_size.z;
+	}
+
+	statement("threadgroup_barrier(mem_flags::mem_threadgroup);");
+	statement("if (spvMeshSizes.y == 0)");
+	begin_scope();
+	statement("return;");
+	end_scope();
+	statement("spvMesh.set_primitive_count(spvMeshSizes.y);");
+
+	statement("const uint spvThreadCount = (gl_WorkGroupSize.x*gl_WorkGroupSize.y*gl_WorkGroupSize.z);");
+	if (builtin_mesh_primitive_indices_id != 0)
+	{
+		if (num_invocaions < mode.output_primitives)
+		{
+		  statement("for (uint spvI = gl_LocalInvocationIndex; spvI < ", mode.output_primitives, "; spvI += spvThreadCount)");
+		}
+		else if (num_invocaions != mode.output_primitives)
+		{
+		  statement("if (gl_LocalInvocationIndex < ", mode.output_primitives, ")");
+		}
+		begin_scope();
+		if (num_invocaions >= mode.output_primitives)
+		{
+		  statement("const uint spvI = gl_LocalInvocationIndex;");
+		}
+		if (mode.flags.get(ExecutionModeOutputTrianglesEXT))
+		{
+		  statement("spvMesh.set_index(spvI * 3u + 0u, gl_PrimitiveTriangleIndicesEXT[spvI].x);");
+		  statement("spvMesh.set_index(spvI * 3u + 1u, gl_PrimitiveTriangleIndicesEXT[spvI].y);");
+		  statement("spvMesh.set_index(spvI * 3u + 2u, gl_PrimitiveTriangleIndicesEXT[spvI].z);");
+		}
+		else if (mode.flags.get(ExecutionModeOutputLinesEXT))
+		{
+		  statement("spvMesh.set_index(spvI * 2u + 0u, gl_PrimitiveLineIndicesEXT[spvI].x);");
+		  statement("spvMesh.set_index(spvI * 2u + 1u, gl_PrimitiveLineIndicesEXT[spvI].y);");
+		}
+		else
+		{
+		  statement("spvMesh.set_index(spvI, gl_PrimitivePointIndicesEXT[spvI]);");
+		}
+		end_scope();
+	}
+
+	if (mesh_out_per_vertex != 0)
+	{
+		auto &type_vert = get<SPIRType>(mesh_out_per_vertex);
+		if (num_invocaions < mode.output_vertices)
+		{
+		  statement("for (uint spvI = gl_LocalInvocationIndex; spvI < ", mode.output_vertices, "; spvI += spvThreadCount)");
+		}
+		else if (num_invocaions != mode.output_vertices)
+		{
+		  statement("if (gl_LocalInvocationIndex < ", mode.output_vertices, ")");
+		}
+		begin_scope();
+		if (num_invocaions >= mode.output_vertices)
+		{
+		  statement("const uint spvI = gl_LocalInvocationIndex;");
+		}
+		statement("spvPerVertex spvV = {};");
+		for (uint32_t index = 0; index < uint32_t(type_vert.member_types.size()); ++index)
+		{
+		  uint32_t orig_var = get_extended_member_decoration(type_vert.self, index, SPIRVCrossDecorationInterfaceOrigID);
+		  uint32_t orig_id = get_extended_member_decoration(type_vert.self, index, SPIRVCrossDecorationInterfaceMemberIndex);
+
+		  if (orig_id==(~0u))
+		  {
+		    // clip/cull distances are special-case
+		    continue;
+		  }
+		  auto &orig = get<SPIRVariable>(orig_var);
+		  auto &orig_type = get<SPIRType>(orig.basetype);
+
+		  BuiltIn builtin = BuiltInMax;
+		  std::string access;
+		  if (orig_type.basetype == SPIRType::Struct)
+		  {
+		    if (has_member_decoration(orig_type.self, orig_id, DecorationBuiltIn))
+		    {
+		      builtin = BuiltIn(get_member_decoration(orig_type.self, orig_id, DecorationBuiltIn));
+		    }
+
+		    switch (builtin)
+		    {
+		      case BuiltInPosition:
+		      case BuiltInPointSize:
+		      case BuiltInClipDistance:
+		      case BuiltInCullDistance:
+		        access = "." + builtin_to_glsl(builtin, StorageClassOutput);
+		        break;
+		      default:
+		        access = "." + to_member_name(orig_type, orig_id);
+		    }
+
+		    if (has_member_decoration(type_vert.self, index, DecorationIndex))
+		    {
+		      // Declare the Clip/CullDistance as [[user(clip/cullN)]].
+		      const uint32_t orig_index = get_member_decoration(type_vert.self, index, DecorationIndex);
+		      access += "[" + to_string(orig_index) + "]";
+		      statement("spvV.", builtin_to_glsl(builtin, StorageClassOutput), "[", orig_index, "] = ", to_name(orig_var), "[spvI]", access, ";");
+		    }
+		  }
+
+		  statement("spvV.", to_member_name(type_vert, index), " = ", to_name(orig_var), "[spvI]", access, ";");
+		  if (options.vertex.flip_vert_y && builtin == BuiltInPosition)
+		  {
+		    statement("spvV.", to_member_name(type_vert, index), ".y = -(", "spvV.",
+		        to_member_name(type_vert, index), ".y);", "    // Invert Y-axis for Metal");
+		  }
+		}
+		statement("spvMesh.set_vertex(spvI, spvV);");
+		end_scope();
+	}
+
+	if (mesh_out_per_primitive != 0)
+	{
+		auto &type_prim = get<SPIRType>(mesh_out_per_primitive);
+		if (num_invocaions < mode.output_primitives)
+		{
+		  statement("for (uint spvI = gl_LocalInvocationIndex; spvI < ", mode.output_primitives, "; spvI += spvThreadCount)");
+		}
+		else if (num_invocaions != mode.output_primitives)
+		{
+		  statement("if (gl_LocalInvocationIndex < ", mode.output_primitives, ")");
+		}
+		begin_scope();
+		if (num_invocaions >= mode.output_primitives)
+		{
+		  statement("const uint spvI = gl_LocalInvocationIndex;");
+		}
+		statement("spvPerPrimitive spvP = {};");
+		for (uint32_t index = 0; index < uint32_t(type_prim.member_types.size()); ++index)
+		{
+		  uint32_t orig_var =
+		      get_extended_member_decoration(type_prim.self, index, SPIRVCrossDecorationInterfaceOrigID);
+		  uint32_t orig_id =
+		      get_extended_member_decoration(type_prim.self, index, SPIRVCrossDecorationInterfaceMemberIndex);
+		  auto &orig = get<SPIRVariable>(orig_var);
+		  auto &orig_type = get<SPIRType>(orig.basetype);
+
+		  BuiltIn builtin = BuiltInMax;
+		  std::string access;
+		  if (orig_type.basetype == SPIRType::Struct)
+		  {
+		    if (has_member_decoration(orig_type.self, orig_id, DecorationBuiltIn))
+		      builtin = BuiltIn(get_member_decoration(orig_type.self, orig_id, DecorationBuiltIn));
+
+		    switch (builtin)
+		    {
+		    case BuiltInPrimitiveId:
+		    case BuiltInLayer:
+		    case BuiltInViewportIndex:
+		    case BuiltInCullPrimitiveEXT:
+		    case BuiltInPrimitiveShadingRateKHR:
+		      access = "." + builtin_to_glsl(builtin, StorageClassOutput);
+		      break;
+		    default:
+		      access = "." + to_member_name(orig_type, orig_id);
+		    }
+		  }
+		  statement("spvP.", to_member_name(type_prim, index), " = ", to_name(orig_var), "[spvI]", access, ";");
+		}
+		statement("spvMesh.set_primitive(spvI, spvP);");
+		end_scope();
+	}
 }
 
 string CompilerMSL::additional_fixed_sample_mask_str() const

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -12671,8 +12671,7 @@ string CompilerMSL::to_struct_member(const SPIRType &type, uint32_t member_type_
 	if (is_mesh_shader())
 	{
 		BuiltIn builtin = BuiltInMax;
-		bool block = has_decoration(type.self, DecorationBlock);
-		if (block && is_member_builtin(type, index, &builtin))
+		if (is_member_builtin(type, index, &builtin))
 		{
 			if (builtin == BuiltInPrimitiveShadingRateKHR)
 			{
@@ -12693,9 +12692,18 @@ string CompilerMSL::to_struct_member(const SPIRType &type, uint32_t member_type_
 
 			is_using_builtin_array = true;
 			std::string result;
-			result = join(type_to_glsl(metallic_type, orig_id, false), " ", qualifier,
-			              builtin_to_glsl(builtin, StorageClassOutput), member_attribute_qualifier(type, index),
-			              array_type, ";");
+			if (has_member_decoration(type.self, orig_id, DecorationBuiltIn))
+			{
+				// avoid '_RESERVED_IDENTIFIER_FIXUP_' in variable name
+				result = join(type_to_glsl(metallic_type, orig_id, false), " ", qualifier,
+				              builtin_to_glsl(builtin, StorageClassOutput), member_attribute_qualifier(type, index),
+				              array_type, ";");
+			}
+			else
+			{
+				result = join(type_to_glsl(metallic_type, orig_id, false), " ", qualifier,
+				              to_member_name(type, index), member_attribute_qualifier(type, index), array_type, ";");
+			}
 			is_using_builtin_array = false;
 			return result;
 		}

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -840,6 +840,7 @@ protected:
 		SPVFuncImplImageFence,
 		SPVFuncImplTextureCast,
 		SPVFuncImplMulExtended,
+		SPVFuncImplSetMeshOutputsEXT,
 	};
 
 	// If the underlying resource has been used for comparison then duplicate loads of that resource must be too
@@ -868,6 +869,8 @@ protected:
 	std::string type_to_glsl(const SPIRType &type, uint32_t id, bool member);
 	std::string type_to_glsl(const SPIRType &type, uint32_t id = 0) override;
 	void emit_block_hints(const SPIRBlock &block) override;
+	void emit_mesh_entry_point();
+	void emit_mesh_outputs();
 
 	// Allow Metal to use the array<T> template to make arrays a value type
 	std::string type_to_array_glsl(const SPIRType &type, uint32_t variable_id) override;
@@ -919,6 +922,7 @@ protected:
 
 	bool is_tesc_shader() const;
 	bool is_tese_shader() const;
+	bool is_mesh_shader() const;
 
 	void preprocess_op_codes();
 	void localize_global_variables();
@@ -933,6 +937,7 @@ protected:
 	                                            std::unordered_set<uint32_t> &processed_func_ids);
 	uint32_t add_interface_block(spv::StorageClass storage, bool patch = false);
 	uint32_t add_interface_block_pointer(uint32_t ib_var_id, spv::StorageClass storage);
+	uint32_t add_meshlet_block(bool per_primitive);
 
 	struct InterfaceBlockMeta
 	{
@@ -1072,6 +1077,8 @@ protected:
 	std::string get_tess_factor_struct_name();
 	SPIRType &get_uint_type();
 	uint32_t get_uint_type_id();
+	uint32_t get_shared_uint_type_id();
+	uint32_t get_meshlet_type_id();
 	void emit_atomic_func_op(uint32_t result_type, uint32_t result_id, const char *op, spv::Op opcode,
 	                         uint32_t mem_order_1, uint32_t mem_order_2, bool has_mem_order_2, uint32_t op0, uint32_t op1 = 0,
 	                         bool op1_is_pointer = false, bool op1_is_literal = false, uint32_t op2 = 0);
@@ -1104,12 +1111,16 @@ protected:
 	uint32_t builtin_stage_input_size_id = 0;
 	uint32_t builtin_local_invocation_index_id = 0;
 	uint32_t builtin_workgroup_size_id = 0;
+	uint32_t builtin_mesh_primitive_indices_id = 0;
+	uint32_t builtin_mesh_sizes_id = 0;
 	uint32_t builtin_frag_depth_id = 0;
 	uint32_t swizzle_buffer_id = 0;
 	uint32_t buffer_size_buffer_id = 0;
 	uint32_t view_mask_buffer_id = 0;
 	uint32_t dynamic_offsets_buffer_id = 0;
 	uint32_t uint_type_id = 0;
+	uint32_t shared_uint_type_id = 0;
+	uint32_t meshlet_type_id = 0;
 	uint32_t argument_buffer_padding_buffer_type_id = 0;
 	uint32_t argument_buffer_padding_image_type_id = 0;
 	uint32_t argument_buffer_padding_sampler_type_id = 0;
@@ -1174,6 +1185,8 @@ protected:
 	VariableID stage_out_ptr_var_id = 0;
 	VariableID tess_level_inner_var_id = 0;
 	VariableID tess_level_outer_var_id = 0;
+	VariableID mesh_out_per_vertex = 0;
+	VariableID mesh_out_per_primitive = 0;
 	VariableID stage_out_masked_builtin_type_id = 0;
 
 	// Handle HLSL-style 0-based vertex/instance index.


### PR DESCRIPTION
Rework of old https://github.com/KhronosGroup/SPIRV-Cross/pull/2074
Also made some changes to make diff smaller and also introduced `SetMeshOutputsEXT`  wrapper, for sake of code-gen clarity.

Only mesh stage, for the sake of code-review. Task will be separated PR.
In tests `taskPayloadSharedEXT` is replaced to `const`; other than that test-cases are copied from HLSL

~Note: shader-playground is down today - wasn't able to fully test output.~
Tested shaders via shader-playground