### PR TITLE
GLSL: Add partial support for NV_cluster_acceleration_structure.

### DIFF
--- a/reference/opt/shaders/vulkan/nv/cluster-id.spv14.nocompat.vk.rahit.vk
+++ b/reference/opt/shaders/vulkan/nv/cluster-id.spv14.nocompat.vk.rahit.vk
@@ -1,0 +1,11 @@
+#version 460
+#extension GL_EXT_ray_tracing : require
+#extension GL_NV_cluster_acceleration_structure : require
+
+layout(location = 0) rayPayloadInEXT int payload;
+
+void main()
+{
+    payload = gl_ClusterIDNV;
+}
+

--- a/reference/opt/shaders/vulkan/nv/ray-query-cluster-id.spv14.nocompat.vk.comp.vk
+++ b/reference/opt/shaders/vulkan/nv/ray-query-cluster-id.spv14.nocompat.vk.comp.vk
@@ -1,0 +1,64 @@
+#version 460
+#extension GL_EXT_ray_query : require
+#extension GL_NV_cluster_acceleration_structure : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(set = 0, binding = 1, std140) uniform Params
+{
+    uint ray_flags;
+    uint cull_mask;
+    vec3 origin;
+    float tmin;
+    vec3 dir;
+    float tmax;
+} _18;
+
+layout(set = 0, binding = 2, std430) buffer SSBO
+{
+    int id;
+} _68;
+
+layout(set = 0, binding = 0) uniform accelerationStructureEXT AS;
+
+rayQueryEXT q;
+
+void main()
+{
+    rayQueryInitializeEXT(q, AS, _18.ray_flags, _18.cull_mask, _18.origin, _18.tmin, _18.dir, _18.tmax);
+    for (;;)
+    {
+        bool _47 = rayQueryProceedEXT(q);
+        if (_47)
+        {
+            uint _49 = rayQueryGetIntersectionTypeEXT(q, bool(0));
+            bool _51 = _49 == 0u;
+            bool _57;
+            if (_51)
+            {
+                int _54 = rayQueryGetIntersectionClusterIdNV(q, bool(0));
+                _57 = _54 != (-1);
+            }
+            else
+            {
+                _57 = _51;
+            }
+            if (_57)
+            {
+                rayQueryTerminateEXT(q);
+                rayQueryConfirmIntersectionEXT(q);
+            }
+            continue;
+        }
+        else
+        {
+            break;
+        }
+    }
+    uint _61 = rayQueryGetIntersectionTypeEXT(q, bool(1));
+    if (_61 == 1u)
+    {
+        int _69 = rayQueryGetIntersectionClusterIdNV(q, bool(1));
+        _68.id = _69;
+    }
+}
+

--- a/reference/shaders/vulkan/nv/cluster-id.spv14.nocompat.vk.rahit.vk
+++ b/reference/shaders/vulkan/nv/cluster-id.spv14.nocompat.vk.rahit.vk
@@ -1,0 +1,11 @@
+#version 460
+#extension GL_EXT_ray_tracing : require
+#extension GL_NV_cluster_acceleration_structure : require
+
+layout(location = 0) rayPayloadInEXT int payload;
+
+void main()
+{
+    payload = gl_ClusterIDNV;
+}
+

--- a/reference/shaders/vulkan/nv/ray-query-cluster-id.spv14.nocompat.vk.comp.vk
+++ b/reference/shaders/vulkan/nv/ray-query-cluster-id.spv14.nocompat.vk.comp.vk
@@ -1,0 +1,64 @@
+#version 460
+#extension GL_EXT_ray_query : require
+#extension GL_NV_cluster_acceleration_structure : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(set = 0, binding = 1, std140) uniform Params
+{
+    uint ray_flags;
+    uint cull_mask;
+    vec3 origin;
+    float tmin;
+    vec3 dir;
+    float tmax;
+} _18;
+
+layout(set = 0, binding = 2, std430) buffer SSBO
+{
+    int id;
+} _68;
+
+layout(set = 0, binding = 0) uniform accelerationStructureEXT AS;
+
+rayQueryEXT q;
+
+void main()
+{
+    rayQueryInitializeEXT(q, AS, _18.ray_flags, _18.cull_mask, _18.origin, _18.tmin, _18.dir, _18.tmax);
+    for (;;)
+    {
+        bool _47 = rayQueryProceedEXT(q);
+        if (_47)
+        {
+            uint _49 = rayQueryGetIntersectionTypeEXT(q, bool(0));
+            bool _51 = _49 == 0u;
+            bool _57;
+            if (_51)
+            {
+                int _54 = rayQueryGetIntersectionClusterIdNV(q, bool(0));
+                _57 = _54 != (-1);
+            }
+            else
+            {
+                _57 = _51;
+            }
+            if (_57)
+            {
+                rayQueryTerminateEXT(q);
+                rayQueryConfirmIntersectionEXT(q);
+            }
+            continue;
+        }
+        else
+        {
+            break;
+        }
+    }
+    uint _61 = rayQueryGetIntersectionTypeEXT(q, bool(1));
+    if (_61 == 1u)
+    {
+        int _69 = rayQueryGetIntersectionClusterIdNV(q, bool(1));
+        _68.id = _69;
+    }
+}
+

--- a/shaders/vulkan/nv/cluster-id.spv14.nocompat.vk.rahit
+++ b/shaders/vulkan/nv/cluster-id.spv14.nocompat.vk.rahit
@@ -1,0 +1,10 @@
+#version 460
+#extension GL_EXT_ray_tracing : require
+#extension GL_NV_cluster_acceleration_structure : require
+
+rayPayloadInEXT int payload;
+
+void main()
+{
+	payload = gl_ClusterIDNV;
+}

--- a/shaders/vulkan/nv/ray-query-cluster-id.spv14.nocompat.vk.comp
+++ b/shaders/vulkan/nv/ray-query-cluster-id.spv14.nocompat.vk.comp
@@ -1,0 +1,40 @@
+#version 460
+#extension GL_EXT_ray_query : require
+#extension GL_EXT_ray_tracing : require
+#extension GL_NV_cluster_acceleration_structure : require
+
+layout(set = 0, binding = 0) uniform accelerationStructureEXT AS;
+
+layout(set = 0, binding = 1) uniform Params
+{
+	uint ray_flags;
+	uint cull_mask;
+	vec3 origin;
+	float tmin;
+	vec3 dir;
+	float tmax;
+};
+
+layout(set = 0, binding = 2) buffer SSBO
+{
+	int id;
+};
+
+void main()
+{
+	rayQueryEXT q;
+	rayQueryInitializeEXT(q, AS, ray_flags, cull_mask, origin, tmin, dir, tmax);
+
+	while (rayQueryProceedEXT(q))
+	{
+		if (rayQueryGetIntersectionTypeEXT(q, false) == gl_RayQueryCandidateIntersectionTriangleEXT
+				&& rayQueryGetIntersectionClusterIdNV(q, false) != gl_ClusterIDNoneNV)
+		{
+			rayQueryTerminateEXT(q);
+			rayQueryConfirmIntersectionEXT(q);
+		}
+	}
+
+	if (rayQueryGetIntersectionTypeEXT(q, true) == gl_RayQueryCommittedIntersectionTriangleEXT)
+		id = rayQueryGetIntersectionClusterIdNV(q, true);
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -617,6 +617,13 @@ void CompilerGLSL::find_static_extensions()
 			ray_tracing_is_khr = true;
 			break;
 
+		case CapabilityRayTracingClusterAccelerationStructureNV:
+			if (options.es || options.version < 460 || !options.vulkan_semantics)
+				SPIRV_CROSS_THROW("Cluster AS requires Vulkan GLSL 460.");
+			require_extension_internal("GL_NV_cluster_acceleration_structure");
+			ray_tracing_is_khr = true;
+			break;
+
 		case CapabilityTensorsARM:
 			if (options.es || options.version < 460 || !options.vulkan_semantics)
 				SPIRV_CROSS_THROW("Tensor requires Vulkan GLSL 460.");
@@ -10305,6 +10312,14 @@ string CompilerGLSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 	case BuiltInCullPrimitiveEXT:
 		return "gl_CullPrimitiveEXT";
 
+	case BuiltInClusterIDNV:
+	{
+		if (!options.vulkan_semantics)
+			SPIRV_CROSS_THROW("Can only use ClusterIDNV in Vulkan GLSL.");
+		require_extension_internal("GL_NV_cluster_acceleration_structure");
+		return "gl_ClusterIDNV";
+	}
+
 	default:
 		return join("gl_BuiltIn_", convert_to_string(builtin));
 	}
@@ -15455,6 +15470,10 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 	GLSL_RAY_QUERY_GET_OP2(IntersectionWorldToObject);
 #undef GLSL_RAY_QUERY_GET_OP
 #undef GLSL_RAY_QUERY_GET_OP2
+	case OpRayQueryGetClusterIdNV:
+		flush_variable_declaration(ops[2]);
+		emit_op(ops[0], ops[1], join("rayQueryGetIntersectionClusterIdNV(", to_expression(ops[2]), ", ", "bool(", to_expression(ops[3]), "))"), false);
+		break;
 	case OpTensorQuerySizeARM:
 		flush_variable_declaration(ops[1]);
 		// tensorSizeARM(tensor, dimension)


### PR DESCRIPTION
The only thing missing is `OpHitObjectGetClusterIdNV` / `hitObjectGetClusterIdNV`.

I am very unsure if this is where the new code should go, let me know if I should move it around.

I'll also try to add some tests later, at which point I'll undraft this.