### PR TITLE
MSL: Use unpacked arguments in texture arguments.

### DIFF
--- a/reference/shaders-msl-no-opt/frag/explicit-lod-unpack-arguments.frag
+++ b/reference/shaders-msl-no-opt/frag/explicit-lod-unpack-arguments.frag
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct MaterialParams
+{
+    float4 myLod[6];
+};
+
+struct main0_out
+{
+    float4 fragColor [[color(0)]];
+};
+
+fragment main0_out main0(constant MaterialParams& materialParams [[buffer(0)]], texture2d<float> mySampler [[texture(0)]], sampler mySamplerSmplr [[sampler(0)]])
+{
+    main0_out out = {};
+    out.fragColor = mySampler.sample(mySamplerSmplr, float2(0.0), level(materialParams.myLod[0].x));
+    return out;
+}
+

--- a/shaders-msl-no-opt/frag/explicit-lod-unpack-arguments.frag
+++ b/shaders-msl-no-opt/frag/explicit-lod-unpack-arguments.frag
@@ -1,0 +1,15 @@
+#version 310 es
+
+precision mediump float;
+
+layout(set = 2, binding = 0, std140) uniform MaterialParams {
+    float myLod[6];
+} materialParams;
+
+layout(binding = 1, set = 2) uniform  sampler2D mySampler;
+
+layout(location = 0) out vec4 fragColor;
+
+void main() {
+   fragColor = textureLod(mySampler, vec2(0.0), materialParams.myLod[0]);
+}


### PR DESCRIPTION
If sourcing arguments directly from std140 UBO arrays or something, we generated broken code.

Fix #2416.