### PR TITLE
GLSL: Add option to emulate alpha test

### DIFF
--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -164,6 +164,18 @@ public:
 			Highp
 		};
 
+		enum CompareFunc
+		{
+			Never,
+			Less,
+			Equal,
+			LessEqual,
+			Greater,
+			NotEqual,
+			GreaterEqual,
+			Always,
+		};
+
 		struct VertexOptions
 		{
 			// "Vertex-like shader" here is any shader stage that can write BuiltInPosition.
@@ -189,6 +201,9 @@ public:
 			// Add precision highp int in ES targets when emitting GLES source.
 			Precision default_float_precision = Mediump;
 			Precision default_int_precision = Highp;
+
+			// If this is not Always, injects an alpha test for the output with location 0.
+			CompareFunc emulate_alpha_test_func = Always;
 		} fragment;
 	};
 


### PR DESCRIPTION
Adds an option to add an emulated alpha test for back-ends not supporting it, which I imagine is a common enough manipulation that it might be worth putting it in SPIRV-Cross, similar to the coordinate system fix-ups. Always tests against the output with location 0, if present. Adds a uniform float variable called `SPIRV_Cross_AlphaTestRef` for the reference value. Alpha test is done at every return point from the main entry point.

Example generated shader:
```glsl
#version 460

uniform float SPIRV_Cross_AlphaTestRef;
layout(location = 4) uniform sampler2D p4;
layout(location = 5) uniform vec4 p5;

layout(location = 0) out vec4 o0;
layout(location = 0) in vec3 i1_0;
layout(location = 1) in vec4 i1_1;

void main()
{
    o0 = textureProj(p4, i1_0);
    o0 += p5;
    o0 *= i1_1;
    if (o0.a <= SPIRV_Cross_AlphaTestRef) discard;
}
```

I can work on unit tests if you like, but I wanted confirmation first whether you think this is in-scope for SPIRV-Cross.

If not, then maybe we can discuss the best way I can hook into SPIRV-Cross to add the test on the engine side (eg. by allowing a custom name for the main entry point so I can concatenate a wrapper).