### PR TITLE
Properly define SPV_EXPECT when builtin not available

### DIFF
--- a/reference/opt/shaders-msl/comp/expect-assume.comp
+++ b/reference/opt/shaders-msl/comp/expect-assume.comp
@@ -5,11 +5,11 @@
 
 using namespace metal;
 
-#if !defined(SPV_ASSUME) && defined(__has_builtin)
-#if __has_builtin(__builtin_assume)
+#if defined(__has_builtin)
+#if !defined(SPV_ASSUME) && __has_builtin(__builtin_assume)
 #define SPV_ASSUME(x) __builtin_assume(x);
 #endif
-#if __has_builtin(__builtin_expect)
+#if !defined(SPV_EXPECT) && __has_builtin(__builtin_expect)
 #define SPV_EXPECT(x, y) __builtin_expect(x, y);
 #endif
 #endif
@@ -17,7 +17,7 @@ using namespace metal;
 #define SPV_ASSUME(x)
 #endif
 #ifndef SPV_EXPECT
-#define SPV_EXPECT(x, y)
+#define SPV_EXPECT(x, y) x
 #endif
 struct buffer_t
 {

--- a/reference/shaders-msl/comp/expect-assume.comp
+++ b/reference/shaders-msl/comp/expect-assume.comp
@@ -5,11 +5,11 @@
 
 using namespace metal;
 
-#if !defined(SPV_ASSUME) && defined(__has_builtin)
-#if __has_builtin(__builtin_assume)
+#if defined(__has_builtin)
+#if !defined(SPV_ASSUME) && __has_builtin(__builtin_assume)
 #define SPV_ASSUME(x) __builtin_assume(x);
 #endif
-#if __has_builtin(__builtin_expect)
+#if !defined(SPV_EXPECT) && __has_builtin(__builtin_expect)
 #define SPV_EXPECT(x, y) __builtin_expect(x, y);
 #endif
 #endif
@@ -17,7 +17,7 @@ using namespace metal;
 #define SPV_ASSUME(x)
 #endif
 #ifndef SPV_EXPECT
-#define SPV_EXPECT(x, y)
+#define SPV_EXPECT(x, y) x
 #endif
 struct buffer_t
 {

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -7870,11 +7870,11 @@ void CompilerMSL::emit_custom_functions()
 			break;
 
 		case SPVFuncImplAssume:
-			statement_no_indent("#if !defined(SPV_ASSUME) && defined(__has_builtin)");
-			statement_no_indent("#if __has_builtin(__builtin_assume)");
+			statement_no_indent("#if defined(__has_builtin)");
+			statement_no_indent("#if !defined(SPV_ASSUME) && __has_builtin(__builtin_assume)");
 			statement_no_indent("#define SPV_ASSUME(x) __builtin_assume(x);");
 			statement_no_indent("#endif");
-			statement_no_indent("#if __has_builtin(__builtin_expect)");
+			statement_no_indent("#if !defined(SPV_EXPECT) && __has_builtin(__builtin_expect)");
 			statement_no_indent("#define SPV_EXPECT(x, y) __builtin_expect(x, y);");
 			statement_no_indent("#endif");
 			statement_no_indent("#endif");
@@ -7884,7 +7884,7 @@ void CompilerMSL::emit_custom_functions()
 			statement_no_indent("#endif");
 
 			statement_no_indent("#ifndef SPV_EXPECT");
-			statement_no_indent("#define SPV_EXPECT(x, y)");
+			statement_no_indent("#define SPV_EXPECT(x, y) x");
 			statement_no_indent("#endif");
 
 			break;


### PR DESCRIPTION
I noticed that `SPV_EXPECT` wasn't defined properly when the builtin wasn't available, and the guards for defining the macros weren't quite right.