### PR TITLE
glsl: support OpAccessChain on OpTypeCooperativeVectorNV

### DIFF
--- a/reference/opt/shaders/comp/cooperative-vec-nv.spv16.vk.nocompat.comp.vk
+++ b/reference/opt/shaders/comp/cooperative-vec-nv.spv16.vk.nocompat.comp.vk
@@ -34,6 +34,7 @@ void main()
     inVec = tempArg_2;
     coopvecNV<float16_t, 8u> a = coopvecNV<float16_t, 8u>(float16_t(0.0));
     inVec = max(inVec, inVec);
+    inVec[5] = inVec[3] + inVec[4];
     coopVecOuterProductAccumulateNV(inVec, inVec, _15.data_q, 0u, 0u, gl_CooperativeVectorMatrixLayoutTrainingOptimalNV, gl_ComponentTypeFloat16NV);
     coopVecReduceSumAccumulateNV(inVec, _15.data_q, 0u);
     coopvecNV<int8_t, 8u> a_8bit = coopvecNV<int8_t, 8u>(int8_t(0));

--- a/reference/shaders/comp/cooperative-vec-nv.spv16.vk.nocompat.comp.vk
+++ b/reference/shaders/comp/cooperative-vec-nv.spv16.vk.nocompat.comp.vk
@@ -34,6 +34,7 @@ void main()
     inVec = tempArg_2;
     coopvecNV<float16_t, 8u> a = coopvecNV<float16_t, 8u>(float16_t(0.0));
     inVec = max(inVec, inVec);
+    inVec[5] = inVec[3] + inVec[4];
     coopVecOuterProductAccumulateNV(inVec, inVec, _15.data_q, 0u, 0u, gl_CooperativeVectorMatrixLayoutTrainingOptimalNV, gl_ComponentTypeFloat16NV);
     coopVecReduceSumAccumulateNV(inVec, _15.data_q, 0u);
     coopvecNV<int8_t, 8u> a_8bit = coopvecNV<int8_t, 8u>(int8_t(0));

--- a/shaders/comp/cooperative-vec-nv.spv16.vk.nocompat.comp
+++ b/shaders/comp/cooperative-vec-nv.spv16.vk.nocompat.comp
@@ -51,6 +51,7 @@ void main()
                     2);
     coopvecNV<float16_t, 8> a = coopvecNV<float16_t, 8>(0);
     inVec = max(inVec, inVec);
+    inVec[5] = inVec[3] + inVec[4];
 
     coopVecOuterProductAccumulateNV(inVec, inVec, data_q, 0, 0, matrixLayout, gl_ComponentTypeFloat16NV);
     coopVecReduceSumAccumulateNV(inVec,  data_q, 0);

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -10621,8 +10621,8 @@ string CompilerGLSL::access_chain_internal(uint32_t base, const uint32_t *indice
 			if (ptr_chain_array_entry)
 				expr = join("(", expr, ")");
 		}
-		// Arrays
-		else if (!type->array.empty())
+		// Arrays and OpTypeCooperativeVectorNV (aka fancy arrays)
+		else if (!type->array.empty() || type->op == spv::OpTypeCooperativeVectorNV)
 		{
 			// If we are flattening multidimensional arrays, only create opening bracket on first
 			// array index.


### PR DESCRIPTION
I realized that #2489 omitted OpAccessChain on OpTypeCooperativeVectorNV. I'm not familiar enough with the code base how to best handle this, but semantically cooperative vectors are pretty much fancy arrays with additional math operations on them. The code path for arrays seems to have the right logic to handle this. There is also a code path for OpTypeCooperativeMatrixNV and normal vectors, but it would require too much distinctions to be used with OpTypeCooperativeVectorNV