### PR TITLE
Geometry shader support for HLSL

### DIFF
--- a/reference/opt/shaders-hlsl/geom/triangles.geom
+++ b/reference/opt/shaders-hlsl/geom/triangles.geom
@@ -1,0 +1,55 @@
+static float4 gl_Position;
+static float4 vPositionIn[1];
+static float3 vColorIn[1];
+static float3 gColor;
+
+struct SPIRV_Cross_Input
+{
+    float4 vPositionIn : TEXCOORD0;
+    float3 vColorIn : TEXCOORD1;
+};
+
+struct SPIRV_Cross_Output
+{
+    float3 gColor : TEXCOORD0;
+    float4 gl_Position : SV_Position;
+};
+
+void geom_main(point SPIRV_Cross_Input stage_input[1], inout TriangleStream<SPIRV_Cross_Output> triStream)
+{
+    gColor = vColorIn[0];
+    gl_Position = vPositionIn[0] + float4(-0.100000001490116119384765625f, -0.100000001490116119384765625f, 0.0f, 0.0f);
+    {
+        SPIRV_Cross_Output stage_output;
+        stage_output.gl_Position = gl_Position;
+        stage_output.gColor = gColor;
+        triStream.Append(stage_output);
+    }
+    gColor = vColorIn[0];
+    gl_Position = vPositionIn[0] + float4(0.100000001490116119384765625f, -0.100000001490116119384765625f, 0.0f, 0.0f);
+    {
+        SPIRV_Cross_Output stage_output;
+        stage_output.gl_Position = gl_Position;
+        stage_output.gColor = gColor;
+        triStream.Append(stage_output);
+    }
+    gColor = vColorIn[0];
+    gl_Position = vPositionIn[0] + float4(0.0f, 0.100000001490116119384765625f, 0.0f, 0.0f);
+    {
+        SPIRV_Cross_Output stage_output;
+        stage_output.gl_Position = gl_Position;
+        stage_output.gColor = gColor;
+        triStream.Append(stage_output);
+    }
+    triStream.RestartStrip();
+}
+
+[maxvertexcount(3)]
+void main(point SPIRV_Cross_Input stage_input[1], inout TriangleStream<SPIRV_Cross_Output> triStream)
+{
+    for(int i = 0; i < 1; i++)
+    vPositionIn[i] = stage_input[i].vPositionIn;
+    for(int i = 0; i < 1; i++)
+    vColorIn[i] = stage_input[i].vColorIn;
+    geom_main(stage_input, triStream);
+}

--- a/reference/shaders-hlsl/geom/triangles.geom
+++ b/reference/shaders-hlsl/geom/triangles.geom
@@ -1,0 +1,57 @@
+static float4 gl_Position;
+static float4 vPositionIn[1];
+static float3 vColorIn[1];
+static float3 gColor;
+
+struct SPIRV_Cross_Input
+{
+    float4 vPositionIn : TEXCOORD0;
+    float3 vColorIn : TEXCOORD1;
+};
+
+struct SPIRV_Cross_Output
+{
+    float3 gColor : TEXCOORD0;
+    float4 gl_Position : SV_Position;
+};
+
+void geom_main(point SPIRV_Cross_Input stage_input[1], inout TriangleStream<SPIRV_Cross_Output> triStream)
+{
+    float4 center = vPositionIn[0];
+    float3 color = vColorIn[0];
+    gColor = color;
+    gl_Position = center + float4(-0.100000001490116119384765625f, -0.100000001490116119384765625f, 0.0f, 0.0f);
+    {
+        SPIRV_Cross_Output stage_output;
+        stage_output.gl_Position = gl_Position;
+        stage_output.gColor = gColor;
+        triStream.Append(stage_output);
+    }
+    gColor = color;
+    gl_Position = center + float4(0.100000001490116119384765625f, -0.100000001490116119384765625f, 0.0f, 0.0f);
+    {
+        SPIRV_Cross_Output stage_output;
+        stage_output.gl_Position = gl_Position;
+        stage_output.gColor = gColor;
+        triStream.Append(stage_output);
+    }
+    gColor = color;
+    gl_Position = center + float4(0.0f, 0.100000001490116119384765625f, 0.0f, 0.0f);
+    {
+        SPIRV_Cross_Output stage_output;
+        stage_output.gl_Position = gl_Position;
+        stage_output.gColor = gColor;
+        triStream.Append(stage_output);
+    }
+    triStream.RestartStrip();
+}
+
+[maxvertexcount(3)]
+void main(point SPIRV_Cross_Input stage_input[1], inout TriangleStream<SPIRV_Cross_Output> triStream)
+{
+    for(int i = 0; i < 1; i++)
+    vPositionIn[i] = stage_input[i].vPositionIn;
+    for(int i = 0; i < 1; i++)
+    vColorIn[i] = stage_input[i].vColorIn;
+    geom_main(stage_input, triStream);
+}

--- a/shaders-hlsl/geom/triangles.geom
+++ b/shaders-hlsl/geom/triangles.geom
@@ -1,0 +1,28 @@
+#version 450
+
+layout(points) in;
+layout(triangle_strip, max_vertices = 3) out;
+
+layout(location = 0) in vec4 vPositionIn[1];
+layout(location = 1) in vec3 vColorIn[1];
+
+layout(location = 0) out vec3 gColor;
+
+void main() {
+    vec4 center = vPositionIn[0];
+    vec3 color = vColorIn[0];
+
+    gColor = color;
+    gl_Position = center + vec4(-0.1, -0.1, 0.0, 0.0);
+    EmitVertex();
+
+    gColor = color;
+    gl_Position = center + vec4(0.1, -0.1, 0.0, 0.0);
+    EmitVertex();
+
+    gColor = color;
+    gl_Position = center + vec4(0.0, 0.1, 0.0, 0.0);
+    EmitVertex();
+
+    EndPrimitive();
+}

--- a/spirv_cross_c.cpp
+++ b/spirv_cross_c.cpp
@@ -55,6 +55,7 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4996)
+#pragma warning(disable : 4065) // switch with 'default' but not 'case'.
 #endif
 
 #ifndef SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1117,7 +1117,9 @@ void CompilerHLSL::emit_interface_block_in_struct(const SPIRVariable &var, unord
 		else
 		{
 			auto decl_type = type;
-			if (execution.model == ExecutionModelMeshEXT || has_decoration(var.self, DecorationPerVertexKHR))
+			if (execution.model == ExecutionModelMeshEXT ||
+			    (execution.model == ExecutionModelGeometry && var.storage == StorageClassInput) ||
+			    has_decoration(var.self, DecorationPerVertexKHR))
 			{
 				decl_type.array.erase(decl_type.array.begin());
 				decl_type.array_size_literal.erase(decl_type.array_size_literal.begin());
@@ -1830,11 +1832,11 @@ void CompilerHLSL::emit_resources()
 		statement("");
 	}
 
-	const bool is_mesh_shader = execution.model == ExecutionModelMeshEXT;
-	if (!output_variables.empty() || !active_output_builtins.empty())
-	{
-		sort(output_variables.begin(), output_variables.end(), variable_compare);
-		require_output = !is_mesh_shader;
+        const bool is_mesh_shader = execution.model == ExecutionModelMeshEXT;
+        if (!output_variables.empty() || !active_output_builtins.empty())
+        {
+                sort(output_variables.begin(), output_variables.end(), variable_compare);
+                require_output = !(is_mesh_shader || execution.model == ExecutionModelGeometry);
 
 		statement(is_mesh_shader ? "struct gl_MeshPerVertexEXT" : "struct SPIRV_Cross_Output");
 		begin_scope();
@@ -2678,6 +2680,83 @@ void CompilerHLSL::emit_mesh_tasks(SPIRBlock &block)
 	}
 }
 
+void CompilerHLSL::emit_geometry_stream_append()
+{
+	begin_scope();
+	statement("SPIRV_Cross_Output stage_output;");
+
+	active_output_builtins.for_each_bit(
+	    [&](uint32_t i)
+	    {
+		    if (i == BuiltInPointSize && hlsl_options.shader_model > 30)
+			    return;
+		    switch (static_cast<BuiltIn>(i))
+		    {
+		    case BuiltInClipDistance:
+			    for (uint32_t clip = 0; clip < clip_distance_count; clip++)
+				    statement("stage_output.gl_ClipDistance", clip / 4, ".", "xyzw"[clip & 3], " = gl_ClipDistance[",
+				              clip, "];");
+			    break;
+		    case BuiltInCullDistance:
+			    for (uint32_t cull = 0; cull < cull_distance_count; cull++)
+				    statement("stage_output.gl_CullDistance", cull / 4, ".", "xyzw"[cull & 3], " = gl_CullDistance[",
+				              cull, "];");
+			    break;
+		    case BuiltInSampleMask:
+			    statement("stage_output.gl_SampleMask = gl_SampleMask[0];");
+			    break;
+		    default:
+		    {
+			    auto builtin_expr = builtin_to_glsl(static_cast<BuiltIn>(i), StorageClassOutput);
+			    statement("stage_output.", builtin_expr, " = ", builtin_expr, ";");
+		    }
+		    break;
+		    }
+	    });
+
+	ir.for_each_typed_id<SPIRVariable>(
+	    [&](uint32_t, SPIRVariable &var)
+	    {
+		    auto &type = this->get<SPIRType>(var.basetype);
+		    bool block = has_decoration(type.self, DecorationBlock);
+
+		    if (var.storage != StorageClassOutput)
+			    return;
+
+		    if (!var.remapped_variable && type.pointer && !is_builtin_variable(var) &&
+		        interface_variable_exists_in_entry_point(var.self))
+		    {
+			    if (block)
+			    {
+				    auto type_name = to_name(type.self);
+				    auto var_name = to_name(var.self);
+				    for (uint32_t mbr_idx = 0; mbr_idx < uint32_t(type.member_types.size()); mbr_idx++)
+				    {
+					    auto mbr_name = to_member_name(type, mbr_idx);
+					    auto flat_name = join(type_name, "_", mbr_name);
+					    statement("stage_output.", flat_name, " = ", var_name, ".", mbr_name, ";");
+				    }
+			    }
+			    else
+			    {
+				    auto name = to_name(var.self);
+				    if (hlsl_options.shader_model <= 30 && get_entry_point().model == ExecutionModelFragment)
+				    {
+					    string output_filler;
+					    for (uint32_t size = type.vecsize; size < 4; ++size)
+						    output_filler += ", 0.0";
+					    statement("stage_output.", name, " = float4(", name, output_filler, ");");
+				    }
+				    else
+					    statement("stage_output.", name, " = ", name, ";");
+			    }
+		    }
+	    });
+
+	statement(geometry_stream, ".Append(stage_output);");
+	end_scope();
+}
+
 void CompilerHLSL::emit_buffer_block(const SPIRVariable &var)
 {
 	auto &type = get<SPIRType>(var.basetype);
@@ -2712,13 +2791,18 @@ void CompilerHLSL::emit_buffer_block(const SPIRVariable &var)
 
 		std::string type_name;
 		if (is_user_type_structured(var.self))
-			type_name = join(is_readonly ? "" : is_interlocked ? "RasterizerOrdered" : "RW", "StructuredBuffer<", to_structuredbuffer_subtype_name(type), ">");
+			type_name = join(is_readonly    ? "" :
+			                 is_interlocked ? "RasterizerOrdered" :
+			                                  "RW",
+			                 "StructuredBuffer<", to_structuredbuffer_subtype_name(type), ">");
 		else
-			type_name = is_readonly ? "ByteAddressBuffer" : is_interlocked ? "RasterizerOrderedByteAddressBuffer" : "RWByteAddressBuffer";
+			type_name = is_readonly    ? "ByteAddressBuffer" :
+			            is_interlocked ? "RasterizerOrderedByteAddressBuffer" :
+			                             "RWByteAddressBuffer";
 
 		add_resource_name(var.self);
-		statement(is_coherent ? "globallycoherent " : "", type_name, " ", to_name(var.self), type_to_array_glsl(type, var.self),
-		          to_resource_binding(var), ";");
+		statement(is_coherent ? "globallycoherent " : "", type_name, " ", to_name(var.self),
+		          type_to_array_glsl(type, var.self), to_resource_binding(var), ";");
 	}
 	else
 	{
@@ -2804,8 +2888,8 @@ void CompilerHLSL::emit_buffer_block(const SPIRVariable &var)
 			}
 
 			emit_struct(get<SPIRType>(type.self));
-			statement("ConstantBuffer<", to_name(type.self), "> ", to_name(var.self), type_to_array_glsl(type, var.self),
-			          to_resource_binding(var), ";");
+			statement("ConstantBuffer<", to_name(type.self), "> ", to_name(var.self),
+			          type_to_array_glsl(type, var.self), to_resource_binding(var), ";");
 		}
 	}
 }
@@ -2940,6 +3024,8 @@ string CompilerHLSL::get_inner_entry_point_name() const
 		return "frag_main";
 	else if (execution.model == ExecutionModelGLCompute)
 		return "comp_main";
+	else if (execution.model == ExecutionModelGeometry)
+		return "geom_main";
 	else if (execution.model == ExecutionModelMeshEXT)
 		return "mesh_main";
 	else if (execution.model == ExecutionModelTaskEXT)
@@ -3041,6 +3127,43 @@ void CompilerHLSL::emit_function_prototype(SPIRFunction &func, const Bitset &ret
 			var->parameter = &arg;
 	}
 
+	if (func.self == ir.default_entry_point && get_entry_point().model == ExecutionModelGeometry)
+	{
+		uint32_t input_vertices = 1;
+		auto &execution = get_entry_point();
+		if (execution.flags.get(ExecutionModeInputLines))
+			input_vertices = 2;
+		else if (execution.flags.get(ExecutionModeInputLinesAdjacency))
+			input_vertices = 4;
+		else if (execution.flags.get(ExecutionModeInputTrianglesAdjacency))
+			input_vertices = 6;
+		else if (execution.flags.get(ExecutionModeTriangles))
+			input_vertices = 3;
+
+		string prim;
+		if (execution.flags.get(ExecutionModeInputLinesAdjacency))
+			prim = "lineadj";
+		else if (execution.flags.get(ExecutionModeInputLines))
+			prim = "line";
+		else if (execution.flags.get(ExecutionModeInputTrianglesAdjacency))
+			prim = "triangleadj";
+		else if (execution.flags.get(ExecutionModeTriangles))
+			prim = "triangle";
+		else
+			prim = "point";
+
+		string stream_type;
+		if (execution.flags.get(ExecutionModeOutputPoints))
+			stream_type = "PointStream";
+		else if (execution.flags.get(ExecutionModeOutputLineStrip))
+			stream_type = "LineStream";
+		else
+			stream_type = "TriangleStream";
+
+		arglist.push_back(join(prim, " SPIRV_Cross_Input stage_input[", input_vertices, "]"));
+		arglist.push_back(join("inout ", stream_type, "<SPIRV_Cross_Output> ", geometry_stream));
+	}
+
 	decl += merge(arglist);
 	decl += ")";
 	statement(decl);
@@ -3050,13 +3173,60 @@ void CompilerHLSL::emit_hlsl_entry_point()
 {
 	SmallVector<string> arguments;
 
-	if (require_input)
+	if (require_input && get_entry_point().model != ExecutionModelGeometry)
 		arguments.push_back("SPIRV_Cross_Input stage_input");
 
 	auto &execution = get_entry_point();
 
+	uint32_t input_vertices = 1;
+
 	switch (execution.model)
 	{
+	case ExecutionModelGeometry:
+	{
+		if (execution.flags.get(ExecutionModeInputLines))
+			input_vertices = 2;
+		else if (execution.flags.get(ExecutionModeInputLinesAdjacency))
+			input_vertices = 4;
+		else if (execution.flags.get(ExecutionModeInputTrianglesAdjacency))
+			input_vertices = 6;
+		else if (execution.flags.get(ExecutionModeTriangles))
+			input_vertices = 3;
+
+		string prim;
+		if (execution.flags.get(ExecutionModeInputLinesAdjacency))
+			prim = "lineadj";
+		else if (execution.flags.get(ExecutionModeInputLines))
+			prim = "line";
+		else if (execution.flags.get(ExecutionModeInputTrianglesAdjacency))
+			prim = "triangleadj";
+		else if (execution.flags.get(ExecutionModeTriangles))
+			prim = "triangle";
+		else
+			prim = "point";
+
+		string stream_type;
+		if (execution.flags.get(ExecutionModeOutputPoints))
+		{
+			stream_type = "PointStream";
+			geometry_stream = "pointStream";
+		}
+		else if (execution.flags.get(ExecutionModeOutputLineStrip))
+		{
+			stream_type = "LineStream";
+			geometry_stream = "lineStream";
+		}
+		else
+		{
+			stream_type = "TriangleStream";
+			geometry_stream = "triStream";
+		}
+
+		statement("[maxvertexcount(", execution.output_vertices, ")]");
+		arguments.push_back(join(prim, " SPIRV_Cross_Input stage_input[", input_vertices, "]"));
+		arguments.push_back(join("inout ", stream_type, "<SPIRV_Cross_Output> ", geometry_stream));
+		break;
+	}
 	case ExecutionModelTaskEXT:
 	case ExecutionModelMeshEXT:
 	case ExecutionModelGLCompute:
@@ -3152,225 +3322,246 @@ void CompilerHLSL::emit_hlsl_entry_point()
 	bool legacy = hlsl_options.shader_model <= 30;
 
 	// Copy builtins from entry point arguments to globals.
-	active_input_builtins.for_each_bit([&](uint32_t i) {
-		auto builtin = builtin_to_glsl(static_cast<BuiltIn>(i), StorageClassInput);
-		switch (static_cast<BuiltIn>(i))
-		{
-		case BuiltInFragCoord:
-			// VPOS in D3D9 is sampled at integer locations, apply half-pixel offset to be consistent.
-			// TODO: Do we need an option here? Any reason why a D3D9 shader would be used
-			// on a D3D10+ system with a different rasterization config?
-			if (legacy)
-				statement(builtin, " = stage_input.", builtin, " + float4(0.5f, 0.5f, 0.0f, 0.0f);");
-			else
-			{
-				statement(builtin, " = stage_input.", builtin, ";");
-				// ZW are undefined in D3D9, only do this fixup here.
-				statement(builtin, ".w = 1.0 / ", builtin, ".w;");
-			}
-			break;
+	active_input_builtins.for_each_bit(
+	    [&](uint32_t i)
+	    {
+		    auto builtin = builtin_to_glsl(static_cast<BuiltIn>(i), StorageClassInput);
+		    switch (static_cast<BuiltIn>(i))
+		    {
+		    case BuiltInFragCoord:
+			    // VPOS in D3D9 is sampled at integer locations, apply half-pixel offset to be consistent.
+			    // TODO: Do we need an option here? Any reason why a D3D9 shader would be used
+			    // on a D3D10+ system with a different rasterization config?
+			    if (legacy)
+				    statement(builtin, " = stage_input.", builtin, " + float4(0.5f, 0.5f, 0.0f, 0.0f);");
+			    else
+			    {
+				    statement(builtin, " = stage_input.", builtin, ";");
+				    // ZW are undefined in D3D9, only do this fixup here.
+				    statement(builtin, ".w = 1.0 / ", builtin, ".w;");
+			    }
+			    break;
 
-		case BuiltInVertexId:
-		case BuiltInVertexIndex:
-		case BuiltInInstanceIndex:
-			// D3D semantics are uint, but shader wants int.
-			if (hlsl_options.support_nonzero_base_vertex_base_instance || hlsl_options.shader_model >= 68)
-			{
-				if (hlsl_options.shader_model >= 68)
-				{
-					if (static_cast<BuiltIn>(i) == BuiltInInstanceIndex)
-						statement(builtin, " = int(stage_input.", builtin, " + stage_input.gl_BaseInstanceARB);");
-					else
-						statement(builtin, " = int(stage_input.", builtin, " + stage_input.gl_BaseVertexARB);");
-				}
-				else
-				{
-					if (static_cast<BuiltIn>(i) == BuiltInInstanceIndex)
-						statement(builtin, " = int(stage_input.", builtin, ") + SPIRV_Cross_BaseInstance;");
-					else
-						statement(builtin, " = int(stage_input.", builtin, ") + SPIRV_Cross_BaseVertex;");
-				}
-			}
-			else
-				statement(builtin, " = int(stage_input.", builtin, ");");
-			break;
+		    case BuiltInVertexId:
+		    case BuiltInVertexIndex:
+		    case BuiltInInstanceIndex:
+			    // D3D semantics are uint, but shader wants int.
+			    if (hlsl_options.support_nonzero_base_vertex_base_instance || hlsl_options.shader_model >= 68)
+			    {
+				    if (hlsl_options.shader_model >= 68)
+				    {
+					    if (static_cast<BuiltIn>(i) == BuiltInInstanceIndex)
+						    statement(builtin, " = int(stage_input.", builtin, " + stage_input.gl_BaseInstanceARB);");
+					    else
+						    statement(builtin, " = int(stage_input.", builtin, " + stage_input.gl_BaseVertexARB);");
+				    }
+				    else
+				    {
+					    if (static_cast<BuiltIn>(i) == BuiltInInstanceIndex)
+						    statement(builtin, " = int(stage_input.", builtin, ") + SPIRV_Cross_BaseInstance;");
+					    else
+						    statement(builtin, " = int(stage_input.", builtin, ") + SPIRV_Cross_BaseVertex;");
+				    }
+			    }
+			    else
+				    statement(builtin, " = int(stage_input.", builtin, ");");
+			    break;
 
-		case BuiltInBaseVertex:
-			if (hlsl_options.shader_model >= 68)
-				statement(builtin, " = stage_input.gl_BaseVertexARB;");
-			else
-				statement(builtin, " = SPIRV_Cross_BaseVertex;");
-			break;
+		    case BuiltInBaseVertex:
+			    if (hlsl_options.shader_model >= 68)
+				    statement(builtin, " = stage_input.gl_BaseVertexARB;");
+			    else
+				    statement(builtin, " = SPIRV_Cross_BaseVertex;");
+			    break;
 
-		case BuiltInBaseInstance:
-			if (hlsl_options.shader_model >= 68)
-				statement(builtin, " = stage_input.gl_BaseInstanceARB;");
-			else
-				statement(builtin, " = SPIRV_Cross_BaseInstance;");
-			break;
+		    case BuiltInBaseInstance:
+			    if (hlsl_options.shader_model >= 68)
+				    statement(builtin, " = stage_input.gl_BaseInstanceARB;");
+			    else
+				    statement(builtin, " = SPIRV_Cross_BaseInstance;");
+			    break;
 
-		case BuiltInInstanceId:
-			// D3D semantics are uint, but shader wants int.
-			statement(builtin, " = int(stage_input.", builtin, ");");
-			break;
+		    case BuiltInInstanceId:
+			    // D3D semantics are uint, but shader wants int.
+			    statement(builtin, " = int(stage_input.", builtin, ");");
+			    break;
 
-		case BuiltInSampleMask:
-			statement(builtin, "[0] = stage_input.", builtin, ";");
-			break;
+		    case BuiltInSampleMask:
+			    statement(builtin, "[0] = stage_input.", builtin, ";");
+			    break;
 
-		case BuiltInNumWorkgroups:
-		case BuiltInPointCoord:
-		case BuiltInSubgroupSize:
-		case BuiltInSubgroupLocalInvocationId:
-		case BuiltInHelperInvocation:
-			break;
+		    case BuiltInNumWorkgroups:
+		    case BuiltInPointCoord:
+		    case BuiltInSubgroupSize:
+		    case BuiltInSubgroupLocalInvocationId:
+		    case BuiltInHelperInvocation:
+			    break;
 
-		case BuiltInSubgroupEqMask:
-			// Emulate these ...
-			// No 64-bit in HLSL, so have to do it in 32-bit and unroll.
-			statement("gl_SubgroupEqMask = 1u << (WaveGetLaneIndex() - uint4(0, 32, 64, 96));");
-			statement("if (WaveGetLaneIndex() >= 32) gl_SubgroupEqMask.x = 0;");
-			statement("if (WaveGetLaneIndex() >= 64 || WaveGetLaneIndex() < 32) gl_SubgroupEqMask.y = 0;");
-			statement("if (WaveGetLaneIndex() >= 96 || WaveGetLaneIndex() < 64) gl_SubgroupEqMask.z = 0;");
-			statement("if (WaveGetLaneIndex() < 96) gl_SubgroupEqMask.w = 0;");
-			break;
+		    case BuiltInSubgroupEqMask:
+			    // Emulate these ...
+			    // No 64-bit in HLSL, so have to do it in 32-bit and unroll.
+			    statement("gl_SubgroupEqMask = 1u << (WaveGetLaneIndex() - uint4(0, 32, 64, 96));");
+			    statement("if (WaveGetLaneIndex() >= 32) gl_SubgroupEqMask.x = 0;");
+			    statement("if (WaveGetLaneIndex() >= 64 || WaveGetLaneIndex() < 32) gl_SubgroupEqMask.y = 0;");
+			    statement("if (WaveGetLaneIndex() >= 96 || WaveGetLaneIndex() < 64) gl_SubgroupEqMask.z = 0;");
+			    statement("if (WaveGetLaneIndex() < 96) gl_SubgroupEqMask.w = 0;");
+			    break;
 
-		case BuiltInSubgroupGeMask:
-			// Emulate these ...
-			// No 64-bit in HLSL, so have to do it in 32-bit and unroll.
-			statement("gl_SubgroupGeMask = ~((1u << (WaveGetLaneIndex() - uint4(0, 32, 64, 96))) - 1u);");
-			statement("if (WaveGetLaneIndex() >= 32) gl_SubgroupGeMask.x = 0u;");
-			statement("if (WaveGetLaneIndex() >= 64) gl_SubgroupGeMask.y = 0u;");
-			statement("if (WaveGetLaneIndex() >= 96) gl_SubgroupGeMask.z = 0u;");
-			statement("if (WaveGetLaneIndex() < 32) gl_SubgroupGeMask.y = ~0u;");
-			statement("if (WaveGetLaneIndex() < 64) gl_SubgroupGeMask.z = ~0u;");
-			statement("if (WaveGetLaneIndex() < 96) gl_SubgroupGeMask.w = ~0u;");
-			break;
+		    case BuiltInSubgroupGeMask:
+			    // Emulate these ...
+			    // No 64-bit in HLSL, so have to do it in 32-bit and unroll.
+			    statement("gl_SubgroupGeMask = ~((1u << (WaveGetLaneIndex() - uint4(0, 32, 64, 96))) - 1u);");
+			    statement("if (WaveGetLaneIndex() >= 32) gl_SubgroupGeMask.x = 0u;");
+			    statement("if (WaveGetLaneIndex() >= 64) gl_SubgroupGeMask.y = 0u;");
+			    statement("if (WaveGetLaneIndex() >= 96) gl_SubgroupGeMask.z = 0u;");
+			    statement("if (WaveGetLaneIndex() < 32) gl_SubgroupGeMask.y = ~0u;");
+			    statement("if (WaveGetLaneIndex() < 64) gl_SubgroupGeMask.z = ~0u;");
+			    statement("if (WaveGetLaneIndex() < 96) gl_SubgroupGeMask.w = ~0u;");
+			    break;
 
-		case BuiltInSubgroupGtMask:
-			// Emulate these ...
-			// No 64-bit in HLSL, so have to do it in 32-bit and unroll.
-			statement("uint gt_lane_index = WaveGetLaneIndex() + 1;");
-			statement("gl_SubgroupGtMask = ~((1u << (gt_lane_index - uint4(0, 32, 64, 96))) - 1u);");
-			statement("if (gt_lane_index >= 32) gl_SubgroupGtMask.x = 0u;");
-			statement("if (gt_lane_index >= 64) gl_SubgroupGtMask.y = 0u;");
-			statement("if (gt_lane_index >= 96) gl_SubgroupGtMask.z = 0u;");
-			statement("if (gt_lane_index >= 128) gl_SubgroupGtMask.w = 0u;");
-			statement("if (gt_lane_index < 32) gl_SubgroupGtMask.y = ~0u;");
-			statement("if (gt_lane_index < 64) gl_SubgroupGtMask.z = ~0u;");
-			statement("if (gt_lane_index < 96) gl_SubgroupGtMask.w = ~0u;");
-			break;
+		    case BuiltInSubgroupGtMask:
+			    // Emulate these ...
+			    // No 64-bit in HLSL, so have to do it in 32-bit and unroll.
+			    statement("uint gt_lane_index = WaveGetLaneIndex() + 1;");
+			    statement("gl_SubgroupGtMask = ~((1u << (gt_lane_index - uint4(0, 32, 64, 96))) - 1u);");
+			    statement("if (gt_lane_index >= 32) gl_SubgroupGtMask.x = 0u;");
+			    statement("if (gt_lane_index >= 64) gl_SubgroupGtMask.y = 0u;");
+			    statement("if (gt_lane_index >= 96) gl_SubgroupGtMask.z = 0u;");
+			    statement("if (gt_lane_index >= 128) gl_SubgroupGtMask.w = 0u;");
+			    statement("if (gt_lane_index < 32) gl_SubgroupGtMask.y = ~0u;");
+			    statement("if (gt_lane_index < 64) gl_SubgroupGtMask.z = ~0u;");
+			    statement("if (gt_lane_index < 96) gl_SubgroupGtMask.w = ~0u;");
+			    break;
 
-		case BuiltInSubgroupLeMask:
-			// Emulate these ...
-			// No 64-bit in HLSL, so have to do it in 32-bit and unroll.
-			statement("uint le_lane_index = WaveGetLaneIndex() + 1;");
-			statement("gl_SubgroupLeMask = (1u << (le_lane_index - uint4(0, 32, 64, 96))) - 1u;");
-			statement("if (le_lane_index >= 32) gl_SubgroupLeMask.x = ~0u;");
-			statement("if (le_lane_index >= 64) gl_SubgroupLeMask.y = ~0u;");
-			statement("if (le_lane_index >= 96) gl_SubgroupLeMask.z = ~0u;");
-			statement("if (le_lane_index >= 128) gl_SubgroupLeMask.w = ~0u;");
-			statement("if (le_lane_index < 32) gl_SubgroupLeMask.y = 0u;");
-			statement("if (le_lane_index < 64) gl_SubgroupLeMask.z = 0u;");
-			statement("if (le_lane_index < 96) gl_SubgroupLeMask.w = 0u;");
-			break;
+		    case BuiltInSubgroupLeMask:
+			    // Emulate these ...
+			    // No 64-bit in HLSL, so have to do it in 32-bit and unroll.
+			    statement("uint le_lane_index = WaveGetLaneIndex() + 1;");
+			    statement("gl_SubgroupLeMask = (1u << (le_lane_index - uint4(0, 32, 64, 96))) - 1u;");
+			    statement("if (le_lane_index >= 32) gl_SubgroupLeMask.x = ~0u;");
+			    statement("if (le_lane_index >= 64) gl_SubgroupLeMask.y = ~0u;");
+			    statement("if (le_lane_index >= 96) gl_SubgroupLeMask.z = ~0u;");
+			    statement("if (le_lane_index >= 128) gl_SubgroupLeMask.w = ~0u;");
+			    statement("if (le_lane_index < 32) gl_SubgroupLeMask.y = 0u;");
+			    statement("if (le_lane_index < 64) gl_SubgroupLeMask.z = 0u;");
+			    statement("if (le_lane_index < 96) gl_SubgroupLeMask.w = 0u;");
+			    break;
 
-		case BuiltInSubgroupLtMask:
-			// Emulate these ...
-			// No 64-bit in HLSL, so have to do it in 32-bit and unroll.
-			statement("gl_SubgroupLtMask = (1u << (WaveGetLaneIndex() - uint4(0, 32, 64, 96))) - 1u;");
-			statement("if (WaveGetLaneIndex() >= 32) gl_SubgroupLtMask.x = ~0u;");
-			statement("if (WaveGetLaneIndex() >= 64) gl_SubgroupLtMask.y = ~0u;");
-			statement("if (WaveGetLaneIndex() >= 96) gl_SubgroupLtMask.z = ~0u;");
-			statement("if (WaveGetLaneIndex() < 32) gl_SubgroupLtMask.y = 0u;");
-			statement("if (WaveGetLaneIndex() < 64) gl_SubgroupLtMask.z = 0u;");
-			statement("if (WaveGetLaneIndex() < 96) gl_SubgroupLtMask.w = 0u;");
-			break;
+		    case BuiltInSubgroupLtMask:
+			    // Emulate these ...
+			    // No 64-bit in HLSL, so have to do it in 32-bit and unroll.
+			    statement("gl_SubgroupLtMask = (1u << (WaveGetLaneIndex() - uint4(0, 32, 64, 96))) - 1u;");
+			    statement("if (WaveGetLaneIndex() >= 32) gl_SubgroupLtMask.x = ~0u;");
+			    statement("if (WaveGetLaneIndex() >= 64) gl_SubgroupLtMask.y = ~0u;");
+			    statement("if (WaveGetLaneIndex() >= 96) gl_SubgroupLtMask.z = ~0u;");
+			    statement("if (WaveGetLaneIndex() < 32) gl_SubgroupLtMask.y = 0u;");
+			    statement("if (WaveGetLaneIndex() < 64) gl_SubgroupLtMask.z = 0u;");
+			    statement("if (WaveGetLaneIndex() < 96) gl_SubgroupLtMask.w = 0u;");
+			    break;
 
-		case BuiltInClipDistance:
-			for (uint32_t clip = 0; clip < clip_distance_count; clip++)
-				statement("gl_ClipDistance[", clip, "] = stage_input.gl_ClipDistance", clip / 4, ".", "xyzw"[clip & 3],
-				          ";");
-			break;
+		    case BuiltInClipDistance:
+			    for (uint32_t clip = 0; clip < clip_distance_count; clip++)
+				    statement("gl_ClipDistance[", clip, "] = stage_input.gl_ClipDistance", clip / 4, ".",
+				              "xyzw"[clip & 3], ";");
+			    break;
 
-		case BuiltInCullDistance:
-			for (uint32_t cull = 0; cull < cull_distance_count; cull++)
-				statement("gl_CullDistance[", cull, "] = stage_input.gl_CullDistance", cull / 4, ".", "xyzw"[cull & 3],
-				          ";");
-			break;
+		    case BuiltInCullDistance:
+			    for (uint32_t cull = 0; cull < cull_distance_count; cull++)
+				    statement("gl_CullDistance[", cull, "] = stage_input.gl_CullDistance", cull / 4, ".",
+				              "xyzw"[cull & 3], ";");
+			    break;
 
-		default:
-			statement(builtin, " = stage_input.", builtin, ";");
-			break;
-		}
-	});
+		    default:
+			    statement(builtin, " = stage_input.", builtin, ";");
+			    break;
+		    }
+	    });
 
 	// Copy from stage input struct to globals.
-	ir.for_each_typed_id<SPIRVariable>([&](uint32_t, SPIRVariable &var) {
-		auto &type = this->get<SPIRType>(var.basetype);
-		bool block = has_decoration(type.self, DecorationBlock);
+	ir.for_each_typed_id<SPIRVariable>(
+	    [&](uint32_t, SPIRVariable &var)
+	    {
+		    auto &type = this->get<SPIRType>(var.basetype);
+		    bool block = has_decoration(type.self, DecorationBlock);
 
-		if (var.storage != StorageClassInput)
-			return;
+		    if (var.storage != StorageClassInput)
+			    return;
 
-		bool need_matrix_unroll = var.storage == StorageClassInput && execution.model == ExecutionModelVertex;
+		    bool need_matrix_unroll = var.storage == StorageClassInput && execution.model == ExecutionModelVertex;
 
-		if (!var.remapped_variable && type.pointer && !is_builtin_variable(var) &&
-		    interface_variable_exists_in_entry_point(var.self))
-		{
-			if (block)
-			{
-				auto type_name = to_name(type.self);
-				auto var_name = to_name(var.self);
-				bool is_per_vertex = has_decoration(var.self, DecorationPerVertexKHR);
-				uint32_t array_size = is_per_vertex ? to_array_size_literal(type) : 0;
+		    if (!var.remapped_variable && type.pointer && !is_builtin_variable(var) &&
+		        interface_variable_exists_in_entry_point(var.self))
+		    {
+			    if (block)
+			    {
+				    auto type_name = to_name(type.self);
+				    auto var_name = to_name(var.self);
+				    bool is_per_vertex = has_decoration(var.self, DecorationPerVertexKHR);
+				    uint32_t array_size = is_per_vertex ? to_array_size_literal(type) : 0;
 
-				for (uint32_t mbr_idx = 0; mbr_idx < uint32_t(type.member_types.size()); mbr_idx++)
-				{
-					auto mbr_name = to_member_name(type, mbr_idx);
-					auto flat_name = join(type_name, "_", mbr_name);
+				    for (uint32_t mbr_idx = 0; mbr_idx < uint32_t(type.member_types.size()); mbr_idx++)
+				    {
+					    auto mbr_name = to_member_name(type, mbr_idx);
+					    auto flat_name = join(type_name, "_", mbr_name);
 
-					if (is_per_vertex)
-					{
-						for (uint32_t i = 0; i < array_size; i++)
-							statement(var_name, "[", i, "].", mbr_name, " = GetAttributeAtVertex(stage_input.", flat_name, ", ", i, ");");
-					}
-					else
-					{
-						statement(var_name, ".", mbr_name, " = stage_input.", flat_name, ";");
-					}
-				}
-			}
-			else
-			{
-				auto name = to_name(var.self);
-				auto &mtype = this->get<SPIRType>(var.basetype);
-				if (need_matrix_unroll && mtype.columns > 1)
-				{
-					// Unroll matrices.
-					for (uint32_t col = 0; col < mtype.columns; col++)
-						statement(name, "[", col, "] = stage_input.", name, "_", col, ";");
-				}
-				else if (has_decoration(var.self, DecorationPerVertexKHR))
-				{
-					uint32_t array_size = to_array_size_literal(type);
-					for (uint32_t i = 0; i < array_size; i++)
-						statement(name, "[", i, "]", " = GetAttributeAtVertex(stage_input.", name, ", ", i, ");");
-				}
-				else
-				{
-					statement(name, " = stage_input.", name, ";");
-				}
-			}
-		}
-	});
+					    if (is_per_vertex)
+					    {
+						    for (uint32_t i = 0; i < array_size; i++)
+						    {
+							    if (execution.model == ExecutionModelGeometry)
+								    statement(var_name, "[", i, "].", mbr_name, " = stage_input[", i, "].", flat_name,
+								              ";");
+							    else
+								    statement(var_name, "[", i, "].", mbr_name, " = GetAttributeAtVertex(stage_input.",
+								              flat_name, ", ", i, ");");
+						    }
+					    }
+					    else
+					    {
+						    statement(var_name, ".", mbr_name, " = stage_input.", flat_name, ";");
+					    }
+				    }
+			    }
+			    else
+			    {
+				    auto name = to_name(var.self);
+				    auto &mtype = this->get<SPIRType>(var.basetype);
+				    if (need_matrix_unroll && mtype.columns > 1)
+				    {
+					    // Unroll matrices.
+					    for (uint32_t col = 0; col < mtype.columns; col++)
+						    statement(name, "[", col, "] = stage_input.", name, "_", col, ";");
+				    }
+				    else if (has_decoration(var.self, DecorationPerVertexKHR))
+				    {
+					    uint32_t array_size = to_array_size_literal(type);
+					    for (uint32_t i = 0; i < array_size; i++)
+					    {
+						    if (execution.model == ExecutionModelGeometry)
+							    statement(name, "[", i, "] = stage_input[", i, "].", name, ";");
+						    else
+							    statement(name, "[", i, "]", " = GetAttributeAtVertex(stage_input.", name, ", ", i,
+							              ");");
+					    }
+				    }
+				    else
+				    {
+					    if (execution.model == ExecutionModelGeometry)
+					    {
+						    statement("for(int i = 0; i < ", input_vertices, "; i++)");
+						    statement(name, "[i] = stage_input[i].", name, ";");
+					    }
+					    else
+						    statement(name, " = stage_input.", name, ";");
+				    }
+			    }
+		    }
+	    });
 
 	// Run the shader.
-	if (execution.model == ExecutionModelVertex ||
-	    execution.model == ExecutionModelFragment ||
-	    execution.model == ExecutionModelGLCompute ||
-	    execution.model == ExecutionModelMeshEXT ||
-	    execution.model == ExecutionModelTaskEXT)
+	if (execution.model == ExecutionModelVertex || execution.model == ExecutionModelFragment ||
+	    execution.model == ExecutionModelGLCompute || execution.model == ExecutionModelMeshEXT ||
+	    execution.model == ExecutionModelGeometry || execution.model == ExecutionModelTaskEXT)
 	{
 		// For mesh shaders, we receive special arguments that we must pass down as function arguments.
 		// HLSL does not support proper reference types for passing these IO blocks,
@@ -3378,8 +3569,16 @@ void CompilerHLSL::emit_hlsl_entry_point()
 		SmallVector<string> arglist;
 		auto &func = get<SPIRFunction>(ir.default_entry_point);
 		// The arguments are marked out, avoid detecting reads and emitting inout.
+
 		for (auto &arg : func.arguments)
 			arglist.push_back(to_expression(arg.id, false));
+
+		if (execution.model == ExecutionModelGeometry)
+		{
+			arglist.push_back("stage_input");
+			arglist.push_back(geometry_stream);
+		}
+
 		statement(get_inner_entry_point_name(), "(", merge(arglist), ");");
 	}
 	else
@@ -3391,80 +3590,83 @@ void CompilerHLSL::emit_hlsl_entry_point()
 		statement("SPIRV_Cross_Output stage_output;");
 
 		// Copy builtins from globals to return struct.
-		active_output_builtins.for_each_bit([&](uint32_t i) {
-			// PointSize doesn't exist in HLSL SM 4+.
-			if (i == BuiltInPointSize && !legacy)
-				return;
+		active_output_builtins.for_each_bit(
+		    [&](uint32_t i)
+		    {
+			    // PointSize doesn't exist in HLSL SM 4+.
+			    if (i == BuiltInPointSize && !legacy)
+				    return;
 
-			switch (static_cast<BuiltIn>(i))
-			{
-			case BuiltInClipDistance:
-				for (uint32_t clip = 0; clip < clip_distance_count; clip++)
-					statement("stage_output.gl_ClipDistance", clip / 4, ".", "xyzw"[clip & 3], " = gl_ClipDistance[",
-					          clip, "];");
-				break;
+			    switch (static_cast<BuiltIn>(i))
+			    {
+			    case BuiltInClipDistance:
+				    for (uint32_t clip = 0; clip < clip_distance_count; clip++)
+					    statement("stage_output.gl_ClipDistance", clip / 4, ".", "xyzw"[clip & 3],
+					              " = gl_ClipDistance[", clip, "];");
+				    break;
 
-			case BuiltInCullDistance:
-				for (uint32_t cull = 0; cull < cull_distance_count; cull++)
-					statement("stage_output.gl_CullDistance", cull / 4, ".", "xyzw"[cull & 3], " = gl_CullDistance[",
-					          cull, "];");
-				break;
+			    case BuiltInCullDistance:
+				    for (uint32_t cull = 0; cull < cull_distance_count; cull++)
+					    statement("stage_output.gl_CullDistance", cull / 4, ".", "xyzw"[cull & 3],
+					              " = gl_CullDistance[", cull, "];");
+				    break;
 
-			case BuiltInSampleMask:
-				statement("stage_output.gl_SampleMask = gl_SampleMask[0];");
-				break;
+			    case BuiltInSampleMask:
+				    statement("stage_output.gl_SampleMask = gl_SampleMask[0];");
+				    break;
 
-			default:
-			{
-				auto builtin_expr = builtin_to_glsl(static_cast<BuiltIn>(i), StorageClassOutput);
-				statement("stage_output.", builtin_expr, " = ", builtin_expr, ";");
-				break;
-			}
-			}
-		});
+			    default:
+			    {
+				    auto builtin_expr = builtin_to_glsl(static_cast<BuiltIn>(i), StorageClassOutput);
+				    statement("stage_output.", builtin_expr, " = ", builtin_expr, ";");
+				    break;
+			    }
+			    }
+		    });
 
-		ir.for_each_typed_id<SPIRVariable>([&](uint32_t, SPIRVariable &var) {
-			auto &type = this->get<SPIRType>(var.basetype);
-			bool block = has_decoration(type.self, DecorationBlock);
+		ir.for_each_typed_id<SPIRVariable>(
+		    [&](uint32_t, SPIRVariable &var)
+		    {
+			    auto &type = this->get<SPIRType>(var.basetype);
+			    bool block = has_decoration(type.self, DecorationBlock);
 
-			if (var.storage != StorageClassOutput)
-				return;
+			    if (var.storage != StorageClassOutput)
+				    return;
 
-			if (!var.remapped_variable && type.pointer &&
-			    !is_builtin_variable(var) &&
-			    interface_variable_exists_in_entry_point(var.self))
-			{
-				if (block)
-				{
-					// I/O blocks need to flatten output.
-					auto type_name = to_name(type.self);
-					auto var_name = to_name(var.self);
-					for (uint32_t mbr_idx = 0; mbr_idx < uint32_t(type.member_types.size()); mbr_idx++)
-					{
-						auto mbr_name = to_member_name(type, mbr_idx);
-						auto flat_name = join(type_name, "_", mbr_name);
-						statement("stage_output.", flat_name, " = ", var_name, ".", mbr_name, ";");
-					}
-				}
-				else
-				{
-					auto name = to_name(var.self);
+			    if (!var.remapped_variable && type.pointer && !is_builtin_variable(var) &&
+			        interface_variable_exists_in_entry_point(var.self))
+			    {
+				    if (block)
+				    {
+					    // I/O blocks need to flatten output.
+					    auto type_name = to_name(type.self);
+					    auto var_name = to_name(var.self);
+					    for (uint32_t mbr_idx = 0; mbr_idx < uint32_t(type.member_types.size()); mbr_idx++)
+					    {
+						    auto mbr_name = to_member_name(type, mbr_idx);
+						    auto flat_name = join(type_name, "_", mbr_name);
+						    statement("stage_output.", flat_name, " = ", var_name, ".", mbr_name, ";");
+					    }
+				    }
+				    else
+				    {
+					    auto name = to_name(var.self);
 
-					if (legacy && execution.model == ExecutionModelFragment)
-					{
-						string output_filler;
-						for (uint32_t size = type.vecsize; size < 4; ++size)
-							output_filler += ", 0.0";
+					    if (legacy && execution.model == ExecutionModelFragment)
+					    {
+						    string output_filler;
+						    for (uint32_t size = type.vecsize; size < 4; ++size)
+							    output_filler += ", 0.0";
 
-						statement("stage_output.", name, " = float4(", name, output_filler, ");");
-					}
-					else
-					{
-						statement("stage_output.", name, " = ", name, ";");
-					}
-				}
-			}
-		});
+						    statement("stage_output.", name, " = float4(", name, output_filler, ");");
+					    }
+					    else
+					    {
+						    statement("stage_output.", name, " = ", name, ";");
+					    }
+				    }
+			    }
+		    });
 
 		statement("return stage_output;");
 	}
@@ -6592,6 +6794,16 @@ void CompilerHLSL::emit_instruction(const Instruction &instruction)
 	case OpSetMeshOutputsEXT:
 	{
 		statement("SetMeshOutputCounts(", to_unpacked_expression(ops[0]), ", ", to_unpacked_expression(ops[1]), ");");
+		break;
+	}
+	case OpEmitVertex:
+	{
+		emit_geometry_stream_append();
+		break;
+	}
+	case OpEndPrimitive:
+	{
+		statement(geometry_stream, ".RestartStrip();");
 		break;
 	}
 	default:

--- a/spirv_hlsl.hpp
+++ b/spirv_hlsl.hpp
@@ -286,6 +286,7 @@ private:
 	                        uint32_t base_offset = 0) override;
 	void emit_rayquery_function(const char *commited, const char *candidate, const uint32_t *ops);
 	void emit_mesh_tasks(SPIRBlock &block) override;
+	void emit_geometry_stream_append();
 
 	const char *to_storage_qualifiers_glsl(const SPIRVariable &var) override;
 	void replace_illegal_names() override;
@@ -295,6 +296,7 @@ private:
 	bool is_hlsl_force_storage_buffer_as_uav(ID id) const;
 
 	Options hlsl_options;
+	std::string geometry_stream = "triStream";
 
 	// TODO: Refactor this to be more similar to MSL, maybe have some common system in place?
 	bool requires_op_fmod = false;


### PR DESCRIPTION
Geometry shaders can now be outputted to HLSL.

This allows apps that ship with precompiled SPIRV shaders to target Direct3D environments even if they use geometry shaders.
