### PR TITLE
MSL: Fix gather functions on Sequoia

### DIFF
--- a/reference/opt/shaders-msl/comp/force-recompile-hooks.swizzle.comp
+++ b/reference/opt/shaders-msl/comp/force-recompile-hooks.swizzle.comp
@@ -5,18 +5,6 @@
 
 using namespace metal;
 
-template<typename T> struct spvRemoveReference { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&> { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&&> { typedef T type; };
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type& x)
-{
-    return static_cast<thread T&&>(x);
-}
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type&& x)
-{
-    return static_cast<thread T&&>(x);
-}
-
 enum class spvSwizzle : uint
 {
     none = 0,

--- a/reference/opt/shaders-msl/frag/array-of-texture-swizzle-nonconstant-uniform.msl2.argument.discrete.swizzle.frag
+++ b/reference/opt/shaders-msl/frag/array-of-texture-swizzle-nonconstant-uniform.msl2.argument.discrete.swizzle.frag
@@ -5,18 +5,6 @@
 
 using namespace metal;
 
-template<typename T> struct spvRemoveReference { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&> { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&&> { typedef T type; };
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type& x)
-{
-    return static_cast<thread T&&>(x);
-}
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type&& x)
-{
-    return static_cast<thread T&&>(x);
-}
-
 enum class spvSwizzle : uint
 {
     none = 0,

--- a/reference/opt/shaders-msl/frag/array-of-texture-swizzle-nonconstant-uniform.msl2.swizzle.frag
+++ b/reference/opt/shaders-msl/frag/array-of-texture-swizzle-nonconstant-uniform.msl2.swizzle.frag
@@ -5,18 +5,6 @@
 
 using namespace metal;
 
-template<typename T> struct spvRemoveReference { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&> { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&&> { typedef T type; };
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type& x)
-{
-    return static_cast<thread T&&>(x);
-}
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type&& x)
-{
-    return static_cast<thread T&&>(x);
-}
-
 enum class spvSwizzle : uint
 {
     none = 0,

--- a/reference/opt/shaders-msl/frag/array-of-texture-swizzle.msl2.argument.discrete.swizzle.frag
+++ b/reference/opt/shaders-msl/frag/array-of-texture-swizzle.msl2.argument.discrete.swizzle.frag
@@ -5,18 +5,6 @@
 
 using namespace metal;
 
-template<typename T> struct spvRemoveReference { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&> { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&&> { typedef T type; };
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type& x)
-{
-    return static_cast<thread T&&>(x);
-}
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type&& x)
-{
-    return static_cast<thread T&&>(x);
-}
-
 enum class spvSwizzle : uint
 {
     none = 0,

--- a/reference/opt/shaders-msl/frag/array-of-texture-swizzle.msl2.swizzle.frag
+++ b/reference/opt/shaders-msl/frag/array-of-texture-swizzle.msl2.swizzle.frag
@@ -5,18 +5,6 @@
 
 using namespace metal;
 
-template<typename T> struct spvRemoveReference { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&> { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&&> { typedef T type; };
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type& x)
-{
-    return static_cast<thread T&&>(x);
-}
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type&& x)
-{
-    return static_cast<thread T&&>(x);
-}
-
 enum class spvSwizzle : uint
 {
     none = 0,

--- a/reference/opt/shaders-msl/frag/gather-compare-const-offsets.frag
+++ b/reference/opt/shaders-msl/frag/gather-compare-const-offsets.frag
@@ -56,40 +56,43 @@ template<typename T> inline constexpr thread T&& spvForward(thread typename spvR
     return static_cast<thread T&&>(x);
 }
 
+template<typename Tex, typename... Tp>
+using spvGatherCompareReturn = decltype(declval<Tex>().gather_compare(declval<sampler>(), declval<Tp>()...));
+
 // Wrapper function that processes a device texture gather with a constant offset array.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename Toff, typename... Tp>
-inline vec<T, 4> spvGatherCompareConstOffsets(const device Tex<T>& t, sampler s, Toff coffsets, Tp... params)
+template<typename Tex, typename Toff, typename... Tp>
+inline spvGatherCompareReturn<Tex, Tp...> spvGatherCompareConstOffsets(const device Tex& t, sampler s, Toff coffsets, Tp... params)
 {
-    vec<T, 4> rslts[4];
+    spvGatherCompareReturn<Tex, Tp...> rslts[4];
     for (uint i = 0; i < 4; i++)
     {
             rslts[i] = t.gather_compare(s, spvForward<Tp>(params)..., coffsets[i]);
     }
-    return vec<T, 4>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
+    return spvGatherCompareReturn<Tex, Tp...>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
 }
 
 // Wrapper function that processes a constant texture gather with a constant offset array.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename Toff, typename... Tp>
-inline vec<T, 4> spvGatherCompareConstOffsets(const constant Tex<T>& t, sampler s, Toff coffsets, Tp... params)
+template<typename Tex, typename Toff, typename... Tp>
+inline spvGatherCompareReturn<Tex, Tp...> spvGatherCompareConstOffsets(const constant Tex& t, sampler s, Toff coffsets, Tp... params)
 {
-    vec<T, 4> rslts[4];
+    spvGatherCompareReturn<Tex, Tp...> rslts[4];
     for (uint i = 0; i < 4; i++)
     {
             rslts[i] = t.gather_compare(s, spvForward<Tp>(params)..., coffsets[i]);
     }
-    return vec<T, 4>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
+    return spvGatherCompareReturn<Tex, Tp...>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
 }
 
 // Wrapper function that processes a thread texture gather with a constant offset array.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename Toff, typename... Tp>
-inline vec<T, 4> spvGatherCompareConstOffsets(const thread Tex<T>& t, sampler s, Toff coffsets, Tp... params)
+template<typename Tex, typename Toff, typename... Tp>
+inline spvGatherCompareReturn<Tex, Tp...> spvGatherCompareConstOffsets(const thread Tex& t, sampler s, Toff coffsets, Tp... params)
 {
-    vec<T, 4> rslts[4];
+    spvGatherCompareReturn<Tex, Tp...> rslts[4];
     for (uint i = 0; i < 4; i++)
     {
             rslts[i] = t.gather_compare(s, spvForward<Tp>(params)..., coffsets[i]);
     }
-    return vec<T, 4>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
+    return spvGatherCompareReturn<Tex, Tp...>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
 }
 
 constant spvUnsafeArray<int2, 4> _38 = spvUnsafeArray<int2, 4>({ int2(-8, 3), int2(-4, 7), int2(0, 3), int2(3, 0) });

--- a/reference/opt/shaders-msl/frag/gather-compare-const-offsets.frag
+++ b/reference/opt/shaders-msl/frag/gather-compare-const-offsets.frag
@@ -44,18 +44,6 @@ struct spvUnsafeArray
     }
 };
 
-template<typename T> struct spvRemoveReference { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&> { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&&> { typedef T type; };
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type& x)
-{
-    return static_cast<thread T&&>(x);
-}
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type&& x)
-{
-    return static_cast<thread T&&>(x);
-}
-
 template<typename Tex, typename... Tp>
 using spvGatherCompareReturn = decltype(declval<Tex>().gather_compare(declval<sampler>(), declval<Tp>()...));
 
@@ -66,7 +54,7 @@ inline spvGatherCompareReturn<Tex, Tp...> spvGatherCompareConstOffsets(const dev
     spvGatherCompareReturn<Tex, Tp...> rslts[4];
     for (uint i = 0; i < 4; i++)
     {
-            rslts[i] = t.gather_compare(s, spvForward<Tp>(params)..., coffsets[i]);
+            rslts[i] = t.gather_compare(s, params..., coffsets[i]);
     }
     return spvGatherCompareReturn<Tex, Tp...>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
 }
@@ -78,7 +66,7 @@ inline spvGatherCompareReturn<Tex, Tp...> spvGatherCompareConstOffsets(const con
     spvGatherCompareReturn<Tex, Tp...> rslts[4];
     for (uint i = 0; i < 4; i++)
     {
-            rslts[i] = t.gather_compare(s, spvForward<Tp>(params)..., coffsets[i]);
+            rslts[i] = t.gather_compare(s, params..., coffsets[i]);
     }
     return spvGatherCompareReturn<Tex, Tp...>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
 }
@@ -90,7 +78,7 @@ inline spvGatherCompareReturn<Tex, Tp...> spvGatherCompareConstOffsets(const thr
     spvGatherCompareReturn<Tex, Tp...> rslts[4];
     for (uint i = 0; i < 4; i++)
     {
-            rslts[i] = t.gather_compare(s, spvForward<Tp>(params)..., coffsets[i]);
+            rslts[i] = t.gather_compare(s, params..., coffsets[i]);
     }
     return spvGatherCompareReturn<Tex, Tp...>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
 }

--- a/reference/opt/shaders-msl/frag/gather-const-offsets.frag
+++ b/reference/opt/shaders-msl/frag/gather-const-offsets.frag
@@ -44,18 +44,6 @@ struct spvUnsafeArray
     }
 };
 
-template<typename T> struct spvRemoveReference { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&> { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&&> { typedef T type; };
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type& x)
-{
-    return static_cast<thread T&&>(x);
-}
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type&& x)
-{
-    return static_cast<thread T&&>(x);
-}
-
 template<typename Tex, typename... Tp>
 using spvGatherReturn = decltype(declval<Tex>().gather(declval<sampler>(), declval<Tp>()...));
 
@@ -69,16 +57,16 @@ inline spvGatherReturn<Tex, Tp...> spvGatherConstOffsets(const device Tex& t, sa
         switch (c)
         {
             case component::x:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::x);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::x);
                 break;
             case component::y:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::y);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::y);
                 break;
             case component::z:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::z);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::z);
                 break;
             case component::w:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::w);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::w);
                 break;
         }
     }
@@ -95,16 +83,16 @@ inline spvGatherReturn<Tex, Tp...> spvGatherConstOffsets(const constant Tex& t, 
         switch (c)
         {
             case component::x:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::x);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::x);
                 break;
             case component::y:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::y);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::y);
                 break;
             case component::z:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::z);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::z);
                 break;
             case component::w:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::w);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::w);
                 break;
         }
     }
@@ -121,16 +109,16 @@ inline spvGatherReturn<Tex, Tp...> spvGatherConstOffsets(const thread Tex& t, sa
         switch (c)
         {
             case component::x:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::x);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::x);
                 break;
             case component::y:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::y);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::y);
                 break;
             case component::z:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::z);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::z);
                 break;
             case component::w:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::w);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::w);
                 break;
         }
     }

--- a/reference/opt/shaders-msl/frag/gather-const-offsets.frag
+++ b/reference/opt/shaders-msl/frag/gather-const-offsets.frag
@@ -56,11 +56,14 @@ template<typename T> inline constexpr thread T&& spvForward(thread typename spvR
     return static_cast<thread T&&>(x);
 }
 
+template<typename Tex, typename... Tp>
+using spvGatherReturn = decltype(declval<Tex>().gather(declval<sampler>(), declval<Tp>()...));
+
 // Wrapper function that processes a device texture gather with a constant offset array.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename Toff, typename... Tp>
-inline vec<T, 4> spvGatherConstOffsets(const device Tex<T>& t, sampler s, Toff coffsets, component c, Tp... params) METAL_CONST_ARG(c)
+template<typename Tex, typename Toff, typename... Tp>
+inline spvGatherReturn<Tex, Tp...> spvGatherConstOffsets(const device Tex& t, sampler s, Toff coffsets, component c, Tp... params) METAL_CONST_ARG(c)
 {
-    vec<T, 4> rslts[4];
+    spvGatherReturn<Tex, Tp...> rslts[4];
     for (uint i = 0; i < 4; i++)
     {
         switch (c)
@@ -79,14 +82,14 @@ inline vec<T, 4> spvGatherConstOffsets(const device Tex<T>& t, sampler s, Toff c
                 break;
         }
     }
-    return vec<T, 4>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
+    return spvGatherReturn<Tex, Tp...>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
 }
 
 // Wrapper function that processes a constant texture gather with a constant offset array.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename Toff, typename... Tp>
-inline vec<T, 4> spvGatherConstOffsets(const constant Tex<T>& t, sampler s, Toff coffsets, component c, Tp... params) METAL_CONST_ARG(c)
+template<typename Tex, typename Toff, typename... Tp>
+inline spvGatherReturn<Tex, Tp...> spvGatherConstOffsets(const constant Tex& t, sampler s, Toff coffsets, component c, Tp... params) METAL_CONST_ARG(c)
 {
-    vec<T, 4> rslts[4];
+    spvGatherReturn<Tex, Tp...> rslts[4];
     for (uint i = 0; i < 4; i++)
     {
         switch (c)
@@ -105,14 +108,14 @@ inline vec<T, 4> spvGatherConstOffsets(const constant Tex<T>& t, sampler s, Toff
                 break;
         }
     }
-    return vec<T, 4>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
+    return spvGatherReturn<Tex, Tp...>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
 }
 
 // Wrapper function that processes a thread texture gather with a constant offset array.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename Toff, typename... Tp>
-inline vec<T, 4> spvGatherConstOffsets(const thread Tex<T>& t, sampler s, Toff coffsets, component c, Tp... params) METAL_CONST_ARG(c)
+template<typename Tex, typename Toff, typename... Tp>
+inline spvGatherReturn<Tex, Tp...> spvGatherConstOffsets(const thread Tex& t, sampler s, Toff coffsets, component c, Tp... params) METAL_CONST_ARG(c)
 {
-    vec<T, 4> rslts[4];
+    spvGatherReturn<Tex, Tp...> rslts[4];
     for (uint i = 0; i < 4; i++)
     {
         switch (c)
@@ -131,7 +134,7 @@ inline vec<T, 4> spvGatherConstOffsets(const thread Tex<T>& t, sampler s, Toff c
                 break;
         }
     }
-    return vec<T, 4>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
+    return spvGatherReturn<Tex, Tp...>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
 }
 
 constant spvUnsafeArray<int2, 4> _30 = spvUnsafeArray<int2, 4>({ int2(-8), int2(-8, 7), int2(7, -8), int2(7) });

--- a/reference/shaders-msl-no-opt/asm/frag/texture-access.swizzle.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/texture-access.swizzle.asm.frag
@@ -12,18 +12,6 @@ uint2 spvTexelBufferCoord(uint tc)
     return uint2(tc % 4096, tc / 4096);
 }
 
-template<typename T> struct spvRemoveReference { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&> { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&&> { typedef T type; };
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type& x)
-{
-    return static_cast<thread T&&>(x);
-}
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type&& x)
-{
-    return static_cast<thread T&&>(x);
-}
-
 enum class spvSwizzle : uint
 {
     none = 0,
@@ -93,25 +81,25 @@ inline spvGatherReturn<Tex, Ts...> spvGatherSwizzle(const thread Tex& t, sampler
             case spvSwizzle::one:
                 return spvGatherReturn<Tex, Ts...>(1, 1, 1, 1);
             case spvSwizzle::red:
-                return t.gather(s, spvForward<Ts>(params)..., component::x);
+                return t.gather(s, params..., component::x);
             case spvSwizzle::green:
-                return t.gather(s, spvForward<Ts>(params)..., component::y);
+                return t.gather(s, params..., component::y);
             case spvSwizzle::blue:
-                return t.gather(s, spvForward<Ts>(params)..., component::z);
+                return t.gather(s, params..., component::z);
             case spvSwizzle::alpha:
-                return t.gather(s, spvForward<Ts>(params)..., component::w);
+                return t.gather(s, params..., component::w);
         }
     }
     switch (c)
     {
         case component::x:
-            return t.gather(s, spvForward<Ts>(params)..., component::x);
+            return t.gather(s, params..., component::x);
         case component::y:
-            return t.gather(s, spvForward<Ts>(params)..., component::y);
+            return t.gather(s, params..., component::y);
         case component::z:
-            return t.gather(s, spvForward<Ts>(params)..., component::z);
+            return t.gather(s, params..., component::z);
         case component::w:
-            return t.gather(s, spvForward<Ts>(params)..., component::w);
+            return t.gather(s, params..., component::w);
     }
 }
 
@@ -135,7 +123,7 @@ inline spvGatherCompareReturn<Tex, Ts...> spvGatherCompareSwizzle(const thread T
                 return spvGatherCompareReturn<Tex, Ts...>(1, 1, 1, 1);
         }
     }
-    return t.gather_compare(s, spvForward<Ts>(params)...);
+    return t.gather_compare(s, params...);
 }
 
 fragment void main0(constant uint* spvSwizzleConstants [[buffer(30)]], texture1d<float> tex1d [[texture(0)]], texture2d<float> tex2d [[texture(1)]], texture3d<float> tex3d [[texture(2)]], texturecube<float> texCube [[texture(3)]], texture2d_array<float> tex2dArray [[texture(4)]], texturecube_array<float> texCubeArray [[texture(5)]], depth2d<float> depth2d [[texture(6)]], depthcube<float> depthCube [[texture(7)]], depth2d_array<float> depth2dArray [[texture(8)]], depthcube_array<float> depthCubeArray [[texture(9)]], texture2d<float> texBuffer [[texture(10)]], sampler tex1dSamp [[sampler(0)]], sampler tex2dSamp [[sampler(1)]], sampler tex3dSamp [[sampler(2)]], sampler texCubeSamp [[sampler(3)]], sampler tex2dArraySamp [[sampler(4)]], sampler texCubeArraySamp [[sampler(5)]], sampler depth2dSamp [[sampler(6)]], sampler depthCubeSamp [[sampler(7)]], sampler depth2dArraySamp [[sampler(8)]], sampler depthCubeArraySamp [[sampler(9)]])

--- a/reference/shaders-msl-no-opt/asm/frag/texture-access.swizzle.asm.frag
+++ b/reference/shaders-msl-no-opt/asm/frag/texture-access.swizzle.asm.frag
@@ -72,9 +72,15 @@ inline T spvTextureSwizzle(T x, uint s)
     return spvTextureSwizzle(vec<T, 4>(x, 0, 0, 1), s).x;
 }
 
+template<typename Tex, typename... Tp>
+using spvGatherReturn = decltype(declval<Tex>().gather(declval<sampler>(), declval<Tp>()...));
+
+template<typename Tex, typename... Tp>
+using spvGatherCompareReturn = decltype(declval<Tex>().gather_compare(declval<sampler>(), declval<Tp>()...));
+
 // Wrapper function that swizzles texture gathers.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename... Ts>
-inline vec<T, 4> spvGatherSwizzle(const thread Tex<T>& t, sampler s, uint sw, component c, Ts... params) METAL_CONST_ARG(c)
+template<typename Tex, typename... Ts>
+inline spvGatherReturn<Tex, Ts...> spvGatherSwizzle(const thread Tex& t, sampler s, uint sw, component c, Ts... params) METAL_CONST_ARG(c)
 {
     if (sw)
     {
@@ -83,9 +89,9 @@ inline vec<T, 4> spvGatherSwizzle(const thread Tex<T>& t, sampler s, uint sw, co
             case spvSwizzle::none:
                 break;
             case spvSwizzle::zero:
-                return vec<T, 4>(0, 0, 0, 0);
+                return spvGatherReturn<Tex, Ts...>(0, 0, 0, 0);
             case spvSwizzle::one:
-                return vec<T, 4>(1, 1, 1, 1);
+                return spvGatherReturn<Tex, Ts...>(1, 1, 1, 1);
             case spvSwizzle::red:
                 return t.gather(s, spvForward<Ts>(params)..., component::x);
             case spvSwizzle::green:
@@ -110,8 +116,8 @@ inline vec<T, 4> spvGatherSwizzle(const thread Tex<T>& t, sampler s, uint sw, co
 }
 
 // Wrapper function that swizzles depth texture gathers.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename... Ts>
-inline vec<T, 4> spvGatherCompareSwizzle(const thread Tex<T>& t, sampler s, uint sw, Ts... params) 
+template<typename Tex, typename... Ts>
+inline spvGatherCompareReturn<Tex, Ts...> spvGatherCompareSwizzle(const thread Tex& t, sampler s, uint sw, Ts... params)
 {
     if (sw)
     {
@@ -124,9 +130,9 @@ inline vec<T, 4> spvGatherCompareSwizzle(const thread Tex<T>& t, sampler s, uint
             case spvSwizzle::green:
             case spvSwizzle::blue:
             case spvSwizzle::alpha:
-                return vec<T, 4>(0, 0, 0, 0);
+                return spvGatherCompareReturn<Tex, Ts...>(0, 0, 0, 0);
             case spvSwizzle::one:
-                return vec<T, 4>(1, 1, 1, 1);
+                return spvGatherCompareReturn<Tex, Ts...>(1, 1, 1, 1);
         }
     }
     return t.gather_compare(s, spvForward<Ts>(params)...);

--- a/reference/shaders-msl-no-opt/frag/texture-access-int.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access-int.swizzle.frag
@@ -12,18 +12,6 @@ uint2 spvTexelBufferCoord(uint tc)
     return uint2(tc % 4096, tc / 4096);
 }
 
-template<typename T> struct spvRemoveReference { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&> { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&&> { typedef T type; };
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type& x)
-{
-    return static_cast<thread T&&>(x);
-}
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type&& x)
-{
-    return static_cast<thread T&&>(x);
-}
-
 enum class spvSwizzle : uint
 {
     none = 0,
@@ -90,25 +78,25 @@ inline spvGatherReturn<Tex, Ts...> spvGatherSwizzle(const thread Tex& t, sampler
             case spvSwizzle::one:
                 return spvGatherReturn<Tex, Ts...>(1, 1, 1, 1);
             case spvSwizzle::red:
-                return t.gather(s, spvForward<Ts>(params)..., component::x);
+                return t.gather(s, params..., component::x);
             case spvSwizzle::green:
-                return t.gather(s, spvForward<Ts>(params)..., component::y);
+                return t.gather(s, params..., component::y);
             case spvSwizzle::blue:
-                return t.gather(s, spvForward<Ts>(params)..., component::z);
+                return t.gather(s, params..., component::z);
             case spvSwizzle::alpha:
-                return t.gather(s, spvForward<Ts>(params)..., component::w);
+                return t.gather(s, params..., component::w);
         }
     }
     switch (c)
     {
         case component::x:
-            return t.gather(s, spvForward<Ts>(params)..., component::x);
+            return t.gather(s, params..., component::x);
         case component::y:
-            return t.gather(s, spvForward<Ts>(params)..., component::y);
+            return t.gather(s, params..., component::y);
         case component::z:
-            return t.gather(s, spvForward<Ts>(params)..., component::z);
+            return t.gather(s, params..., component::z);
         case component::w:
-            return t.gather(s, spvForward<Ts>(params)..., component::w);
+            return t.gather(s, params..., component::w);
     }
 }
 

--- a/reference/shaders-msl-no-opt/frag/texture-access-int.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access-int.swizzle.frag
@@ -72,9 +72,12 @@ inline T spvTextureSwizzle(T x, uint s)
     return spvTextureSwizzle(vec<T, 4>(x, 0, 0, 1), s).x;
 }
 
+template<typename Tex, typename... Tp>
+using spvGatherReturn = decltype(declval<Tex>().gather(declval<sampler>(), declval<Tp>()...));
+
 // Wrapper function that swizzles texture gathers.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename... Ts>
-inline vec<T, 4> spvGatherSwizzle(const thread Tex<T>& t, sampler s, uint sw, component c, Ts... params) METAL_CONST_ARG(c)
+template<typename Tex, typename... Ts>
+inline spvGatherReturn<Tex, Ts...> spvGatherSwizzle(const thread Tex& t, sampler s, uint sw, component c, Ts... params) METAL_CONST_ARG(c)
 {
     if (sw)
     {
@@ -83,9 +86,9 @@ inline vec<T, 4> spvGatherSwizzle(const thread Tex<T>& t, sampler s, uint sw, co
             case spvSwizzle::none:
                 break;
             case spvSwizzle::zero:
-                return vec<T, 4>(0, 0, 0, 0);
+                return spvGatherReturn<Tex, Ts...>(0, 0, 0, 0);
             case spvSwizzle::one:
-                return vec<T, 4>(1, 1, 1, 1);
+                return spvGatherReturn<Tex, Ts...>(1, 1, 1, 1);
             case spvSwizzle::red:
                 return t.gather(s, spvForward<Ts>(params)..., component::x);
             case spvSwizzle::green:

--- a/reference/shaders-msl-no-opt/frag/texture-access-leaf.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access-leaf.swizzle.frag
@@ -12,18 +12,6 @@ uint2 spvTexelBufferCoord(uint tc)
     return uint2(tc % 4096, tc / 4096);
 }
 
-template<typename T> struct spvRemoveReference { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&> { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&&> { typedef T type; };
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type& x)
-{
-    return static_cast<thread T&&>(x);
-}
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type&& x)
-{
-    return static_cast<thread T&&>(x);
-}
-
 enum class spvSwizzle : uint
 {
     none = 0,
@@ -93,25 +81,25 @@ inline spvGatherReturn<Tex, Ts...> spvGatherSwizzle(const thread Tex& t, sampler
             case spvSwizzle::one:
                 return spvGatherReturn<Tex, Ts...>(1, 1, 1, 1);
             case spvSwizzle::red:
-                return t.gather(s, spvForward<Ts>(params)..., component::x);
+                return t.gather(s, params..., component::x);
             case spvSwizzle::green:
-                return t.gather(s, spvForward<Ts>(params)..., component::y);
+                return t.gather(s, params..., component::y);
             case spvSwizzle::blue:
-                return t.gather(s, spvForward<Ts>(params)..., component::z);
+                return t.gather(s, params..., component::z);
             case spvSwizzle::alpha:
-                return t.gather(s, spvForward<Ts>(params)..., component::w);
+                return t.gather(s, params..., component::w);
         }
     }
     switch (c)
     {
         case component::x:
-            return t.gather(s, spvForward<Ts>(params)..., component::x);
+            return t.gather(s, params..., component::x);
         case component::y:
-            return t.gather(s, spvForward<Ts>(params)..., component::y);
+            return t.gather(s, params..., component::y);
         case component::z:
-            return t.gather(s, spvForward<Ts>(params)..., component::z);
+            return t.gather(s, params..., component::z);
         case component::w:
-            return t.gather(s, spvForward<Ts>(params)..., component::w);
+            return t.gather(s, params..., component::w);
     }
 }
 
@@ -135,7 +123,7 @@ inline spvGatherCompareReturn<Tex, Ts...> spvGatherCompareSwizzle(const thread T
                 return spvGatherCompareReturn<Tex, Ts...>(1, 1, 1, 1);
         }
     }
-    return t.gather_compare(s, spvForward<Ts>(params)...);
+    return t.gather_compare(s, params...);
 }
 
 static inline __attribute__((always_inline))

--- a/reference/shaders-msl-no-opt/frag/texture-access-leaf.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access-leaf.swizzle.frag
@@ -72,9 +72,15 @@ inline T spvTextureSwizzle(T x, uint s)
     return spvTextureSwizzle(vec<T, 4>(x, 0, 0, 1), s).x;
 }
 
+template<typename Tex, typename... Tp>
+using spvGatherReturn = decltype(declval<Tex>().gather(declval<sampler>(), declval<Tp>()...));
+
+template<typename Tex, typename... Tp>
+using spvGatherCompareReturn = decltype(declval<Tex>().gather_compare(declval<sampler>(), declval<Tp>()...));
+
 // Wrapper function that swizzles texture gathers.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename... Ts>
-inline vec<T, 4> spvGatherSwizzle(const thread Tex<T>& t, sampler s, uint sw, component c, Ts... params) METAL_CONST_ARG(c)
+template<typename Tex, typename... Ts>
+inline spvGatherReturn<Tex, Ts...> spvGatherSwizzle(const thread Tex& t, sampler s, uint sw, component c, Ts... params) METAL_CONST_ARG(c)
 {
     if (sw)
     {
@@ -83,9 +89,9 @@ inline vec<T, 4> spvGatherSwizzle(const thread Tex<T>& t, sampler s, uint sw, co
             case spvSwizzle::none:
                 break;
             case spvSwizzle::zero:
-                return vec<T, 4>(0, 0, 0, 0);
+                return spvGatherReturn<Tex, Ts...>(0, 0, 0, 0);
             case spvSwizzle::one:
-                return vec<T, 4>(1, 1, 1, 1);
+                return spvGatherReturn<Tex, Ts...>(1, 1, 1, 1);
             case spvSwizzle::red:
                 return t.gather(s, spvForward<Ts>(params)..., component::x);
             case spvSwizzle::green:
@@ -110,8 +116,8 @@ inline vec<T, 4> spvGatherSwizzle(const thread Tex<T>& t, sampler s, uint sw, co
 }
 
 // Wrapper function that swizzles depth texture gathers.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename... Ts>
-inline vec<T, 4> spvGatherCompareSwizzle(const thread Tex<T>& t, sampler s, uint sw, Ts... params) 
+template<typename Tex, typename... Ts>
+inline spvGatherCompareReturn<Tex, Ts...> spvGatherCompareSwizzle(const thread Tex& t, sampler s, uint sw, Ts... params)
 {
     if (sw)
     {
@@ -124,9 +130,9 @@ inline vec<T, 4> spvGatherCompareSwizzle(const thread Tex<T>& t, sampler s, uint
             case spvSwizzle::green:
             case spvSwizzle::blue:
             case spvSwizzle::alpha:
-                return vec<T, 4>(0, 0, 0, 0);
+                return spvGatherCompareReturn<Tex, Ts...>(0, 0, 0, 0);
             case spvSwizzle::one:
-                return vec<T, 4>(1, 1, 1, 1);
+                return spvGatherCompareReturn<Tex, Ts...>(1, 1, 1, 1);
         }
     }
     return t.gather_compare(s, spvForward<Ts>(params)...);

--- a/reference/shaders-msl-no-opt/frag/texture-access-uint.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access-uint.swizzle.frag
@@ -12,18 +12,6 @@ uint2 spvTexelBufferCoord(uint tc)
     return uint2(tc % 4096, tc / 4096);
 }
 
-template<typename T> struct spvRemoveReference { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&> { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&&> { typedef T type; };
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type& x)
-{
-    return static_cast<thread T&&>(x);
-}
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type&& x)
-{
-    return static_cast<thread T&&>(x);
-}
-
 enum class spvSwizzle : uint
 {
     none = 0,
@@ -90,25 +78,25 @@ inline spvGatherReturn<Tex, Ts...> spvGatherSwizzle(const thread Tex& t, sampler
             case spvSwizzle::one:
                 return spvGatherReturn<Tex, Ts...>(1, 1, 1, 1);
             case spvSwizzle::red:
-                return t.gather(s, spvForward<Ts>(params)..., component::x);
+                return t.gather(s, params..., component::x);
             case spvSwizzle::green:
-                return t.gather(s, spvForward<Ts>(params)..., component::y);
+                return t.gather(s, params..., component::y);
             case spvSwizzle::blue:
-                return t.gather(s, spvForward<Ts>(params)..., component::z);
+                return t.gather(s, params..., component::z);
             case spvSwizzle::alpha:
-                return t.gather(s, spvForward<Ts>(params)..., component::w);
+                return t.gather(s, params..., component::w);
         }
     }
     switch (c)
     {
         case component::x:
-            return t.gather(s, spvForward<Ts>(params)..., component::x);
+            return t.gather(s, params..., component::x);
         case component::y:
-            return t.gather(s, spvForward<Ts>(params)..., component::y);
+            return t.gather(s, params..., component::y);
         case component::z:
-            return t.gather(s, spvForward<Ts>(params)..., component::z);
+            return t.gather(s, params..., component::z);
         case component::w:
-            return t.gather(s, spvForward<Ts>(params)..., component::w);
+            return t.gather(s, params..., component::w);
     }
 }
 

--- a/reference/shaders-msl-no-opt/frag/texture-access-uint.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access-uint.swizzle.frag
@@ -72,9 +72,12 @@ inline T spvTextureSwizzle(T x, uint s)
     return spvTextureSwizzle(vec<T, 4>(x, 0, 0, 1), s).x;
 }
 
+template<typename Tex, typename... Tp>
+using spvGatherReturn = decltype(declval<Tex>().gather(declval<sampler>(), declval<Tp>()...));
+
 // Wrapper function that swizzles texture gathers.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename... Ts>
-inline vec<T, 4> spvGatherSwizzle(const thread Tex<T>& t, sampler s, uint sw, component c, Ts... params) METAL_CONST_ARG(c)
+template<typename Tex, typename... Ts>
+inline spvGatherReturn<Tex, Ts...> spvGatherSwizzle(const thread Tex& t, sampler s, uint sw, component c, Ts... params) METAL_CONST_ARG(c)
 {
     if (sw)
     {
@@ -83,9 +86,9 @@ inline vec<T, 4> spvGatherSwizzle(const thread Tex<T>& t, sampler s, uint sw, co
             case spvSwizzle::none:
                 break;
             case spvSwizzle::zero:
-                return vec<T, 4>(0, 0, 0, 0);
+                return spvGatherReturn<Tex, Ts...>(0, 0, 0, 0);
             case spvSwizzle::one:
-                return vec<T, 4>(1, 1, 1, 1);
+                return spvGatherReturn<Tex, Ts...>(1, 1, 1, 1);
             case spvSwizzle::red:
                 return t.gather(s, spvForward<Ts>(params)..., component::x);
             case spvSwizzle::green:

--- a/reference/shaders-msl-no-opt/frag/texture-access.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access.swizzle.frag
@@ -12,18 +12,6 @@ uint2 spvTexelBufferCoord(uint tc)
     return uint2(tc % 4096, tc / 4096);
 }
 
-template<typename T> struct spvRemoveReference { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&> { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&&> { typedef T type; };
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type& x)
-{
-    return static_cast<thread T&&>(x);
-}
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type&& x)
-{
-    return static_cast<thread T&&>(x);
-}
-
 enum class spvSwizzle : uint
 {
     none = 0,
@@ -93,25 +81,25 @@ inline spvGatherReturn<Tex, Ts...> spvGatherSwizzle(const thread Tex& t, sampler
             case spvSwizzle::one:
                 return spvGatherReturn<Tex, Ts...>(1, 1, 1, 1);
             case spvSwizzle::red:
-                return t.gather(s, spvForward<Ts>(params)..., component::x);
+                return t.gather(s, params..., component::x);
             case spvSwizzle::green:
-                return t.gather(s, spvForward<Ts>(params)..., component::y);
+                return t.gather(s, params..., component::y);
             case spvSwizzle::blue:
-                return t.gather(s, spvForward<Ts>(params)..., component::z);
+                return t.gather(s, params..., component::z);
             case spvSwizzle::alpha:
-                return t.gather(s, spvForward<Ts>(params)..., component::w);
+                return t.gather(s, params..., component::w);
         }
     }
     switch (c)
     {
         case component::x:
-            return t.gather(s, spvForward<Ts>(params)..., component::x);
+            return t.gather(s, params..., component::x);
         case component::y:
-            return t.gather(s, spvForward<Ts>(params)..., component::y);
+            return t.gather(s, params..., component::y);
         case component::z:
-            return t.gather(s, spvForward<Ts>(params)..., component::z);
+            return t.gather(s, params..., component::z);
         case component::w:
-            return t.gather(s, spvForward<Ts>(params)..., component::w);
+            return t.gather(s, params..., component::w);
     }
 }
 
@@ -135,7 +123,7 @@ inline spvGatherCompareReturn<Tex, Ts...> spvGatherCompareSwizzle(const thread T
                 return spvGatherCompareReturn<Tex, Ts...>(1, 1, 1, 1);
         }
     }
-    return t.gather_compare(s, spvForward<Ts>(params)...);
+    return t.gather_compare(s, params...);
 }
 
 fragment void main0(constant uint* spvSwizzleConstants [[buffer(30)]], texture1d<float> tex1d [[texture(0)]], texture2d<float> tex2d [[texture(1)]], texture3d<float> tex3d [[texture(2)]], texturecube<float> texCube [[texture(3)]], texture2d_array<float> tex2dArray [[texture(4)]], texturecube_array<float> texCubeArray [[texture(5)]], depth2d<float> depth2d [[texture(6)]], depthcube<float> depthCube [[texture(7)]], depth2d_array<float> depth2dArray [[texture(8)]], depthcube_array<float> depthCubeArray [[texture(9)]], texture2d<float> texBuffer [[texture(10)]], sampler tex1dSmplr [[sampler(0)]], sampler tex2dSmplr [[sampler(1)]], sampler tex3dSmplr [[sampler(2)]], sampler texCubeSmplr [[sampler(3)]], sampler tex2dArraySmplr [[sampler(4)]], sampler texCubeArraySmplr [[sampler(5)]], sampler depth2dSmplr [[sampler(6)]], sampler depthCubeSmplr [[sampler(7)]], sampler depth2dArraySmplr [[sampler(8)]], sampler depthCubeArraySmplr [[sampler(9)]])

--- a/reference/shaders-msl-no-opt/frag/texture-access.swizzle.frag
+++ b/reference/shaders-msl-no-opt/frag/texture-access.swizzle.frag
@@ -72,9 +72,15 @@ inline T spvTextureSwizzle(T x, uint s)
     return spvTextureSwizzle(vec<T, 4>(x, 0, 0, 1), s).x;
 }
 
+template<typename Tex, typename... Tp>
+using spvGatherReturn = decltype(declval<Tex>().gather(declval<sampler>(), declval<Tp>()...));
+
+template<typename Tex, typename... Tp>
+using spvGatherCompareReturn = decltype(declval<Tex>().gather_compare(declval<sampler>(), declval<Tp>()...));
+
 // Wrapper function that swizzles texture gathers.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename... Ts>
-inline vec<T, 4> spvGatherSwizzle(const thread Tex<T>& t, sampler s, uint sw, component c, Ts... params) METAL_CONST_ARG(c)
+template<typename Tex, typename... Ts>
+inline spvGatherReturn<Tex, Ts...> spvGatherSwizzle(const thread Tex& t, sampler s, uint sw, component c, Ts... params) METAL_CONST_ARG(c)
 {
     if (sw)
     {
@@ -83,9 +89,9 @@ inline vec<T, 4> spvGatherSwizzle(const thread Tex<T>& t, sampler s, uint sw, co
             case spvSwizzle::none:
                 break;
             case spvSwizzle::zero:
-                return vec<T, 4>(0, 0, 0, 0);
+                return spvGatherReturn<Tex, Ts...>(0, 0, 0, 0);
             case spvSwizzle::one:
-                return vec<T, 4>(1, 1, 1, 1);
+                return spvGatherReturn<Tex, Ts...>(1, 1, 1, 1);
             case spvSwizzle::red:
                 return t.gather(s, spvForward<Ts>(params)..., component::x);
             case spvSwizzle::green:
@@ -110,8 +116,8 @@ inline vec<T, 4> spvGatherSwizzle(const thread Tex<T>& t, sampler s, uint sw, co
 }
 
 // Wrapper function that swizzles depth texture gathers.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename... Ts>
-inline vec<T, 4> spvGatherCompareSwizzle(const thread Tex<T>& t, sampler s, uint sw, Ts... params) 
+template<typename Tex, typename... Ts>
+inline spvGatherCompareReturn<Tex, Ts...> spvGatherCompareSwizzle(const thread Tex& t, sampler s, uint sw, Ts... params)
 {
     if (sw)
     {
@@ -124,9 +130,9 @@ inline vec<T, 4> spvGatherCompareSwizzle(const thread Tex<T>& t, sampler s, uint
             case spvSwizzle::green:
             case spvSwizzle::blue:
             case spvSwizzle::alpha:
-                return vec<T, 4>(0, 0, 0, 0);
+                return spvGatherCompareReturn<Tex, Ts...>(0, 0, 0, 0);
             case spvSwizzle::one:
-                return vec<T, 4>(1, 1, 1, 1);
+                return spvGatherCompareReturn<Tex, Ts...>(1, 1, 1, 1);
         }
     }
     return t.gather_compare(s, spvForward<Ts>(params)...);

--- a/reference/shaders-msl-no-opt/vulkan/frag/texture-access-function.swizzle.vk.frag
+++ b/reference/shaders-msl-no-opt/vulkan/frag/texture-access-function.swizzle.vk.frag
@@ -12,18 +12,6 @@ uint2 spvTexelBufferCoord(uint tc)
     return uint2(tc % 4096, tc / 4096);
 }
 
-template<typename T> struct spvRemoveReference { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&> { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&&> { typedef T type; };
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type& x)
-{
-    return static_cast<thread T&&>(x);
-}
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type&& x)
-{
-    return static_cast<thread T&&>(x);
-}
-
 enum class spvSwizzle : uint
 {
     none = 0,
@@ -93,25 +81,25 @@ inline spvGatherReturn<Tex, Ts...> spvGatherSwizzle(const thread Tex& t, sampler
             case spvSwizzle::one:
                 return spvGatherReturn<Tex, Ts...>(1, 1, 1, 1);
             case spvSwizzle::red:
-                return t.gather(s, spvForward<Ts>(params)..., component::x);
+                return t.gather(s, params..., component::x);
             case spvSwizzle::green:
-                return t.gather(s, spvForward<Ts>(params)..., component::y);
+                return t.gather(s, params..., component::y);
             case spvSwizzle::blue:
-                return t.gather(s, spvForward<Ts>(params)..., component::z);
+                return t.gather(s, params..., component::z);
             case spvSwizzle::alpha:
-                return t.gather(s, spvForward<Ts>(params)..., component::w);
+                return t.gather(s, params..., component::w);
         }
     }
     switch (c)
     {
         case component::x:
-            return t.gather(s, spvForward<Ts>(params)..., component::x);
+            return t.gather(s, params..., component::x);
         case component::y:
-            return t.gather(s, spvForward<Ts>(params)..., component::y);
+            return t.gather(s, params..., component::y);
         case component::z:
-            return t.gather(s, spvForward<Ts>(params)..., component::z);
+            return t.gather(s, params..., component::z);
         case component::w:
-            return t.gather(s, spvForward<Ts>(params)..., component::w);
+            return t.gather(s, params..., component::w);
     }
 }
 
@@ -135,7 +123,7 @@ inline spvGatherCompareReturn<Tex, Ts...> spvGatherCompareSwizzle(const thread T
                 return spvGatherCompareReturn<Tex, Ts...>(1, 1, 1, 1);
         }
     }
-    return t.gather_compare(s, spvForward<Ts>(params)...);
+    return t.gather_compare(s, params...);
 }
 
 struct main0_out

--- a/reference/shaders-msl-no-opt/vulkan/frag/texture-access-function.swizzle.vk.frag
+++ b/reference/shaders-msl-no-opt/vulkan/frag/texture-access-function.swizzle.vk.frag
@@ -72,9 +72,15 @@ inline T spvTextureSwizzle(T x, uint s)
     return spvTextureSwizzle(vec<T, 4>(x, 0, 0, 1), s).x;
 }
 
+template<typename Tex, typename... Tp>
+using spvGatherReturn = decltype(declval<Tex>().gather(declval<sampler>(), declval<Tp>()...));
+
+template<typename Tex, typename... Tp>
+using spvGatherCompareReturn = decltype(declval<Tex>().gather_compare(declval<sampler>(), declval<Tp>()...));
+
 // Wrapper function that swizzles texture gathers.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename... Ts>
-inline vec<T, 4> spvGatherSwizzle(const thread Tex<T>& t, sampler s, uint sw, component c, Ts... params) METAL_CONST_ARG(c)
+template<typename Tex, typename... Ts>
+inline spvGatherReturn<Tex, Ts...> spvGatherSwizzle(const thread Tex& t, sampler s, uint sw, component c, Ts... params) METAL_CONST_ARG(c)
 {
     if (sw)
     {
@@ -83,9 +89,9 @@ inline vec<T, 4> spvGatherSwizzle(const thread Tex<T>& t, sampler s, uint sw, co
             case spvSwizzle::none:
                 break;
             case spvSwizzle::zero:
-                return vec<T, 4>(0, 0, 0, 0);
+                return spvGatherReturn<Tex, Ts...>(0, 0, 0, 0);
             case spvSwizzle::one:
-                return vec<T, 4>(1, 1, 1, 1);
+                return spvGatherReturn<Tex, Ts...>(1, 1, 1, 1);
             case spvSwizzle::red:
                 return t.gather(s, spvForward<Ts>(params)..., component::x);
             case spvSwizzle::green:
@@ -110,8 +116,8 @@ inline vec<T, 4> spvGatherSwizzle(const thread Tex<T>& t, sampler s, uint sw, co
 }
 
 // Wrapper function that swizzles depth texture gathers.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename... Ts>
-inline vec<T, 4> spvGatherCompareSwizzle(const thread Tex<T>& t, sampler s, uint sw, Ts... params) 
+template<typename Tex, typename... Ts>
+inline spvGatherCompareReturn<Tex, Ts...> spvGatherCompareSwizzle(const thread Tex& t, sampler s, uint sw, Ts... params)
 {
     if (sw)
     {
@@ -124,9 +130,9 @@ inline vec<T, 4> spvGatherCompareSwizzle(const thread Tex<T>& t, sampler s, uint
             case spvSwizzle::green:
             case spvSwizzle::blue:
             case spvSwizzle::alpha:
-                return vec<T, 4>(0, 0, 0, 0);
+                return spvGatherCompareReturn<Tex, Ts...>(0, 0, 0, 0);
             case spvSwizzle::one:
-                return vec<T, 4>(1, 1, 1, 1);
+                return spvGatherCompareReturn<Tex, Ts...>(1, 1, 1, 1);
         }
     }
     return t.gather_compare(s, spvForward<Ts>(params)...);

--- a/reference/shaders-msl/comp/force-recompile-hooks.swizzle.comp
+++ b/reference/shaders-msl/comp/force-recompile-hooks.swizzle.comp
@@ -5,18 +5,6 @@
 
 using namespace metal;
 
-template<typename T> struct spvRemoveReference { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&> { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&&> { typedef T type; };
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type& x)
-{
-    return static_cast<thread T&&>(x);
-}
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type&& x)
-{
-    return static_cast<thread T&&>(x);
-}
-
 enum class spvSwizzle : uint
 {
     none = 0,

--- a/reference/shaders-msl/frag/array-of-texture-swizzle-nonconstant-uniform.msl2.argument.discrete.swizzle.frag
+++ b/reference/shaders-msl/frag/array-of-texture-swizzle-nonconstant-uniform.msl2.argument.discrete.swizzle.frag
@@ -5,18 +5,6 @@
 
 using namespace metal;
 
-template<typename T> struct spvRemoveReference { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&> { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&&> { typedef T type; };
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type& x)
-{
-    return static_cast<thread T&&>(x);
-}
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type&& x)
-{
-    return static_cast<thread T&&>(x);
-}
-
 enum class spvSwizzle : uint
 {
     none = 0,

--- a/reference/shaders-msl/frag/array-of-texture-swizzle-nonconstant-uniform.msl2.swizzle.frag
+++ b/reference/shaders-msl/frag/array-of-texture-swizzle-nonconstant-uniform.msl2.swizzle.frag
@@ -5,18 +5,6 @@
 
 using namespace metal;
 
-template<typename T> struct spvRemoveReference { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&> { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&&> { typedef T type; };
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type& x)
-{
-    return static_cast<thread T&&>(x);
-}
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type&& x)
-{
-    return static_cast<thread T&&>(x);
-}
-
 enum class spvSwizzle : uint
 {
     none = 0,

--- a/reference/shaders-msl/frag/array-of-texture-swizzle.msl2.argument.discrete.swizzle.frag
+++ b/reference/shaders-msl/frag/array-of-texture-swizzle.msl2.argument.discrete.swizzle.frag
@@ -5,18 +5,6 @@
 
 using namespace metal;
 
-template<typename T> struct spvRemoveReference { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&> { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&&> { typedef T type; };
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type& x)
-{
-    return static_cast<thread T&&>(x);
-}
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type&& x)
-{
-    return static_cast<thread T&&>(x);
-}
-
 enum class spvSwizzle : uint
 {
     none = 0,

--- a/reference/shaders-msl/frag/array-of-texture-swizzle.msl2.swizzle.frag
+++ b/reference/shaders-msl/frag/array-of-texture-swizzle.msl2.swizzle.frag
@@ -5,18 +5,6 @@
 
 using namespace metal;
 
-template<typename T> struct spvRemoveReference { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&> { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&&> { typedef T type; };
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type& x)
-{
-    return static_cast<thread T&&>(x);
-}
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type&& x)
-{
-    return static_cast<thread T&&>(x);
-}
-
 enum class spvSwizzle : uint
 {
     none = 0,

--- a/reference/shaders-msl/frag/gather-compare-const-offsets.frag
+++ b/reference/shaders-msl/frag/gather-compare-const-offsets.frag
@@ -56,40 +56,43 @@ template<typename T> inline constexpr thread T&& spvForward(thread typename spvR
     return static_cast<thread T&&>(x);
 }
 
+template<typename Tex, typename... Tp>
+using spvGatherCompareReturn = decltype(declval<Tex>().gather_compare(declval<sampler>(), declval<Tp>()...));
+
 // Wrapper function that processes a device texture gather with a constant offset array.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename Toff, typename... Tp>
-inline vec<T, 4> spvGatherCompareConstOffsets(const device Tex<T>& t, sampler s, Toff coffsets, Tp... params)
+template<typename Tex, typename Toff, typename... Tp>
+inline spvGatherCompareReturn<Tex, Tp...> spvGatherCompareConstOffsets(const device Tex& t, sampler s, Toff coffsets, Tp... params)
 {
-    vec<T, 4> rslts[4];
+    spvGatherCompareReturn<Tex, Tp...> rslts[4];
     for (uint i = 0; i < 4; i++)
     {
             rslts[i] = t.gather_compare(s, spvForward<Tp>(params)..., coffsets[i]);
     }
-    return vec<T, 4>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
+    return spvGatherCompareReturn<Tex, Tp...>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
 }
 
 // Wrapper function that processes a constant texture gather with a constant offset array.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename Toff, typename... Tp>
-inline vec<T, 4> spvGatherCompareConstOffsets(const constant Tex<T>& t, sampler s, Toff coffsets, Tp... params)
+template<typename Tex, typename Toff, typename... Tp>
+inline spvGatherCompareReturn<Tex, Tp...> spvGatherCompareConstOffsets(const constant Tex& t, sampler s, Toff coffsets, Tp... params)
 {
-    vec<T, 4> rslts[4];
+    spvGatherCompareReturn<Tex, Tp...> rslts[4];
     for (uint i = 0; i < 4; i++)
     {
             rslts[i] = t.gather_compare(s, spvForward<Tp>(params)..., coffsets[i]);
     }
-    return vec<T, 4>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
+    return spvGatherCompareReturn<Tex, Tp...>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
 }
 
 // Wrapper function that processes a thread texture gather with a constant offset array.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename Toff, typename... Tp>
-inline vec<T, 4> spvGatherCompareConstOffsets(const thread Tex<T>& t, sampler s, Toff coffsets, Tp... params)
+template<typename Tex, typename Toff, typename... Tp>
+inline spvGatherCompareReturn<Tex, Tp...> spvGatherCompareConstOffsets(const thread Tex& t, sampler s, Toff coffsets, Tp... params)
 {
-    vec<T, 4> rslts[4];
+    spvGatherCompareReturn<Tex, Tp...> rslts[4];
     for (uint i = 0; i < 4; i++)
     {
             rslts[i] = t.gather_compare(s, spvForward<Tp>(params)..., coffsets[i]);
     }
-    return vec<T, 4>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
+    return spvGatherCompareReturn<Tex, Tp...>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
 }
 
 constant spvUnsafeArray<int2, 4> _38 = spvUnsafeArray<int2, 4>({ int2(-8, 3), int2(-4, 7), int2(0, 3), int2(3, 0) });

--- a/reference/shaders-msl/frag/gather-compare-const-offsets.frag
+++ b/reference/shaders-msl/frag/gather-compare-const-offsets.frag
@@ -44,18 +44,6 @@ struct spvUnsafeArray
     }
 };
 
-template<typename T> struct spvRemoveReference { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&> { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&&> { typedef T type; };
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type& x)
-{
-    return static_cast<thread T&&>(x);
-}
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type&& x)
-{
-    return static_cast<thread T&&>(x);
-}
-
 template<typename Tex, typename... Tp>
 using spvGatherCompareReturn = decltype(declval<Tex>().gather_compare(declval<sampler>(), declval<Tp>()...));
 
@@ -66,7 +54,7 @@ inline spvGatherCompareReturn<Tex, Tp...> spvGatherCompareConstOffsets(const dev
     spvGatherCompareReturn<Tex, Tp...> rslts[4];
     for (uint i = 0; i < 4; i++)
     {
-            rslts[i] = t.gather_compare(s, spvForward<Tp>(params)..., coffsets[i]);
+            rslts[i] = t.gather_compare(s, params..., coffsets[i]);
     }
     return spvGatherCompareReturn<Tex, Tp...>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
 }
@@ -78,7 +66,7 @@ inline spvGatherCompareReturn<Tex, Tp...> spvGatherCompareConstOffsets(const con
     spvGatherCompareReturn<Tex, Tp...> rslts[4];
     for (uint i = 0; i < 4; i++)
     {
-            rslts[i] = t.gather_compare(s, spvForward<Tp>(params)..., coffsets[i]);
+            rslts[i] = t.gather_compare(s, params..., coffsets[i]);
     }
     return spvGatherCompareReturn<Tex, Tp...>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
 }
@@ -90,7 +78,7 @@ inline spvGatherCompareReturn<Tex, Tp...> spvGatherCompareConstOffsets(const thr
     spvGatherCompareReturn<Tex, Tp...> rslts[4];
     for (uint i = 0; i < 4; i++)
     {
-            rslts[i] = t.gather_compare(s, spvForward<Tp>(params)..., coffsets[i]);
+            rslts[i] = t.gather_compare(s, params..., coffsets[i]);
     }
     return spvGatherCompareReturn<Tex, Tp...>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
 }

--- a/reference/shaders-msl/frag/gather-const-offsets.frag
+++ b/reference/shaders-msl/frag/gather-const-offsets.frag
@@ -44,18 +44,6 @@ struct spvUnsafeArray
     }
 };
 
-template<typename T> struct spvRemoveReference { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&> { typedef T type; };
-template<typename T> struct spvRemoveReference<thread T&&> { typedef T type; };
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type& x)
-{
-    return static_cast<thread T&&>(x);
-}
-template<typename T> inline constexpr thread T&& spvForward(thread typename spvRemoveReference<T>::type&& x)
-{
-    return static_cast<thread T&&>(x);
-}
-
 template<typename Tex, typename... Tp>
 using spvGatherReturn = decltype(declval<Tex>().gather(declval<sampler>(), declval<Tp>()...));
 
@@ -69,16 +57,16 @@ inline spvGatherReturn<Tex, Tp...> spvGatherConstOffsets(const device Tex& t, sa
         switch (c)
         {
             case component::x:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::x);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::x);
                 break;
             case component::y:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::y);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::y);
                 break;
             case component::z:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::z);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::z);
                 break;
             case component::w:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::w);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::w);
                 break;
         }
     }
@@ -95,16 +83,16 @@ inline spvGatherReturn<Tex, Tp...> spvGatherConstOffsets(const constant Tex& t, 
         switch (c)
         {
             case component::x:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::x);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::x);
                 break;
             case component::y:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::y);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::y);
                 break;
             case component::z:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::z);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::z);
                 break;
             case component::w:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::w);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::w);
                 break;
         }
     }
@@ -121,16 +109,16 @@ inline spvGatherReturn<Tex, Tp...> spvGatherConstOffsets(const thread Tex& t, sa
         switch (c)
         {
             case component::x:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::x);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::x);
                 break;
             case component::y:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::y);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::y);
                 break;
             case component::z:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::z);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::z);
                 break;
             case component::w:
-                rslts[i] = t.gather(s, spvForward<Tp>(params)..., coffsets[i], component::w);
+                rslts[i] = t.gather(s, params..., coffsets[i], component::w);
                 break;
         }
     }

--- a/reference/shaders-msl/frag/gather-const-offsets.frag
+++ b/reference/shaders-msl/frag/gather-const-offsets.frag
@@ -56,11 +56,14 @@ template<typename T> inline constexpr thread T&& spvForward(thread typename spvR
     return static_cast<thread T&&>(x);
 }
 
+template<typename Tex, typename... Tp>
+using spvGatherReturn = decltype(declval<Tex>().gather(declval<sampler>(), declval<Tp>()...));
+
 // Wrapper function that processes a device texture gather with a constant offset array.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename Toff, typename... Tp>
-inline vec<T, 4> spvGatherConstOffsets(const device Tex<T>& t, sampler s, Toff coffsets, component c, Tp... params) METAL_CONST_ARG(c)
+template<typename Tex, typename Toff, typename... Tp>
+inline spvGatherReturn<Tex, Tp...> spvGatherConstOffsets(const device Tex& t, sampler s, Toff coffsets, component c, Tp... params) METAL_CONST_ARG(c)
 {
-    vec<T, 4> rslts[4];
+    spvGatherReturn<Tex, Tp...> rslts[4];
     for (uint i = 0; i < 4; i++)
     {
         switch (c)
@@ -79,14 +82,14 @@ inline vec<T, 4> spvGatherConstOffsets(const device Tex<T>& t, sampler s, Toff c
                 break;
         }
     }
-    return vec<T, 4>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
+    return spvGatherReturn<Tex, Tp...>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
 }
 
 // Wrapper function that processes a constant texture gather with a constant offset array.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename Toff, typename... Tp>
-inline vec<T, 4> spvGatherConstOffsets(const constant Tex<T>& t, sampler s, Toff coffsets, component c, Tp... params) METAL_CONST_ARG(c)
+template<typename Tex, typename Toff, typename... Tp>
+inline spvGatherReturn<Tex, Tp...> spvGatherConstOffsets(const constant Tex& t, sampler s, Toff coffsets, component c, Tp... params) METAL_CONST_ARG(c)
 {
-    vec<T, 4> rslts[4];
+    spvGatherReturn<Tex, Tp...> rslts[4];
     for (uint i = 0; i < 4; i++)
     {
         switch (c)
@@ -105,14 +108,14 @@ inline vec<T, 4> spvGatherConstOffsets(const constant Tex<T>& t, sampler s, Toff
                 break;
         }
     }
-    return vec<T, 4>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
+    return spvGatherReturn<Tex, Tp...>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
 }
 
 // Wrapper function that processes a thread texture gather with a constant offset array.
-template<typename T, template<typename, access = access::sample, typename = void> class Tex, typename Toff, typename... Tp>
-inline vec<T, 4> spvGatherConstOffsets(const thread Tex<T>& t, sampler s, Toff coffsets, component c, Tp... params) METAL_CONST_ARG(c)
+template<typename Tex, typename Toff, typename... Tp>
+inline spvGatherReturn<Tex, Tp...> spvGatherConstOffsets(const thread Tex& t, sampler s, Toff coffsets, component c, Tp... params) METAL_CONST_ARG(c)
 {
-    vec<T, 4> rslts[4];
+    spvGatherReturn<Tex, Tp...> rslts[4];
     for (uint i = 0; i < 4; i++)
     {
         switch (c)
@@ -131,7 +134,7 @@ inline vec<T, 4> spvGatherConstOffsets(const thread Tex<T>& t, sampler s, Toff c
                 break;
         }
     }
-    return vec<T, 4>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
+    return spvGatherReturn<Tex, Tp...>(rslts[0].w, rslts[1].w, rslts[2].w, rslts[3].w);
 }
 
 constant spvUnsafeArray<int2, 4> _30 = spvUnsafeArray<int2, 4>({ int2(-8), int2(-8, 7), int2(7, -8), int2(7) });

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -793,10 +793,7 @@ protected:
 		SPVFuncImplInverse4x4,
 		SPVFuncImplInverse3x3,
 		SPVFuncImplInverse2x2,
-		// It is very important that this come before *Swizzle and ChromaReconstruct*, to ensure it's
-		// emitted before them.
-		SPVFuncImplForwardArgs,
-		// Likewise, this must come before *Swizzle.
+		// It is very important that this come before *Swizzle, to ensure it's emitted before them.
 		SPVFuncImplGetSwizzle,
 		SPVFuncImplTextureSwizzle,
 		SPVFuncImplGatherReturn,

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -799,6 +799,8 @@ protected:
 		// Likewise, this must come before *Swizzle.
 		SPVFuncImplGetSwizzle,
 		SPVFuncImplTextureSwizzle,
+		SPVFuncImplGatherReturn,
+		SPVFuncImplGatherCompareReturn,
 		SPVFuncImplGatherSwizzle,
 		SPVFuncImplGatherCompareSwizzle,
 		SPVFuncImplGatherConstOffsets,


### PR DESCRIPTION
Sequoia's texture2d has a new template parameter (`template <typename T, access a, memory_coherence c, typename _Enable> struct texture2d : _texture2d<T, a, c>`), making the old template matching fail to match.  Switch to using decltype on the method we plan to call.

I also removed `spvForward`, as nothing really has custom copy/move constructors in MSL (and you can't easily use forwarding references due to the explicit address space qualifier requirement).