### PR TITLE
GLSL/MSL: Implement SPV_KHR_subgroup_rotate

### DIFF
--- a/reference/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl21.comp
+++ b/reference/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl21.comp
@@ -184,6 +184,24 @@ inline vec<bool, N> spvSubgroupShuffleDown(vec<bool, N> value, ushort delta)
 }
 
 template<typename T>
+inline T spvSubgroupRotate(T value, ushort delta)
+{
+    return simd_shuffle_rotate_down(value, delta);
+}
+
+template<>
+inline bool spvSubgroupRotate(bool value, ushort delta)
+{
+    return !!simd_shuffle_rotate_down((ushort)value, delta);
+}
+
+template<uint N>
+inline vec<bool, N> spvSubgroupRotate(vec<bool, N> value, ushort delta)
+{
+    return (vec<bool, N>)simd_shuffle_rotate_down((vec<ushort, N>)value, delta);
+}
+
+template<typename T>
 inline T spvQuadBroadcast(T value, uint lane)
 {
     return quad_broadcast(value, lane);
@@ -269,6 +287,8 @@ kernel void main0(device SSBO& _9 [[buffer(0)]], uint gl_NumSubgroups [[simdgrou
     bool shuffled_up_bool = spvSubgroupShuffleUp(true, 4u);
     uint shuffled_down = spvSubgroupShuffleDown(20u, 4u);
     bool shuffled_down_bool = spvSubgroupShuffleDown(false, 4u);
+    uint rotated = spvSubgroupRotate(20u, 4u);
+    bool rotated_bool = spvSubgroupRotate(false, 4u);
     bool has_all = simd_all(true);
     bool has_any = simd_any(true);
     bool has_equal = spvSubgroupAllEqual(0);

--- a/reference/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl21.fixed-subgroup.comp
+++ b/reference/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl21.fixed-subgroup.comp
@@ -184,6 +184,24 @@ inline vec<bool, N> spvSubgroupShuffleDown(vec<bool, N> value, ushort delta)
 }
 
 template<typename T>
+inline T spvSubgroupRotate(T value, ushort delta)
+{
+    return simd_shuffle_rotate_down(value, delta);
+}
+
+template<>
+inline bool spvSubgroupRotate(bool value, ushort delta)
+{
+    return !!simd_shuffle_rotate_down((ushort)value, delta);
+}
+
+template<uint N>
+inline vec<bool, N> spvSubgroupRotate(vec<bool, N> value, ushort delta)
+{
+    return (vec<bool, N>)simd_shuffle_rotate_down((vec<ushort, N>)value, delta);
+}
+
+template<typename T>
 inline T spvQuadBroadcast(T value, uint lane)
 {
     return quad_broadcast(value, lane);
@@ -270,6 +288,8 @@ kernel void main0(device SSBO& _9 [[buffer(0)]], uint gl_NumSubgroups [[simdgrou
     bool shuffled_up_bool = spvSubgroupShuffleUp(true, 4u);
     uint shuffled_down = spvSubgroupShuffleDown(20u, 4u);
     bool shuffled_down_bool = spvSubgroupShuffleDown(false, 4u);
+    uint rotated = spvSubgroupRotate(20u, 4u);
+    bool rotated_bool = spvSubgroupRotate(false, 4u);
     bool has_all = simd_all(true);
     bool has_any = simd_any(true);
     bool has_equal = spvSubgroupAllEqual(0);

--- a/reference/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl22.ios.comp
+++ b/reference/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl22.ios.comp
@@ -179,6 +179,24 @@ inline vec<bool, N> spvSubgroupShuffleDown(vec<bool, N> value, ushort delta)
 }
 
 template<typename T>
+inline T spvSubgroupRotate(T value, ushort delta)
+{
+    return quad_shuffle_rotate_down(value, delta);
+}
+
+template<>
+inline bool spvSubgroupRotate(bool value, ushort delta)
+{
+    return !!quad_shuffle_rotate_down((ushort)value, delta);
+}
+
+template<uint N>
+inline vec<bool, N> spvSubgroupRotate(vec<bool, N> value, ushort delta)
+{
+    return (vec<bool, N>)quad_shuffle_rotate_down((vec<ushort, N>)value, delta);
+}
+
+template<typename T>
 inline T spvQuadBroadcast(T value, uint lane)
 {
     return quad_broadcast(value, lane);
@@ -264,6 +282,8 @@ kernel void main0(device SSBO& _9 [[buffer(0)]], uint gl_NumSubgroups [[quadgrou
     bool shuffled_up_bool = spvSubgroupShuffleUp(true, 4u);
     uint shuffled_down = spvSubgroupShuffleDown(20u, 4u);
     bool shuffled_down_bool = spvSubgroupShuffleDown(false, 4u);
+    uint rotated = spvSubgroupRotate(20u, 4u);
+    bool rotated_bool = spvSubgroupRotate(false, 4u);
     bool has_all = quad_all(true);
     bool has_any = quad_any(true);
     bool has_equal = spvSubgroupAllEqual(0);

--- a/reference/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl23.ios.simd.comp
+++ b/reference/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl23.ios.simd.comp
@@ -179,6 +179,24 @@ inline vec<bool, N> spvSubgroupShuffleDown(vec<bool, N> value, ushort delta)
 }
 
 template<typename T>
+inline T spvSubgroupRotate(T value, ushort delta)
+{
+    return simd_shuffle_rotate_down(value, delta);
+}
+
+template<>
+inline bool spvSubgroupRotate(bool value, ushort delta)
+{
+    return !!simd_shuffle_rotate_down((ushort)value, delta);
+}
+
+template<uint N>
+inline vec<bool, N> spvSubgroupRotate(vec<bool, N> value, ushort delta)
+{
+    return (vec<bool, N>)simd_shuffle_rotate_down((vec<ushort, N>)value, delta);
+}
+
+template<typename T>
 inline T spvQuadBroadcast(T value, uint lane)
 {
     return quad_broadcast(value, lane);
@@ -264,6 +282,8 @@ kernel void main0(device SSBO& _9 [[buffer(0)]], uint gl_NumSubgroups [[simdgrou
     bool shuffled_up_bool = spvSubgroupShuffleUp(true, 4u);
     uint shuffled_down = spvSubgroupShuffleDown(20u, 4u);
     bool shuffled_down_bool = spvSubgroupShuffleDown(false, 4u);
+    uint rotated = spvSubgroupRotate(20u, 4u);
+    bool rotated_bool = spvSubgroupRotate(false, 4u);
     bool has_all = simd_all(true);
     bool has_any = simd_any(true);
     bool has_equal = spvSubgroupAllEqual(0);

--- a/reference/shaders-no-opt/comp/subgroups.nocompat.invalid.vk.comp.vk
+++ b/reference/shaders-no-opt/comp/subgroups.nocompat.invalid.vk.comp.vk
@@ -3,6 +3,7 @@
 #extension GL_KHR_shader_subgroup_ballot : require
 #extension GL_KHR_shader_subgroup_shuffle : require
 #extension GL_KHR_shader_subgroup_shuffle_relative : require
+#extension GL_KHR_shader_subgroup_rotate : require
 #extension GL_KHR_shader_subgroup_vote : require
 #extension GL_KHR_shader_subgroup_arithmetic : require
 #extension GL_KHR_shader_subgroup_clustered : require
@@ -46,6 +47,8 @@ void main()
     uint shuffled_xor = subgroupShuffleXor(30u, 8u);
     uint shuffled_up = subgroupShuffleUp(20u, 4u);
     uint shuffled_down = subgroupShuffleDown(20u, 4u);
+    uint rotated = subgroupRotate(20u, 4u);
+    uint rotated_clustered = subgroupClusteredRotate(20u, 4u, 8u);
     bool has_all = subgroupAll(true);
     bool has_any = subgroupAny(true);
     bool has_equal = subgroupAllEqual(true);

--- a/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl21.comp
+++ b/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl21.comp
@@ -7,6 +7,7 @@
 #extension GL_KHR_shader_subgroup_arithmetic : require
 #extension GL_KHR_shader_subgroup_clustered : require
 #extension GL_KHR_shader_subgroup_quad : require
+#extension GL_KHR_shader_subgroup_rotate : require
 layout(local_size_x = 1) in;
 
 layout(std430, binding = 0) buffer SSBO
@@ -58,6 +59,10 @@ void main()
 	bool shuffled_up_bool = subgroupShuffleUp(true, 4u);
 	uint shuffled_down = subgroupShuffleDown(20u, 4u);
 	bool shuffled_down_bool = subgroupShuffleDown(false, 4u);
+
+	// rotate
+	uint rotated = subgroupRotate(20u, 4u);
+	bool rotated_bool = subgroupRotate(false, 4u);
 
 	// vote
 	bool has_all = subgroupAll(true);

--- a/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl21.fixed-subgroup.comp
+++ b/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl21.fixed-subgroup.comp
@@ -7,6 +7,7 @@
 #extension GL_KHR_shader_subgroup_arithmetic : require
 #extension GL_KHR_shader_subgroup_clustered : require
 #extension GL_KHR_shader_subgroup_quad : require
+#extension GL_KHR_shader_subgroup_rotate : require
 layout(local_size_x = 1) in;
 
 layout(std430, binding = 0) buffer SSBO
@@ -58,6 +59,10 @@ void main()
 	bool shuffled_up_bool = subgroupShuffleUp(true, 4u);
 	uint shuffled_down = subgroupShuffleDown(20u, 4u);
 	bool shuffled_down_bool = subgroupShuffleDown(false, 4u);
+
+	// rotate
+	uint rotated = subgroupRotate(20u, 4u);
+	bool rotated_bool = subgroupRotate(false, 4u);
 
 	// vote
 	bool has_all = subgroupAll(true);

--- a/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl22.ios.comp
+++ b/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl22.ios.comp
@@ -5,6 +5,7 @@
 #extension GL_KHR_shader_subgroup_shuffle : require
 #extension GL_KHR_shader_subgroup_shuffle_relative : require
 #extension GL_KHR_shader_subgroup_quad : require
+#extension GL_KHR_shader_subgroup_rotate : require
 layout(local_size_x = 1) in;
 
 layout(std430, binding = 0) buffer SSBO
@@ -58,6 +59,10 @@ void main()
 	bool shuffled_up_bool = subgroupShuffleUp(true, 4u);
 	uint shuffled_down = subgroupShuffleDown(20u, 4u);
 	bool shuffled_down_bool = subgroupShuffleDown(false, 4u);
+
+	// rotate
+	uint rotated = subgroupRotate(20u, 4u);
+	bool rotated_bool = subgroupRotate(false, 4u);
 
 	// vote
 	bool has_all = subgroupAll(true);

--- a/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl23.ios.simd.comp
+++ b/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl23.ios.simd.comp
@@ -7,6 +7,7 @@
 #extension GL_KHR_shader_subgroup_arithmetic : require
 #extension GL_KHR_shader_subgroup_clustered : require
 #extension GL_KHR_shader_subgroup_quad : require
+#extension GL_KHR_shader_subgroup_rotate : require
 layout(local_size_x = 1) in;
 
 layout(std430, binding = 0) buffer SSBO
@@ -58,6 +59,10 @@ void main()
 	bool shuffled_up_bool = subgroupShuffleUp(true, 4u);
 	uint shuffled_down = subgroupShuffleDown(20u, 4u);
 	bool shuffled_down_bool = subgroupShuffleDown(false, 4u);
+
+	// rotate
+	uint rotated = subgroupRotate(20u, 4u);
+	bool rotated_bool = subgroupRotate(false, 4u);
 
 	// vote
 	bool has_all = subgroupAll(true);

--- a/shaders-no-opt/comp/subgroups.nocompat.invalid.vk.comp
+++ b/shaders-no-opt/comp/subgroups.nocompat.invalid.vk.comp
@@ -7,6 +7,7 @@
 #extension GL_KHR_shader_subgroup_arithmetic : require
 #extension GL_KHR_shader_subgroup_clustered : require
 #extension GL_KHR_shader_subgroup_quad : require
+#extension GL_KHR_shader_subgroup_rotate : require
 layout(local_size_x = 1) in;
 
 layout(std430, binding = 0) buffer SSBO
@@ -52,6 +53,10 @@ void main()
 	// shuffle relative 
 	uint shuffled_up = subgroupShuffleUp(20u, 4u);
 	uint shuffled_down = subgroupShuffleDown(20u, 4u);
+
+	// rotate
+	uint rotated = subgroupRotate(20u, 4u);
+	uint rotated_clustered = subgroupClusteredRotate(20u, 4u, 8u);
 
 	// vote
 	bool has_all = subgroupAll(true);

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -171,6 +171,7 @@ bool Compiler::block_is_control_dependent(const SPIRBlock &block)
 		case OpGroupNonUniformLogicalXor:
 		case OpGroupNonUniformQuadBroadcast:
 		case OpGroupNonUniformQuadSwap:
+		case OpGroupNonUniformRotateKHR:
 
 		// Control barriers
 		case OpControlBarrier:

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -9387,6 +9387,10 @@ void CompilerGLSL::emit_subgroup_op(const Instruction &i)
 		require_extension_internal("GL_KHR_shader_subgroup_shuffle_relative");
 		break;
 
+	case OpGroupNonUniformRotateKHR:
+		require_extension_internal("GL_KHR_shader_subgroup_rotate");
+		break;
+
 	case OpGroupNonUniformAll:
 	case OpGroupNonUniformAny:
 	case OpGroupNonUniformAllEqual:
@@ -9531,6 +9535,13 @@ void CompilerGLSL::emit_subgroup_op(const Instruction &i)
 
 	case OpGroupNonUniformShuffleDown:
 		emit_binary_func_op(result_type, id, ops[3], ops[4], "subgroupShuffleDown");
+		break;
+
+	case OpGroupNonUniformRotateKHR:
+		if (i.length > 5)
+			emit_trinary_func_op(result_type, id, ops[3], ops[4], ops[5], "subgroupClusteredRotate");
+		else
+			emit_binary_func_op(result_type, id, ops[3], ops[4], "subgroupRotate");
 		break;
 
 	case OpGroupNonUniformAll:
@@ -15073,6 +15084,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 	case OpGroupNonUniformLogicalXor:
 	case OpGroupNonUniformQuadSwap:
 	case OpGroupNonUniformQuadBroadcast:
+	case OpGroupNonUniformRotateKHR:
 		emit_subgroup_op(instruction);
 		break;
 

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -814,6 +814,7 @@ protected:
 		SPVFuncImplSubgroupShuffleXor,
 		SPVFuncImplSubgroupShuffleUp,
 		SPVFuncImplSubgroupShuffleDown,
+		SPVFuncImplSubgroupRotate,
 		SPVFuncImplQuadBroadcast,
 		SPVFuncImplQuadSwap,
 		SPVFuncImplReflectScalar,


### PR DESCRIPTION
Adds GLSL and MSL support for `SPV_KHR_subgroup_rotate`.
* For GLSL both clustered and non-clustered variants are supported.
* For MSL, clustered is not supported as I could not find an option available for this, but it is behind a separate Vulkan feature flag anyway.