### PR TITLE
Bump to CMake 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@
 #  2. The MIT License, found at <http://opensource.org/licenses/MIT>.
 #
 
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.10)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 


### PR DESCRIPTION
Fix the following deprecation warning when using CMake 3.31:

> CMake Deprecation Warning at external/SPIRV-Cross/CMakeLists.txt:22 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.
>
>  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

From https://cmake.org/cmake/help/latest/release/3.31.html#deprecated-and-removed-features:
> Compatibility with versions of CMake older than 3.10 is now deprecated and will be removed from a future version. Calls to [cmake_minimum_required()](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required) or [cmake_policy()](https://cmake.org/cmake/help/latest/command/cmake_policy.html#command:cmake_policy) that set the policy version to an older value now issue a deprecation diagnostic.