### PR TITLE
ci: Build dependency for Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,8 @@ jobs:
         run: ctest --verbose -C Release
 
   build-mobile:
+    # iOS is 10x expensive to run on GitHub machines, so only run if we know something else passed as well
+    needs: build
     name: "Build ${{ matrix.sdk }}"
     strategy:
       matrix:


### PR DESCRIPTION
Recently we have found productivty slow down in other KhronosGroups repos because it can take hours for CI to run due to running out of Github Actions minutes. We have found that MacOS/iOS are charged as 10x the minute cost which really starts to add up. The goal is to not have those expensive CI actions run unless we know other things work first.

(There is an internal issue on this, but for short term, I have just been apply these types of YAML chanegs aroudn the repos https://gitlab.khronos.org/khronos-general/khronos-issues/-/issues/127)