### PR TITLE
GLSL: Use u literal suffix in legacy GLSL if GL_EXT_gpu_shader4 is available

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -6438,7 +6438,7 @@ string CompilerGLSL::constant_expression_vector(const SPIRConstant &c, uint32_t 
 		if (splat)
 		{
 			res += convert_to_string(c.scalar(vector, 0));
-			if (is_legacy())
+			if (is_legacy() && !has_extension("GL_EXT_gpu_shader4"))
 			{
 				// Fake unsigned constant literals with signed ones if possible.
 				// Things like array sizes, etc, tend to be unsigned even though they could just as easily be signed.
@@ -6457,7 +6457,7 @@ string CompilerGLSL::constant_expression_vector(const SPIRConstant &c, uint32_t 
 				else
 				{
 					res += convert_to_string(c.scalar(vector, i));
-					if (is_legacy())
+					if (is_legacy() && !has_extension("GL_EXT_gpu_shader4"))
 					{
 						// Fake unsigned constant literals with signed ones if possible.
 						// Things like array sizes, etc, tend to be unsigned even though they could just as easily be signed.


### PR DESCRIPTION
Fixes a compile error due to constants not having proper suffix and legacy GLSL having no implicit conversion.

I tried to create a unit test but the test_shaders.py script doesn't have a way to build for desktop legacy GLSL.