### PR TITLE
Fix invariant propagation

### DIFF
--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -2569,15 +2569,25 @@ void Compiler::add_active_interface_variable(uint32_t var_id)
 
 void Compiler::inherit_expression_dependencies(uint32_t dst, uint32_t source_expression)
 {
-	// Don't inherit any expression dependencies if the expression in dst
-	// is not a forwarded temporary.
-	if (forwarded_temporaries.find(dst) == end(forwarded_temporaries) ||
-	    forced_temporaries.find(dst) != end(forced_temporaries))
+	// When position is invariant we'll need the full dependency chain to be available
+	// in order to force all dependencies into temporaries
+	if( !is_position_invariant() )
+	{
+		// Don't inherit any expression dependencies if the expression in dst
+		// is not a forwarded temporary.
+		if( forwarded_temporaries.find( dst ) == end( forwarded_temporaries ) ||
+			forced_temporaries.find( dst ) != end( forced_temporaries ) )
+		{
+			return;
+		}
+	}
+
+	auto *e_ptr = maybe_get<SPIRExpression>(dst);
+	if( !e_ptr )
 	{
 		return;
 	}
-
-	auto &e = get<SPIRExpression>(dst);
+	auto& e = *e_ptr;
 	auto *phi = maybe_get<SPIRVariable>(source_expression);
 	if (phi && phi->phi_variable)
 	{

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -11766,13 +11766,13 @@ void CompilerGLSL::disallow_forwarding_in_expression_chain(const SPIRExpression 
 	// Allow trivially forwarded expressions like OpLoad or trivial shuffles,
 	// these will be marked as having suppressed usage tracking.
 	// Our only concern is to make sure arithmetic operations are done in similar ways.
-	if (expression_is_forwarded(expr.self) && !expression_suppresses_usage_tracking(expr.self) &&
-	    forced_invariant_temporaries.count(expr.self) == 0)
+	if( ( forced_invariant_temporaries.count( expr.self ) == 0 ) &&
+		( backend.force_invariant_temporaries || ( expression_is_forwarded( expr.self ) && !expression_suppresses_usage_tracking( expr.self ) ) ) )
 	{
 		force_temporary_and_recompile(expr.self);
 		forced_invariant_temporaries.insert(expr.self);
 
-		for (auto &dependent : expr.expression_dependencies)
+		for (auto &dependent : expr.invariance_dependencies)
 			disallow_forwarding_in_expression_chain(get<SPIRExpression>(dependent));
 	}
 }

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -655,6 +655,7 @@ protected:
 		bool workgroup_size_is_hidden = false;
 		bool requires_relaxed_precision_analysis = false;
 		bool implicit_c_integer_promotion_rules = false;
+		bool force_invariant_temporaries = false;
 	} backend;
 
 	void emit_struct(SPIRType &type);

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1619,6 +1619,7 @@ string CompilerMSL::compile()
 	backend.support_pointer_to_pointer = true;
 	backend.implicit_c_integer_promotion_rules = true;
 
+	backend.force_invariant_temporaries = true;
 	capture_output_to_buffer = msl_options.capture_output_to_buffer;
 	is_rasterization_disabled = msl_options.disable_rasterization || capture_output_to_buffer;
 


### PR DESCRIPTION
GLSL/SPIRV output seems to work fine (i.e., no problems/glitches detected when using _invariant_), thus only for MSL output invariant position dependencies are forced into temporaries.