### PR TITLE
Fix crash due to regression caused by recent changes to location calculations.

### DIFF
--- a/reference/opt/shaders-msl/frag/input_outuput_matching_nested_composites.frag
+++ b/reference/opt/shaders-msl/frag/input_outuput_matching_nested_composites.frag
@@ -1,0 +1,73 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct t_6
+{
+    float2x4 m_m0;
+    float4 m_m1;
+    float m_m2;
+    float m_m3;
+    float m_m4;
+    float m_m5;
+};
+
+struct t_7_8
+{
+    t_6 m_m0;
+};
+
+struct t_6_1
+{
+    float2x4 m_m0;
+    float4 m_m1;
+    float m_m2;
+    float m_m3;
+    float m_m4;
+    float m_m5;
+};
+
+struct t_19
+{
+    t_6_1 m_m0;
+};
+
+struct main0_out
+{
+    float4 v_3 [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 v_4 [[user(locn1)]];
+    float4 v_5_m_m0_m_m0_0 [[user(locn2)]];
+    float4 v_5_m_m0_m_m0_1 [[user(locn3)]];
+    float4 v_5_m_m0_m_m1 [[user(locn4)]];
+    float v_5_m_m0_m_m2 [[user(locn5)]];
+    float v_5_m_m0_m_m3 [[user(locn6)]];
+    float v_5_m_m0_m_m4 [[user(locn7)]];
+    float v_5_m_m0_m_m5 [[user(locn8)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], device t_7_8& v_8 [[buffer(0)]])
+{
+    main0_out out = {};
+    t_19 v_5 = {};
+    v_5.m_m0.m_m0[0] = in.v_5_m_m0_m_m0_0;
+    v_5.m_m0.m_m0[1] = in.v_5_m_m0_m_m0_1;
+    v_5.m_m0.m_m1 = in.v_5_m_m0_m_m1;
+    v_5.m_m0.m_m2 = in.v_5_m_m0_m_m2;
+    v_5.m_m0.m_m3 = in.v_5_m_m0_m_m3;
+    v_5.m_m0.m_m4 = in.v_5_m_m0_m_m4;
+    v_5.m_m0.m_m5 = in.v_5_m_m0_m_m5;
+    out.v_3 = in.v_4;
+    v_8.m_m0.m_m0 = v_5.m_m0.m_m0;
+    v_8.m_m0.m_m1 = v_5.m_m0.m_m1;
+    v_8.m_m0.m_m2 = v_5.m_m0.m_m2;
+    v_8.m_m0.m_m3 = v_5.m_m0.m_m3;
+    v_8.m_m0.m_m4 = v_5.m_m0.m_m4;
+    v_8.m_m0.m_m5 = v_5.m_m0.m_m5;
+    return out;
+}
+

--- a/reference/opt/shaders-msl/vert/input_outuput_matching_nested_composites.vert
+++ b/reference/opt/shaders-msl/vert/input_outuput_matching_nested_composites.vert
@@ -1,0 +1,56 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct t_9
+{
+    float2x4 m_m0;
+    float4 m_m1;
+    float m_m2;
+    float m_m3;
+    float m_m4;
+    float m_m5;
+};
+
+struct t_10
+{
+    t_9 m_m0;
+};
+
+struct main0_out
+{
+    float4 v_5 [[user(locn1)]];
+    float4 v_7_m_m0_m_m0_0 [[user(locn2)]];
+    float4 v_7_m_m0_m_m0_1 [[user(locn3)]];
+    float4 v_7_m_m0_m_m1 [[user(locn4)]];
+    float v_7_m_m0_m_m2 [[user(locn5)]];
+    float v_7_m_m0_m_m3 [[user(locn6)]];
+    float v_7_m_m0_m_m4 [[user(locn7)]];
+    float v_7_m_m0_m_m5 [[user(locn8)]];
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 v_4 [[attribute(0)]];
+    float4 v_6 [[attribute(1)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    t_10 v_7 = {};
+    v_7 = t_10{ t_9{ float2x4(float4(1.0), float4(1.0)), float4(1.0), 1.0, 1.0, 1.0, 1.0 } };
+    out.gl_Position = in.v_4;
+    out.v_5 = in.v_6;
+    out.v_7_m_m0_m_m0_0 = v_7.m_m0.m_m0[0];
+    out.v_7_m_m0_m_m0_1 = v_7.m_m0.m_m0[1];
+    out.v_7_m_m0_m_m1 = v_7.m_m0.m_m1;
+    out.v_7_m_m0_m_m2 = v_7.m_m0.m_m2;
+    out.v_7_m_m0_m_m3 = v_7.m_m0.m_m3;
+    out.v_7_m_m0_m_m4 = v_7.m_m0.m_m4;
+    out.v_7_m_m0_m_m5 = v_7.m_m0.m_m5;
+    return out;
+}
+

--- a/reference/shaders-msl/frag/input_outuput_matching_nested_composites.frag
+++ b/reference/shaders-msl/frag/input_outuput_matching_nested_composites.frag
@@ -1,0 +1,73 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct t_6
+{
+    float2x4 m_m0;
+    float4 m_m1;
+    float m_m2;
+    float m_m3;
+    float m_m4;
+    float m_m5;
+};
+
+struct t_7_8
+{
+    t_6 m_m0;
+};
+
+struct t_6_1
+{
+    float2x4 m_m0;
+    float4 m_m1;
+    float m_m2;
+    float m_m3;
+    float m_m4;
+    float m_m5;
+};
+
+struct t_19
+{
+    t_6_1 m_m0;
+};
+
+struct main0_out
+{
+    float4 v_3 [[color(0)]];
+};
+
+struct main0_in
+{
+    float4 v_4 [[user(locn1)]];
+    float4 v_5_m_m0_m_m0_0 [[user(locn2)]];
+    float4 v_5_m_m0_m_m0_1 [[user(locn3)]];
+    float4 v_5_m_m0_m_m1 [[user(locn4)]];
+    float v_5_m_m0_m_m2 [[user(locn5)]];
+    float v_5_m_m0_m_m3 [[user(locn6)]];
+    float v_5_m_m0_m_m4 [[user(locn7)]];
+    float v_5_m_m0_m_m5 [[user(locn8)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], device t_7_8& v_8 [[buffer(0)]])
+{
+    main0_out out = {};
+    t_19 v_5 = {};
+    v_5.m_m0.m_m0[0] = in.v_5_m_m0_m_m0_0;
+    v_5.m_m0.m_m0[1] = in.v_5_m_m0_m_m0_1;
+    v_5.m_m0.m_m1 = in.v_5_m_m0_m_m1;
+    v_5.m_m0.m_m2 = in.v_5_m_m0_m_m2;
+    v_5.m_m0.m_m3 = in.v_5_m_m0_m_m3;
+    v_5.m_m0.m_m4 = in.v_5_m_m0_m_m4;
+    v_5.m_m0.m_m5 = in.v_5_m_m0_m_m5;
+    out.v_3 = in.v_4;
+    v_8.m_m0.m_m0 = v_5.m_m0.m_m0;
+    v_8.m_m0.m_m1 = v_5.m_m0.m_m1;
+    v_8.m_m0.m_m2 = v_5.m_m0.m_m2;
+    v_8.m_m0.m_m3 = v_5.m_m0.m_m3;
+    v_8.m_m0.m_m4 = v_5.m_m0.m_m4;
+    v_8.m_m0.m_m5 = v_5.m_m0.m_m5;
+    return out;
+}
+

--- a/reference/shaders-msl/vert/input_outuput_matching_nested_composites.vert
+++ b/reference/shaders-msl/vert/input_outuput_matching_nested_composites.vert
@@ -1,0 +1,57 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct t_9
+{
+    float2x4 m_m0;
+    float4 m_m1;
+    float m_m2;
+    float m_m3;
+    float m_m4;
+    float m_m5;
+};
+
+struct t_10
+{
+    t_9 m_m0;
+};
+
+struct main0_out
+{
+    float4 v_5 [[user(locn1)]];
+    float4 v_7_m_m0_m_m0_0 [[user(locn2)]];
+    float4 v_7_m_m0_m_m0_1 [[user(locn3)]];
+    float4 v_7_m_m0_m_m1 [[user(locn4)]];
+    float v_7_m_m0_m_m2 [[user(locn5)]];
+    float v_7_m_m0_m_m3 [[user(locn6)]];
+    float v_7_m_m0_m_m4 [[user(locn7)]];
+    float v_7_m_m0_m_m5 [[user(locn8)]];
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 v_4 [[attribute(0)]];
+    float4 v_6 [[attribute(1)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    t_10 v_7 = {};
+    t_10 v_33 = t_10{ t_9{ float2x4(float4(1.0), float4(1.0)), float4(1.0), 1.0, 1.0, 1.0, 1.0 } };
+    v_7 = t_10{ t_9{ float2x4(float4(1.0), float4(1.0)), float4(1.0), 1.0, 1.0, 1.0, 1.0 } };
+    out.gl_Position = in.v_4;
+    out.v_5 = in.v_6;
+    out.v_7_m_m0_m_m0_0 = v_7.m_m0.m_m0[0];
+    out.v_7_m_m0_m_m0_1 = v_7.m_m0.m_m0[1];
+    out.v_7_m_m0_m_m1 = v_7.m_m0.m_m1;
+    out.v_7_m_m0_m_m2 = v_7.m_m0.m_m2;
+    out.v_7_m_m0_m_m3 = v_7.m_m0.m_m3;
+    out.v_7_m_m0_m_m4 = v_7.m_m0.m_m4;
+    out.v_7_m_m0_m_m5 = v_7.m_m0.m_m5;
+    return out;
+}
+

--- a/shaders-msl/frag/input_outuput_matching_nested_composites.frag
+++ b/shaders-msl/frag/input_outuput_matching_nested_composites.frag
@@ -1,0 +1,31 @@
+#version 430
+
+struct t_6
+{
+    mat2x4 m_m0;
+    vec4 m_m1;
+    float m_m2;
+    float m_m3;
+    float m_m4;
+    float m_m5;
+};
+
+struct t_19
+{
+    t_6 m_m0;
+};
+
+layout(set = 0, binding = 0, std430) buffer t_7_8
+{
+    t_6 m_m0;
+} v_8;
+
+layout(location = 0) out vec4 v_3;
+layout(location = 1) in vec4 v_4;
+layout(location = 2) in t_19 v_5;
+
+void main()
+{
+    v_3 = v_4;
+    v_8.m_m0 = v_5.m_m0;
+}

--- a/shaders-msl/vert/input_outuput_matching_nested_composites.vert
+++ b/shaders-msl/vert/input_outuput_matching_nested_composites.vert
@@ -1,0 +1,37 @@
+#version 430
+
+out gl_PerVertex
+{
+    vec4 gl_Position;
+    float gl_PointSize;
+    float gl_ClipDistance[1];
+};
+
+struct t_9
+{
+    mat2x4 m_m0;
+    vec4 m_m1;
+    float m_m2;
+    float m_m3;
+    float m_m4;
+    float m_m5;
+};
+
+struct t_10
+{
+    t_9 m_m0;
+};
+
+layout(location = 0) in vec4 v_4;
+layout(location = 1) out vec4 v_5;
+layout(location = 1) in vec4 v_6;
+layout(location = 2) out t_10 v_7;
+t_10 v_33 = t_10(t_9(mat2x4(vec4(1.0), vec4(1.0)), vec4(1.0), 1.0, 1.0, 1.0, 1.0));
+const t_10 v_7_init = t_10(t_9(mat2x4(vec4(1.0), vec4(1.0)), vec4(1.0), 1.0, 1.0, 1.0, 1.0));
+
+void main()
+{
+    v_7 = v_7_init;
+    gl_Position = v_4;
+    v_5 = v_6;
+}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -3215,16 +3215,20 @@ void CompilerMSL::add_composite_member_variable_to_interface_block(StorageClass 
 		bool has_var_loc_decor = has_decoration(var.self, DecorationLocation);
 		uint32_t orig_vecsize = UINT32_MAX;
 
-		if (has_member_loc_decor)
-			ir_location = get_member_decoration(var_type.self, mbr_idx, DecorationLocation);
-		else if (has_var_loc_decor)
-			ir_location = get_accumulated_member_location(var, mbr_idx, meta.strip_array);
-		else if (is_builtin)
+		// If we haven't established a location base yet, do so here.
+		if (location == UINT32_MAX)
 		{
-			if (is_tessellation_shader() && storage == StorageClassInput && inputs_by_builtin.count(builtin))
-				ir_location = inputs_by_builtin[builtin].location;
-			else if (capture_output_to_buffer && storage == StorageClassOutput && outputs_by_builtin.count(builtin))
-				ir_location = outputs_by_builtin[builtin].location;
+			if (has_member_loc_decor)
+				ir_location = get_member_decoration(var_type.self, mbr_idx, DecorationLocation);
+			else if (has_var_loc_decor)
+				ir_location = get_accumulated_member_location(var, mbr_idx, meta.strip_array);
+			else if (is_builtin)
+			{
+				if (is_tessellation_shader() && storage == StorageClassInput && inputs_by_builtin.count(builtin))
+					ir_location = inputs_by_builtin[builtin].location;
+				else if (capture_output_to_buffer && storage == StorageClassOutput && outputs_by_builtin.count(builtin))
+					ir_location = outputs_by_builtin[builtin].location;
+			}
 		}
 
 		// Once we determine the location of the first member within nested structures,


### PR DESCRIPTION
Commit dcbb41f introduced a new way of determining interface struct member locations, but did not handle nested structs, causing array out of bounds by attempting to restart location calculation for each nested struct.

- Only retrieve base location once for each interface variable, instead of separately for each nested struct, and determine locations of all nested struct members from that base variable location.
- Add test shaders