### PR TITLE
MSL: Add option to provide a default point size.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,7 @@ set(spirv-cross-util-sources
 		${CMAKE_CURRENT_SOURCE_DIR}/spirv_cross_util.hpp)
 
 set(spirv-cross-abi-major 0)
-set(spirv-cross-abi-minor 65)
+set(spirv-cross-abi-minor 66)
 set(spirv-cross-abi-patch 0)
 set(SPIRV_CROSS_VERSION ${spirv-cross-abi-major}.${spirv-cross-abi-minor}.${spirv-cross-abi-patch})
 

--- a/main.cpp
+++ b/main.cpp
@@ -684,6 +684,8 @@ struct CLIArguments
 	bool msl_input_attachment_is_ds_attachment = false;
 	bool msl_disable_rasterization = false;
 	bool msl_auto_disable_rasterization = false;
+	bool msl_enable_point_size_default = false;
+	float msl_default_point_size = 1.0f;
 	const char *msl_combined_sampler_suffix = nullptr;
 	bool glsl_emit_push_constant_as_ubo = false;
 	bool glsl_emit_ubo_as_plain_uniforms = false;
@@ -987,7 +989,8 @@ static void print_help_msl()
 	                "\t\tpartially transformed. This fixup gives correct results on Apple Silicon.\n"
 	                "\t[--msl-combined-sampler-suffix <suffix>]:\n\t\tUses a custom suffix for combined samplers.\n"
 	                "\t[--msl-disable-rasterization]:\n\t\tDisables rasterization and returns void from vertex-like entry points.\n"
-	                "\t[--msl-auto-disable-rasterization]:\n\t\tDisables rasterization if BuiltInPosition is not written.\n");
+	                "\t[--msl-auto-disable-rasterization]:\n\t\tDisables rasterization if BuiltInPosition is not written.\n"
+	                "\t[--msl-default-point-size <size>]:\n\t\tApplies a default value if BuiltInPointSize is not written.\n");
 	// clang-format on
 }
 
@@ -1271,6 +1274,8 @@ static string compile_iteration(const CLIArguments &args, std::vector<uint32_t> 
 		msl_opts.agx_manual_cube_grad_fixup = args.msl_agx_manual_cube_grad_fixup;
 		msl_opts.disable_rasterization = args.msl_disable_rasterization;
 		msl_opts.auto_disable_rasterization = args.msl_auto_disable_rasterization;
+		msl_opts.enable_point_size_default = args.msl_enable_point_size_default;
+		msl_opts.default_point_size = args.msl_default_point_size;
 		msl_comp->set_msl_options(msl_opts);
 		for (auto &v : args.msl_discrete_descriptor_sets)
 			msl_comp->add_discrete_descriptor_set(v);
@@ -1838,6 +1843,10 @@ static int main_inner(int argc, char *argv[])
 	cbs.add("--msl-input-attachment-is-ds-attachment", [&args](CLIParser &) { args.msl_input_attachment_is_ds_attachment = true; });
 	cbs.add("--msl-disable-rasterization", [&args](CLIParser &) { args.msl_disable_rasterization = true; });
 	cbs.add("--msl-auto-disable-rasterization", [&args](CLIParser &) { args.msl_auto_disable_rasterization = true; });
+	cbs.add("--msl-default-point-size", [&args](CLIParser &parser) {
+		args.msl_enable_point_size_default = true;
+		args.msl_default_point_size = static_cast<float>(parser.next_double());
+	});
 	cbs.add("--extension", [&args](CLIParser &parser) { args.extensions.push_back(parser.next_string()); });
 	cbs.add("--rename-entry-point", [&args](CLIParser &parser) {
 		auto old_name = parser.next_string();

--- a/reference/shaders-msl/vert/no_pointsize.default-point-size.vert
+++ b/reference/shaders-msl/vert/no_pointsize.default-point-size.vert
@@ -1,0 +1,33 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct params
+{
+    float4x4 mvp;
+    float psize;
+};
+
+struct main0_out
+{
+    float4 color [[user(locn0)]];
+    float4 gl_Position [[position]];
+    float gl_PointSize [[point_size]];
+};
+
+struct main0_in
+{
+    float4 position [[attribute(0)]];
+    float4 color0 [[attribute(1)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant params& _19 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = _19.mvp * in.position;
+    out.color = in.color0;
+    out.gl_PointSize = 1.0;
+    return out;
+}
+

--- a/reference/shaders-msl/vert/pointsize.default-point-size.vert
+++ b/reference/shaders-msl/vert/pointsize.default-point-size.vert
@@ -1,0 +1,33 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct params
+{
+    float4x4 mvp;
+    float psize;
+};
+
+struct main0_out
+{
+    float4 color [[user(locn0)]];
+    float4 gl_Position [[position]];
+    float gl_PointSize [[point_size]];
+};
+
+struct main0_in
+{
+    float4 position [[attribute(0)]];
+    float4 color0 [[attribute(1)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant params& _19 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = _19.mvp * in.position;
+    out.gl_PointSize = _19.psize;
+    out.color = in.color0;
+    return out;
+}
+

--- a/shaders-msl/vert/no_pointsize.default-point-size.vert
+++ b/shaders-msl/vert/no_pointsize.default-point-size.vert
@@ -1,0 +1,14 @@
+#version 450
+uniform params {
+    mat4 mvp;
+    float psize;
+};
+
+layout(location = 0) in vec4 position;
+layout(location = 1) in vec4 color0;
+layout(location = 0) out vec4 color;
+
+void main() {
+    gl_Position = mvp * position;
+    color = color0;
+}

--- a/shaders-msl/vert/pointsize.default-point-size.vert
+++ b/shaders-msl/vert/pointsize.default-point-size.vert
@@ -1,0 +1,15 @@
+#version 450
+uniform params {
+    mat4 mvp;
+    float psize;
+};
+
+layout(location = 0) in vec4 position;
+layout(location = 1) in vec4 color0;
+layout(location = 0) out vec4 color;
+
+void main() {
+    gl_Position = mvp * position;
+    gl_PointSize = psize;
+    color = color0;
+}

--- a/spirv_cross_c.cpp
+++ b/spirv_cross_c.cpp
@@ -565,6 +565,10 @@ spvc_result spvc_compiler_options_set_uint(spvc_compiler_options options, spvc_c
 		options->msl.enable_point_size_builtin = value != 0;
 		break;
 
+	case SPVC_COMPILER_OPTION_MSL_ENABLE_POINT_SIZE_DEFAULT:
+		options->msl.enable_point_size_default = value != 0;
+		break;
+
 	case SPVC_COMPILER_OPTION_MSL_DISABLE_RASTERIZATION:
 		options->msl.disable_rasterization = value != 0;
 		break;

--- a/spirv_cross_c.h
+++ b/spirv_cross_c.h
@@ -40,7 +40,7 @@ extern "C" {
 /* Bumped if ABI or API breaks backwards compatibility. */
 #define SPVC_C_API_VERSION_MAJOR 0
 /* Bumped if APIs or enumerations are added in a backwards compatible way. */
-#define SPVC_C_API_VERSION_MINOR 65
+#define SPVC_C_API_VERSION_MINOR 66
 /* Bumped if internal implementation details change. */
 #define SPVC_C_API_VERSION_PATCH 0
 
@@ -749,6 +749,8 @@ typedef enum spvc_compiler_option
 	SPVC_COMPILER_OPTION_HLSL_PRESERVE_STRUCTURED_BUFFERS = 91 | SPVC_COMPILER_OPTION_HLSL_BIT,
 
 	SPVC_COMPILER_OPTION_MSL_AUTO_DISABLE_RASTERIZATION = 92 | SPVC_COMPILER_OPTION_MSL_BIT,
+
+	SPVC_COMPILER_OPTION_MSL_ENABLE_POINT_SIZE_DEFAULT = 93 | SPVC_COMPILER_OPTION_MSL_BIT,
 
 	SPVC_COMPILER_OPTION_INT_MAX = 0x7fffffff
 } spvc_compiler_option;

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -279,11 +279,15 @@ void CompilerMSL::build_implicit_builtins()
 	bool force_frag_depth_passthrough =
 	    get_execution_model() == ExecutionModelFragment && !uses_explicit_early_fragment_test() && need_subpass_input &&
 	    msl_options.enable_frag_depth_builtin && msl_options.input_attachment_is_ds_attachment;
+	bool need_point_size =
+	    msl_options.enable_point_size_builtin && msl_options.enable_point_size_default &&
+	    get_execution_model() == ExecutionModelVertex;
 
 	if (need_subpass_input || need_sample_pos || need_subgroup_mask || need_vertex_params || need_tesc_params ||
 	    need_tese_params || need_multiview || need_dispatch_base || need_vertex_base_params || need_grid_params ||
 	    needs_sample_id || needs_subgroup_invocation_id || needs_subgroup_size || needs_helper_invocation ||
-	    has_additional_fixed_sample_mask() || need_local_invocation_index || need_workgroup_size || force_frag_depth_passthrough || is_mesh_shader())
+	    has_additional_fixed_sample_mask() || need_local_invocation_index || need_workgroup_size ||
+	    force_frag_depth_passthrough || need_point_size || is_mesh_shader())
 	{
 		bool has_frag_coord = false;
 		bool has_sample_id = false;
@@ -301,6 +305,7 @@ void CompilerMSL::build_implicit_builtins()
 		bool has_local_invocation_index = false;
 		bool has_workgroup_size = false;
 		bool has_frag_depth = false;
+		bool has_point_size = false;
 		uint32_t workgroup_id_type = 0;
 
 		ir.for_each_typed_id<SPIRVariable>([&](uint32_t, SPIRVariable &var) {
@@ -308,6 +313,22 @@ void CompilerMSL::build_implicit_builtins()
 				return;
 			if (!interface_variable_exists_in_entry_point(var.self))
 				return;
+
+			auto &type = this->get<SPIRType>(var.basetype);
+			if (need_point_size && has_decoration(type.self, DecorationBlock))
+			{
+				const auto member_count = static_cast<uint32_t>(type.member_types.size());
+				for (uint32_t i = 0; i < member_count; i++)
+				{
+					if (get_member_decoration(type.self, i, DecorationBuiltIn) == BuiltInPointSize)
+					{
+						has_point_size = true;
+						active_output_builtins.set(BuiltInPointSize);
+						break;
+					}
+				}
+			}
+
 			if (!has_decoration(var.self, DecorationBuiltIn))
 				return;
 
@@ -328,6 +349,12 @@ void CompilerMSL::build_implicit_builtins()
 					mark_implicit_builtin(StorageClassOutput, BuiltInFragDepth, var.self);
 					has_frag_depth = true;
 				}
+			}
+
+			if (builtin == BuiltInPointSize)
+			{
+				has_point_size = true;
+				active_output_builtins.set(BuiltInPointSize);
 			}
 
 			if (builtin == BuiltInPrimitivePointIndicesEXT ||
@@ -954,6 +981,34 @@ void CompilerMSL::build_implicit_builtins()
 			builtin_frag_depth_id = var_id;
 			mark_implicit_builtin(StorageClassOutput, BuiltInFragDepth, var_id);
 			active_output_builtins.set(BuiltInFragDepth);
+		}
+
+		if (!has_point_size && need_point_size)
+		{
+			uint32_t offset = ir.increase_bound_by(3);
+			uint32_t type_id = offset;
+			uint32_t type_ptr_id = offset + 1;
+			uint32_t var_id = offset + 2;
+
+			// Create gl_PointSize
+			SPIRType float_type { OpTypeFloat };
+			float_type.basetype = SPIRType::Float;
+			float_type.width = 32;
+			float_type.vecsize = 1;
+			set<SPIRType>(type_id, float_type);
+
+			SPIRType float_type_ptr_in = float_type;
+			float_type_ptr_in.op = spv::OpTypePointer;
+			float_type_ptr_in.pointer = true;
+			float_type_ptr_in.pointer_depth++;
+			float_type_ptr_in.parent_type = type_id;
+			float_type_ptr_in.storage = StorageClassOutput;
+
+			auto &ptr_in_type = set<SPIRType>(type_ptr_id, float_type_ptr_in);
+			ptr_in_type.self = type_id;
+			set<SPIRVariable>(var_id, type_ptr_id, StorageClassOutput);
+			set_decoration(var_id, DecorationBuiltIn, BuiltInPointSize);
+			mark_implicit_builtin(StorageClassOutput, BuiltInPointSize, var_id);
 		}
 	}
 
@@ -9752,6 +9807,9 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		if (needs_frag_discard_checks() &&
 		    (type.storage == StorageClassStorageBuffer || type.storage == StorageClassUniform))
 			end_scope();
+		if (has_decoration(ops[0], DecorationBuiltIn) && get_decoration(ops[0], DecorationBuiltIn) == BuiltInPointSize)
+			writes_to_point_size = true;
+
 		break;
 	}
 
@@ -12742,6 +12800,9 @@ void CompilerMSL::emit_fixup()
 {
 	if (is_vertex_like_shader() && stage_out_var_id && !qual_pos_var_name.empty() && !capture_output_to_buffer)
 	{
+		if (msl_options.enable_point_size_default && !writes_to_point_size)
+			statement(builtin_to_glsl(BuiltInPointSize, StorageClassOutput), " = ", format_float(msl_options.default_point_size), ";");
+
 		if (options.vertex.fixup_clipspace)
 			statement(qual_pos_var_name, ".z = (", qual_pos_var_name, ".z + ", qual_pos_var_name,
 			          ".w) * 0.5;       // Adjust clip-space for Metal");

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -324,6 +324,8 @@ public:
 		// of the shader with the additional fixed sample mask.
 		uint32_t additional_fixed_sample_mask = 0xffffffff;
 		bool enable_point_size_builtin = true;
+		bool enable_point_size_default = false;
+		float default_point_size = 1.0f;
 		bool enable_frag_depth_builtin = true;
 		bool enable_frag_stencil_ref_builtin = true;
 		bool disable_rasterization = false;
@@ -1231,6 +1233,7 @@ protected:
 	bool needs_helper_invocation = false;
 	bool needs_workgroup_zero_init = false;
 	bool writes_to_depth = false;
+	bool writes_to_point_size = false;
 	std::string qual_pos_var_name;
 	std::string stage_in_var_name = "in";
 	std::string stage_out_var_name = "out";

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -396,6 +396,9 @@ def cross_compile_msl(shader, spirv, opt, iterations, paths):
         msl_args.append('--msl-auto-disable-rasterization')
     if '.disable-rasterization.' in shader:
         msl_args.append('--msl-disable-rasterization')
+    if '.default-point-size.' in shader:
+        msl_args.append('--msl-default-point-size')
+        msl_args.append('1.0')
 
     subprocess.check_call(msl_args)
 


### PR DESCRIPTION
`VK_KHR_maintenance5` requires that `PointSize` default to `1.0` when not written in a shader. In order to support this requirement, this PR adds an option for MSL to emit a default `PointSize` value when it was not written, as according to Metal documentation the point size must be specified within the vertex shader.

I considered using the existing `enable_point_size_builtin` flag for this but it currently defaults to true. Changing this could negatively impact users relying on the default conversion behavior respecting `PointSize`, and leaving it means every shader emits a default value unless explicitly disabled. Thus I added a new flag to control emitting the default, and a new float option to set what that default is.

Have also added tests with this option where the point size is provided by the shader, meaning it should not be defaulted, and where the point size is not provided by the shader, meaning it should be.