### PR TITLE
Fix using buffer reference blocks as struct members in glsl

### DIFF
--- a/reference/opt/shaders/vulkan/comp/array-of-buffer-reference.nocompat.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/array-of-buffer-reference.nocompat.vk.comp.vk
@@ -3,6 +3,7 @@
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer Block;
+
 layout(buffer_reference, buffer_reference_align = 4, std430) buffer Block
 {
     float v;

--- a/reference/opt/shaders/vulkan/comp/buffer-reference-atomic.nocompat.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/buffer-reference-atomic.nocompat.vk.comp.vk
@@ -4,6 +4,7 @@ layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer Bar;
 layout(buffer_reference) buffer Foo;
+
 layout(buffer_reference, buffer_reference_align = 8, std430) buffer Bar
 {
     uint a;

--- a/reference/opt/shaders/vulkan/comp/buffer-reference-base-alignment-promote.nocompat.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/buffer-reference-base-alignment-promote.nocompat.vk.comp.vk
@@ -4,6 +4,7 @@ layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer Bar;
 layout(buffer_reference) buffer Foo;
+
 layout(buffer_reference, buffer_reference_align = 8, std430) buffer Bar
 {
     uint a;

--- a/reference/opt/shaders/vulkan/comp/buffer-reference-bitcast-uvec2-2.nocompat.invalid.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/buffer-reference-bitcast-uvec2-2.nocompat.invalid.vk.comp.vk
@@ -4,6 +4,7 @@
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer PtrInt;
+
 layout(buffer_reference, buffer_reference_align = 4, std430) buffer PtrInt
 {
     int value;

--- a/reference/opt/shaders/vulkan/comp/buffer-reference-bitcast-uvec2.nocompat.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/buffer-reference-bitcast-uvec2.nocompat.vk.comp.vk
@@ -4,6 +4,7 @@
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer PtrInt;
+
 layout(buffer_reference, buffer_reference_align = 16, std430) buffer PtrInt
 {
     int value;

--- a/reference/opt/shaders/vulkan/comp/buffer-reference-bitcast.nocompat.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/buffer-reference-bitcast.nocompat.vk.comp.vk
@@ -4,6 +4,7 @@ layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer PtrUint;
 layout(buffer_reference) buffer PtrInt;
+
 layout(buffer_reference, buffer_reference_align = 4, std430) buffer PtrUint
 {
     uint value;

--- a/reference/opt/shaders/vulkan/comp/buffer-reference-decorations.nocompat.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/buffer-reference-decorations.nocompat.vk.comp.vk
@@ -5,6 +5,7 @@ layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 layout(buffer_reference) buffer RO;
 layout(buffer_reference) buffer RW;
 layout(buffer_reference) buffer WO;
+
 layout(buffer_reference, buffer_reference_align = 16, std430) readonly buffer RO
 {
     vec4 v[];

--- a/reference/opt/shaders/vulkan/comp/buffer-reference.nocompat.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/buffer-reference.nocompat.vk.comp.vk
@@ -8,6 +8,7 @@
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer Node;
+
 layout(buffer_reference, buffer_reference_align = 16, std430) buffer Node
 {
     layout(offset = 0) int value;

--- a/reference/shaders/vulkan/comp/array-of-buffer-reference.nocompat.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/array-of-buffer-reference.nocompat.vk.comp.vk
@@ -3,6 +3,7 @@
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer Block;
+
 layout(buffer_reference, buffer_reference_align = 4, std430) buffer Block
 {
     float v;

--- a/reference/shaders/vulkan/comp/buffer-reference-atomic.nocompat.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/buffer-reference-atomic.nocompat.vk.comp.vk
@@ -4,6 +4,7 @@ layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer Bar;
 layout(buffer_reference) buffer Foo;
+
 layout(buffer_reference, buffer_reference_align = 8, std430) buffer Bar
 {
     uint a;

--- a/reference/shaders/vulkan/comp/buffer-reference-base-alignment-promote.nocompat.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/buffer-reference-base-alignment-promote.nocompat.vk.comp.vk
@@ -4,6 +4,7 @@ layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer Bar;
 layout(buffer_reference) buffer Foo;
+
 layout(buffer_reference, buffer_reference_align = 8, std430) buffer Bar
 {
     uint a;

--- a/reference/shaders/vulkan/comp/buffer-reference-bitcast-uvec2-2.nocompat.invalid.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/buffer-reference-bitcast-uvec2-2.nocompat.invalid.vk.comp.vk
@@ -4,6 +4,7 @@
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer PtrInt;
+
 layout(buffer_reference, buffer_reference_align = 4, std430) buffer PtrInt
 {
     int value;

--- a/reference/shaders/vulkan/comp/buffer-reference-bitcast-uvec2.nocompat.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/buffer-reference-bitcast-uvec2.nocompat.vk.comp.vk
@@ -4,6 +4,7 @@
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer PtrInt;
+
 layout(buffer_reference, buffer_reference_align = 16, std430) buffer PtrInt
 {
     int value;

--- a/reference/shaders/vulkan/comp/buffer-reference-bitcast.nocompat.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/buffer-reference-bitcast.nocompat.vk.comp.vk
@@ -4,6 +4,7 @@ layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer PtrUint;
 layout(buffer_reference) buffer PtrInt;
+
 layout(buffer_reference, buffer_reference_align = 4, std430) buffer PtrUint
 {
     uint value;

--- a/reference/shaders/vulkan/comp/buffer-reference-decorations.nocompat.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/buffer-reference-decorations.nocompat.vk.comp.vk
@@ -5,6 +5,7 @@ layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 layout(buffer_reference) buffer RO;
 layout(buffer_reference) buffer RW;
 layout(buffer_reference) buffer WO;
+
 layout(buffer_reference, buffer_reference_align = 16, std430) readonly buffer RO
 {
     vec4 v[];

--- a/reference/shaders/vulkan/comp/buffer-reference.nocompat.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/buffer-reference.nocompat.vk.comp.vk
@@ -8,6 +8,7 @@
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(buffer_reference) buffer Node;
+
 layout(buffer_reference, buffer_reference_align = 16, std430) buffer Node
 {
     layout(offset = 0) int value;


### PR DESCRIPTION
Buffer reference blocks are always emitted after structs, even when forward declared. This causes invalid GLSL to be generated if a buffer reference block is used as a struct member.

This patch fixes the problem by emitting buffer reference block forward declarations before emitting structs.