### PR TITLE
MSL: Add support for DebugPrintf.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     name: "Build ${{ matrix.platform }}"
     strategy:
       matrix:
-        platform: [windows-latest, ubuntu-24.04, ubuntu-22.04, macos-latest]
+        platform: [windows-latest, ubuntu-24.04, ubuntu-22.04, macos-15]
     env:
       PARALLEL: -j 2
 
@@ -90,7 +90,7 @@ jobs:
     env:
       PARALLEL: -j 2
 
-    runs-on: "macos-latest"
+    runs-on: "macos-15"
     steps:
       - uses: actions/checkout@v3
 

--- a/reference/shaders-msl-no-opt/asm/vert/debug-printf.asm.msl32.vert
+++ b/reference/shaders-msl-no-opt/asm/vert/debug-printf.asm.msl32.vert
@@ -1,0 +1,19 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+vertex main0_out main0()
+{
+    main0_out out = {};
+    os_log_default.log("Foo %f %f", 1.0, 2.0);
+    float4 _16 = float4(0.0, 0.0, 0.0, 1.0);
+    out.gl_Position = float4(0.0, 0.0, 0.0, 1.0);
+    return out;
+}
+

--- a/shaders-msl-no-opt/asm/vert/debug-printf.asm.msl32.vert
+++ b/shaders-msl-no-opt/asm/vert/debug-printf.asm.msl32.vert
@@ -1,0 +1,29 @@
+               OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.DebugPrintf"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %vert "main" %gl_Position
+          %4 = OpString "Foo %f %f"
+               OpSource HLSL 600
+               OpName %vert "vert"
+               OpDecorate %gl_Position BuiltIn Position
+      %float = OpTypeFloat 32
+    %float_1 = OpConstant %float 1
+    %float_2 = OpConstant %float 2
+    %float_0 = OpConstant %float 0
+    %v4float = OpTypeVector %float 4
+          %9 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_1
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+       %void = OpTypeVoid
+         %12 = OpTypeFunction %void
+         %13 = OpTypeFunction %v4float
+%gl_Position = OpVariable %_ptr_Output_v4float Output
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+       %vert = OpFunction %void None %12
+         %15 = OpLabel
+         %16 = OpVariable %_ptr_Function_v4float Function
+         %17 = OpExtInst %void %1 1 %4 %float_1 %float_2
+               OpStore %16 %9
+               OpStore %gl_Position %9
+               OpReturn
+               OpFunctionEnd

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -14885,7 +14885,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 					SPIRV_CROSS_THROW("Debug printf is only supported in Vulkan GLSL.\n");
 				require_extension_internal("GL_EXT_debug_printf");
 				auto &format_string = get<SPIRString>(ops[4]).str;
-				string expr = join("debugPrintfEXT(\"", format_string, "\"");
+				string expr = join(backend.printf_function, "(\"", format_string, "\"");
 				for (uint32_t i = 5; i < length; i++)
 				{
 					expr += ", ";

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -626,6 +626,7 @@ protected:
 		const char *uint16_t_literal_suffix = "us";
 		const char *nonuniform_qualifier = "nonuniformEXT";
 		const char *boolean_mix_function = "mix";
+		const char *printf_function = "debugPrintfEXT";
 		std::string constant_null_initializer = "";
 		SPIRType::BaseType boolean_in_struct_remapped_type = SPIRType::Boolean;
 		bool swizzle_is_function = false;

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1600,6 +1600,7 @@ string CompilerMSL::compile()
 	backend.basic_int16_type = "short";
 	backend.basic_uint16_type = "ushort";
 	backend.boolean_mix_function = "select";
+	backend.printf_function = "os_log_default.log";
 	backend.swizzle_is_function = false;
 	backend.shared_is_implied = false;
 	backend.use_initializer_list = true;
@@ -18031,7 +18032,8 @@ bool CompilerMSL::OpCodePreprocessor::handle(Op opcode, const uint32_t *args, ui
 	case OpExtInst:
 	{
 		uint32_t extension_set = args[2];
-		if (compiler.get<SPIRExtension>(extension_set).ext == SPIRExtension::GLSL)
+		SPIRExtension::Extension ext = compiler.get<SPIRExtension>(extension_set).ext;
+		if (ext == SPIRExtension::GLSL)
 		{
 			auto op_450 = static_cast<GLSLstd450>(args[3]);
 			switch (op_450)
@@ -18073,6 +18075,12 @@ bool CompilerMSL::OpCodePreprocessor::handle(Op opcode, const uint32_t *args, ui
 			default:
 				break;
 			}
+		}
+		else if (ext == SPIRExtension::NonSemanticDebugPrintf)
+		{
+			// Operation 1 is printf.
+			if (args[3] == 1 && !compiler.msl_options.supports_msl_version(3, 2))
+				SPIRV_CROSS_THROW("Debug printf requires MSL 3.2.");
 		}
 		break;
 	}

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -117,6 +117,8 @@ def print_msl_compiler_version():
         pass
 
 def path_to_msl_standard(shader):
+    if '.msl32.' in shader:
+        return '-std=metal3.2'
     if '.msl31.' in shader:
         return '-std=metal3.1'
     elif '.msl3.' in shader:
@@ -155,6 +157,8 @@ def path_to_msl_standard(shader):
             return '-std=macos-metal1.2'
 
 def path_to_msl_standard_cli(shader):
+    if '.msl32.' in shader:
+        return '30200'
     if '.msl31.' in shader:
         return '30100'
     elif '.msl3.' in shader:


### PR DESCRIPTION
Translates `DebugPrintf` to `os_log_default.log`, provided in MSL 3.2.

I don't think this is needed for MoltenVK as the Vulkan Validation Layer is responsible for instrumenting debug prints into buffer writes, but may be useful for users translating SPIR-V for use with Metal directly.