### PR TITLE
GLSL/MSL: Add support for SPV_KHR_quad_control.

### DIFF
--- a/reference/opt/shaders-msl/frag/full-quads.msl21.frag
+++ b/reference/opt/shaders-msl/frag/full-quads.msl21.frag
@@ -1,0 +1,37 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 outColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float2 inCoords [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> tex1 [[texture(0)]], texture2d<float> tex2 [[texture(1)]], sampler tex1Smplr [[sampler(0)]], sampler tex2Smplr [[sampler(1)]], float4 gl_FragCoord [[position]])
+{
+    main0_out out = {};
+    bool _19 = gl_FragCoord.y < 10.0;
+    if (quad_all(_19))
+    {
+        out.outColor = tex1.sample(tex1Smplr, in.inCoords);
+    }
+    else
+    {
+        if (quad_any(_19))
+        {
+            out.outColor = tex2.sample(tex2Smplr, in.inCoords);
+        }
+        else
+        {
+            out.outColor = float4(0.0, 0.0, 0.0, 1.0);
+        }
+    }
+    return out;
+}
+

--- a/reference/opt/shaders-msl/frag/quad-derivatives.msl21.frag
+++ b/reference/opt/shaders-msl/frag/quad-derivatives.msl21.frag
@@ -1,0 +1,37 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 outColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float2 inCoords [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> tex1 [[texture(0)]], texture2d<float> tex2 [[texture(1)]], sampler tex1Smplr [[sampler(0)]], sampler tex2Smplr [[sampler(1)]], float4 gl_FragCoord [[position]])
+{
+    main0_out out = {};
+    bool _19 = gl_FragCoord.y < 10.0;
+    if (quad_all(_19))
+    {
+        out.outColor = tex1.sample(tex1Smplr, in.inCoords);
+    }
+    else
+    {
+        if (quad_any(_19))
+        {
+            out.outColor = tex2.sample(tex2Smplr, in.inCoords);
+        }
+        else
+        {
+            out.outColor = float4(0.0, 0.0, 0.0, 1.0);
+        }
+    }
+    return out;
+}
+

--- a/reference/opt/shaders-msl/vert/no_pointsize.default-point-size.vert
+++ b/reference/opt/shaders-msl/vert/no_pointsize.default-point-size.vert
@@ -1,0 +1,33 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct params
+{
+    float4x4 mvp;
+    float psize;
+};
+
+struct main0_out
+{
+    float4 color [[user(locn0)]];
+    float4 gl_Position [[position]];
+    float gl_PointSize [[point_size]];
+};
+
+struct main0_in
+{
+    float4 position [[attribute(0)]];
+    float4 color0 [[attribute(1)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant params& _19 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = _19.mvp * in.position;
+    out.color = in.color0;
+    out.gl_PointSize = 1.0;
+    return out;
+}
+

--- a/reference/opt/shaders-msl/vert/pointsize.default-point-size.vert
+++ b/reference/opt/shaders-msl/vert/pointsize.default-point-size.vert
@@ -1,0 +1,33 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct params
+{
+    float4x4 mvp;
+    float psize;
+};
+
+struct main0_out
+{
+    float4 color [[user(locn0)]];
+    float4 gl_Position [[position]];
+    float gl_PointSize [[point_size]];
+};
+
+struct main0_in
+{
+    float4 position [[attribute(0)]];
+    float4 color0 [[attribute(1)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant params& _19 [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = _19.mvp * in.position;
+    out.gl_PointSize = _19.psize;
+    out.color = in.color0;
+    return out;
+}
+

--- a/reference/opt/shaders/vulkan/frag/full-quads.vk.nocompat.frag.vk
+++ b/reference/opt/shaders/vulkan/frag/full-quads.vk.nocompat.frag.vk
@@ -1,0 +1,31 @@
+#version 450
+#extension GL_EXT_shader_quad_control : require
+#extension GL_KHR_shader_subgroup_vote : require
+layout(full_quads) in;
+
+layout(set = 0, binding = 0) uniform sampler2D tex1;
+layout(set = 0, binding = 1) uniform sampler2D tex2;
+
+layout(location = 0) out vec4 outColor;
+layout(location = 0) in vec2 inCoords;
+
+void main()
+{
+    bool _19 = gl_FragCoord.y < 10.0;
+    if (subgroupQuadAll(_19))
+    {
+        outColor = texture(tex1, inCoords);
+    }
+    else
+    {
+        if (subgroupQuadAny(_19))
+        {
+            outColor = texture(tex2, inCoords);
+        }
+        else
+        {
+            outColor = vec4(0.0, 0.0, 0.0, 1.0);
+        }
+    }
+}
+

--- a/reference/opt/shaders/vulkan/frag/quad-derivatives.vk.nocompat.frag.vk
+++ b/reference/opt/shaders/vulkan/frag/quad-derivatives.vk.nocompat.frag.vk
@@ -1,0 +1,31 @@
+#version 450
+#extension GL_EXT_shader_quad_control : require
+#extension GL_KHR_shader_subgroup_vote : require
+layout(quad_derivatives) in;
+
+layout(set = 0, binding = 0) uniform sampler2D tex1;
+layout(set = 0, binding = 1) uniform sampler2D tex2;
+
+layout(location = 0) out vec4 outColor;
+layout(location = 0) in vec2 inCoords;
+
+void main()
+{
+    bool _19 = gl_FragCoord.y < 10.0;
+    if (subgroupQuadAll(_19))
+    {
+        outColor = texture(tex1, inCoords);
+    }
+    else
+    {
+        if (subgroupQuadAny(_19))
+        {
+            outColor = texture(tex2, inCoords);
+        }
+        else
+        {
+            outColor = vec4(0.0, 0.0, 0.0, 1.0);
+        }
+    }
+}
+

--- a/reference/shaders-msl/frag/full-quads.msl21.frag
+++ b/reference/shaders-msl/frag/full-quads.msl21.frag
@@ -1,0 +1,37 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 outColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float2 inCoords [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> tex1 [[texture(0)]], texture2d<float> tex2 [[texture(1)]], sampler tex1Smplr [[sampler(0)]], sampler tex2Smplr [[sampler(1)]], float4 gl_FragCoord [[position]])
+{
+    main0_out out = {};
+    bool condition = gl_FragCoord.y < 10.0;
+    if (quad_all(condition))
+    {
+        out.outColor = tex1.sample(tex1Smplr, in.inCoords);
+    }
+    else
+    {
+        if (quad_any(condition))
+        {
+            out.outColor = tex2.sample(tex2Smplr, in.inCoords);
+        }
+        else
+        {
+            out.outColor = float4(0.0, 0.0, 0.0, 1.0);
+        }
+    }
+    return out;
+}
+

--- a/reference/shaders-msl/frag/quad-derivatives.msl21.frag
+++ b/reference/shaders-msl/frag/quad-derivatives.msl21.frag
@@ -1,0 +1,37 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 outColor [[color(0)]];
+};
+
+struct main0_in
+{
+    float2 inCoords [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> tex1 [[texture(0)]], texture2d<float> tex2 [[texture(1)]], sampler tex1Smplr [[sampler(0)]], sampler tex2Smplr [[sampler(1)]], float4 gl_FragCoord [[position]])
+{
+    main0_out out = {};
+    bool condition = gl_FragCoord.y < 10.0;
+    if (quad_all(condition))
+    {
+        out.outColor = tex1.sample(tex1Smplr, in.inCoords);
+    }
+    else
+    {
+        if (quad_any(condition))
+        {
+            out.outColor = tex2.sample(tex2Smplr, in.inCoords);
+        }
+        else
+        {
+            out.outColor = float4(0.0, 0.0, 0.0, 1.0);
+        }
+    }
+    return out;
+}
+

--- a/reference/shaders/vulkan/frag/full-quads.vk.nocompat.frag.vk
+++ b/reference/shaders/vulkan/frag/full-quads.vk.nocompat.frag.vk
@@ -1,0 +1,31 @@
+#version 450
+#extension GL_EXT_shader_quad_control : require
+#extension GL_KHR_shader_subgroup_vote : require
+layout(full_quads) in;
+
+layout(set = 0, binding = 0) uniform sampler2D tex1;
+layout(set = 0, binding = 1) uniform sampler2D tex2;
+
+layout(location = 0) out vec4 outColor;
+layout(location = 0) in vec2 inCoords;
+
+void main()
+{
+    bool condition = gl_FragCoord.y < 10.0;
+    if (subgroupQuadAll(condition))
+    {
+        outColor = texture(tex1, inCoords);
+    }
+    else
+    {
+        if (subgroupQuadAny(condition))
+        {
+            outColor = texture(tex2, inCoords);
+        }
+        else
+        {
+            outColor = vec4(0.0, 0.0, 0.0, 1.0);
+        }
+    }
+}
+

--- a/reference/shaders/vulkan/frag/quad-derivatives.vk.nocompat.frag.vk
+++ b/reference/shaders/vulkan/frag/quad-derivatives.vk.nocompat.frag.vk
@@ -1,0 +1,31 @@
+#version 450
+#extension GL_EXT_shader_quad_control : require
+#extension GL_KHR_shader_subgroup_vote : require
+layout(quad_derivatives) in;
+
+layout(set = 0, binding = 0) uniform sampler2D tex1;
+layout(set = 0, binding = 1) uniform sampler2D tex2;
+
+layout(location = 0) out vec4 outColor;
+layout(location = 0) in vec2 inCoords;
+
+void main()
+{
+    bool condition = gl_FragCoord.y < 10.0;
+    if (subgroupQuadAll(condition))
+    {
+        outColor = texture(tex1, inCoords);
+    }
+    else
+    {
+        if (subgroupQuadAny(condition))
+        {
+            outColor = texture(tex2, inCoords);
+        }
+        else
+        {
+            outColor = vec4(0.0, 0.0, 0.0, 1.0);
+        }
+    }
+}
+

--- a/shaders-msl/frag/full-quads.msl21.frag
+++ b/shaders-msl/frag/full-quads.msl21.frag
@@ -1,0 +1,20 @@
+#version 450
+#extension GL_KHR_shader_subgroup_vote: enable
+#extension GL_EXT_shader_quad_control: enable
+
+layout(full_quads) in;
+layout(location = 0) in vec2 inCoords;
+layout(location = 0) out vec4 outColor;
+layout(binding = 0) uniform sampler2D tex1;
+layout(binding = 1) uniform sampler2D tex2;
+
+void main()
+{
+    bool condition = gl_FragCoord.y < 10.0;
+    if (subgroupQuadAll(condition))
+        outColor = texture(tex1, inCoords);
+    else if (subgroupQuadAny(condition))
+        outColor = texture(tex2, inCoords);
+    else
+        outColor = vec4(0.0, 0.0, 0.0, 1.0);
+}

--- a/shaders-msl/frag/quad-derivatives.msl21.frag
+++ b/shaders-msl/frag/quad-derivatives.msl21.frag
@@ -1,0 +1,20 @@
+#version 450
+#extension GL_KHR_shader_subgroup_vote: enable
+#extension GL_EXT_shader_quad_control: enable
+
+layout(quad_derivatives) in;
+layout(location = 0) in vec2 inCoords;
+layout(location = 0) out vec4 outColor;
+layout(binding = 0) uniform sampler2D tex1;
+layout(binding = 1) uniform sampler2D tex2;
+
+void main()
+{
+    bool condition = gl_FragCoord.y < 10.0;
+    if (subgroupQuadAll(condition))
+        outColor = texture(tex1, inCoords);
+    else if (subgroupQuadAny(condition))
+        outColor = texture(tex2, inCoords);
+    else
+        outColor = vec4(0.0, 0.0, 0.0, 1.0);
+}

--- a/shaders/vulkan/frag/full-quads.vk.nocompat.frag
+++ b/shaders/vulkan/frag/full-quads.vk.nocompat.frag
@@ -1,0 +1,20 @@
+#version 450
+#extension GL_KHR_shader_subgroup_vote: enable
+#extension GL_EXT_shader_quad_control: enable
+
+layout(full_quads) in;
+layout(location = 0) in vec2 inCoords;
+layout(location = 0) out vec4 outColor;
+layout(binding = 0) uniform sampler2D tex1;
+layout(binding = 1) uniform sampler2D tex2;
+
+void main()
+{
+    bool condition = gl_FragCoord.y < 10.0;
+    if (subgroupQuadAll(condition))
+        outColor = texture(tex1, inCoords);
+    else if (subgroupQuadAny(condition))
+        outColor = texture(tex2, inCoords);
+    else
+        outColor = vec4(0.0, 0.0, 0.0, 1.0);
+}

--- a/shaders/vulkan/frag/quad-derivatives.vk.nocompat.frag
+++ b/shaders/vulkan/frag/quad-derivatives.vk.nocompat.frag
@@ -1,0 +1,20 @@
+#version 450
+#extension GL_KHR_shader_subgroup_vote: enable
+#extension GL_EXT_shader_quad_control: enable
+
+layout(quad_derivatives) in;
+layout(location = 0) in vec2 inCoords;
+layout(location = 0) out vec4 outColor;
+layout(binding = 0) uniform sampler2D tex1;
+layout(binding = 1) uniform sampler2D tex2;
+
+void main()
+{
+    bool condition = gl_FragCoord.y < 10.0;
+    if (subgroupQuadAll(condition))
+        outColor = texture(tex1, inCoords);
+    else if (subgroupQuadAny(condition))
+        outColor = texture(tex2, inCoords);
+    else
+        outColor = vec4(0.0, 0.0, 0.0, 1.0);
+}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -16759,13 +16759,16 @@ void CompilerMSL::emit_subgroup_op(const Instruction &i)
 	Scope scope;
 	switch (op)
 	{
+	// These earlier instructions don't have the scope operand.
 	case OpSubgroupBallotKHR:
 	case OpSubgroupFirstInvocationKHR:
 	case OpSubgroupReadInvocationKHR:
 	case OpSubgroupAllKHR:
 	case OpSubgroupAnyKHR:
 	case OpSubgroupAllEqualKHR:
-		// These earlier instructions don't have the scope operand.
+	// These instructions are always quad-scoped and thus do not have a scope operand.
+	case OpGroupNonUniformQuadAllKHR:
+	case OpGroupNonUniformQuadAnyKHR:
 		scope = ScopeSubgroup;
 		break;
 	default:
@@ -16989,6 +16992,14 @@ case OpGroupNonUniform##op: \
 
 	case OpGroupNonUniformQuadBroadcast:
 		emit_binary_func_op(result_type, id, ops[op_idx], ops[op_idx + 1], "spvQuadBroadcast");
+		break;
+
+	case OpGroupNonUniformQuadAllKHR:
+		emit_unary_func_op(result_type, id, ops[op_idx], "quad_all");
+		break;
+
+	case OpGroupNonUniformQuadAnyKHR:
+		emit_unary_func_op(result_type, id, ops[op_idx], "quad_any");
 		break;
 
 	default:


### PR DESCRIPTION
Implements the execution modes and instructions of `SPV_KHR_quad_control` for GLSL and MSL.

For GLSL, everything translates basically 1:1 to the corresponding `GL_EXT_shader_quad_control`. For MSL, we use `quad_all` and `quad_any` for the instructions, and the execution modes for quad derivatives and full quads pass tests without doing anything special.

_Note:_ For MSL, the quad ops under divergent conditions currently fail a CTS test related to only considering active threads. This seems to be a Metal bug as the MSL spec matches the SPIR-V spec in claiming to only consider active threads. Additionally, in a trace capture, the Xcode shader debugger says the shader should return the correct values, but the actual rendered output does not reflect this. I've reported this issue to Apple.