### PR TITLE
Treat raytracing::acceleration_structure as a texture resource in argument buffer

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -19572,7 +19572,7 @@ void CompilerMSL::analyze_argument_buffers()
 				SetBindingPair pair = { desc_set, binding };
 
 				if (resource.basetype == SPIRType::Image || resource.basetype == SPIRType::Sampler ||
-				    resource.basetype == SPIRType::SampledImage)
+				    resource.basetype == SPIRType::SampledImage || resource.basetype == SPIRType::AccelerationStructure)
 				{
 					// Drop pointer information when we emit the resources into a struct.
 					buffer_type.member_types.push_back(get_variable_data_type_id(var));


### PR DESCRIPTION
Currently, acceleration structures in argument buffers are treated as buffers, so the constant qualifier and a pointer are added to raytracing::acceleration_structure.
This results in code that does not compile.

```
struct spvDescriptorSetBuffer0
{
    constant raytracing::acceleration_structure<raytracing::instancing>* RTAS [[id(0)]];
};
```

This PR fixes the issue by handling acceleration structures in argument buffers in the same way as textures, ensuring that the generated code is compilable.

```
struct spvDescriptorSetBuffer0
{
    raytracing::acceleration_structure<raytracing::instancing> RTAS [[id(0)]];
};
```