### PR TITLE
MSL: Fix edge case where a reference is taken of packed vector element.

### DIFF
--- a/reference/shaders-msl-no-opt/comp/atomic-cmpxchg-packed-vector.comp
+++ b/reference/shaders-msl-no-opt/comp/atomic-cmpxchg-packed-vector.comp
@@ -1,0 +1,37 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include <metal_atomic>
+
+using namespace metal;
+
+struct AttData0
+{
+    packed_uint3 att0[1];
+};
+
+kernel void main0(device AttData0& __restrict _22 [[buffer(0)]])
+{
+    uint newVal = 432u;
+    uint prevVal = 0u;
+    uint curVal = 0u;
+    for (;;)
+    {
+        uint _30;
+        do
+        {
+            _30 = prevVal;
+        } while (!atomic_compare_exchange_weak_explicit((device atomic_uint*)&((device uint*)&_22.att0[0])[0u], &_30, newVal, memory_order_relaxed, memory_order_relaxed) && _30 == prevVal);
+        curVal = _30;
+        if (_30 != prevVal)
+        {
+            continue;
+        }
+        else
+        {
+            break;
+        }
+    }
+}
+

--- a/reference/shaders-msl-no-opt/packing/isolated-scalar-access.comp
+++ b/reference/shaders-msl-no-opt/packing/isolated-scalar-access.comp
@@ -17,7 +17,7 @@ kernel void main0(device SSBO& _12 [[buffer(0)]])
     threadgroup float4 shared_vec4;
     threadgroup float3 shared_vec3;
     ((device float*)&_12.v)[0u] = 10.0;
-    _12.v3[1u] = 40.0;
+    ((device float*)&_12.v3)[1u] = 40.0;
     ((device float*)&_12.cm[1])[2u] = 20.0;
     ((device float*)&_12.rm[1u])[3] = 30.0;
     ((threadgroup float*)&shared_vec4)[2u] = 40.0;

--- a/reference/shaders-msl-no-opt/packing/matrix-2x3-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-2x3-scalar.comp
@@ -74,8 +74,8 @@ void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 static inline __attribute__((always_inline))
 void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    _29.col_major0[0][1u] = ((device float*)&_41.row_major0[1u])[0];
-    ((device float*)&_41.row_major0[1u])[0] = _29.col_major0[0][1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
 kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])

--- a/reference/shaders-msl-no-opt/packing/matrix-3x2-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x2-scalar.comp
@@ -73,8 +73,8 @@ void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 static inline __attribute__((always_inline))
 void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&_29.col_major0[0])[1u] = _41.row_major0[1u][0];
-    _41.row_major0[1u][0] = ((device float*)&_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
 kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])

--- a/reference/shaders-msl-no-opt/packing/matrix-3x3-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x3-scalar.comp
@@ -84,8 +84,8 @@ void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 static inline __attribute__((always_inline))
 void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    _29.col_major0[0][1u] = _41.row_major0[1u][0];
-    _41.row_major0[1u][0] = _29.col_major0[0][1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
 kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])

--- a/reference/shaders-msl-no-opt/packing/matrix-3x4-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-3x4-scalar.comp
@@ -81,8 +81,8 @@ void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 static inline __attribute__((always_inline))
 void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    ((device float*)&_29.col_major0[0])[1u] = _41.row_major0[1u][0];
-    _41.row_major0[1u][0] = ((device float*)&_29.col_major0[0])[1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
 kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])

--- a/reference/shaders-msl-no-opt/packing/matrix-4x3-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/matrix-4x3-scalar.comp
@@ -80,8 +80,8 @@ void copy_columns(device SSBOCol& _29, device SSBORow& _41)
 static inline __attribute__((always_inline))
 void copy_elements(device SSBOCol& _29, device SSBORow& _41)
 {
-    _29.col_major0[0][1u] = ((device float*)&_41.row_major0[1u])[0];
-    ((device float*)&_41.row_major0[1u])[0] = _29.col_major0[0][1u];
+    ((device float*)&_29.col_major0[0])[1u] = ((device float*)&_41.row_major0[1u])[0];
+    ((device float*)&_41.row_major0[1u])[0] = ((device float*)&_29.col_major0[0])[1u];
 }
 
 kernel void main0(device SSBOCol& _29 [[buffer(0)]], device SSBORow& _41 [[buffer(1)]])

--- a/reference/shaders-msl-no-opt/packing/struct-packing-array-of-scalar.comp
+++ b/reference/shaders-msl-no-opt/packing/struct-packing-array-of-scalar.comp
@@ -17,6 +17,6 @@ constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 kernel void main0(device SSBOScalar& buffer_scalar [[buffer(0)]])
 {
-    buffer_scalar.v[1].a[1u] = 1.0;
+    ((device float*)&buffer_scalar.v[1].a)[1u] = 1.0;
 }
 

--- a/reference/shaders-msl-no-opt/packing/struct-packing-recursive.comp
+++ b/reference/shaders-msl-no-opt/packing/struct-packing-recursive.comp
@@ -28,6 +28,6 @@ constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 kernel void main0(device SSBOScalar& buffer_scalar [[buffer(0)]])
 {
-    buffer_scalar.baz.a.a.a[3u] = 10.0;
+    ((device float*)&buffer_scalar.baz.a.a.a)[3u] = 10.0;
 }
 

--- a/reference/shaders-msl-no-opt/packing/struct-packing.comp
+++ b/reference/shaders-msl-no-opt/packing/struct-packing.comp
@@ -23,7 +23,7 @@ constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 kernel void main0(device SSBOScalar& buffer_scalar [[buffer(0)]])
 {
-    buffer_scalar.foo.a[0u] = 10.0;
-    buffer_scalar.bar.a[0u] = 20.0;
+    ((device float*)&buffer_scalar.foo.a)[0u] = 10.0;
+    ((device float*)&buffer_scalar.bar.a)[0u] = 20.0;
 }
 

--- a/shaders-msl-no-opt/comp/atomic-cmpxchg-packed-vector.comp
+++ b/shaders-msl-no-opt/comp/atomic-cmpxchg-packed-vector.comp
@@ -1,0 +1,17 @@
+#version 460
+#extension GL_EXT_nonuniform_qualifier : enable
+#extension GL_EXT_scalar_block_layout : require
+
+layout(scalar, binding=1) restrict buffer AttData0 {
+    uvec3 att0[];
+};
+
+void main() {
+    uint newVal = 432;
+    uint prevVal = 0;
+    uint curVal = 0;
+    
+    while ( (curVal = atomicCompSwap(att0[0].x, prevVal, newVal)) != prevVal)
+    {
+    }
+};


### PR DESCRIPTION
Apparently, this is not allowed.

Fix #2515.