### PR TITLE
glsl: Implement `SPV_EXT_replicated_composites`

### DIFF
--- a/reference/opt/shaders-hlsl/asm/comp/replicated-composites.spv16.vk.asm.comp
+++ b/reference/opt/shaders-hlsl/asm/comp/replicated-composites.spv16.vk.asm.comp
@@ -1,0 +1,30 @@
+#ifndef SPIRV_CROSS_CONSTANT_ID_0
+#define SPIRV_CROSS_CONSTANT_ID_0 0.0f
+#endif
+static const float spec_const = SPIRV_CROSS_CONSTANT_ID_0;
+static const float4 _20 = float4(spec_const);
+static float _42;
+
+static const float _26[8] = { 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f };
+
+cbuffer UBO : register(b0)
+{
+    float ubo_uniform_float : packoffset(c0);
+};
+
+
+void comp_main()
+{
+    float4 a = float4(0.0f);
+    float4x4 b = float4x4(float4(1.0f), float4(1.0f), float4(1.0f), float4(1.0f));
+    float4 c = _20;
+    float4 _36 = float4(ubo_uniform_float);
+    float4 d = _36;
+    float4x4 e = float4x4(_36, _36, _36, _36);
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    comp_main();
+}

--- a/reference/opt/shaders-msl/asm/comp/replicated-composites.spv16.asm.comp
+++ b/reference/opt/shaders-msl/asm/comp/replicated-composites.spv16.asm.comp
@@ -1,0 +1,69 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wmissing-braces"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+template<typename T, size_t Num>
+struct spvUnsafeArray
+{
+    T elements[Num ? Num : 1];
+    
+    thread T& operator [] (size_t pos) thread
+    {
+        return elements[pos];
+    }
+    constexpr const thread T& operator [] (size_t pos) const thread
+    {
+        return elements[pos];
+    }
+    
+    device T& operator [] (size_t pos) device
+    {
+        return elements[pos];
+    }
+    constexpr const device T& operator [] (size_t pos) const device
+    {
+        return elements[pos];
+    }
+    
+    constexpr const constant T& operator [] (size_t pos) const constant
+    {
+        return elements[pos];
+    }
+    
+    threadgroup T& operator [] (size_t pos) threadgroup
+    {
+        return elements[pos];
+    }
+    constexpr const threadgroup T& operator [] (size_t pos) const threadgroup
+    {
+        return elements[pos];
+    }
+};
+
+constant float spec_const_tmp [[function_constant(0)]];
+constant float spec_const = is_function_constant_defined(spec_const_tmp) ? spec_const_tmp : 0.0;
+constant float4 _20 = float4(spec_const);
+
+struct UBO
+{
+    float uniform_float;
+};
+
+constant float _42 = {};
+
+constant spvUnsafeArray<float, 8> _26 = spvUnsafeArray<float, 8>({ 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 });
+
+kernel void main0(constant UBO& ubo [[buffer(0)]])
+{
+    float4 a = float4(0.0);
+    float4x4 b = float4x4(float4(1.0), float4(1.0), float4(1.0), float4(1.0));
+    float4 c = _20;
+    float4 _36 = float4(ubo.uniform_float);
+    float4 d = _36;
+    float4x4 e = float4x4(_36, _36, _36, _36);
+}
+

--- a/reference/opt/shaders/vulkan/comp/replicated-composites.nocompat.spv16.asm.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/replicated-composites.nocompat.spv16.asm.vk.comp.vk
@@ -1,0 +1,35 @@
+#version 450
+#if defined(GL_AMD_gpu_shader_half_float)
+#extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_EXT_shader_explicit_arithmetic_types_float16)
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#else
+#error No extension available for FP16.
+#endif
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_KHR_cooperative_matrix : require
+#extension GL_KHR_memory_scope_semantics : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const float spec_const = 0.0;
+const vec4 _29 = vec4(spec_const);
+float _55;
+
+layout(set = 0, binding = 0, std140) uniform UBO
+{
+    float uniform_float;
+} ubo;
+
+void main()
+{
+    vec4 a = vec4(0.0);
+    mat4 b = mat4(vec4(1.0), vec4(1.0), vec4(1.0), vec4(1.0));
+    coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(float16_t(0.0));
+    vec4 c = _29;
+    vec4 _44 = vec4(ubo.uniform_float);
+    vec4 d = _44;
+    mat4 e = mat4(_44, _44, _44, _44);
+    float16_t _51 = float16_t(ubo.uniform_float);
+    coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix2 = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(_51);
+}
+

--- a/reference/opt/shaders/vulkan/comp/replicated-composites.spv16.vk.nocompat.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/replicated-composites.spv16.vk.nocompat.comp.vk
@@ -1,0 +1,35 @@
+#version 450
+#if defined(GL_AMD_gpu_shader_half_float)
+#extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_EXT_shader_explicit_arithmetic_types_float16)
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#else
+#error No extension available for FP16.
+#endif
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_KHR_cooperative_matrix : require
+#extension GL_KHR_memory_scope_semantics : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const float spec_const = 0.0;
+const vec4 _29 = vec4(spec_const);
+float _53;
+
+layout(set = 0, binding = 0, std140) uniform UBO
+{
+    float uniform_float;
+} ubo;
+
+void main()
+{
+    vec4 a = vec4(0.0);
+    mat4 b = mat4(vec4(1.0), vec4(1.0), vec4(1.0), vec4(1.0));
+    coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(float16_t(0.0));
+    vec4 c = _29;
+    vec4 _44 = vec4(ubo.uniform_float);
+    vec4 d = _44;
+    mat4 e = mat4(_44, _44, _44, _44);
+    float16_t _51 = float16_t(ubo.uniform_float);
+    coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix2 = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(_51);
+}
+

--- a/reference/shaders-hlsl/asm/comp/replicated-composites.spv16.vk.asm.comp
+++ b/reference/shaders-hlsl/asm/comp/replicated-composites.spv16.vk.asm.comp
@@ -1,0 +1,29 @@
+#ifndef SPIRV_CROSS_CONSTANT_ID_0
+#define SPIRV_CROSS_CONSTANT_ID_0 0.0f
+#endif
+static const float spec_const = SPIRV_CROSS_CONSTANT_ID_0;
+static const float4 _20 = float4(spec_const);
+
+static const float _26[8] = { 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f };
+
+cbuffer UBO : register(b0)
+{
+    float ubo_uniform_float : packoffset(c0);
+};
+
+
+void comp_main()
+{
+    float4 a = float4(0.0f);
+    float4x4 b = float4x4(float4(1.0f), float4(1.0f), float4(1.0f), float4(1.0f));
+    float4 c = _20;
+    float4 d = float4(ubo_uniform_float);
+    float4x4 e = float4x4(d, d, d, d);
+    float f[8] = {ubo_uniform_float, ubo_uniform_float, ubo_uniform_float, ubo_uniform_float, ubo_uniform_float, ubo_uniform_float, ubo_uniform_float, ubo_uniform_float};
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    comp_main();
+}

--- a/reference/shaders-msl/asm/comp/replicated-composites.spv16.asm.comp
+++ b/reference/shaders-msl/asm/comp/replicated-composites.spv16.asm.comp
@@ -1,0 +1,67 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wmissing-braces"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+template<typename T, size_t Num>
+struct spvUnsafeArray
+{
+    T elements[Num ? Num : 1];
+    
+    thread T& operator [] (size_t pos) thread
+    {
+        return elements[pos];
+    }
+    constexpr const thread T& operator [] (size_t pos) const thread
+    {
+        return elements[pos];
+    }
+    
+    device T& operator [] (size_t pos) device
+    {
+        return elements[pos];
+    }
+    constexpr const device T& operator [] (size_t pos) const device
+    {
+        return elements[pos];
+    }
+    
+    constexpr const constant T& operator [] (size_t pos) const constant
+    {
+        return elements[pos];
+    }
+    
+    threadgroup T& operator [] (size_t pos) threadgroup
+    {
+        return elements[pos];
+    }
+    constexpr const threadgroup T& operator [] (size_t pos) const threadgroup
+    {
+        return elements[pos];
+    }
+};
+
+constant float spec_const_tmp [[function_constant(0)]];
+constant float spec_const = is_function_constant_defined(spec_const_tmp) ? spec_const_tmp : 0.0;
+constant float4 _20 = float4(spec_const);
+
+struct UBO
+{
+    float uniform_float;
+};
+
+constant spvUnsafeArray<float, 8> _26 = spvUnsafeArray<float, 8>({ 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 });
+
+kernel void main0(constant UBO& ubo [[buffer(0)]])
+{
+    float4 a = float4(0.0);
+    float4x4 b = float4x4(float4(1.0), float4(1.0), float4(1.0), float4(1.0));
+    float4 c = _20;
+    float4 d = float4(ubo.uniform_float);
+    float4x4 e = float4x4(d, d, d, d);
+    spvUnsafeArray<float, 8> f = {ubo.uniform_float, ubo.uniform_float, ubo.uniform_float, ubo.uniform_float, ubo.uniform_float, ubo.uniform_float, ubo.uniform_float, ubo.uniform_float};
+}
+

--- a/reference/shaders/vulkan/comp/replicated-composites.nocompat.spv16.asm.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/replicated-composites.nocompat.spv16.asm.vk.comp.vk
@@ -1,0 +1,35 @@
+#version 450
+#if defined(GL_AMD_gpu_shader_half_float)
+#extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_EXT_shader_explicit_arithmetic_types_float16)
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#else
+#error No extension available for FP16.
+#endif
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_KHR_cooperative_matrix : require
+#extension GL_KHR_memory_scope_semantics : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const float spec_const = 0.0;
+const vec4 _29 = vec4(spec_const);
+const float _34[8] = float[](1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0);
+
+layout(set = 0, binding = 0, std140) uniform UBO
+{
+    float uniform_float;
+} ubo;
+
+void main()
+{
+    vec4 a = vec4(0.0);
+    mat4 b = mat4(vec4(1.0), vec4(1.0), vec4(1.0), vec4(1.0));
+    coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(float16_t(0.0));
+    vec4 c = _29;
+    vec4 d = vec4(ubo.uniform_float);
+    mat4 e = mat4(d, d, d, d);
+    float16_t _51 = float16_t(ubo.uniform_float);
+    coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix2 = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(_51);
+    float _54[8] = float[](ubo.uniform_float, ubo.uniform_float, ubo.uniform_float, ubo.uniform_float, ubo.uniform_float, ubo.uniform_float, ubo.uniform_float, ubo.uniform_float);
+}
+

--- a/reference/shaders/vulkan/comp/replicated-composites.spv16.vk.nocompat.comp.vk
+++ b/reference/shaders/vulkan/comp/replicated-composites.spv16.vk.nocompat.comp.vk
@@ -1,0 +1,34 @@
+#version 450
+#if defined(GL_AMD_gpu_shader_half_float)
+#extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_EXT_shader_explicit_arithmetic_types_float16)
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#else
+#error No extension available for FP16.
+#endif
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_KHR_cooperative_matrix : require
+#extension GL_KHR_memory_scope_semantics : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const float spec_const = 0.0;
+const vec4 _29 = vec4(spec_const);
+const float _34[8] = float[](1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0);
+
+layout(set = 0, binding = 0, std140) uniform UBO
+{
+    float uniform_float;
+} ubo;
+
+void main()
+{
+    vec4 a = vec4(0.0);
+    mat4 b = mat4(vec4(1.0), vec4(1.0), vec4(1.0), vec4(1.0));
+    coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(float16_t(0.0));
+    vec4 c = _29;
+    vec4 d = vec4(ubo.uniform_float);
+    mat4 e = mat4(d, d, d, d);
+    float16_t _51 = float16_t(ubo.uniform_float);
+    coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix2 = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(_51);
+}
+

--- a/shaders-hlsl/asm/comp/replicated-composites.spv16.vk.asm.comp
+++ b/shaders-hlsl/asm/comp/replicated-composites.spv16.vk.asm.comp
@@ -1,0 +1,81 @@
+; SPIR-V
+; Version: 1.6
+; Generator: Khronos Glslang Reference Front End; 11
+; Bound: 41
+; Schema: 0
+               OpCapability Shader
+               OpCapability ReplicatedCompositesEXT
+               OpExtension "SPV_EXT_replicated_composites"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %ubo
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_shader_explicit_arithmetic_types_float16"
+               OpSourceExtension "GL_KHR_memory_scope_semantics"
+               OpName %main "main"
+               OpName %a "a"
+               OpName %b "b"
+               OpName %c "c"
+               OpName %spec_const "spec_const"
+               OpName %array "array"
+               OpName %d "d"
+               OpName %UBO "UBO"
+               OpMemberName %UBO 0 "uniform_float"
+               OpName %ubo "ubo"
+               OpName %e "e"
+               OpName %f "f"
+               OpDecorate %spec_const SpecId 0
+               OpDecorate %UBO Block
+               OpMemberDecorate %UBO 0 Offset 0
+               OpDecorate %ubo Binding 0
+               OpDecorate %ubo DescriptorSet 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+    %float_0 = OpConstant %float 0
+         %11 = OpConstantCompositeReplicateEXT %v4float %float_0
+%mat4v4float = OpTypeMatrix %v4float 4
+%_ptr_Function_mat4v4float = OpTypePointer Function %mat4v4float
+    %float_1 = OpConstant %float 1
+         %16 = OpConstantCompositeReplicateEXT %v4float %float_1
+         %17 = OpConstantCompositeReplicateEXT %mat4v4float %16
+ %spec_const = OpSpecConstant %float 0
+         %20 = OpSpecConstantCompositeReplicateEXT %v4float %spec_const
+       %uint = OpTypeInt 32 0
+     %uint_8 = OpConstant %uint 8
+%_arr_float_uint_8 = OpTypeArray %float %uint_8
+%_ptr_Function__arr_float_uint_8 = OpTypePointer Function %_arr_float_uint_8
+         %26 = OpConstantCompositeReplicateEXT %_arr_float_uint_8 %float_1
+        %UBO = OpTypeStruct %float
+%_ptr_Uniform_UBO = OpTypePointer Uniform %UBO
+        %ubo = OpVariable %_ptr_Uniform_UBO Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %a = OpVariable %_ptr_Function_v4float Function
+          %b = OpVariable %_ptr_Function_mat4v4float Function
+          %c = OpVariable %_ptr_Function_v4float Function
+      %array = OpVariable %_ptr_Function__arr_float_uint_8 Function
+          %d = OpVariable %_ptr_Function_v4float Function
+          %e = OpVariable %_ptr_Function_mat4v4float Function
+          %f = OpVariable %_ptr_Function__arr_float_uint_8 Function
+               OpStore %a %11
+               OpStore %b %17
+               OpStore %c %20
+               OpStore %array %26
+         %34 = OpAccessChain %_ptr_Uniform_float %ubo %int_0
+         %35 = OpLoad %float %34
+         %36 = OpCompositeConstructReplicateEXT %v4float %35
+               OpStore %d %36
+         %38 = OpLoad %v4float %d
+         %39 = OpCompositeConstructReplicateEXT %mat4v4float %38
+               OpStore %e %39
+         %40 = OpCompositeConstructReplicateEXT %_arr_float_uint_8 %35
+               OpStore %f %40
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl/asm/comp/replicated-composites.spv16.asm.comp
+++ b/shaders-msl/asm/comp/replicated-composites.spv16.asm.comp
@@ -1,0 +1,81 @@
+; SPIR-V
+; Version: 1.6
+; Generator: Khronos Glslang Reference Front End; 11
+; Bound: 41
+; Schema: 0
+               OpCapability Shader
+               OpCapability ReplicatedCompositesEXT
+               OpExtension "SPV_EXT_replicated_composites"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %ubo
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_shader_explicit_arithmetic_types_float16"
+               OpSourceExtension "GL_KHR_memory_scope_semantics"
+               OpName %main "main"
+               OpName %a "a"
+               OpName %b "b"
+               OpName %c "c"
+               OpName %spec_const "spec_const"
+               OpName %array "array"
+               OpName %d "d"
+               OpName %UBO "UBO"
+               OpMemberName %UBO 0 "uniform_float"
+               OpName %ubo "ubo"
+               OpName %e "e"
+               OpName %f "f"
+               OpDecorate %spec_const SpecId 0
+               OpDecorate %UBO Block
+               OpMemberDecorate %UBO 0 Offset 0
+               OpDecorate %ubo Binding 0
+               OpDecorate %ubo DescriptorSet 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+    %float_0 = OpConstant %float 0
+         %11 = OpConstantCompositeReplicateEXT %v4float %float_0
+%mat4v4float = OpTypeMatrix %v4float 4
+%_ptr_Function_mat4v4float = OpTypePointer Function %mat4v4float
+    %float_1 = OpConstant %float 1
+         %16 = OpConstantCompositeReplicateEXT %v4float %float_1
+         %17 = OpConstantCompositeReplicateEXT %mat4v4float %16
+ %spec_const = OpSpecConstant %float 0
+         %20 = OpSpecConstantCompositeReplicateEXT %v4float %spec_const
+       %uint = OpTypeInt 32 0
+     %uint_8 = OpConstant %uint 8
+%_arr_float_uint_8 = OpTypeArray %float %uint_8
+%_ptr_Function__arr_float_uint_8 = OpTypePointer Function %_arr_float_uint_8
+         %26 = OpConstantCompositeReplicateEXT %_arr_float_uint_8 %float_1
+        %UBO = OpTypeStruct %float
+%_ptr_Uniform_UBO = OpTypePointer Uniform %UBO
+        %ubo = OpVariable %_ptr_Uniform_UBO Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %a = OpVariable %_ptr_Function_v4float Function
+          %b = OpVariable %_ptr_Function_mat4v4float Function
+          %c = OpVariable %_ptr_Function_v4float Function
+      %array = OpVariable %_ptr_Function__arr_float_uint_8 Function
+          %d = OpVariable %_ptr_Function_v4float Function
+          %e = OpVariable %_ptr_Function_mat4v4float Function
+          %f = OpVariable %_ptr_Function__arr_float_uint_8 Function
+               OpStore %a %11
+               OpStore %b %17
+               OpStore %c %20
+               OpStore %array %26
+         %34 = OpAccessChain %_ptr_Uniform_float %ubo %int_0
+         %35 = OpLoad %float %34
+         %36 = OpCompositeConstructReplicateEXT %v4float %35
+               OpStore %d %36
+         %38 = OpLoad %v4float %d
+         %39 = OpCompositeConstructReplicateEXT %mat4v4float %38
+               OpStore %e %39
+         %40 = OpCompositeConstructReplicateEXT %_arr_float_uint_8 %35
+               OpStore %f %40
+               OpReturn
+               OpFunctionEnd

--- a/shaders/vulkan/comp/replicated-composites.nocompat.spv16.asm.vk.comp
+++ b/shaders/vulkan/comp/replicated-composites.nocompat.spv16.asm.vk.comp
@@ -1,0 +1,102 @@
+; SPIR-V
+; Version: 1.6
+; Generator: Khronos Glslang Reference Front End; 11
+; Bound: 53
+; Schema: 0
+               OpCapability Shader
+               OpCapability Float16
+               OpCapability VulkanMemoryModel
+               OpCapability CooperativeMatrixKHR
+               OpCapability ReplicatedCompositesEXT
+               OpExtension "SPV_EXT_replicated_composites"
+               OpExtension "SPV_KHR_cooperative_matrix"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical Vulkan
+               OpEntryPoint GLCompute %main "main" %ubo
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_shader_explicit_arithmetic_types_float16"
+               OpSourceExtension "GL_KHR_cooperative_matrix"
+               OpSourceExtension "GL_KHR_memory_scope_semantics"
+               OpName %main "main"
+               OpName %a "a"
+               OpName %b "b"
+               OpName %matrix "matrix"
+               OpName %c "c"
+               OpName %spec_const "spec_const"
+               OpName %array "array"
+               OpName %d "d"
+               OpName %UBO "UBO"
+               OpMemberName %UBO 0 "uniform_float"
+               OpName %ubo "ubo"
+               OpName %e "e"
+               OpName %matrix2 "matrix2"
+               OpDecorate %spec_const SpecId 0
+               OpDecorate %UBO Block
+               OpMemberDecorate %UBO 0 Offset 0
+               OpDecorate %ubo Binding 0
+               OpDecorate %ubo DescriptorSet 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+    %float_0 = OpConstant %float 0
+         %11 = OpConstantCompositeReplicateEXT %v4float %float_0
+%mat4v4float = OpTypeMatrix %v4float 4
+%_ptr_Function_mat4v4float = OpTypePointer Function %mat4v4float
+    %float_1 = OpConstant %float 1
+         %16 = OpConstantCompositeReplicateEXT %v4float %float_1
+         %17 = OpConstantCompositeReplicateEXT %mat4v4float %16
+       %half = OpTypeFloat 16
+       %uint = OpTypeInt 32 0
+     %uint_2 = OpConstant %uint 2
+    %uint_16 = OpConstant %uint 16
+         %22 = OpTypeCooperativeMatrixKHR %half %uint_2 %uint_16 %uint_16 %uint_2
+%_ptr_Function_22 = OpTypePointer Function %22
+%half_0x0p_0 = OpConstant %half 0x0p+0
+         %26 = OpConstantCompositeReplicateEXT %22 %half_0x0p_0
+ %spec_const = OpSpecConstant %float 0
+         %29 = OpSpecConstantCompositeReplicateEXT %v4float %spec_const
+     %uint_8 = OpConstant %uint 8
+%_arr_float_uint_8 = OpTypeArray %float %uint_8
+%_ptr_Function__arr_float_uint_8 = OpTypePointer Function %_arr_float_uint_8
+         %34 = OpConstantCompositeReplicateEXT %_arr_float_uint_8 %float_1
+        %UBO = OpTypeStruct %float
+%_ptr_Uniform_UBO = OpTypePointer Uniform %UBO
+        %ubo = OpVariable %_ptr_Uniform_UBO Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %a = OpVariable %_ptr_Function_v4float Function
+          %b = OpVariable %_ptr_Function_mat4v4float Function
+     %matrix = OpVariable %_ptr_Function_22 Function
+          %c = OpVariable %_ptr_Function_v4float Function
+      %array = OpVariable %_ptr_Function__arr_float_uint_8 Function
+          %d = OpVariable %_ptr_Function_v4float Function
+          %e = OpVariable %_ptr_Function_mat4v4float Function
+    %matrix2 = OpVariable %_ptr_Function_22 Function
+          %f = OpVariable %_ptr_Function__arr_float_uint_8 Function
+               OpStore %a %11
+               OpStore %b %17
+               OpStore %matrix %26
+               OpStore %c %29
+               OpStore %array %34
+         %42 = OpAccessChain %_ptr_Uniform_float %ubo %int_0
+         %43 = OpLoad %float %42
+         %44 = OpCompositeConstructReplicateEXT %v4float %43
+               OpStore %d %44
+         %46 = OpLoad %v4float %d
+         %47 = OpCompositeConstructReplicateEXT %mat4v4float %46
+               OpStore %e %47
+         %49 = OpAccessChain %_ptr_Uniform_float %ubo %int_0
+         %50 = OpLoad %float %49
+         %51 = OpFConvert %half %50
+         %52 = OpCompositeConstructReplicateEXT %22 %51
+               OpStore %matrix2 %52
+         %53 = OpCompositeConstructReplicateEXT %_arr_float_uint_8 %43
+               OpStore %f %53
+               OpReturn
+               OpFunctionEnd

--- a/shaders/vulkan/comp/replicated-composites.spv16.vk.nocompat.comp
+++ b/shaders/vulkan/comp/replicated-composites.spv16.vk.nocompat.comp
@@ -1,0 +1,28 @@
+#version 450
+#pragma use_replicated_composites
+
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+
+#extension GL_KHR_memory_scope_semantics : enable
+#extension GL_KHR_cooperative_matrix : enable
+//#extension GL_NV_cooperative_vector : enable
+layout (constant_id = 0) const float spec_const = 0;
+
+layout (set = 0, binding = 0) uniform UBO {
+    float uniform_float;
+} ubo;
+
+void main() {
+    // constants
+    vec4 a = vec4(0.0);
+    mat4 b = mat4(vec4(1.0), vec4(1.0), vec4(1.0), vec4(1.0));
+    coopmat<float16_t, gl_ScopeWorkgroup, 16, 16, gl_MatrixUseAccumulator> matrix = coopmat<float16_t, gl_ScopeWorkgroup, 16, 16, gl_MatrixUseAccumulator>(0);
+    //coopvecNV<float16_t, 16> vec = coopvecNV<float16_t, 16>(0);
+    vec4 c = vec4(spec_const);
+    float array[] = float[](1.0, 1.0, 1.0, 1.0, 1.0, 1.0f, 1.0, 1.0f);
+
+    // runtime variables
+    vec4 d = vec4(ubo.uniform_float);
+    mat4 e = mat4(d, d, d, d);
+    coopmat<float16_t, gl_ScopeWorkgroup, 16, 16, gl_MatrixUseAccumulator> matrix2 = coopmat<float16_t, gl_ScopeWorkgroup, 16, 16, gl_MatrixUseAccumulator>(ubo.uniform_float);
+}

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -1356,9 +1356,10 @@ struct SPIRConstant : IVariant
 
 	SPIRConstant() = default;
 
-	SPIRConstant(TypeID constant_type_, const uint32_t *elements, uint32_t num_elements, bool specialized)
+	SPIRConstant(TypeID constant_type_, const uint32_t *elements, uint32_t num_elements, bool specialized, bool replicated_ = false)
 	    : constant_type(constant_type_)
 	    , specialization(specialized)
+	    , replicated(replicated_)
 	{
 		subconstants.reserve(num_elements);
 		for (uint32_t i = 0; i < num_elements; i++)
@@ -1436,6 +1437,9 @@ struct SPIRConstant : IVariant
 
 	// For composites which are constant arrays, etc.
 	SmallVector<ConstantID> subconstants;
+
+	// Whether the subconstants are intended to be replicated (e.g. OpConstantCompositeReplicateEXT)
+	bool replicated = false;
 
 	// Non-Vulkan GLSL, HLSL and sometimes MSL emits defines for each specialization constant,
 	// and uses them to initialize the constant. This allows the user

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -6018,9 +6018,8 @@ string CompilerGLSL::constant_expression(const SPIRConstant &c,
 		size_t num_elements = c.subconstants.size();
 		if (c.replicated)
 		{
-			if (type.array.size() != 1) {
+			if (type.array.size() != 1)
 				SPIRV_CROSS_THROW("Multidimensional arrays not yet supported as replicated constans");
-			}
 			num_elements = type.array[0];
 		}
 		for (size_t i = 0; i < num_elements; i++)
@@ -15653,13 +15652,9 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 				}
 			}
 			if (backend.use_initializer_list && type.op == spv::OpTypeArray)
-			{
 				rhs += "}";
-			}
 			else
-			{
 				rhs += ")";
-			}
 		}
 		else
 		{

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -5954,9 +5954,7 @@ string CompilerGLSL::constant_expression(const SPIRConstant &c,
 			{
 				res += to_expression(c.subconstants[0]);
 				if (i < num_elements - 1)
-				{
 					res += ", ";
-				}
 			}
 			res += ")";
 			return res;
@@ -15647,9 +15645,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 			{
 				rhs += value_to_replicate;
 				if (i < num_elements - 1)
-				{
 					rhs += ", ";
-				}
 			}
 			if (backend.use_initializer_list && type.op == spv::OpTypeArray)
 				rhs += "}";

--- a/spirv_parser.cpp
+++ b/spirv_parser.cpp
@@ -866,17 +866,27 @@ void Parser::parse(const Instruction &instruction)
 		break;
 	}
 
-		// Constants
+	// Constants
 	case OpSpecConstant:
 	case OpConstant:
+	case OpConstantCompositeReplicateEXT:
+	case OpSpecConstantCompositeReplicateEXT:
 	{
 		uint32_t id = ops[1];
 		auto &type = get<SPIRType>(ops[0]);
-
-		if (type.width > 32)
-			set<SPIRConstant>(id, ops[0], ops[2] | (uint64_t(ops[3]) << 32), op == OpSpecConstant);
+		if (op == OpConstantCompositeReplicateEXT || op == OpSpecConstantCompositeReplicateEXT)
+		{
+			auto subconstant = uint32_t(ops[2]);
+			set<SPIRConstant>(id, ops[0], &subconstant, 1, op == OpSpecConstantCompositeReplicateEXT, true);
+		}
 		else
-			set<SPIRConstant>(id, ops[0], ops[2], op == OpSpecConstant);
+		{
+
+			if (type.width > 32)
+				set<SPIRConstant>(id, ops[0], ops[2] | (uint64_t(ops[3]) << 32), op == OpSpecConstant);
+			else
+				set<SPIRConstant>(id, ops[0], ops[2], op == OpSpecConstant);
+		}
 		break;
 	}
 


### PR DESCRIPTION
https://github.khronos.org/SPIRV-Registry/extensions/EXT/SPV_EXT_replicated_composites.html offers a streamlined way to initialize composites like vectors and matrices. Also, from extensions like `SPV_KHR_cooperative_matrix` or `SPV_NV_cooperative_vector`.

For constants, we piggyback on the existing logic for constant composites adding an additional bool to indicate whether our composites consists of multiple subconstants or a single replicated one.

In GLSL, most types support replication using their constructor. A notable exception to that are matrices like `mat4` which support `mat4(0.0)` but not `mat4(vec4(0.0))` how they are represented in SPIRV.

One motivation for this PR is to support construction from scalars for https://github.khronos.org/SPIRV-Registry/extensions/NV/SPV_NV_cooperative_vector.html 