### PR TITLE
[MSL] Added some more reserved keywords

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -15584,6 +15584,9 @@ const std::unordered_set<std::string> &CompilerMSL::get_illegal_func_names()
 {
 	static const unordered_set<string> illegal_func_names = {
 		"main",
+		"fragment",
+		"vertex",
+		"kernel",
 		"saturate",
 		"assert",
 		"fmin3",


### PR DESCRIPTION
The generated MSL can fail when compiling when the entry points are Metal reserved keywords, this adds some extra as required by Bevy game engine as it uses these keywords quite often. 

We should probably have to add some more keywords that are accepted by SPIRV but are Metal reserved keywords.