### PR TITLE
MSL: Implement subgroup clustered rotate.

### DIFF
--- a/reference/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl21.comp
+++ b/reference/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl21.comp
@@ -244,29 +244,38 @@ struct SSBO
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(device SSBO& _9 [[buffer(0)]], uint gl_NumSubgroups [[simdgroups_per_threadgroup]], uint gl_SubgroupID [[simdgroup_index_in_threadgroup]], uint gl_SubgroupSize [[thread_execution_width]], uint gl_SubgroupInvocationID [[thread_index_in_simdgroup]])
+static inline __attribute__((always_inline))
+void doClusteredRotate(thread uint& gl_SubgroupInvocationID)
+{
+    uint _15 = spvSubgroupShuffle(20u, ((gl_SubgroupInvocationID + 4u) & 7) + (gl_SubgroupInvocationID & 4294967288));
+    uint rotated_clustered = _15;
+    bool _20 = spvSubgroupShuffle(false, ((gl_SubgroupInvocationID + 4u) & 7) + (gl_SubgroupInvocationID & 4294967288));
+    bool rotated_clustered_bool = _20;
+}
+
+kernel void main0(device SSBO& _24 [[buffer(0)]], uint gl_NumSubgroups [[simdgroups_per_threadgroup]], uint gl_SubgroupID [[simdgroup_index_in_threadgroup]], uint gl_SubgroupSize [[thread_execution_width]], uint gl_SubgroupInvocationID [[thread_index_in_simdgroup]])
 {
     uint4 gl_SubgroupEqMask = gl_SubgroupInvocationID >= 32 ? uint4(0, (1 << (gl_SubgroupInvocationID - 32)), uint2(0)) : uint4(1 << gl_SubgroupInvocationID, uint3(0));
     uint4 gl_SubgroupGeMask = uint4(insert_bits(0u, 0xFFFFFFFF, min(gl_SubgroupInvocationID, 32u), (uint)max(min((int)gl_SubgroupSize, 32) - (int)gl_SubgroupInvocationID, 0)), insert_bits(0u, 0xFFFFFFFF, (uint)max((int)gl_SubgroupInvocationID - 32, 0), (uint)max((int)gl_SubgroupSize - (int)max(gl_SubgroupInvocationID, 32u), 0)), uint2(0));
     uint4 gl_SubgroupGtMask = uint4(insert_bits(0u, 0xFFFFFFFF, min(gl_SubgroupInvocationID + 1, 32u), (uint)max(min((int)gl_SubgroupSize, 32) - (int)gl_SubgroupInvocationID - 1, 0)), insert_bits(0u, 0xFFFFFFFF, (uint)max((int)gl_SubgroupInvocationID + 1 - 32, 0), (uint)max((int)gl_SubgroupSize - (int)max(gl_SubgroupInvocationID + 1, 32u), 0)), uint2(0));
     uint4 gl_SubgroupLeMask = uint4(extract_bits(0xFFFFFFFF, 0, min(gl_SubgroupInvocationID + 1, 32u)), extract_bits(0xFFFFFFFF, 0, (uint)max((int)gl_SubgroupInvocationID + 1 - 32, 0)), uint2(0));
     uint4 gl_SubgroupLtMask = uint4(extract_bits(0xFFFFFFFF, 0, min(gl_SubgroupInvocationID, 32u)), extract_bits(0xFFFFFFFF, 0, (uint)max((int)gl_SubgroupInvocationID - 32, 0)), uint2(0));
-    _9.FragColor = float(gl_NumSubgroups);
-    _9.FragColor = float(gl_SubgroupID);
-    _9.FragColor = float(gl_SubgroupSize);
-    _9.FragColor = float(gl_SubgroupInvocationID);
+    _24.FragColor = float(gl_NumSubgroups);
+    _24.FragColor = float(gl_SubgroupID);
+    _24.FragColor = float(gl_SubgroupSize);
+    _24.FragColor = float(gl_SubgroupInvocationID);
     simdgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup | mem_flags::mem_texture);
     simdgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup | mem_flags::mem_texture);
     simdgroup_barrier(mem_flags::mem_device);
     simdgroup_barrier(mem_flags::mem_threadgroup);
     simdgroup_barrier(mem_flags::mem_texture);
-    bool _39 = simd_is_first();
-    bool elected = _39;
-    _9.FragColor = float4(gl_SubgroupEqMask).x;
-    _9.FragColor = float4(gl_SubgroupGeMask).x;
-    _9.FragColor = float4(gl_SubgroupGtMask).x;
-    _9.FragColor = float4(gl_SubgroupLeMask).x;
-    _9.FragColor = float4(gl_SubgroupLtMask).x;
+    bool _50 = simd_is_first();
+    bool elected = _50;
+    _24.FragColor = float4(gl_SubgroupEqMask).x;
+    _24.FragColor = float4(gl_SubgroupGeMask).x;
+    _24.FragColor = float4(gl_SubgroupGtMask).x;
+    _24.FragColor = float4(gl_SubgroupLeMask).x;
+    _24.FragColor = float4(gl_SubgroupLtMask).x;
     float4 broadcasted = spvSubgroupBroadcast(float4(10.0), 8u);
     bool2 broadcasted_bool = spvSubgroupBroadcast(bool2(true), 8u);
     float3 first = spvSubgroupBroadcastFirst(float3(20.0));
@@ -289,6 +298,7 @@ kernel void main0(device SSBO& _9 [[buffer(0)]], uint gl_NumSubgroups [[simdgrou
     bool shuffled_down_bool = spvSubgroupShuffleDown(false, 4u);
     uint rotated = spvSubgroupRotate(20u, 4u);
     bool rotated_bool = spvSubgroupRotate(false, 4u);
+    doClusteredRotate(gl_SubgroupInvocationID);
     bool has_all = simd_all(true);
     bool has_any = simd_any(true);
     bool has_equal = spvSubgroupAllEqual(0);

--- a/reference/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl21.fixed-subgroup.comp
+++ b/reference/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl21.fixed-subgroup.comp
@@ -244,7 +244,16 @@ struct SSBO
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(device SSBO& _9 [[buffer(0)]], uint gl_NumSubgroups [[simdgroups_per_threadgroup]], uint gl_SubgroupID [[simdgroup_index_in_threadgroup]], uint gl_SubgroupInvocationID [[thread_index_in_simdgroup]])
+static inline __attribute__((always_inline))
+void doClusteredRotate(thread uint& gl_SubgroupInvocationID)
+{
+    uint _15 = spvSubgroupShuffle(20u, ((gl_SubgroupInvocationID + 4u) & 7) + (gl_SubgroupInvocationID & 4294967288));
+    uint rotated_clustered = _15;
+    bool _20 = spvSubgroupShuffle(false, ((gl_SubgroupInvocationID + 4u) & 7) + (gl_SubgroupInvocationID & 4294967288));
+    bool rotated_clustered_bool = _20;
+}
+
+kernel void main0(device SSBO& _24 [[buffer(0)]], uint gl_NumSubgroups [[simdgroups_per_threadgroup]], uint gl_SubgroupID [[simdgroup_index_in_threadgroup]], uint gl_SubgroupInvocationID [[thread_index_in_simdgroup]])
 {
     uint gl_SubgroupSize = 32;
     uint4 gl_SubgroupEqMask = gl_SubgroupInvocationID >= 32 ? uint4(0, (1 << (gl_SubgroupInvocationID - 32)), uint2(0)) : uint4(1 << gl_SubgroupInvocationID, uint3(0));
@@ -252,22 +261,22 @@ kernel void main0(device SSBO& _9 [[buffer(0)]], uint gl_NumSubgroups [[simdgrou
     uint4 gl_SubgroupGtMask = uint4(insert_bits(0u, 0xFFFFFFFF, gl_SubgroupInvocationID + 1, 32 - gl_SubgroupInvocationID - 1), uint3(0));
     uint4 gl_SubgroupLeMask = uint4(extract_bits(0xFFFFFFFF, 0, min(gl_SubgroupInvocationID + 1, 32u)), extract_bits(0xFFFFFFFF, 0, (uint)max((int)gl_SubgroupInvocationID + 1 - 32, 0)), uint2(0));
     uint4 gl_SubgroupLtMask = uint4(extract_bits(0xFFFFFFFF, 0, min(gl_SubgroupInvocationID, 32u)), extract_bits(0xFFFFFFFF, 0, (uint)max((int)gl_SubgroupInvocationID - 32, 0)), uint2(0));
-    _9.FragColor = float(gl_NumSubgroups);
-    _9.FragColor = float(gl_SubgroupID);
-    _9.FragColor = float(gl_SubgroupSize);
-    _9.FragColor = float(gl_SubgroupInvocationID);
+    _24.FragColor = float(gl_NumSubgroups);
+    _24.FragColor = float(gl_SubgroupID);
+    _24.FragColor = float(gl_SubgroupSize);
+    _24.FragColor = float(gl_SubgroupInvocationID);
     simdgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup | mem_flags::mem_texture);
     simdgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup | mem_flags::mem_texture);
     simdgroup_barrier(mem_flags::mem_device);
     simdgroup_barrier(mem_flags::mem_threadgroup);
     simdgroup_barrier(mem_flags::mem_texture);
-    bool _39 = simd_is_first();
-    bool elected = _39;
-    _9.FragColor = float4(gl_SubgroupEqMask).x;
-    _9.FragColor = float4(gl_SubgroupGeMask).x;
-    _9.FragColor = float4(gl_SubgroupGtMask).x;
-    _9.FragColor = float4(gl_SubgroupLeMask).x;
-    _9.FragColor = float4(gl_SubgroupLtMask).x;
+    bool _50 = simd_is_first();
+    bool elected = _50;
+    _24.FragColor = float4(gl_SubgroupEqMask).x;
+    _24.FragColor = float4(gl_SubgroupGeMask).x;
+    _24.FragColor = float4(gl_SubgroupGtMask).x;
+    _24.FragColor = float4(gl_SubgroupLeMask).x;
+    _24.FragColor = float4(gl_SubgroupLtMask).x;
     float4 broadcasted = spvSubgroupBroadcast(float4(10.0), 8u);
     bool2 broadcasted_bool = spvSubgroupBroadcast(bool2(true), 8u);
     float3 first = spvSubgroupBroadcastFirst(float3(20.0));
@@ -290,6 +299,7 @@ kernel void main0(device SSBO& _9 [[buffer(0)]], uint gl_NumSubgroups [[simdgrou
     bool shuffled_down_bool = spvSubgroupShuffleDown(false, 4u);
     uint rotated = spvSubgroupRotate(20u, 4u);
     bool rotated_bool = spvSubgroupRotate(false, 4u);
+    doClusteredRotate(gl_SubgroupInvocationID);
     bool has_all = simd_all(true);
     bool has_any = simd_any(true);
     bool has_equal = spvSubgroupAllEqual(0);

--- a/reference/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl22.ios.comp
+++ b/reference/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl22.ios.comp
@@ -239,29 +239,38 @@ struct SSBO
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(device SSBO& _9 [[buffer(0)]], uint gl_NumSubgroups [[quadgroups_per_threadgroup]], uint gl_SubgroupID [[quadgroup_index_in_threadgroup]], uint gl_SubgroupSize [[thread_execution_width]], uint gl_SubgroupInvocationID [[thread_index_in_quadgroup]])
+static inline __attribute__((always_inline))
+void doClusteredRotate(thread uint& gl_SubgroupInvocationID)
+{
+    uint _15 = spvSubgroupShuffle(20u, ((gl_SubgroupInvocationID + 4u) & 7) + (gl_SubgroupInvocationID & 4294967288));
+    uint rotated_clustered = _15;
+    bool _20 = spvSubgroupShuffle(false, ((gl_SubgroupInvocationID + 4u) & 7) + (gl_SubgroupInvocationID & 4294967288));
+    bool rotated_clustered_bool = _20;
+}
+
+kernel void main0(device SSBO& _24 [[buffer(0)]], uint gl_NumSubgroups [[quadgroups_per_threadgroup]], uint gl_SubgroupID [[quadgroup_index_in_threadgroup]], uint gl_SubgroupSize [[thread_execution_width]], uint gl_SubgroupInvocationID [[thread_index_in_quadgroup]])
 {
     uint4 gl_SubgroupEqMask = uint4(1 << gl_SubgroupInvocationID, uint3(0));
     uint4 gl_SubgroupGeMask = uint4(insert_bits(0u, 0xFFFFFFFF, gl_SubgroupInvocationID, gl_SubgroupSize - gl_SubgroupInvocationID), uint3(0));
     uint4 gl_SubgroupGtMask = uint4(insert_bits(0u, 0xFFFFFFFF, gl_SubgroupInvocationID + 1, gl_SubgroupSize - gl_SubgroupInvocationID - 1), uint3(0));
     uint4 gl_SubgroupLeMask = uint4(extract_bits(0xFFFFFFFF, 0, gl_SubgroupInvocationID + 1), uint3(0));
     uint4 gl_SubgroupLtMask = uint4(extract_bits(0xFFFFFFFF, 0, gl_SubgroupInvocationID), uint3(0));
-    _9.FragColor = float(gl_NumSubgroups);
-    _9.FragColor = float(gl_SubgroupID);
-    _9.FragColor = float(gl_SubgroupSize);
-    _9.FragColor = float(gl_SubgroupInvocationID);
+    _24.FragColor = float(gl_NumSubgroups);
+    _24.FragColor = float(gl_SubgroupID);
+    _24.FragColor = float(gl_SubgroupSize);
+    _24.FragColor = float(gl_SubgroupInvocationID);
     simdgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup | mem_flags::mem_texture);
     simdgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup | mem_flags::mem_texture);
     simdgroup_barrier(mem_flags::mem_device);
     simdgroup_barrier(mem_flags::mem_threadgroup);
     simdgroup_barrier(mem_flags::mem_texture);
-    bool _39 = quad_is_first();
-    bool elected = _39;
-    _9.FragColor = float4(gl_SubgroupEqMask).x;
-    _9.FragColor = float4(gl_SubgroupGeMask).x;
-    _9.FragColor = float4(gl_SubgroupGtMask).x;
-    _9.FragColor = float4(gl_SubgroupLeMask).x;
-    _9.FragColor = float4(gl_SubgroupLtMask).x;
+    bool _50 = quad_is_first();
+    bool elected = _50;
+    _24.FragColor = float4(gl_SubgroupEqMask).x;
+    _24.FragColor = float4(gl_SubgroupGeMask).x;
+    _24.FragColor = float4(gl_SubgroupGtMask).x;
+    _24.FragColor = float4(gl_SubgroupLeMask).x;
+    _24.FragColor = float4(gl_SubgroupLtMask).x;
     float4 broadcasted = spvSubgroupBroadcast(float4(10.0), 8u);
     bool2 broadcasted_bool = spvSubgroupBroadcast(bool2(true), 8u);
     float3 first = spvSubgroupBroadcastFirst(float3(20.0));
@@ -284,6 +293,7 @@ kernel void main0(device SSBO& _9 [[buffer(0)]], uint gl_NumSubgroups [[quadgrou
     bool shuffled_down_bool = spvSubgroupShuffleDown(false, 4u);
     uint rotated = spvSubgroupRotate(20u, 4u);
     bool rotated_bool = spvSubgroupRotate(false, 4u);
+    doClusteredRotate(gl_SubgroupInvocationID);
     bool has_all = quad_all(true);
     bool has_any = quad_any(true);
     bool has_equal = spvSubgroupAllEqual(0);

--- a/reference/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl23.ios.simd.comp
+++ b/reference/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl23.ios.simd.comp
@@ -239,29 +239,38 @@ struct SSBO
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(device SSBO& _9 [[buffer(0)]], uint gl_NumSubgroups [[simdgroups_per_threadgroup]], uint gl_SubgroupID [[simdgroup_index_in_threadgroup]], uint gl_SubgroupSize [[thread_execution_width]], uint gl_SubgroupInvocationID [[thread_index_in_simdgroup]])
+static inline __attribute__((always_inline))
+void doClusteredRotate(thread uint& gl_SubgroupInvocationID)
+{
+    uint _15 = spvSubgroupShuffle(20u, ((gl_SubgroupInvocationID + 4u) & 7) + (gl_SubgroupInvocationID & 4294967288));
+    uint rotated_clustered = _15;
+    bool _20 = spvSubgroupShuffle(false, ((gl_SubgroupInvocationID + 4u) & 7) + (gl_SubgroupInvocationID & 4294967288));
+    bool rotated_clustered_bool = _20;
+}
+
+kernel void main0(device SSBO& _24 [[buffer(0)]], uint gl_NumSubgroups [[simdgroups_per_threadgroup]], uint gl_SubgroupID [[simdgroup_index_in_threadgroup]], uint gl_SubgroupSize [[thread_execution_width]], uint gl_SubgroupInvocationID [[thread_index_in_simdgroup]])
 {
     uint4 gl_SubgroupEqMask = uint4(1 << gl_SubgroupInvocationID, uint3(0));
     uint4 gl_SubgroupGeMask = uint4(insert_bits(0u, 0xFFFFFFFF, gl_SubgroupInvocationID, gl_SubgroupSize - gl_SubgroupInvocationID), uint3(0));
     uint4 gl_SubgroupGtMask = uint4(insert_bits(0u, 0xFFFFFFFF, gl_SubgroupInvocationID + 1, gl_SubgroupSize - gl_SubgroupInvocationID - 1), uint3(0));
     uint4 gl_SubgroupLeMask = uint4(extract_bits(0xFFFFFFFF, 0, gl_SubgroupInvocationID + 1), uint3(0));
     uint4 gl_SubgroupLtMask = uint4(extract_bits(0xFFFFFFFF, 0, gl_SubgroupInvocationID), uint3(0));
-    _9.FragColor = float(gl_NumSubgroups);
-    _9.FragColor = float(gl_SubgroupID);
-    _9.FragColor = float(gl_SubgroupSize);
-    _9.FragColor = float(gl_SubgroupInvocationID);
+    _24.FragColor = float(gl_NumSubgroups);
+    _24.FragColor = float(gl_SubgroupID);
+    _24.FragColor = float(gl_SubgroupSize);
+    _24.FragColor = float(gl_SubgroupInvocationID);
     simdgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup | mem_flags::mem_texture);
     simdgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup | mem_flags::mem_texture);
     simdgroup_barrier(mem_flags::mem_device);
     simdgroup_barrier(mem_flags::mem_threadgroup);
     simdgroup_barrier(mem_flags::mem_texture);
-    bool _39 = simd_is_first();
-    bool elected = _39;
-    _9.FragColor = float4(gl_SubgroupEqMask).x;
-    _9.FragColor = float4(gl_SubgroupGeMask).x;
-    _9.FragColor = float4(gl_SubgroupGtMask).x;
-    _9.FragColor = float4(gl_SubgroupLeMask).x;
-    _9.FragColor = float4(gl_SubgroupLtMask).x;
+    bool _50 = simd_is_first();
+    bool elected = _50;
+    _24.FragColor = float4(gl_SubgroupEqMask).x;
+    _24.FragColor = float4(gl_SubgroupGeMask).x;
+    _24.FragColor = float4(gl_SubgroupGtMask).x;
+    _24.FragColor = float4(gl_SubgroupLeMask).x;
+    _24.FragColor = float4(gl_SubgroupLtMask).x;
     float4 broadcasted = spvSubgroupBroadcast(float4(10.0), 8u);
     bool2 broadcasted_bool = spvSubgroupBroadcast(bool2(true), 8u);
     float3 first = spvSubgroupBroadcastFirst(float3(20.0));
@@ -284,6 +293,7 @@ kernel void main0(device SSBO& _9 [[buffer(0)]], uint gl_NumSubgroups [[simdgrou
     bool shuffled_down_bool = spvSubgroupShuffleDown(false, 4u);
     uint rotated = spvSubgroupRotate(20u, 4u);
     bool rotated_bool = spvSubgroupRotate(false, 4u);
+    doClusteredRotate(gl_SubgroupInvocationID);
     bool has_all = simd_all(true);
     bool has_any = simd_any(true);
     bool has_equal = spvSubgroupAllEqual(0);

--- a/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl21.comp
+++ b/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl21.comp
@@ -15,6 +15,12 @@ layout(std430, binding = 0) buffer SSBO
 	float FragColor;
 };
 
+void doClusteredRotate()
+{
+	uint rotated_clustered = subgroupClusteredRotate(20u, 4u, 8u);
+	bool rotated_clustered_bool = subgroupClusteredRotate(false, 4u, 8u);
+}
+
 void main()
 {
 	// basic
@@ -63,6 +69,7 @@ void main()
 	// rotate
 	uint rotated = subgroupRotate(20u, 4u);
 	bool rotated_bool = subgroupRotate(false, 4u);
+	doClusteredRotate();
 
 	// vote
 	bool has_all = subgroupAll(true);

--- a/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl21.fixed-subgroup.comp
+++ b/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl21.fixed-subgroup.comp
@@ -15,6 +15,12 @@ layout(std430, binding = 0) buffer SSBO
 	float FragColor;
 };
 
+void doClusteredRotate()
+{
+	uint rotated_clustered = subgroupClusteredRotate(20u, 4u, 8u);
+	bool rotated_clustered_bool = subgroupClusteredRotate(false, 4u, 8u);
+}
+
 void main()
 {
 	// basic
@@ -63,6 +69,7 @@ void main()
 	// rotate
 	uint rotated = subgroupRotate(20u, 4u);
 	bool rotated_bool = subgroupRotate(false, 4u);
+	doClusteredRotate();
 
 	// vote
 	bool has_all = subgroupAll(true);

--- a/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl22.ios.comp
+++ b/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl22.ios.comp
@@ -15,6 +15,12 @@ layout(std430, binding = 0) buffer SSBO
 
 // Reduced test for functionality exposed on iOS.
 
+void doClusteredRotate()
+{
+	uint rotated_clustered = subgroupClusteredRotate(20u, 4u, 8u);
+	bool rotated_clustered_bool = subgroupClusteredRotate(false, 4u, 8u);
+}
+
 void main()
 {
 	// basic
@@ -63,6 +69,7 @@ void main()
 	// rotate
 	uint rotated = subgroupRotate(20u, 4u);
 	bool rotated_bool = subgroupRotate(false, 4u);
+	doClusteredRotate();
 
 	// vote
 	bool has_all = subgroupAll(true);

--- a/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl23.ios.simd.comp
+++ b/shaders-msl-no-opt/comp/subgroups.nocompat.invalid.vk.msl23.ios.simd.comp
@@ -15,6 +15,12 @@ layout(std430, binding = 0) buffer SSBO
 	float FragColor;
 };
 
+void doClusteredRotate()
+{
+	uint rotated_clustered = subgroupClusteredRotate(20u, 4u, 8u);
+	bool rotated_clustered_bool = subgroupClusteredRotate(false, 4u, 8u);
+}
+
 void main()
 {
 	// basic
@@ -63,6 +69,7 @@ void main()
 	// rotate
 	uint rotated = subgroupRotate(20u, 4u);
 	bool rotated_bool = subgroupRotate(false, 4u);
+	doClusteredRotate();
 
 	// vote
 	bool has_all = subgroupAll(true);

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -274,7 +274,7 @@ void CompilerMSL::build_implicit_builtins()
 	     active_input_builtins.get(BuiltInInstanceIndex) || active_input_builtins.get(BuiltInBaseInstance));
 	bool need_local_invocation_index =
 		(msl_options.emulate_subgroups && active_input_builtins.get(BuiltInSubgroupId)) || is_mesh_shader() ||
-		needs_workgroup_zero_init;
+		needs_workgroup_zero_init || needs_local_invocation_index;
 	bool need_workgroup_size = msl_options.emulate_subgroups && active_input_builtins.get(BuiltInNumSubgroups);
 	bool force_frag_depth_passthrough =
 	    get_execution_model() == ExecutionModelFragment && !uses_explicit_early_fragment_test() && need_subpass_input &&
@@ -1802,6 +1802,8 @@ void CompilerMSL::preprocess_op_codes()
 		capture_output_to_buffer = true;
 	}
 
+	if (preproc.needs_local_invocation_index)
+		needs_local_invocation_index = true;
 	if (preproc.needs_subgroup_invocation_id)
 		needs_subgroup_invocation_id = true;
 	if (preproc.needs_subgroup_size)
@@ -2152,6 +2154,15 @@ void CompilerMSL::extract_global_variables_from_function(uint32_t func_id, std::
 				default:
 					break;
 				}
+				break;
+			}
+
+			case OpGroupNonUniformRotateKHR:
+			{
+				// Add the correct invocation ID for calculating clustered rotate case.
+				if (i.length > 5)
+					added_arg_ids.insert(static_cast<Scope>(evaluate_constant_u32(ops[2])) == ScopeSubgroup
+						? builtin_subgroup_invocation_id_id : builtin_local_invocation_index_id);
 				break;
 			}
 
@@ -16776,10 +16787,21 @@ void CompilerMSL::emit_subgroup_op(const Instruction &i)
 		break;
 
 	case OpGroupNonUniformRotateKHR:
+	{
 		if (i.length > 5)
-			SPIRV_CROSS_THROW("Subgroup rotate ClusterSize is not supported.");
-		emit_binary_func_op(result_type, id, ops[op_idx], ops[op_idx + 1], "spvSubgroupRotate");
+		{
+			// MSL does not have a cluster size parameter, so calculate the invocation ID manually and using a shuffle.
+			auto delta_expr = enclose_expression(to_unpacked_expression(ops[op_idx + 1]));
+			auto cluster_size_minus_one = evaluate_constant_u32(ops[op_idx + 2]) - 1;
+			auto local_id_expr = to_unpacked_expression(scope == ScopeSubgroup
+				? builtin_subgroup_invocation_id_id : builtin_local_invocation_index_id);
+			auto shuffle_idx = join("((", local_id_expr, " + ", delta_expr, ")", " & ", std::to_string(cluster_size_minus_one),
+				") + (", local_id_expr, " & ", std::to_string(~cluster_size_minus_one), ")");
+			emit_op(result_type, id, join("spvSubgroupShuffle(", to_unpacked_expression(ops[op_idx]), ", ", shuffle_idx, ")"), false);
+		} else
+			emit_binary_func_op(result_type, id, ops[op_idx], ops[op_idx + 1], "spvSubgroupRotate");
 		break;
+	}
 
 	case OpGroupNonUniformAll:
 	case OpSubgroupAllKHR:
@@ -17862,7 +17884,7 @@ bool CompilerMSL::OpCodePreprocessor::handle(Op opcode, const uint32_t *args, ui
 	// suppress_missing_prototypes to suppress compiler warnings of missing function prototypes.
 
 	// Mark if the input requires the implementation of an SPIR-V function that does not exist in Metal.
-	SPVFuncImpl spv_func = get_spv_func_impl(opcode, args);
+	SPVFuncImpl spv_func = get_spv_func_impl(opcode, args, length);
 	if (spv_func != SPVFuncImplNone)
 	{
 		compiler.spv_function_implementations.insert(spv_func);
@@ -17969,6 +17991,17 @@ bool CompilerMSL::OpCodePreprocessor::handle(Op opcode, const uint32_t *args, ui
 			needs_subgroup_invocation_id = true;
 		break;
 
+	case OpGroupNonUniformRotateKHR:
+		// Add the correct invocation ID for calculating clustered rotate case.
+		if (length > 5)
+		{
+			if (static_cast<Scope>(compiler.evaluate_constant_u32(args[2])) == ScopeSubgroup)
+				needs_subgroup_invocation_id = true;
+			else
+				needs_local_invocation_index = true;
+		}
+		break;
+
 	case OpArrayLength:
 	{
 		auto *var = compiler.maybe_get_backing_variable(args[2]);
@@ -18071,7 +18104,7 @@ void CompilerMSL::OpCodePreprocessor::check_resource_write(uint32_t var_id)
 }
 
 // Returns an enumeration of a SPIR-V function that needs to be output for certain Op codes.
-CompilerMSL::SPVFuncImpl CompilerMSL::OpCodePreprocessor::get_spv_func_impl(Op opcode, const uint32_t *args)
+CompilerMSL::SPVFuncImpl CompilerMSL::OpCodePreprocessor::get_spv_func_impl(Op opcode, const uint32_t *args, uint32_t length)
 {
 	switch (opcode)
 	{
@@ -18254,6 +18287,9 @@ CompilerMSL::SPVFuncImpl CompilerMSL::OpCodePreprocessor::get_spv_func_impl(Op o
 		return SPVFuncImplSubgroupShuffleDown;
 
 	case OpGroupNonUniformRotateKHR:
+		// Clustered rotate is performed using shuffle.
+		if (length > 5)
+			return SPVFuncImplSubgroupShuffle;
 		return SPVFuncImplSubgroupRotate;
 
 	case OpGroupNonUniformQuadBroadcast:

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -1224,6 +1224,7 @@ protected:
 	bool needs_swizzle_buffer_def = false;
 	bool used_swizzle_buffer = false;
 	bool added_builtin_tess_level = false;
+	bool needs_local_invocation_index = false;
 	bool needs_subgroup_invocation_id = false;
 	bool needs_subgroup_size = false;
 	bool needs_sample_id = false;
@@ -1324,7 +1325,7 @@ protected:
 		}
 
 		bool handle(spv::Op opcode, const uint32_t *args, uint32_t length) override;
-		CompilerMSL::SPVFuncImpl get_spv_func_impl(spv::Op opcode, const uint32_t *args);
+		CompilerMSL::SPVFuncImpl get_spv_func_impl(spv::Op opcode, const uint32_t *args, uint32_t length);
 		void check_resource_write(uint32_t var_id);
 
 		CompilerMSL &compiler;
@@ -1335,6 +1336,7 @@ protected:
 		bool uses_image_write = false;
 		bool uses_buffer_write = false;
 		bool uses_discard = false;
+		bool needs_local_invocation_index = false;
 		bool needs_subgroup_invocation_id = false;
 		bool needs_subgroup_size = false;
 		bool needs_sample_id = false;


### PR DESCRIPTION
Implements the clustered form of subgroup rotate for MSL by manually calculating the invocation ID and using shuffle.

For the tests here I put the operations in a separate function from main, to also validate that the required built-in is propagated into the function.

CTS results for `dEQP-VK.subgroups.shuffle.compute.subgroupclustered*` using MoltenVK:
```
Test run totals:
  Passed:        72/192 (37.5%)
  Failed:        16/192 (8.3%)
  Not supported: 104/192 (54.2%)
  Warnings:      0/192 (0.0%)
  Waived:        0/192 (0.0%)
```

The 16 failures are due to existing limitation where 64-bit types are not supported by MSL SIMD functions; all other supported tests pass.