### PR TITLE
MSL: Don't use fast::normalize for half at all.

### DIFF
--- a/reference/shaders-msl-no-opt/frag/fp16.desktop.invalid.frag
+++ b/reference/shaders-msl-no-opt/frag/fp16.desktop.invalid.frag
@@ -150,7 +150,7 @@ void test_builtins(thread half4& v4, thread half3& v3, thread half& v1)
     t0 = distance(v4, v4);
     t0 = dot(v4, v4);
     half3 res3 = cross(v3, v3);
-    res = fast::normalize(v4);
+    res = normalize(v4);
     res = faceforward(v4, v4, v4);
     res = reflect(v4, v4);
     res = refract(v4, v4, v1);

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -11535,11 +11535,11 @@ void CompilerMSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop, 
 	{
 		auto &exp_type = expression_type(args[0]);
 		// MSL does not support scalar versions here.
-		// MSL has no implementation for normalize in the fast:: namespace for half2 and half3
+		// MSL has no implementation for normalize in the fast:: namespace for half
 		// Returns -1 or 1 for valid input, sign() does the job.
 		if (exp_type.vecsize == 1)
 			emit_unary_func_op(result_type, id, args[0], "sign");
-		else if (exp_type.vecsize <= 3 && exp_type.basetype == SPIRType::Half)
+		else if (exp_type.basetype == SPIRType::Half)
 			emit_unary_func_op(result_type, id, args[0], "normalize");
 		else
 			emit_unary_func_op(result_type, id, args[0], "fast::normalize");


### PR DESCRIPTION
Clearly doesn't exist on shader playground, so ... *shrug*

Fix #2524.