### PR TITLE
glsl: Correct version number check for texture buffers

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -15956,7 +15956,7 @@ string CompilerGLSL::image_type_glsl(const SPIRType &type, uint32_t id, bool /*m
 	case DimBuffer:
 		if (options.es && options.version < 320)
 			require_extension_internal("GL_EXT_texture_buffer");
-		else if (!options.es && options.version < 300)
+		else if (!options.es && options.version < 140)
 			require_extension_internal("GL_EXT_texture_buffer_object");
 		res += "Buffer";
 		break;


### PR DESCRIPTION
Texture buffers were introduced in GLSL 140 on desktop. There is no GLSL 300 on desktop.