### PR TITLE
MSL: Don't emit const for BDA pointers.

### DIFF
--- a/reference/shaders-msl-no-opt/comp/bda-nonwritable-glslang-workaround.comp
+++ b/reference/shaders-msl-no-opt/comp/bda-nonwritable-glslang-workaround.comp
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct SSBO;
+
+struct Registers
+{
+    uint2 bda;
+};
+
+struct SSBO
+{
+    float data[1];
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(256u, 1u, 1u);
+
+kernel void main0(constant Registers& _10 [[buffer(0)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+{
+    (reinterpret_cast<device SSBO*>(as_type<ulong>(_10.bda)))->data[gl_GlobalInvocationID.x] = 0.0;
+}
+

--- a/reference/shaders-msl/vert/buffer_device_address.msl2.vert
+++ b/reference/shaders-msl/vert/buffer_device_address.msl2.vert
@@ -42,7 +42,7 @@ vertex main0_out main0(constant Registers& registers [[buffer(0)]], uint gl_Inst
 {
     main0_out out = {};
     int slice = int(gl_InstanceIndex);
-    const device Position* __restrict positions = registers.references->buffers[slice];
+    device Position* __restrict positions = registers.references->buffers[slice];
     float2 pos = positions->positions[int(gl_VertexIndex)] * 2.5;
     pos += ((float2(float(spvSMod(slice, 8)), float(slice / 8)) - float2(3.5)) * 3.0);
     out.gl_Position = registers.view_projection * float4(pos, 0.0, 1.0);

--- a/shaders-msl-no-opt/comp/bda-nonwritable-glslang-workaround.comp
+++ b/shaders-msl-no-opt/comp/bda-nonwritable-glslang-workaround.comp
@@ -1,0 +1,22 @@
+#version 460
+#extension GL_EXT_buffer_reference_uvec2 : require
+
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+
+layout(push_constant) uniform Registers
+{
+	uvec2 bda;
+};
+
+// glslang emits NonWritable on the member, but forgets to actually validate that,
+// meaning we cannot trust NonWritable on BDA.
+layout(buffer_reference) readonly buffer SSBO
+{
+	float data[];
+};
+
+void main()
+{
+	SSBO(bda).data[gl_GlobalInvocationID.x] = 0.0;
+}


### PR DESCRIPTION
glslang has a bug here and emitting const pointers isn't super useful, since it's mostly just a programmer aid in C++, it doesn't have same semantic meaning as NonWritable in SPIR-V.

Closes #2476.