### PR TITLE
Add mesh shaders to reflection

### DIFF
--- a/spirv_reflect.cpp
+++ b/spirv_reflect.cpp
@@ -510,7 +510,9 @@ void CompilerReflection::emit_entry_points()
 			json_stream->begin_json_object();
 			json_stream->emit_json_key_value("name", e.name);
 			json_stream->emit_json_key_value("mode", execution_model_to_str(e.execution_model));
-			if (e.execution_model == ExecutionModelGLCompute)
+			if (e.execution_model == ExecutionModelGLCompute || e.execution_model == spv::ExecutionModelMeshEXT ||
+			    e.execution_model == spv::ExecutionModelMeshNV || e.execution_model == spv::ExecutionModelTaskEXT ||
+			    e.execution_model == spv::ExecutionModelTaskNV)
 			{
 				const auto &spv_entry = get_entry_point(e.name, e.execution_model);
 

--- a/spirv_reflect.cpp
+++ b/spirv_reflect.cpp
@@ -477,6 +477,12 @@ string CompilerReflection::execution_model_to_str(spv::ExecutionModel model)
 		return "rmiss";
 	case ExecutionModelCallableNV:
 		return "rcall";
+	case ExecutionModelMeshNV:
+	case ExecutionModelMeshEXT:
+		return "mesh";
+	case ExecutionModelTaskNV:
+	case ExecutionModelTaskEXT:
+		return "task";
 	default:
 		return "???";
 	}


### PR DESCRIPTION
Couple reflection touch ups related to mesh shaders.

1. It seems that `execution_model_to_str` lucks mesh shading execution models, so when reflecting spirv, it outputs:

```
✦ ❯ ./spirv-cross --reflect --msl triangle_ms.spv
{
    "entryPoints" : [
        {
            "name" : "main_ms",
            "mode" : "???"
        }
    ],
```

After this change:

```
✦ ❯ ./spirv-cross --reflect --msl triangle_ms.spv
{
    "entryPoints" : [
        {
            "name" : "main_ms",
            "mode" : "mesh"
        }
    ],
```

2. Output `workgroup_size` for mesh/task shaders:
```bash
✦ ❯ /Users/mpavlenko/Github/SPIRV-Cross/spirv-cross --reflect --msl triangle_as.spv
{
    "entryPoints" : [
        {
            "name" : "main_as",
            "mode" : "task",
            "workgroup_size" : [
                1,
                1,
                1
            ],
            "workgroup_size_is_spec_constant_id" : [
                false,
                false,
                false
            ]
        }
    ],
```