### PR TITLE
MSL: Add support for SPV_KHR_expect_assume

### DIFF
--- a/reference/opt/shaders-msl/comp/expect-assume.comp
+++ b/reference/opt/shaders-msl/comp/expect-assume.comp
@@ -1,0 +1,34 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+#if !defined(SPV_ASSUME) && defined(__has_builtin)
+#if __has_builtin(__builtin_assume)
+#define SPV_ASSUME(x) __builtin_assume(x);
+#endif
+#if __has_builtin(__builtin_expect)
+#define SPV_EXPECT(x, y) __builtin_expect(x, y);
+#endif
+#endif
+#ifndef SPV_ASSUME
+#define SPV_ASSUME(x)
+#endif
+#ifndef SPV_EXPECT
+#define SPV_EXPECT(x, y)
+#endif
+struct buffer_t
+{
+    uint z;
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(32u, 1u, 1u);
+
+kernel void main0(device buffer_t& buf [[buffer(0)]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
+{
+    SPV_ASSUME(gl_WorkGroupID.x < 32u)
+    buf.z = SPV_EXPECT(gl_WorkGroupID.z, 0u);
+}
+

--- a/reference/shaders-msl/comp/expect-assume.comp
+++ b/reference/shaders-msl/comp/expect-assume.comp
@@ -1,0 +1,34 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+#if !defined(SPV_ASSUME) && defined(__has_builtin)
+#if __has_builtin(__builtin_assume)
+#define SPV_ASSUME(x) __builtin_assume(x);
+#endif
+#if __has_builtin(__builtin_expect)
+#define SPV_EXPECT(x, y) __builtin_expect(x, y);
+#endif
+#endif
+#ifndef SPV_ASSUME
+#define SPV_ASSUME(x)
+#endif
+#ifndef SPV_EXPECT
+#define SPV_EXPECT(x, y)
+#endif
+struct buffer_t
+{
+    uint z;
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(32u, 1u, 1u);
+
+kernel void main0(device buffer_t& buf [[buffer(0)]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
+{
+    SPV_ASSUME(gl_WorkGroupID.x < 32u)
+    buf.z = SPV_EXPECT(gl_WorkGroupID.z, 0u);
+}
+

--- a/shaders-msl/comp/expect-assume.comp
+++ b/shaders-msl/comp/expect-assume.comp
@@ -1,0 +1,19 @@
+#version 450
+#extension GL_EXT_spirv_intrinsics : require
+
+layout(local_size_x = 32) in;
+
+layout(std430, binding = 0) buffer buffer_t {
+    uint z;
+} buf;
+
+spirv_instruction (extensions = ["SPV_KHR_expect_assume"], capabilities = [5629], id = 5630)
+void assume_true(bool condition);
+
+spirv_instruction (extensions = ["SPV_KHR_expect_assume"], capabilities = [5629], id = 5631)
+uint expect(uint value, uint exp_value);
+
+void main() {
+    assume_true(gl_WorkGroupID.x < 32);
+    buf.z = expect(gl_WorkGroupID.z, uint(0));
+}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -10245,7 +10245,7 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 	case OpAssumeTrueKHR:
 	{
 		auto condition = ops[0];
-		statement(join("SPV_ASSUME(", to_expression(condition), ")"));
+		statement(join("SPV_ASSUME(", to_unpacked_expression(condition), ")"));
 		break;
 	}
 
@@ -10256,7 +10256,7 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		auto value = ops[2];
 		auto exp_value = ops[3];
 
-		auto exp = join("SPV_EXPECT(", to_expression(value), ", ", to_expression(exp_value), ")");
+		auto exp = join("SPV_EXPECT(", to_unpacked_expression(value), ", ", to_unpacked_expression(exp_value), ")");
 		emit_op(result_type, ret, exp, should_forward(value), should_forward(exp_value));
 		inherit_expression_dependencies(ret, value);
 		inherit_expression_dependencies(ret, exp_value);

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -849,6 +849,7 @@ protected:
 		SPVFuncImplTextureCast,
 		SPVFuncImplMulExtended,
 		SPVFuncImplSetMeshOutputsEXT,
+		SPVFuncImplAssume,
 	};
 
 	// If the underlying resource has been used for comparison then duplicate loads of that resource must be too


### PR DESCRIPTION
Not sure about using the func impl thingy for defining macros, but this seems to work & compile fine. Couldn't think of a good test that actually had any codegen/performance improvements, but the LLVM IR does show that the Metal compiler is using the builtins at least to some degree.

Essentially, this just defines macros around the `__builtin_assume` and `__builtin_expect` builtins to be used for the two SPIR-V instructions, which are both builtins supported by Clang.

Relevant for KhronosGroup/MoltenVK#2490