### PR TITLE
GLSL/MSL: Support VK_KHR_zero_initialize_workgroup_memory

### DIFF
--- a/reference/opt/shaders-msl/comp/shared-zero-init-simple.comp
+++ b/reference/opt/shaders-msl/comp/shared-zero-init-simple.comp
@@ -1,0 +1,31 @@
+#pragma clang diagnostic ignored "-Wsometimes-uninitialized"
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct SSBO
+{
+    float in_data[1];
+};
+
+struct SSBO2
+{
+    float out_data[1];
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(4u, 1u, 1u);
+
+kernel void main0(const device SSBO& _22 [[buffer(0)]], device SSBO2& _32 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]])
+{
+    threadgroup float sShared;
+    {
+        if (gl_LocalInvocationIndex == 0)
+        {
+            sShared = 0.0;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    _32.out_data[gl_GlobalInvocationID.x] = sShared + _22.in_data[gl_GlobalInvocationID.x];
+}
+

--- a/reference/opt/shaders-msl/comp/shared-zero-init.comp
+++ b/reference/opt/shaders-msl/comp/shared-zero-init.comp
@@ -1,0 +1,90 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wmissing-braces"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+template<typename T, size_t Num>
+struct spvUnsafeArray
+{
+    T elements[Num ? Num : 1];
+    
+    thread T& operator [] (size_t pos) thread
+    {
+        return elements[pos];
+    }
+    constexpr const thread T& operator [] (size_t pos) const thread
+    {
+        return elements[pos];
+    }
+    
+    device T& operator [] (size_t pos) device
+    {
+        return elements[pos];
+    }
+    constexpr const device T& operator [] (size_t pos) const device
+    {
+        return elements[pos];
+    }
+    
+    constexpr const constant T& operator [] (size_t pos) const constant
+    {
+        return elements[pos];
+    }
+    
+    threadgroup T& operator [] (size_t pos) threadgroup
+    {
+        return elements[pos];
+    }
+    constexpr const threadgroup T& operator [] (size_t pos) const threadgroup
+    {
+        return elements[pos];
+    }
+};
+
+struct SSBO
+{
+    float in_data[1];
+};
+
+struct SSBO2
+{
+    float out_data[1];
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(4u, 1u, 1u);
+
+constant spvUnsafeArray<float, 4> _31 = spvUnsafeArray<float, 4>({ 0.0, 0.0, 0.0, 0.0 });
+
+kernel void main0(const device SSBO& _22 [[buffer(0)]], device SSBO2& _48 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]])
+{
+    threadgroup spvUnsafeArray<float, 4> sShared;
+    {
+        threadgroup uint *sShared_ptr = (threadgroup uint *)&sShared;
+        uint sShared_sz = sizeof(sShared);
+        uint sShared_pos = gl_LocalInvocationIndex;
+        uint sShared_stride = gl_WorkGroupSize.x * gl_WorkGroupSize.y * gl_WorkGroupSize.z;
+        while (sizeof(uint) * sShared_pos < sShared_sz)
+        {
+            sShared_ptr[sShared_pos] = 0u;
+            sShared_pos += sShared_stride;
+        }
+        if (gl_LocalInvocationIndex == 0)
+        {
+            sShared_pos = (sShared_sz / sizeof(uint)) * sizeof(uint);
+            threadgroup uchar *sShared_ptr2 = (threadgroup uchar *)&sShared;
+            while (sShared_pos < sShared_sz)
+            {
+                sShared_ptr2[sShared_pos] = '\0';
+                sShared_pos++;
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    sShared[gl_LocalInvocationIndex] += _22.in_data[gl_GlobalInvocationID.x];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    _48.out_data[gl_GlobalInvocationID.x] = sShared[3u - gl_LocalInvocationIndex];
+}
+

--- a/reference/opt/shaders/comp/spec-const-arraydim-init.comp
+++ b/reference/opt/shaders/comp/spec-const-arraydim-init.comp
@@ -1,0 +1,27 @@
+#version 450
+#extension GL_EXT_null_initializer : require
+layout(local_size_x = 2, local_size_y = 1, local_size_z = 1) in;
+
+struct Data
+{
+    float a;
+    float b;
+};
+
+#ifndef SPIRV_CROSS_CONSTANT_ID_0
+#define SPIRV_CROSS_CONSTANT_ID_0 2
+#endif
+const int arraySize = SPIRV_CROSS_CONSTANT_ID_0;
+const Data _25[arraySize] = { };
+
+layout(binding = 0, std430) buffer SSBO
+{
+    Data outdata[];
+} _11;
+
+void main()
+{
+    _11.outdata[gl_WorkGroupID.x].a = _25[gl_WorkGroupID.x].a;
+    _11.outdata[gl_WorkGroupID.x].b = _25[gl_WorkGroupID.x].b;
+}
+

--- a/reference/shaders-msl/comp/shared-zero-init-simple.comp
+++ b/reference/shaders-msl/comp/shared-zero-init-simple.comp
@@ -1,0 +1,33 @@
+#pragma clang diagnostic ignored "-Wsometimes-uninitialized"
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct SSBO
+{
+    float in_data[1];
+};
+
+struct SSBO2
+{
+    float out_data[1];
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(4u, 1u, 1u);
+
+kernel void main0(const device SSBO& _22 [[buffer(0)]], device SSBO2& _32 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]])
+{
+    threadgroup float sShared;
+    {
+        if (gl_LocalInvocationIndex == 0)
+        {
+            sShared = 0.0;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    uint ident = gl_GlobalInvocationID.x;
+    float idata = _22.in_data[ident];
+    _32.out_data[ident] = sShared + idata;
+}
+

--- a/reference/shaders-msl/comp/shared-zero-init.comp
+++ b/reference/shaders-msl/comp/shared-zero-init.comp
@@ -1,0 +1,92 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wmissing-braces"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+template<typename T, size_t Num>
+struct spvUnsafeArray
+{
+    T elements[Num ? Num : 1];
+    
+    thread T& operator [] (size_t pos) thread
+    {
+        return elements[pos];
+    }
+    constexpr const thread T& operator [] (size_t pos) const thread
+    {
+        return elements[pos];
+    }
+    
+    device T& operator [] (size_t pos) device
+    {
+        return elements[pos];
+    }
+    constexpr const device T& operator [] (size_t pos) const device
+    {
+        return elements[pos];
+    }
+    
+    constexpr const constant T& operator [] (size_t pos) const constant
+    {
+        return elements[pos];
+    }
+    
+    threadgroup T& operator [] (size_t pos) threadgroup
+    {
+        return elements[pos];
+    }
+    constexpr const threadgroup T& operator [] (size_t pos) const threadgroup
+    {
+        return elements[pos];
+    }
+};
+
+struct SSBO
+{
+    float in_data[1];
+};
+
+struct SSBO2
+{
+    float out_data[1];
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(4u, 1u, 1u);
+
+constant spvUnsafeArray<float, 4> _31 = spvUnsafeArray<float, 4>({ 0.0, 0.0, 0.0, 0.0 });
+
+kernel void main0(const device SSBO& _22 [[buffer(0)]], device SSBO2& _48 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]])
+{
+    threadgroup spvUnsafeArray<float, 4> sShared;
+    {
+        threadgroup uint *sShared_ptr = (threadgroup uint *)&sShared;
+        uint sShared_sz = sizeof(sShared);
+        uint sShared_pos = gl_LocalInvocationIndex;
+        uint sShared_stride = gl_WorkGroupSize.x * gl_WorkGroupSize.y * gl_WorkGroupSize.z;
+        while (sizeof(uint) * sShared_pos < sShared_sz)
+        {
+            sShared_ptr[sShared_pos] = 0u;
+            sShared_pos += sShared_stride;
+        }
+        if (gl_LocalInvocationIndex == 0)
+        {
+            sShared_pos = (sShared_sz / sizeof(uint)) * sizeof(uint);
+            threadgroup uchar *sShared_ptr2 = (threadgroup uchar *)&sShared;
+            while (sShared_pos < sShared_sz)
+            {
+                sShared_ptr2[sShared_pos] = '\0';
+                sShared_pos++;
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    uint ident = gl_GlobalInvocationID.x;
+    float idata = _22.in_data[ident];
+    sShared[gl_LocalInvocationIndex] += idata;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    _48.out_data[ident] = sShared[(4u - gl_LocalInvocationIndex) - 1u];
+}
+

--- a/reference/shaders/comp/spec-const-arraydim-init.comp
+++ b/reference/shaders/comp/spec-const-arraydim-init.comp
@@ -1,0 +1,27 @@
+#version 450
+#extension GL_EXT_null_initializer : require
+layout(local_size_x = 2, local_size_y = 1, local_size_z = 1) in;
+
+struct Data
+{
+    float a;
+    float b;
+};
+
+#ifndef SPIRV_CROSS_CONSTANT_ID_0
+#define SPIRV_CROSS_CONSTANT_ID_0 2
+#endif
+const int arraySize = SPIRV_CROSS_CONSTANT_ID_0;
+const Data _25[arraySize] = { };
+
+layout(binding = 0, std430) buffer SSBO
+{
+    Data outdata[];
+} _11;
+
+void main()
+{
+    _11.outdata[gl_WorkGroupID.x].a = _25[gl_WorkGroupID.x].a;
+    _11.outdata[gl_WorkGroupID.x].b = _25[gl_WorkGroupID.x].b;
+}
+

--- a/shaders-msl/comp/shared-zero-init-simple.comp
+++ b/shaders-msl/comp/shared-zero-init-simple.comp
@@ -1,0 +1,24 @@
+#version 450
+#extension GL_EXT_null_initializer : enable
+layout(local_size_x = 4) in;
+
+shared float sShared = {};
+
+layout(std430, binding = 0) readonly buffer SSBO
+{
+    float in_data[];
+};
+
+layout(std430, binding = 1) writeonly buffer SSBO2
+{
+    float out_data[];
+};
+
+void main()
+{
+    uint ident = gl_GlobalInvocationID.x;
+    float idata = in_data[ident];
+
+    out_data[ident] = sShared + idata;
+}
+

--- a/shaders-msl/comp/shared-zero-init.comp
+++ b/shaders-msl/comp/shared-zero-init.comp
@@ -1,0 +1,28 @@
+#version 450
+#extension GL_EXT_null_initializer : enable
+layout(local_size_x = 4) in;
+
+shared float sShared[gl_WorkGroupSize.x] = {};
+
+layout(std430, binding = 0) readonly buffer SSBO
+{
+    float in_data[];
+};
+
+layout(std430, binding = 1) writeonly buffer SSBO2
+{
+    float out_data[];
+};
+
+void main()
+{
+    uint ident = gl_GlobalInvocationID.x;
+    float idata = in_data[ident];
+
+    sShared[gl_LocalInvocationIndex] += idata;
+    memoryBarrierShared();
+    barrier();
+
+    out_data[ident] = sShared[gl_WorkGroupSize.x - gl_LocalInvocationIndex - 1u];
+}
+

--- a/shaders/comp/spec-const-arraydim-init.comp
+++ b/shaders/comp/spec-const-arraydim-init.comp
@@ -1,0 +1,22 @@
+#version 450
+#extension GL_EXT_null_initializer : require
+
+layout(constant_id = 0) const int arraySize = 2;
+layout(local_size_x = 2) in;
+
+struct Data
+{
+	float a;
+	float b;
+};
+
+layout(std430, binding = 0) buffer SSBO
+{
+	Data outdata[];
+};
+
+void main()
+{
+	Data d[arraySize] = {};
+	outdata[gl_WorkGroupID.x] = d[gl_WorkGroupID.x];
+}

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -1410,6 +1410,10 @@ struct SPIRConstant : IVariant
 	// If true, this is a LUT, and should always be declared in the outer scope.
 	bool is_used_as_lut = false;
 
+	// If this is a null constant of array type with specialized length.
+	// May require special handling in initializer
+	bool is_null_array_specialized_length = false;
+
 	// For composites which are constant arrays, etc.
 	SmallVector<ConstantID> subconstants;
 

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -4911,13 +4911,16 @@ void Compiler::make_constant_null(uint32_t id, uint32_t type)
 		uint32_t parent_id = ir.increase_bound_by(1);
 		make_constant_null(parent_id, constant_type.parent_type);
 
-		if (!constant_type.array_size_literal.back())
-			SPIRV_CROSS_THROW("Array size of OpConstantNull must be a literal.");
-
-		SmallVector<uint32_t> elements(constant_type.array.back());
-		for (uint32_t i = 0; i < constant_type.array.back(); i++)
+		// The array size of OpConstantNull can be either literal or specialization constant.
+		// In the latter case, we cannot take the value as-is, as it can be changed to anything.
+		// Rather, we assume it to be *one* for the sake of initializer.
+		bool is_literal_array_size = constant_type.array_size_literal.back();
+		uint32_t count = is_literal_array_size ? constant_type.array.back() : 1;
+		SmallVector<uint32_t> elements(count);
+		for (uint32_t i = 0; i < count; i++)
 			elements[i] = parent_id;
-		set<SPIRConstant>(id, type, elements.data(), uint32_t(elements.size()), false);
+		auto &constant = set<SPIRConstant>(id, type, elements.data(), uint32_t(elements.size()), false);
+		constant.is_null_array_specialized_length = !is_literal_array_size;
 	}
 	else if (!constant_type.member_types.empty())
 	{

--- a/spirv_cross_parsed_ir.cpp
+++ b/spirv_cross_parsed_ir.cpp
@@ -1050,16 +1050,21 @@ void ParsedIR::make_constant_null(uint32_t id, uint32_t type, bool add_to_typed_
 		uint32_t parent_id = increase_bound_by(1);
 		make_constant_null(parent_id, constant_type.parent_type, add_to_typed_id_set);
 
-		if (!constant_type.array_size_literal.back())
-			SPIRV_CROSS_THROW("Array size of OpConstantNull must be a literal.");
+		// The array size of OpConstantNull can be either literal or specialization constant.
+		// In the latter case, we cannot take the value as-is, as it can be changed to anything.
+		// Rather, we assume it to be *one* for the sake of initializer.
+		bool is_literal_array_size = constant_type.array_size_literal.back();
+		uint32_t count = is_literal_array_size ? constant_type.array.back() : 1;
 
-		SmallVector<uint32_t> elements(constant_type.array.back());
-		for (uint32_t i = 0; i < constant_type.array.back(); i++)
+		SmallVector<uint32_t> elements(count);
+		for (uint32_t i = 0; i < count; i++)
 			elements[i] = parent_id;
 
 		if (add_to_typed_id_set)
 			add_typed_id(TypeConstant, id);
-		variant_set<SPIRConstant>(ids[id], type, elements.data(), uint32_t(elements.size()), false).self = id;
+		auto& constant = variant_set<SPIRConstant>(ids[id], type, elements.data(), uint32_t(elements.size()), false);
+		constant.self = id;
+		constant.is_null_array_specialized_length = !is_literal_array_size;
 	}
 	else if (!constant_type.member_types.empty())
 	{

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -681,6 +681,8 @@ string CompilerGLSL::compile()
 	backend.requires_relaxed_precision_analysis = options.es || options.vulkan_semantics;
 	backend.support_precise_qualifier =
 			(!options.es && options.version >= 400) || (options.es && options.version >= 320);
+	backend.constant_null_initializer = "{ }";
+	backend.requires_matching_array_initializer = true;
 
 	if (is_legacy_es())
 		backend.support_case_fallthrough = false;
@@ -5901,6 +5903,11 @@ string CompilerGLSL::constant_expression(const SPIRConstant &c,
 	if (is_pointer(type))
 	{
 		return backend.null_pointer_literal;
+	}
+	else if (c.is_null_array_specialized_length && backend.requires_matching_array_initializer)
+	{
+		require_extension_internal("GL_EXT_null_initializer");
+		return backend.constant_null_initializer;
 	}
 	else if (!c.subconstants.empty())
 	{

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -15812,13 +15812,24 @@ string CompilerGLSL::variable_decl(const SPIRVariable &variable)
 		else if (options.force_zero_initialized_variables && type_can_zero_initialize(type))
 			res += join(" = ", to_zero_initialized_expression(get_variable_data_type_id(variable)));
 	}
-	else if (variable.initializer && !variable_decl_is_remapped_storage(variable, StorageClassWorkgroup))
+	else if (variable.initializer)
 	{
-		uint32_t expr = variable.initializer;
-		if (ir.ids[expr].get_type() != TypeUndef)
-			res += join(" = ", to_initializer_expression(variable));
-		else if (options.force_zero_initialized_variables && type_can_zero_initialize(type))
-			res += join(" = ", to_zero_initialized_expression(get_variable_data_type_id(variable)));
+		if (!variable_decl_is_remapped_storage(variable, StorageClassWorkgroup))
+		{
+			uint32_t expr = variable.initializer;
+			if (ir.ids[expr].get_type() != TypeUndef)
+				res += join(" = ", to_initializer_expression(variable));
+			else if (options.force_zero_initialized_variables && type_can_zero_initialize(type))
+				res += join(" = ", to_zero_initialized_expression(get_variable_data_type_id(variable)));
+		}
+		else
+		{
+			// Workgroup memory requires special handling. First, it can only be Null-Initialized.
+			// GLSL will handle this with null initializer, while others require more work after the decl
+			require_extension_internal("GL_EXT_null_initializer");
+			if (!backend.constant_null_initializer.empty())
+				res += join(" = ", backend.constant_null_initializer);
+		}
 	}
 
 	return res;
@@ -16579,6 +16590,12 @@ void CompilerGLSL::emit_function(SPIRFunction &func, const Bitset &return_flags)
 			// Comes from MSL which can push global variables as local variables in main function.
 			add_local_variable_name(var.self);
 			statement(variable_decl(var), ";");
+
+			// "Real" workgroup variables in compute shaders needs extra caretaking.
+			// They need to be initialized with an extra routine as they come in arbitrary form.
+			if (var.storage == StorageClassWorkgroup && var.initializer)
+				emit_workgroup_initialization(var);
+
 			var.deferred_declaration = false;
 		}
 		else if (var.storage == StorageClassPrivate)
@@ -16683,6 +16700,10 @@ void CompilerGLSL::emit_fixup()
 		if (options.vertex.flip_vert_y)
 			statement("gl_Position.y = -gl_Position.y;");
 	}
+}
+
+void CompilerGLSL::emit_workgroup_initialization(const SPIRVariable &)
+{
 }
 
 void CompilerGLSL::flush_phi(BlockID from, BlockID to)

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -625,6 +625,7 @@ protected:
 		const char *uint16_t_literal_suffix = "us";
 		const char *nonuniform_qualifier = "nonuniformEXT";
 		const char *boolean_mix_function = "mix";
+		std::string constant_null_initializer = "";
 		SPIRType::BaseType boolean_in_struct_remapped_type = SPIRType::Boolean;
 		bool swizzle_is_function = false;
 		bool shared_is_implied = false;
@@ -632,6 +633,7 @@ protected:
 		bool explicit_struct_type = false;
 		bool use_initializer_list = false;
 		bool use_typed_initializer_list = false;
+		bool requires_matching_array_initializer = false;
 		bool can_declare_struct_inline = true;
 		bool can_declare_arrays_inline = true;
 		bool native_row_major_matrix = true;

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -453,6 +453,7 @@ protected:
 	virtual std::string variable_decl(const SPIRType &type, const std::string &name, uint32_t id = 0);
 	virtual bool variable_decl_is_remapped_storage(const SPIRVariable &var, spv::StorageClass storage) const;
 	virtual std::string to_func_call_arg(const SPIRFunction::Parameter &arg, uint32_t id);
+	virtual void emit_workgroup_initialization(const SPIRVariable &var);
 
 	struct TextureFunctionBaseArguments
 	{

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -881,6 +881,7 @@ protected:
 	void emit_mesh_entry_point();
 	void emit_mesh_outputs();
 	void emit_mesh_tasks(SPIRBlock &block) override;
+	void emit_workgroup_initialization(const SPIRVariable &var) override;
 
 	// Allow Metal to use the array<T> template to make arrays a value type
 	std::string type_to_array_glsl(const SPIRType &type, uint32_t variable_id) override;
@@ -1142,6 +1143,7 @@ protected:
 	void emit_store_statement(uint32_t lhs_expression, uint32_t rhs_expression) override;
 
 	void analyze_sampled_image_usage();
+	void analyze_workgroup_variables();
 
 	bool access_chain_needs_stage_io_builtin_translation(uint32_t base) override;
 	bool prepare_access_chain_for_scalar_access(std::string &expr, const SPIRType &type, spv::StorageClass storage,
@@ -1224,6 +1226,7 @@ protected:
 	bool needs_subgroup_size = false;
 	bool needs_sample_id = false;
 	bool needs_helper_invocation = false;
+	bool needs_workgroup_zero_init = false;
 	bool writes_to_depth = false;
 	std::string qual_pos_var_name;
 	std::string stage_in_var_name = "in";
@@ -1286,6 +1289,7 @@ protected:
 
 	bool suppress_missing_prototypes = false;
 	bool suppress_incompatible_pointer_types_discard_qualifiers = false;
+	bool suppress_sometimes_unitialized = false;
 
 	void add_spv_func_and_recompile(SPVFuncImpl spv_func);
 


### PR DESCRIPTION
The extension allows initializing workgroup memory with OpConstantNull, and is a part of Vulkan 1.3.

In GLSL, the support is realized via GL_EXT_null_initializer. While in MSL, we have to generate code snippets to let the threads initialize the memory. Currently I don't have a corresponding implementation for HLSL due to my lack of knowledge.

When connected with MoltenVK, the implementation can pass all Vulkan CTS compute tests enabled by the extension when an independent fix for specialization constants (https://github.com/KhronosGroup/MoltenVK/pull/2434) is applied. The MoltenVK code (with downstream fix) is available at: https://github.com/dboyan/MoltenVK/tree/zero_init_wg_mem-specfix (need to manually specify SPIRV-Cross tree with this PR branch when using `fetchDependencies` while building).

Vulkan CTS compute cases before enabling VK_KHR_zero_initialize_workgroup_memory:
```
  Passed:        81/45160 (0.2%)
  Failed:        0/45160 (0.0%)
  Not supported: 45079/45160 (99.8%)
```

Vulkan CTS compute cases after enabling VK_KHR_zero_initialize_workgroup_memory (with https://github.com/KhronosGroup/MoltenVK/pull/2434 applied):
```
  Passed:        712/45160 (1.6%)
  Failed:        0/45160 (0.0%)
  Not supported: 44448/45160 (98.4%)
```

Closes: #2443 