### PR TITLE
Add source language to parsed IR source data

### DIFF
--- a/spirv_cross_parsed_ir.hpp
+++ b/spirv_cross_parsed_ir.hpp
@@ -111,6 +111,7 @@ public:
 
 	struct Source
 	{
+		spv::SourceLanguage lang = spv::SourceLanguageUnknown;
 		uint32_t version = 0;
 		bool es = false;
 		bool known = false;

--- a/spirv_parser.cpp
+++ b/spirv_parser.cpp
@@ -213,8 +213,8 @@ void Parser::parse(const Instruction &instruction)
 
 	case OpSource:
 	{
-		auto lang = static_cast<SourceLanguage>(ops[0]);
-		switch (lang)
+		ir.source.lang = static_cast<SourceLanguage>(ops[0]);
+		switch (ir.source.lang)
 		{
 		case SourceLanguageESSL:
 			ir.source.es = true;


### PR DESCRIPTION
Currently, `ParsedIR::Source` struct contains partial information about the source language. The source language itself obtained from the byte code is dropped, while in some scenarios it may be useful. In our specific use case, we need to know whether the byte code was produced by slang.

This minor change adds the `lang` member to `ParsedIR::Source` struct so that clients can access it.