### PR TITLE
Draft: GLSL: implement `SPV_NV_cooperative_vector`

### DIFF
--- a/reference/opt/shaders-msl/asm/comp/replicated-composites.spv16.asm.comp
+++ b/reference/opt/shaders-msl/asm/comp/replicated-composites.spv16.asm.comp
@@ -1,0 +1,69 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wmissing-braces"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+template<typename T, size_t Num>
+struct spvUnsafeArray
+{
+    T elements[Num ? Num : 1];
+    
+    thread T& operator [] (size_t pos) thread
+    {
+        return elements[pos];
+    }
+    constexpr const thread T& operator [] (size_t pos) const thread
+    {
+        return elements[pos];
+    }
+    
+    device T& operator [] (size_t pos) device
+    {
+        return elements[pos];
+    }
+    constexpr const device T& operator [] (size_t pos) const device
+    {
+        return elements[pos];
+    }
+    
+    constexpr const constant T& operator [] (size_t pos) const constant
+    {
+        return elements[pos];
+    }
+    
+    threadgroup T& operator [] (size_t pos) threadgroup
+    {
+        return elements[pos];
+    }
+    constexpr const threadgroup T& operator [] (size_t pos) const threadgroup
+    {
+        return elements[pos];
+    }
+};
+
+constant float spec_const_tmp [[function_constant(0)]];
+constant float spec_const = is_function_constant_defined(spec_const_tmp) ? spec_const_tmp : 0.0;
+constant float4 _20 = float4(spec_const);
+
+struct UBO
+{
+    float uniform_float;
+};
+
+constant float _42 = {};
+
+constant spvUnsafeArray<float, 8> _26 = spvUnsafeArray<float, 8>({ 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 });
+
+kernel void main0(constant UBO& ubo [[buffer(0)]])
+{
+    float4 a = float4(0.0);
+    float4x4 b = float4x4(float4(1.0), float4(1.0), float4(1.0), float4(1.0));
+    float4 c = _20;
+    float4 _36 = float4(ubo.uniform_float);
+    float4 d = _36;
+    float4x4 e = float4x4(_36, _36, _36, _36);
+}
+

--- a/reference/opt/shaders/comp/cooperative-vec-nv.spv16.vk.nocompat.comp.vk
+++ b/reference/opt/shaders/comp/cooperative-vec-nv.spv16.vk.nocompat.comp.vk
@@ -1,0 +1,38 @@
+#version 450
+#if defined(GL_AMD_gpu_shader_half_float)
+#extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_EXT_shader_explicit_arithmetic_types_float16)
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#else
+#error No extension available for FP16.
+#endif
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_NV_cooperative_vector : require
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+
+layout(set = 0, binding = 0, std430) buffer Q
+{
+    float16_t data_q[];
+} _15;
+
+void main()
+{
+    coopvecNV<float16_t, 16u> _20;
+    coopVecLoadNV(_20, _15.data_q, 16u);
+    coopvecNV<float16_t, 16u> tempArg = _20;
+    coopvecNV<float16_t, 16u> inVec = tempArg;
+    coopVecStoreNV(inVec, _15.data_q, 16u);
+    coopvecNV<float16_t, 16u> _33;
+    coopVecMatMulAddNV(_33, inVec, gl_ComponentTypeFloat16NV, _15.data_q, 16u, gl_ComponentTypeFloat16NV, _15.data_q, 16u, gl_ComponentTypeFloat16NV, 16u, 16u, 4, false, 2u);
+    coopvecNV<float16_t, 16u> tempArg_1 = _33;
+    inVec = tempArg_1;
+    coopvecNV<float16_t, 16u> _38;
+    coopVecMatMulNV(_38, inVec, gl_ComponentTypeFloat16NV, _15.data_q, 16u, gl_ComponentTypeFloat16NV, 16u, 16u, 4, false, 2u);
+    coopvecNV<float16_t, 16u> tempArg_2 = _38;
+    inVec = tempArg_2;
+    coopvecNV<float16_t, 8u> a = coopvecNV<float16_t, 8u>(float16_t(0.0));
+    inVec = max(inVec, inVec);
+    coopVecOuterProductAccumulateNV(inVec, inVec, _15.data_q, 0u, 0u, 4, gl_ComponentTypeFloat16NV);
+    coopVecReduceSumAccumulateNV(inVec, _15.data_q, 0u);
+}
+

--- a/reference/opt/shaders/vulkan/comp/replicated-composites.nocompat.spv16.asm.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/replicated-composites.nocompat.spv16.asm.vk.comp.vk
@@ -1,0 +1,35 @@
+#version 450
+#if defined(GL_AMD_gpu_shader_half_float)
+#extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_EXT_shader_explicit_arithmetic_types_float16)
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#else
+#error No extension available for FP16.
+#endif
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_KHR_cooperative_matrix : require
+#extension GL_KHR_memory_scope_semantics : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const float spec_const = 0.0;
+const vec4 _29 = vec4(spec_const);
+float _55;
+
+layout(set = 0, binding = 0, std140) uniform UBO
+{
+    float uniform_float;
+} ubo;
+
+void main()
+{
+    vec4 a = vec4(0.0);
+    mat4 b = mat4(vec4(1.0), vec4(1.0), vec4(1.0), vec4(1.0));
+    coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(float16_t(0.0));
+    vec4 c = _29;
+    vec4 _44 = vec4(ubo.uniform_float);
+    vec4 d = _44;
+    mat4 e = mat4(_44, _44, _44, _44);
+    float16_t _51 = float16_t(ubo.uniform_float);
+    coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix2 = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(_51);
+}
+

--- a/reference/opt/shaders/vulkan/comp/replicated-composites.spv16.vk.nocompat.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/replicated-composites.spv16.vk.nocompat.comp.vk
@@ -1,0 +1,35 @@
+#version 450
+#if defined(GL_AMD_gpu_shader_half_float)
+#extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_EXT_shader_explicit_arithmetic_types_float16)
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#else
+#error No extension available for FP16.
+#endif
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_KHR_cooperative_matrix : require
+#extension GL_KHR_memory_scope_semantics : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const float spec_const = 0.0;
+const vec4 _29 = vec4(spec_const);
+float _53;
+
+layout(set = 0, binding = 0, std140) uniform UBO
+{
+    float uniform_float;
+} ubo;
+
+void main()
+{
+    vec4 a = vec4(0.0);
+    mat4 b = mat4(vec4(1.0), vec4(1.0), vec4(1.0), vec4(1.0));
+    coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(float16_t(0.0));
+    vec4 c = _29;
+    vec4 _44 = vec4(ubo.uniform_float);
+    vec4 d = _44;
+    mat4 e = mat4(_44, _44, _44, _44);
+    float16_t _51 = float16_t(ubo.uniform_float);
+    coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix2 = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(_51);
+}
+

--- a/reference/opt/shaders/vulkan/comp/replicated-composites.spv16.vk.nocompat.comp.vk
+++ b/reference/opt/shaders/vulkan/comp/replicated-composites.spv16.vk.nocompat.comp.vk
@@ -9,11 +9,12 @@
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_KHR_cooperative_matrix : require
 #extension GL_KHR_memory_scope_semantics : require
+#extension GL_NV_cooperative_vector : require
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(constant_id = 0) const float spec_const = 0.0;
-const vec4 _29 = vec4(spec_const);
-float _53;
+const vec4 _33 = vec4(spec_const);
+float _62;
 
 layout(set = 0, binding = 0, std140) uniform UBO
 {
@@ -25,11 +26,13 @@ void main()
     vec4 a = vec4(0.0);
     mat4 b = mat4(vec4(1.0), vec4(1.0), vec4(1.0), vec4(1.0));
     coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(float16_t(0.0));
-    vec4 c = _29;
-    vec4 _44 = vec4(ubo.uniform_float);
-    vec4 d = _44;
-    mat4 e = mat4(_44, _44, _44, _44);
-    float16_t _51 = float16_t(ubo.uniform_float);
-    coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix2 = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(_51);
+    coopvecNV<float16_t, 16u> vec = coopvecNV<float16_t, 16u>(float16_t(0.0));
+    vec4 c = _33;
+    vec4 _48 = vec4(ubo.uniform_float);
+    vec4 d = _48;
+    mat4 e = mat4(_48, _48, _48, _48);
+    float16_t _55 = float16_t(ubo.uniform_float);
+    coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix2 = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(_55);
+    coopvecNV<float16_t, 16u> vec_dynamic = coopvecNV<float16_t, 16u>(_55);
 }
 

--- a/reference/shaders-hlsl/asm/comp/replicated-composites.spv16.vk.asm.comp
+++ b/reference/shaders-hlsl/asm/comp/replicated-composites.spv16.vk.asm.comp
@@ -1,0 +1,29 @@
+#ifndef SPIRV_CROSS_CONSTANT_ID_0
+#define SPIRV_CROSS_CONSTANT_ID_0 0.0f
+#endif
+static const float spec_const = SPIRV_CROSS_CONSTANT_ID_0;
+static const float4 _20 = float4(spec_const);
+
+static const float _26[8] = { 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f };
+
+cbuffer UBO : register(b0)
+{
+    float ubo_uniform_float : packoffset(c0);
+};
+
+
+void comp_main()
+{
+    float4 a = float4(0.0f);
+    float4x4 b = float4x4(float4(1.0f), float4(1.0f), float4(1.0f), float4(1.0f));
+    float4 c = _20;
+    float4 d = float4(ubo_uniform_float);
+    float4x4 e = float4x4(d, d, d, d);
+    float f[8] = {ubo_uniform_float, ubo_uniform_float, ubo_uniform_float, ubo_uniform_float, ubo_uniform_float, ubo_uniform_float, ubo_uniform_float, ubo_uniform_float};
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    comp_main();
+}

--- a/reference/shaders-msl/asm/comp/replicated-composites.spv16.asm.comp
+++ b/reference/shaders-msl/asm/comp/replicated-composites.spv16.asm.comp
@@ -1,0 +1,67 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wmissing-braces"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+template<typename T, size_t Num>
+struct spvUnsafeArray
+{
+    T elements[Num ? Num : 1];
+    
+    thread T& operator [] (size_t pos) thread
+    {
+        return elements[pos];
+    }
+    constexpr const thread T& operator [] (size_t pos) const thread
+    {
+        return elements[pos];
+    }
+    
+    device T& operator [] (size_t pos) device
+    {
+        return elements[pos];
+    }
+    constexpr const device T& operator [] (size_t pos) const device
+    {
+        return elements[pos];
+    }
+    
+    constexpr const constant T& operator [] (size_t pos) const constant
+    {
+        return elements[pos];
+    }
+    
+    threadgroup T& operator [] (size_t pos) threadgroup
+    {
+        return elements[pos];
+    }
+    constexpr const threadgroup T& operator [] (size_t pos) const threadgroup
+    {
+        return elements[pos];
+    }
+};
+
+constant float spec_const_tmp [[function_constant(0)]];
+constant float spec_const = is_function_constant_defined(spec_const_tmp) ? spec_const_tmp : 0.0;
+constant float4 _20 = float4(spec_const);
+
+struct UBO
+{
+    float uniform_float;
+};
+
+constant spvUnsafeArray<float, 8> _26 = spvUnsafeArray<float, 8>({ 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 });
+
+kernel void main0(constant UBO& ubo [[buffer(0)]])
+{
+    float4 a = float4(0.0);
+    float4x4 b = float4x4(float4(1.0), float4(1.0), float4(1.0), float4(1.0));
+    float4 c = _20;
+    float4 d = float4(ubo.uniform_float);
+    float4x4 e = float4x4(d, d, d, d);
+    spvUnsafeArray<float, 8> f = {ubo.uniform_float, ubo.uniform_float, ubo.uniform_float, ubo.uniform_float, ubo.uniform_float, ubo.uniform_float, ubo.uniform_float, ubo.uniform_float};
+}
+

--- a/reference/shaders/comp/cooperative-vec-nv.spv16.vk.nocompat.comp.vk
+++ b/reference/shaders/comp/cooperative-vec-nv.spv16.vk.nocompat.comp.vk
@@ -1,0 +1,38 @@
+#version 450
+#if defined(GL_AMD_gpu_shader_half_float)
+#extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_EXT_shader_explicit_arithmetic_types_float16)
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#else
+#error No extension available for FP16.
+#endif
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_NV_cooperative_vector : require
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+
+layout(set = 0, binding = 0, std430) buffer Q
+{
+    float16_t data_q[];
+} _15;
+
+void main()
+{
+    coopvecNV<float16_t, 16u> _20;
+    coopVecLoadNV(_20, _15.data_q, 16u);
+    coopvecNV<float16_t, 16u> tempArg = _20;
+    coopvecNV<float16_t, 16u> inVec = tempArg;
+    coopVecStoreNV(inVec, _15.data_q, 16u);
+    coopvecNV<float16_t, 16u> _33;
+    coopVecMatMulAddNV(_33, inVec, gl_ComponentTypeFloat16NV, _15.data_q, 16u, gl_ComponentTypeFloat16NV, _15.data_q, 16u, gl_ComponentTypeFloat16NV, 16u, 16u, 4, false, 2u);
+    coopvecNV<float16_t, 16u> tempArg_1 = _33;
+    inVec = tempArg_1;
+    coopvecNV<float16_t, 16u> _38;
+    coopVecMatMulNV(_38, inVec, gl_ComponentTypeFloat16NV, _15.data_q, 16u, gl_ComponentTypeFloat16NV, 16u, 16u, 4, false, 2u);
+    coopvecNV<float16_t, 16u> tempArg_2 = _38;
+    inVec = tempArg_2;
+    coopvecNV<float16_t, 8u> a = coopvecNV<float16_t, 8u>(float16_t(0.0));
+    inVec = max(inVec, inVec);
+    coopVecOuterProductAccumulateNV(inVec, inVec, _15.data_q, 0u, 0u, 4, gl_ComponentTypeFloat16NV);
+    coopVecReduceSumAccumulateNV(inVec, _15.data_q, 0u);
+}
+

--- a/reference/shaders/comp/coopmat2-nv.spv16.vk.nocompat.comp.vk
+++ b/reference/shaders/comp/coopmat2-nv.spv16.vk.nocompat.comp.vk
@@ -1,0 +1,7 @@
+#version 450
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+void main()
+{
+}
+

--- a/reference/shaders/vulkan/comp/replicated-composites.nocompat.spv16.asm.vk.comp.vk
+++ b/reference/shaders/vulkan/comp/replicated-composites.nocompat.spv16.asm.vk.comp.vk
@@ -1,0 +1,35 @@
+#version 450
+#if defined(GL_AMD_gpu_shader_half_float)
+#extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_EXT_shader_explicit_arithmetic_types_float16)
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#else
+#error No extension available for FP16.
+#endif
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_KHR_cooperative_matrix : require
+#extension GL_KHR_memory_scope_semantics : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const float spec_const = 0.0;
+const vec4 _29 = vec4(spec_const);
+const float _34[8] = float[](1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0);
+
+layout(set = 0, binding = 0, std140) uniform UBO
+{
+    float uniform_float;
+} ubo;
+
+void main()
+{
+    vec4 a = vec4(0.0);
+    mat4 b = mat4(vec4(1.0), vec4(1.0), vec4(1.0), vec4(1.0));
+    coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(float16_t(0.0));
+    vec4 c = _29;
+    vec4 d = vec4(ubo.uniform_float);
+    mat4 e = mat4(d, d, d, d);
+    float16_t _51 = float16_t(ubo.uniform_float);
+    coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix2 = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(_51);
+    float _54[8] = float[](ubo.uniform_float, ubo.uniform_float, ubo.uniform_float, ubo.uniform_float, ubo.uniform_float, ubo.uniform_float, ubo.uniform_float, ubo.uniform_float);
+}
+

--- a/reference/shaders/vulkan/comp/replicated-composites.spv16.vk.nocompat.comp.vk
+++ b/reference/shaders/vulkan/comp/replicated-composites.spv16.vk.nocompat.comp.vk
@@ -1,0 +1,34 @@
+#version 450
+#if defined(GL_AMD_gpu_shader_half_float)
+#extension GL_AMD_gpu_shader_half_float : require
+#elif defined(GL_EXT_shader_explicit_arithmetic_types_float16)
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#else
+#error No extension available for FP16.
+#endif
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_KHR_cooperative_matrix : require
+#extension GL_KHR_memory_scope_semantics : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const float spec_const = 0.0;
+const vec4 _29 = vec4(spec_const);
+const float _34[8] = float[](1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0);
+
+layout(set = 0, binding = 0, std140) uniform UBO
+{
+    float uniform_float;
+} ubo;
+
+void main()
+{
+    vec4 a = vec4(0.0);
+    mat4 b = mat4(vec4(1.0), vec4(1.0), vec4(1.0), vec4(1.0));
+    coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(float16_t(0.0));
+    vec4 c = _29;
+    vec4 d = vec4(ubo.uniform_float);
+    mat4 e = mat4(d, d, d, d);
+    float16_t _51 = float16_t(ubo.uniform_float);
+    coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix2 = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(_51);
+}
+

--- a/reference/shaders/vulkan/comp/replicated-composites.spv16.vk.nocompat.comp.vk
+++ b/reference/shaders/vulkan/comp/replicated-composites.spv16.vk.nocompat.comp.vk
@@ -9,11 +9,12 @@
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_KHR_cooperative_matrix : require
 #extension GL_KHR_memory_scope_semantics : require
+#extension GL_NV_cooperative_vector : require
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(constant_id = 0) const float spec_const = 0.0;
-const vec4 _29 = vec4(spec_const);
-const float _34[8] = float[](1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0);
+const vec4 _33 = vec4(spec_const);
+const float _38[8] = float[](1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0);
 
 layout(set = 0, binding = 0, std140) uniform UBO
 {
@@ -25,10 +26,13 @@ void main()
     vec4 a = vec4(0.0);
     mat4 b = mat4(vec4(1.0), vec4(1.0), vec4(1.0), vec4(1.0));
     coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(float16_t(0.0));
-    vec4 c = _29;
+    coopvecNV<float16_t, 16u> vec = coopvecNV<float16_t, 16u>(float16_t(0.0));
+    vec4 c = _33;
     vec4 d = vec4(ubo.uniform_float);
     mat4 e = mat4(d, d, d, d);
-    float16_t _51 = float16_t(ubo.uniform_float);
-    coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix2 = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(_51);
+    float16_t _55 = float16_t(ubo.uniform_float);
+    coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator> matrix2 = coopmat<float16_t, gl_ScopeWorkgroup, 16u, 16u, gl_MatrixUseAccumulator>(_55);
+    float16_t _60 = float16_t(ubo.uniform_float);
+    coopvecNV<float16_t, 16u> vec_dynamic = coopvecNV<float16_t, 16u>(_60);
 }
 

--- a/shaders-hlsl/asm/comp/replicated-composites.spv16.vk.asm.comp
+++ b/shaders-hlsl/asm/comp/replicated-composites.spv16.vk.asm.comp
@@ -1,0 +1,81 @@
+; SPIR-V
+; Version: 1.6
+; Generator: Khronos Glslang Reference Front End; 11
+; Bound: 41
+; Schema: 0
+               OpCapability Shader
+               OpCapability ReplicatedCompositesEXT
+               OpExtension "SPV_EXT_replicated_composites"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %ubo
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_shader_explicit_arithmetic_types_float16"
+               OpSourceExtension "GL_KHR_memory_scope_semantics"
+               OpName %main "main"
+               OpName %a "a"
+               OpName %b "b"
+               OpName %c "c"
+               OpName %spec_const "spec_const"
+               OpName %array "array"
+               OpName %d "d"
+               OpName %UBO "UBO"
+               OpMemberName %UBO 0 "uniform_float"
+               OpName %ubo "ubo"
+               OpName %e "e"
+               OpName %f "f"
+               OpDecorate %spec_const SpecId 0
+               OpDecorate %UBO Block
+               OpMemberDecorate %UBO 0 Offset 0
+               OpDecorate %ubo Binding 0
+               OpDecorate %ubo DescriptorSet 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+    %float_0 = OpConstant %float 0
+         %11 = OpConstantCompositeReplicateEXT %v4float %float_0
+%mat4v4float = OpTypeMatrix %v4float 4
+%_ptr_Function_mat4v4float = OpTypePointer Function %mat4v4float
+    %float_1 = OpConstant %float 1
+         %16 = OpConstantCompositeReplicateEXT %v4float %float_1
+         %17 = OpConstantCompositeReplicateEXT %mat4v4float %16
+ %spec_const = OpSpecConstant %float 0
+         %20 = OpSpecConstantCompositeReplicateEXT %v4float %spec_const
+       %uint = OpTypeInt 32 0
+     %uint_8 = OpConstant %uint 8
+%_arr_float_uint_8 = OpTypeArray %float %uint_8
+%_ptr_Function__arr_float_uint_8 = OpTypePointer Function %_arr_float_uint_8
+         %26 = OpConstantCompositeReplicateEXT %_arr_float_uint_8 %float_1
+        %UBO = OpTypeStruct %float
+%_ptr_Uniform_UBO = OpTypePointer Uniform %UBO
+        %ubo = OpVariable %_ptr_Uniform_UBO Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %a = OpVariable %_ptr_Function_v4float Function
+          %b = OpVariable %_ptr_Function_mat4v4float Function
+          %c = OpVariable %_ptr_Function_v4float Function
+      %array = OpVariable %_ptr_Function__arr_float_uint_8 Function
+          %d = OpVariable %_ptr_Function_v4float Function
+          %e = OpVariable %_ptr_Function_mat4v4float Function
+          %f = OpVariable %_ptr_Function__arr_float_uint_8 Function
+               OpStore %a %11
+               OpStore %b %17
+               OpStore %c %20
+               OpStore %array %26
+         %34 = OpAccessChain %_ptr_Uniform_float %ubo %int_0
+         %35 = OpLoad %float %34
+         %36 = OpCompositeConstructReplicateEXT %v4float %35
+               OpStore %d %36
+         %38 = OpLoad %v4float %d
+         %39 = OpCompositeConstructReplicateEXT %mat4v4float %38
+               OpStore %e %39
+         %40 = OpCompositeConstructReplicateEXT %_arr_float_uint_8 %35
+               OpStore %f %40
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl/asm/comp/replicated-composites.spv16.asm.comp
+++ b/shaders-msl/asm/comp/replicated-composites.spv16.asm.comp
@@ -1,0 +1,81 @@
+; SPIR-V
+; Version: 1.6
+; Generator: Khronos Glslang Reference Front End; 11
+; Bound: 41
+; Schema: 0
+               OpCapability Shader
+               OpCapability ReplicatedCompositesEXT
+               OpExtension "SPV_EXT_replicated_composites"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %ubo
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_shader_explicit_arithmetic_types_float16"
+               OpSourceExtension "GL_KHR_memory_scope_semantics"
+               OpName %main "main"
+               OpName %a "a"
+               OpName %b "b"
+               OpName %c "c"
+               OpName %spec_const "spec_const"
+               OpName %array "array"
+               OpName %d "d"
+               OpName %UBO "UBO"
+               OpMemberName %UBO 0 "uniform_float"
+               OpName %ubo "ubo"
+               OpName %e "e"
+               OpName %f "f"
+               OpDecorate %spec_const SpecId 0
+               OpDecorate %UBO Block
+               OpMemberDecorate %UBO 0 Offset 0
+               OpDecorate %ubo Binding 0
+               OpDecorate %ubo DescriptorSet 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+    %float_0 = OpConstant %float 0
+         %11 = OpConstantCompositeReplicateEXT %v4float %float_0
+%mat4v4float = OpTypeMatrix %v4float 4
+%_ptr_Function_mat4v4float = OpTypePointer Function %mat4v4float
+    %float_1 = OpConstant %float 1
+         %16 = OpConstantCompositeReplicateEXT %v4float %float_1
+         %17 = OpConstantCompositeReplicateEXT %mat4v4float %16
+ %spec_const = OpSpecConstant %float 0
+         %20 = OpSpecConstantCompositeReplicateEXT %v4float %spec_const
+       %uint = OpTypeInt 32 0
+     %uint_8 = OpConstant %uint 8
+%_arr_float_uint_8 = OpTypeArray %float %uint_8
+%_ptr_Function__arr_float_uint_8 = OpTypePointer Function %_arr_float_uint_8
+         %26 = OpConstantCompositeReplicateEXT %_arr_float_uint_8 %float_1
+        %UBO = OpTypeStruct %float
+%_ptr_Uniform_UBO = OpTypePointer Uniform %UBO
+        %ubo = OpVariable %_ptr_Uniform_UBO Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %a = OpVariable %_ptr_Function_v4float Function
+          %b = OpVariable %_ptr_Function_mat4v4float Function
+          %c = OpVariable %_ptr_Function_v4float Function
+      %array = OpVariable %_ptr_Function__arr_float_uint_8 Function
+          %d = OpVariable %_ptr_Function_v4float Function
+          %e = OpVariable %_ptr_Function_mat4v4float Function
+          %f = OpVariable %_ptr_Function__arr_float_uint_8 Function
+               OpStore %a %11
+               OpStore %b %17
+               OpStore %c %20
+               OpStore %array %26
+         %34 = OpAccessChain %_ptr_Uniform_float %ubo %int_0
+         %35 = OpLoad %float %34
+         %36 = OpCompositeConstructReplicateEXT %v4float %35
+               OpStore %d %36
+         %38 = OpLoad %v4float %d
+         %39 = OpCompositeConstructReplicateEXT %mat4v4float %38
+               OpStore %e %39
+         %40 = OpCompositeConstructReplicateEXT %_arr_float_uint_8 %35
+               OpStore %f %40
+               OpReturn
+               OpFunctionEnd

--- a/shaders/comp/cooperative-vec-nv.spv16.vk.nocompat.comp
+++ b/shaders/comp/cooperative-vec-nv.spv16.vk.nocompat.comp
@@ -1,0 +1,55 @@
+#version 450
+
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+
+#extension GL_KHR_memory_scope_semantics : enable
+#extension GL_NV_cooperative_vector : enable
+#extension GL_EXT_buffer_reference : enable
+#extension GL_EXT_null_initializer : enable
+
+layout(local_size_x = 64) in;
+
+layout (binding = 0) buffer Q {float16_t data_q[];};
+
+
+void main()
+{
+    coopvecNV<float16_t, 16> inVec;
+    coopvecNV<float16_t, 16> outVec;
+
+
+    coopVecLoadNV(inVec, data_q, 16);
+    coopVecStoreNV(inVec, data_q, 16);
+    
+    const int matrixLayout = 4;
+    const int interpretation = gl_ComponentTypeFloat16NV;
+    coopVecMatMulAddNV(inVec,
+                       inVec,
+                       interpretation,
+                       data_q,
+                       16,
+                       interpretation,
+                       data_q,
+                       16,
+                       interpretation,
+                       16, 16,
+                       matrixLayout,
+                       false,
+                       2);
+    coopVecMatMulNV(inVec,
+                       inVec,
+                       interpretation,
+                       data_q,
+                       16,
+                       interpretation,
+                       16, 16,
+                       matrixLayout,
+                       false,
+                       2);
+    coopvecNV<float16_t, 8> a = coopvecNV<float16_t, 8>(0);
+    inVec = max(inVec, inVec);
+
+    coopVecOuterProductAccumulateNV(inVec, inVec, data_q, 0, 0, matrixLayout, gl_ComponentTypeFloat16NV);
+    coopVecReduceSumAccumulateNV(inVec,  data_q, 0);
+}

--- a/shaders/vulkan/comp/replicated-composites.nocompat.spv16.asm.vk.comp
+++ b/shaders/vulkan/comp/replicated-composites.nocompat.spv16.asm.vk.comp
@@ -1,0 +1,102 @@
+; SPIR-V
+; Version: 1.6
+; Generator: Khronos Glslang Reference Front End; 11
+; Bound: 53
+; Schema: 0
+               OpCapability Shader
+               OpCapability Float16
+               OpCapability VulkanMemoryModel
+               OpCapability CooperativeMatrixKHR
+               OpCapability ReplicatedCompositesEXT
+               OpExtension "SPV_EXT_replicated_composites"
+               OpExtension "SPV_KHR_cooperative_matrix"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical Vulkan
+               OpEntryPoint GLCompute %main "main" %ubo
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_shader_explicit_arithmetic_types_float16"
+               OpSourceExtension "GL_KHR_cooperative_matrix"
+               OpSourceExtension "GL_KHR_memory_scope_semantics"
+               OpName %main "main"
+               OpName %a "a"
+               OpName %b "b"
+               OpName %matrix "matrix"
+               OpName %c "c"
+               OpName %spec_const "spec_const"
+               OpName %array "array"
+               OpName %d "d"
+               OpName %UBO "UBO"
+               OpMemberName %UBO 0 "uniform_float"
+               OpName %ubo "ubo"
+               OpName %e "e"
+               OpName %matrix2 "matrix2"
+               OpDecorate %spec_const SpecId 0
+               OpDecorate %UBO Block
+               OpMemberDecorate %UBO 0 Offset 0
+               OpDecorate %ubo Binding 0
+               OpDecorate %ubo DescriptorSet 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+    %float_0 = OpConstant %float 0
+         %11 = OpConstantCompositeReplicateEXT %v4float %float_0
+%mat4v4float = OpTypeMatrix %v4float 4
+%_ptr_Function_mat4v4float = OpTypePointer Function %mat4v4float
+    %float_1 = OpConstant %float 1
+         %16 = OpConstantCompositeReplicateEXT %v4float %float_1
+         %17 = OpConstantCompositeReplicateEXT %mat4v4float %16
+       %half = OpTypeFloat 16
+       %uint = OpTypeInt 32 0
+     %uint_2 = OpConstant %uint 2
+    %uint_16 = OpConstant %uint 16
+         %22 = OpTypeCooperativeMatrixKHR %half %uint_2 %uint_16 %uint_16 %uint_2
+%_ptr_Function_22 = OpTypePointer Function %22
+%half_0x0p_0 = OpConstant %half 0x0p+0
+         %26 = OpConstantCompositeReplicateEXT %22 %half_0x0p_0
+ %spec_const = OpSpecConstant %float 0
+         %29 = OpSpecConstantCompositeReplicateEXT %v4float %spec_const
+     %uint_8 = OpConstant %uint 8
+%_arr_float_uint_8 = OpTypeArray %float %uint_8
+%_ptr_Function__arr_float_uint_8 = OpTypePointer Function %_arr_float_uint_8
+         %34 = OpConstantCompositeReplicateEXT %_arr_float_uint_8 %float_1
+        %UBO = OpTypeStruct %float
+%_ptr_Uniform_UBO = OpTypePointer Uniform %UBO
+        %ubo = OpVariable %_ptr_Uniform_UBO Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %a = OpVariable %_ptr_Function_v4float Function
+          %b = OpVariable %_ptr_Function_mat4v4float Function
+     %matrix = OpVariable %_ptr_Function_22 Function
+          %c = OpVariable %_ptr_Function_v4float Function
+      %array = OpVariable %_ptr_Function__arr_float_uint_8 Function
+          %d = OpVariable %_ptr_Function_v4float Function
+          %e = OpVariable %_ptr_Function_mat4v4float Function
+    %matrix2 = OpVariable %_ptr_Function_22 Function
+          %f = OpVariable %_ptr_Function__arr_float_uint_8 Function
+               OpStore %a %11
+               OpStore %b %17
+               OpStore %matrix %26
+               OpStore %c %29
+               OpStore %array %34
+         %42 = OpAccessChain %_ptr_Uniform_float %ubo %int_0
+         %43 = OpLoad %float %42
+         %44 = OpCompositeConstructReplicateEXT %v4float %43
+               OpStore %d %44
+         %46 = OpLoad %v4float %d
+         %47 = OpCompositeConstructReplicateEXT %mat4v4float %46
+               OpStore %e %47
+         %49 = OpAccessChain %_ptr_Uniform_float %ubo %int_0
+         %50 = OpLoad %float %49
+         %51 = OpFConvert %half %50
+         %52 = OpCompositeConstructReplicateEXT %22 %51
+               OpStore %matrix2 %52
+         %53 = OpCompositeConstructReplicateEXT %_arr_float_uint_8 %43
+               OpStore %f %53
+               OpReturn
+               OpFunctionEnd

--- a/shaders/vulkan/comp/replicated-composites.spv16.vk.nocompat.comp
+++ b/shaders/vulkan/comp/replicated-composites.spv16.vk.nocompat.comp
@@ -1,0 +1,28 @@
+#version 450
+#pragma use_replicated_composites
+
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+
+#extension GL_KHR_memory_scope_semantics : enable
+#extension GL_KHR_cooperative_matrix : enable
+//#extension GL_NV_cooperative_vector : enable
+layout (constant_id = 0) const float spec_const = 0;
+
+layout (set = 0, binding = 0) uniform UBO {
+    float uniform_float;
+} ubo;
+
+void main() {
+    // constants
+    vec4 a = vec4(0.0);
+    mat4 b = mat4(vec4(1.0), vec4(1.0), vec4(1.0), vec4(1.0));
+    coopmat<float16_t, gl_ScopeWorkgroup, 16, 16, gl_MatrixUseAccumulator> matrix = coopmat<float16_t, gl_ScopeWorkgroup, 16, 16, gl_MatrixUseAccumulator>(0);
+    //coopvecNV<float16_t, 16> vec = coopvecNV<float16_t, 16>(0);
+    vec4 c = vec4(spec_const);
+    float array[] = float[](1.0, 1.0, 1.0, 1.0, 1.0, 1.0f, 1.0, 1.0f);
+
+    // runtime variables
+    vec4 d = vec4(ubo.uniform_float);
+    mat4 e = mat4(d, d, d, d);
+    coopmat<float16_t, gl_ScopeWorkgroup, 16, 16, gl_MatrixUseAccumulator> matrix2 = coopmat<float16_t, gl_ScopeWorkgroup, 16, 16, gl_MatrixUseAccumulator>(ubo.uniform_float);
+}

--- a/shaders/vulkan/comp/replicated-composites.spv16.vk.nocompat.comp
+++ b/shaders/vulkan/comp/replicated-composites.spv16.vk.nocompat.comp
@@ -5,7 +5,7 @@
 
 #extension GL_KHR_memory_scope_semantics : enable
 #extension GL_KHR_cooperative_matrix : enable
-//#extension GL_NV_cooperative_vector : enable
+#extension GL_NV_cooperative_vector : enable
 layout (constant_id = 0) const float spec_const = 0;
 
 layout (set = 0, binding = 0) uniform UBO {
@@ -17,7 +17,7 @@ void main() {
     vec4 a = vec4(0.0);
     mat4 b = mat4(vec4(1.0), vec4(1.0), vec4(1.0), vec4(1.0));
     coopmat<float16_t, gl_ScopeWorkgroup, 16, 16, gl_MatrixUseAccumulator> matrix = coopmat<float16_t, gl_ScopeWorkgroup, 16, 16, gl_MatrixUseAccumulator>(0);
-    //coopvecNV<float16_t, 16> vec = coopvecNV<float16_t, 16>(0);
+    coopvecNV<float16_t, 16> vec = coopvecNV<float16_t, 16>(0);
     vec4 c = vec4(spec_const);
     float array[] = float[](1.0, 1.0, 1.0, 1.0, 1.0, 1.0f, 1.0, 1.0f);
 
@@ -25,4 +25,5 @@ void main() {
     vec4 d = vec4(ubo.uniform_float);
     mat4 e = mat4(d, d, d, d);
     coopmat<float16_t, gl_ScopeWorkgroup, 16, 16, gl_MatrixUseAccumulator> matrix2 = coopmat<float16_t, gl_ScopeWorkgroup, 16, 16, gl_MatrixUseAccumulator>(ubo.uniform_float);
+    coopvecNV<float16_t, 16> vec_dynamic = coopvecNV<float16_t, 16>(ubo.uniform_float);
 }

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -1353,9 +1353,10 @@ struct SPIRConstant : IVariant
 
 	SPIRConstant() = default;
 
-	SPIRConstant(TypeID constant_type_, const uint32_t *elements, uint32_t num_elements, bool specialized)
+	SPIRConstant(TypeID constant_type_, const uint32_t *elements, uint32_t num_elements, bool specialized, bool _replicated = false)
 	    : constant_type(constant_type_)
 	    , specialization(specialized)
+	    , replicated(_replicated)
 	{
 		subconstants.reserve(num_elements);
 		for (uint32_t i = 0; i < num_elements; i++)
@@ -1433,6 +1434,9 @@ struct SPIRConstant : IVariant
 
 	// For composites which are constant arrays, etc.
 	SmallVector<ConstantID> subconstants;
+
+	// Whether the subconstants are intended to be replicated (e.g. OpConstantCompositeReplicateEXT)
+	bool replicated = false;
 
 	// Non-Vulkan GLSL, HLSL and sometimes MSL emits defines for each specialization constant,
 	// and uses them to initialize the constant. This allows the user

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -574,6 +574,7 @@ struct SPIRType : IVariant
 		Sampler,
 		AccelerationStructure,
 		RayQuery,
+		CoopVecNv,
 
 		// Keep internal types at the end.
 		ControlPointArray,
@@ -613,6 +614,12 @@ struct SPIRType : IVariant
 		uint32_t columns_id = 0;
 		uint32_t scope_id = 0;
 	} cooperative;
+
+	struct
+	{
+		uint32_t component_type_id = 0;
+		uint32_t component_count_id = 0;
+	} coopVecNv;
 
 	spv::StorageClass storage = spv::StorageClassGeneric;
 

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -23,6 +23,7 @@
 
 #include "spirv_cross.hpp"
 #include "GLSL.std.450.h"
+#include "spirv.hpp"
 #include "spirv_cfg.hpp"
 #include "spirv_common.hpp"
 #include "spirv_parser.hpp"
@@ -373,6 +374,7 @@ void Compiler::register_global_read_dependencies(const SPIRBlock &block, uint32_
 
 		case OpLoad:
 		case OpCooperativeMatrixLoadKHR:
+		case OpCooperativeVectorLoadNV:
 		case OpImageRead:
 		{
 			// If we're in a storage class which does not get invalidated, adding dependencies here is no big deal.
@@ -4334,6 +4336,7 @@ bool Compiler::may_read_undefined_variable_in_block(const SPIRBlock &block, uint
 
 		case OpCopyObject:
 		case OpLoad:
+		case OpCooperativeVectorLoadNV:
 		case OpCooperativeMatrixLoadKHR:
 			if (ops[2] == var)
 				return true;
@@ -5436,6 +5439,7 @@ bool Compiler::InterlockedResourceAccessHandler::handle(Op opcode, const uint32_
 	{
 	case OpLoad:
 	case OpCooperativeMatrixLoadKHR:
+	case OpCooperativeVectorLoadNV:
 	{
 		if (length < 3)
 			return false;
@@ -5514,6 +5518,7 @@ bool Compiler::InterlockedResourceAccessHandler::handle(Op opcode, const uint32_
 	case OpImageWrite:
 	case OpAtomicStore:
 	case OpCooperativeMatrixStoreKHR:
+	case OpCooperativeVectorStoreNV:
 	{
 		if (length < 1)
 			return false;

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -27,18 +27,17 @@
 #include "spirv_common.hpp"
 #include "spirv_cross_error_handling.hpp"
 #include <algorithm>
+#include <array>
 #include <assert.h>
 #include <cmath>
 #include <cstdint>
 #include <limits>
 #include <locale.h>
 #include <utility>
-#include <array>
 
 #ifndef _WIN32
 #include <langinfo.h>
 #endif
-#include <locale.h>
 
 using namespace spv;
 using namespace SPIRV_CROSS_NAMESPACE;
@@ -49,6 +48,36 @@ enum ExtraSubExpressionType
 	// Create masks above any legal ID range to allow multiple address spaces into the extra_sub_expressions map.
 	EXTRA_SUB_EXPRESSION_TYPE_STREAM_OFFSET = 0x10000000,
 	EXTRA_SUB_EXPRESSION_TYPE_AUX = 0x20000000
+};
+
+const std::vector<std::tuple<uint32_t, const char *>> COOPVEC_COMPONENT_TYPE_NAMES = {
+	{ 0, "gl_ComponentTypeFloat16NV" },
+	{ 1, "gl_ComponentTypeFloat32NV" },
+	{ 2, "gl_ComponentTypeFloat64NV" },
+	{ 3, "gl_ComponentTypeSignedInt8NV" },
+	{ 4, "gl_ComponentTypeSignedInt16NV" },
+	{ 5, "gl_ComponentTypeSignedInt32NV" },
+	{ 6, "gl_ComponentTypeSignedInt64NV" },
+	{ 7, "gl_ComponentTypeUnsignedInt8NV" },
+	{ 8, "gl_ComponentTypeUnsignedInt16NV" },
+	{ 9, "gl_ComponentTypeUnsignedInt32NV" },
+	{ 10, "gl_ComponentTypeUnsignedInt64NV" },
+	{ 1000491000, "gl_ComponentTypeSignedInt8PackedNV" },
+	{ 1000491001, "gl_ComponentTypeUnsignedInt8PackedNV" },
+	{ 1000491002, "gl_ComponentTypeFloatE4M3NV" },
+	{ 1000491003, "gl_ComponentTypeFloatE5M2NV" },
+};
+
+const std::vector<std::tuple<uint32_t, const char *>> COOPVEC_MATRIX_LAYOUT_NAMES = {
+	{ 0, "gl_CooperativeVectorMatrixLayoutRowMajorNV" },
+	{ 1, "gl_CooperativeVectorMatrixLayoutColumnMajorNV" },
+	{ 2, "gl_CooperativeVectorMatrixLayoutInferencingOptimalNV" },
+	{ 3, "gl_CooperativeVectorMatrixLayoutTrainingOptimalNV" },
+};
+
+const std::vector<std::tuple<uint32_t, const char *>> COOPMAT_MATRIX_LAYOUT_NAMES = {
+	{ 0, "gl_CooperativeMatrixLayoutRowMajor" },
+	{ 1, "gl_CooperativeMatrixLayoutColumnMajor" },
 };
 
 static bool is_unsigned_opcode(Op op)
@@ -6953,6 +6982,10 @@ SPIRType CompilerGLSL::binary_op_bitcast_helper(string &cast_op0, string &cast_o
                                                 uint32_t op0, uint32_t op1, bool skip_cast_if_equal_type)
 {
 	auto &type0 = expression_type(op0);
+	if (type0.basetype == SPIRType::BaseType::CoopVecNv)
+	{
+		return type0;
+	}
 	auto &type1 = expression_type(op1);
 
 	// We have to bitcast if our inputs are of different type, or if our types are not equal to expected inputs.
@@ -15502,6 +15535,111 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		break;
 	}
 
+	case OpCooperativeVectorLoadNV:
+	{
+		uint32_t result_type = ops[0];
+		uint32_t id = ops[1];
+
+		emit_uninitialized_temporary_expression(result_type, id);
+
+		statement("coopVecLoadNV(", to_expression(id), ", ", to_expression(ops[2]), ", ", to_expression(ops[3]), ");");
+		register_read(id, ops[2], false);
+		break;
+	}
+
+	case OpCooperativeVectorStoreNV:
+	{
+		uint32_t id = ops[0];
+
+		statement("coopVecStoreNV(", to_expression(ops[2]), ", ", to_expression(id), ", ", to_expression(ops[1]), ");");
+		register_write(ops[2]);
+		break;
+	}
+
+	case OpCooperativeVectorOuterProductAccumulateNV:
+	{
+		//Pointer
+		//Offset
+		//A
+		//B
+		//MemoryLayout
+		//MatrixInterpretation
+		//MatrixStride
+		auto buf = ops[0];
+		auto offset = ops[1];
+		auto v1 = ops[2];
+		auto v2 = ops[3];
+		auto matrix_layout_id = ops[4];
+		auto matrix_iterpretation_id = ops[5];
+		auto matrix_stride_id = length >= 6 ? ops[6] : 0;
+		//void coopVecOuterProductAccumulateNV(const coopvecNV<T, M> v1, const coopvecNV<T, N> v2,
+		//T[] buf, uint offset, uint stride,
+		//int matrixLayout, int matrixInterpretation);
+		statement(join("coopVecOuterProductAccumulateNV(", to_expression(v1), ", ", to_expression(v2), ", ",
+		               to_expression(buf), ", ", to_expression(offset), ", ",
+		               matrix_stride_id ? to_expression(matrix_stride_id) : "0", ", ", to_expression(matrix_layout_id),
+		               ", ", to_pretty_expression_if_int_constant(matrix_iterpretation_id, COOPVEC_COMPONENT_TYPE_NAMES),
+		               ");"));
+		register_write(ops[0]);
+		break;
+	}
+
+	case OpCooperativeVectorReduceSumAccumulateNV:
+	{
+		//Pointer
+		//Offset
+		//V
+		auto buf = ops[0];
+		auto offset = ops[1];
+		auto v1 = ops[2];
+		//void coopVecReduceSumAccumulateNV(const coopvecNV<VectorElemTy, NumComps> v,
+		//T[] buf, uint offset);
+		statement(join("coopVecReduceSumAccumulateNV(", to_expression(v1), ", ", to_expression(buf), ", ",
+		               to_expression(offset), ");"));
+		register_write(ops[0]);
+		break;
+	}
+
+	case OpCooperativeVectorMatrixMulNV:
+	case OpCooperativeVectorMatrixMulAddNV:
+	{
+		uint32_t result_type = ops[0];
+		uint32_t id = ops[1];
+
+		emit_uninitialized_temporary_expression(result_type, id);
+
+		spirv_cross::StringStream<> ss;
+		switch (opcode)
+		{
+		case OpCooperativeVectorMatrixMulAddNV:
+			ss << "coopVecMatMulAddNV(";
+			break;
+		case OpCooperativeVectorMatrixMulNV:
+			ss << "coopVecMatMulNV(";
+			break;
+		default:
+			SPIRV_CROSS_THROW("Invalid op code for coopvec instruction.");
+		}
+		for (uint32_t i = 1; i < length; i++)
+		{
+			if (i == 3 || i == 6 || (i == 9 && opcode == OpCooperativeVectorMatrixMulAddNV))
+			{
+				ss << to_pretty_expression_if_int_constant(ops[i], COOPVEC_COMPONENT_TYPE_NAMES);
+			}
+			else
+			{
+				ss << to_expression(ops[i]);
+			}
+			if (i < length - 1)
+			{
+				ss << ", ";
+			}
+		}
+		ss << ");";
+		statement(ss.str());
+		break;
+	}
+
 	case OpCooperativeMatrixLengthKHR:
 	{
 		// Need to synthesize a dummy temporary, since the SPIR-V opcode is based on the type.
@@ -15529,27 +15667,9 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		if (!is_forcing_recompilation())
 			split_expr = split_coopmat_pointer(expr);
 
-		string layout_expr;
-		if (const auto *layout = maybe_get<SPIRConstant>(ops[3]))
-		{
-			if (!layout->specialization)
-			{
-				if (layout->scalar() == spv::CooperativeMatrixLayoutColumnMajorKHR)
-					layout_expr = "gl_CooperativeMatrixLayoutColumnMajor";
-				else
-					layout_expr = "gl_CooperativeMatrixLayoutRowMajor";
-			}
-		}
-
-		if (layout_expr.empty())
-			layout_expr = join("int(", to_expression(ops[3]), ")");
-
-		statement("coopMatLoad(",
-		          to_expression(id), ", ",
-		          split_expr.first, ", ",
-		          split_expr.second, ", ",
-		          to_expression(ops[4]), ", ",
-		          layout_expr, ");");
+		string layout_expr = to_pretty_expression_if_int_constant(ops[3], COOPMAT_MATRIX_LAYOUT_NAMES);
+		statement("coopMatLoad(", to_expression(id), ", ", split_expr.first, ", ", split_expr.second, ", ",
+		          to_expression(ops[4]), ", ", layout_expr, ");");
 
 		register_read(id, ops[2], false);
 		break;
@@ -15569,27 +15689,10 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		if (!is_forcing_recompilation())
 			split_expr = split_coopmat_pointer(expr);
 
-		string layout_expr;
-		if (const auto *layout = maybe_get<SPIRConstant>(ops[2]))
-		{
-			if (!layout->specialization)
-			{
-				if (layout->scalar() == spv::CooperativeMatrixLayoutColumnMajorKHR)
-					layout_expr = "gl_CooperativeMatrixLayoutColumnMajor";
-				else
-					layout_expr = "gl_CooperativeMatrixLayoutRowMajor";
-			}
-		}
+		string layout_expr = to_pretty_expression_if_int_constant(ops[2], COOPMAT_MATRIX_LAYOUT_NAMES);
 
-		if (layout_expr.empty())
-			layout_expr = join("int(", to_expression(ops[2]), ")");
-
-		statement("coopMatStore(",
-		          to_expression(ops[1]), ", ",
-		          split_expr.first, ", ",
-		          split_expr.second, ", ",
-		          to_expression(ops[3]), ", ",
-		          layout_expr, ");");
+		statement("coopMatStore(", to_expression(ops[1]), ", ", split_expr.first, ", ", split_expr.second, ", ",
+		          to_expression(ops[3]), ", ", layout_expr, ");");
 
 		// TODO: Do we care about memory operands?
 
@@ -16509,6 +16612,17 @@ string CompilerGLSL::type_to_glsl(const SPIRType &type, uint32_t id)
 			SPIRV_CROSS_THROW("At least ESSL 3.10 required for atomic counters.");
 		else if (!options.es && options.version < 420)
 			require_extension_internal("GL_ARB_shader_atomic_counters");
+	}
+
+	if (type.op == spv::OpTypeCooperativeVectorNV)
+	{
+		require_extension_internal("GL_NV_cooperative_vector");
+		if (!options.vulkan_semantics)
+			SPIRV_CROSS_THROW("Cooperative vector NV only available in Vulkan.");
+
+		std::string component_type_str = type_to_glsl(get<SPIRType>(type.coopVecNv.component_type_id));
+
+		return join("coopvecNV<", component_type_str, ", ", to_expression(type.coopVecNv.component_count_id), ">");
 	}
 
 	const SPIRType *coop_type = &type;
@@ -19662,3 +19776,22 @@ std::string CompilerGLSL::format_double(double value) const
 	return convert_to_string(value, current_locale_radix_character);
 }
 
+std::string CompilerGLSL::to_pretty_expression_if_int_constant(
+    uint32_t id, const std::vector<std::tuple<uint32_t, const char *>> pretty_names, bool register_expression_read)
+{
+	{
+		auto maybe_constant = maybe_get<SPIRConstant>(id);
+		if (maybe_constant && !maybe_constant->specialization)
+		{
+			auto value = static_cast<size_t>(maybe_constant->scalar());
+			auto pretty_name = std::find_if(pretty_names.begin(), pretty_names.end(),
+			                                [value](std::tuple<uint32_t, const char *> idx_name)
+			                                { return std::get<0>(idx_name) == value; });
+			if (pretty_name != pretty_names.end())
+			{
+				return std::get<1>(*pretty_name);
+			}
+		}
+		return join("int(", to_expression(id, register_expression_read), ")");
+	}
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -23,10 +23,13 @@
 
 #include "spirv_glsl.hpp"
 #include "GLSL.std.450.h"
+#include "spirv.hpp"
 #include "spirv_common.hpp"
+#include "spirv_cross_error_handling.hpp"
 #include <algorithm>
 #include <assert.h>
 #include <cmath>
+#include <cstdint>
 #include <limits>
 #include <locale.h>
 #include <utility>
@@ -5940,6 +5943,32 @@ string CompilerGLSL::constant_expression(const SPIRConstant &c,
 		require_extension_internal("GL_EXT_null_initializer");
 		return backend.constant_null_initializer;
 	}
+	else if (c.replicated && type.op != spv::OpTypeArray)
+	{
+		if (type.op == spv::OpTypeMatrix)
+		{
+			uint32_t num_elements = type.columns;
+			// GLSL does not allow the replication constructor for matrices
+			// mat4(vec4(0.0)) needs to be manually expanded to mat4(vec4(0.0), vec4(0.0), vec4(0.0), vec4(0.0));
+			spirv_cross::StringStream<> ss;
+			ss << type_to_glsl(type);
+			ss << "(";
+			for (uint32_t i = 0; i < num_elements; i++)
+			{
+				ss << to_expression(c.subconstants[0]);
+				if (i < num_elements - 1)
+				{
+					ss << ", ";
+				}
+			}
+			ss << ")";
+			return ss.str();
+		}
+		else
+		{
+			return join(type_to_glsl(type), "(", to_expression(c.subconstants[0]), ")");
+		}
+	}
 	else if (!c.subconstants.empty())
 	{
 		// Handles Arrays and structures.
@@ -5989,8 +6018,16 @@ string CompilerGLSL::constant_expression(const SPIRConstant &c,
 		}
 
 		uint32_t subconstant_index = 0;
-		for (auto &elem : c.subconstants)
+		size_t num_elements = c.subconstants.size();
+		if (c.replicated) {
+			if (type.array.size() != 1) {
+				SPIRV_CROSS_THROW("Multidimensional arrays not yet supported as replicated constans");
+			}
+			num_elements = type.array[0];
+		}
+		for (size_t i = 0; i < num_elements; i++)
 		{
+			auto &elem = c.subconstants[c.replicated ? 0 : i];
 			if (auto *op = maybe_get<SPIRConstantOp>(elem))
 			{
 				res += constant_op_expression(*op);
@@ -6021,7 +6058,7 @@ string CompilerGLSL::constant_expression(const SPIRConstant &c,
 				}
 			}
 
-			if (&elem != &c.subconstants.back())
+			if (i != num_elements - 1)
 				res += ", ";
 
 			subconstant_index++;
@@ -15580,6 +15617,50 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		inherit_expression_dependencies(id, A);
 		inherit_expression_dependencies(id, B);
 		inherit_expression_dependencies(id, C);
+		break;
+	}
+
+	case OpCompositeConstructReplicateEXT:
+	{
+
+		uint32_t result_type = ops[0];
+		uint32_t id = ops[1];
+
+		auto &type = get<SPIRType>(result_type);
+		auto value_to_replicate = to_expression(ops[2]);
+		std::string rhs;
+		// Matrices don't have a replicating constructor for vectors. Need to manually replicate
+		if (type.op == spv::OpTypeMatrix || type.op == spv::OpTypeArray)
+		{
+			// TODO: nested arrays
+			uint32_t num_elements = type.op == spv::OpTypeMatrix ? type.columns : type.array[0];
+			spirv_cross::StringStream<> ss;
+			if (backend.use_initializer_list && type.op == spv::OpTypeArray) {
+				ss << "{";
+			} else {
+				ss << type_to_glsl_constructor(type);
+				ss << "(";
+			}
+			for (uint32_t i = 0; i < num_elements; i++)
+			{
+				ss << value_to_replicate;
+				if (i < num_elements - 1)
+				{
+					ss << ", ";
+				}
+			}
+			if (backend.use_initializer_list && type.op == spv::OpTypeArray) {
+				ss << "}";
+			} else {
+				ss << ")";
+			}
+			rhs = ss.str();
+		}
+		else
+		{
+			rhs = join(type_to_glsl(type), "(", to_expression(ops[2]), ")");
+		}
+		emit_op(result_type, id, rhs, true);
 		break;
 	}
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -802,6 +802,9 @@ protected:
 	void append_global_func_args(const SPIRFunction &func, uint32_t index, SmallVector<std::string> &arglist);
 	std::string to_non_uniform_aware_expression(uint32_t id);
 	std::string to_atomic_ptr_expression(uint32_t id);
+	std::string to_pretty_expression_if_int_constant(uint32_t id,
+	                                                 const std::vector<std::tuple<uint32_t, const char *>> pretty_names,
+	                                                 bool register_expression_read = true);
 	std::string to_expression(uint32_t id, bool register_expression_read = true);
 	std::string to_composite_constructor_expression(const SPIRType &parent_type, uint32_t id, bool block_like_type);
 	std::string to_rerolled_array_expression(const SPIRType &parent_type, const std::string &expr, const SPIRType &type);

--- a/spirv_parser.cpp
+++ b/spirv_parser.cpp
@@ -866,17 +866,27 @@ void Parser::parse(const Instruction &instruction)
 		break;
 	}
 
-		// Constants
+	// Constants
 	case OpSpecConstant:
 	case OpConstant:
+	case OpConstantCompositeReplicateEXT:
+	case OpSpecConstantCompositeReplicateEXT:
 	{
 		uint32_t id = ops[1];
 		auto &type = get<SPIRType>(ops[0]);
-
-		if (type.width > 32)
-			set<SPIRConstant>(id, ops[0], ops[2] | (uint64_t(ops[3]) << 32), op == OpSpecConstant);
+		if (op == OpConstantCompositeReplicateEXT || op == OpSpecConstantCompositeReplicateEXT)
+		{
+			auto subconstant = uint32_t(ops[2]);
+			set<SPIRConstant>(id, ops[0], &subconstant, 1, op == OpSpecConstantCompositeReplicateEXT, true);
+		}
 		else
-			set<SPIRConstant>(id, ops[0], ops[2], op == OpSpecConstant);
+		{
+
+			if (type.width > 32)
+				set<SPIRConstant>(id, ops[0], ops[2] | (uint64_t(ops[3]) << 32), op == OpSpecConstant);
+			else
+				set<SPIRConstant>(id, ops[0], ops[2], op == OpSpecConstant);
+		}
 		break;
 	}
 

--- a/spirv_parser.cpp
+++ b/spirv_parser.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "spirv_parser.hpp"
+#include "spirv.hpp"
 #include <assert.h>
 
 using namespace std;
@@ -620,6 +621,18 @@ void Parser::parse(const Instruction &instruction)
 		matrixbase.cooperative.use_id = ops[5];
 		matrixbase.self = id;
 		matrixbase.parent_type = ops[1];
+		break;
+	}
+
+	case OpTypeCooperativeVectorNV:
+	{
+		uint32_t id = ops[0];
+		auto &type = set<SPIRType>(id, op);
+
+		type.basetype = SPIRType::CoopVecNv;
+		type.op = op;
+		type.coopVecNv.component_type_id = ops[1];
+		type.coopVecNv.component_count_id = ops[2];
 		break;
 	}
 


### PR DESCRIPTION
This is on top of #2488 since replicated composites often occur in the initialization of cooperative vectors. This should stay in draft status until all issues with the previous PR are resolved.

I tried to roughly follow the implementation of `SPV_EXT_cooperative_matrix`. Though I might not have tracked  all dependencies of the instructions correctly. This is my first time working with spirv-cross, so some concepts are still unfamiliar to me. I tested the implementation on shaders in https://github.com/jeffbolznv/vk_cooperative_vector_perf

There is a roughly equivalent proposal for HLSL to which this SPV extension could be mapped: https://github.com/microsoft/hlsl-specs/blob/main/proposals/0026-hlsl-long-vector-type.md

