### PR TITLE
ci: Use ubuntu-24.04 image instead.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     name: "Build ${{ matrix.platform }}"
     strategy:
       matrix:
-        platform: [windows-latest, ubuntu-20.04, ubuntu-22.04, macos-latest]
+        platform: [windows-latest, ubuntu-24.04, ubuntu-22.04, macos-latest]
     env:
       PARALLEL: -j 2
 


### PR DESCRIPTION
20.04 is removed.