### PR TITLE
MSL: Pad array elements in Metal argument buffer when shader declares scalar.

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -18858,7 +18858,7 @@ void CompilerMSL::analyze_argument_buffers()
 				// If the current resource is an array in the descriptor, but is a scalar
 				// in the shader, only the first element will be consumed. The next pass
 				// will add a padding member to consume the remaining array elements.
-				if(count > 1 && type.array.empty())
+				if (count > 1 && type.array.empty())
 					count = prev_was_scalar_on_array_offset = 1;
 
 				// Adjust the number of slots consumed by current member itself.


### PR DESCRIPTION
A shader may declare and access the first element of a descriptor array as a scalar, which throws off the remaining structure of a Metal Argument Buffer. Add a padding member to the shader Metal argument buffer struct to consume the descriptor elements beyond the first.

- `CompilerMSL::analyze_argument_buffers()`: Track when a descriptor array is declared as a scalar in shader, and add a subsequent member to the Metal argument buffer struct to consume the elements beyond the first.
- `CompilerMSL::get_resource_array_size()`: Ensure variable id is valid.