### PR TITLE
MSL: Fix boolean spec const as_type<> invalid output

### DIFF
--- a/shaders-msl/asm/frag/spec-constant-bool-mixed.asm.frag
+++ b/shaders-msl/asm/frag/spec-constant-bool-mixed.asm.frag
@@ -1,0 +1,38 @@
+; SPIR-V
+; Option A test: same SpecId used for bool and uint
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %outColor
+OpExecutionMode %main OriginUpperLeft
+
+%void = OpTypeVoid
+%fn = OpTypeFunction %void
+%float = OpTypeFloat 32
+%v4float = OpTypeVector %float 4
+%uint = OpTypeInt 32 0
+%bool = OpTypeBool
+
+%ptr_Output_v4float = OpTypePointer Output %v4float
+%outColor = OpVariable %ptr_Output_v4float Output
+
+%float_0 = OpConstant %float 0
+%float_1 = OpConstant %float 1
+
+%specBool = OpSpecConstantTrue %bool
+%specUint = OpSpecConstant %uint 0
+
+OpDecorate %outColor Location 0
+OpDecorate %specBool SpecId 0
+OpDecorate %specUint SpecId 0
+
+%main = OpFunction %void None %fn
+%entry = OpLabel
+%u_to_f = OpConvertUToF %float %specUint
+%sel = OpSelect %float %specBool %float_1 %float_0
+%sum = OpFAdd %float %u_to_f %sel
+%vec = OpCompositeConstruct %v4float %sum %sum %sum %sum
+OpStore %outColor %vec
+OpReturn
+OpFunctionEnd
+
+

--- a/shaders-msl/asm/frag/spec-constant-bool-mixed.asm.frag
+++ b/shaders-msl/asm/frag/spec-constant-bool-mixed.asm.frag
@@ -5,6 +5,10 @@ OpMemoryModel Logical GLSL450
 OpEntryPoint Fragment %main "main" %outColor
 OpExecutionMode %main OriginUpperLeft
 
+OpDecorate %outColor Location 0
+OpDecorate %specBool SpecId 0
+OpDecorate %specUint SpecId 0
+
 %void = OpTypeVoid
 %fn = OpTypeFunction %void
 %float = OpTypeFloat 32
@@ -12,18 +16,14 @@ OpExecutionMode %main OriginUpperLeft
 %uint = OpTypeInt 32 0
 %bool = OpTypeBool
 
-%ptr_Output_v4float = OpTypePointer Output %v4float
-%outColor = OpVariable %ptr_Output_v4float Output
-
 %float_0 = OpConstant %float 0
 %float_1 = OpConstant %float 1
 
 %specBool = OpSpecConstantTrue %bool
 %specUint = OpSpecConstant %uint 0
 
-OpDecorate %outColor Location 0
-OpDecorate %specBool SpecId 0
-OpDecorate %specUint SpecId 0
+%ptr_Output_v4float = OpTypePointer Output %v4float
+%outColor = OpVariable %ptr_Output_v4float Output
 
 %main = OpFunction %void None %fn
 %entry = OpLabel


### PR DESCRIPTION
RenderDoc generates SPIR-V that may reuse boolean specialization constants, resulting in invalid MSL being generated.

- Updated `emit_specialization_constants_and_structs` to deduplicate function constants and handle boolean types correctly, avoiding illegal bitcasting in Metal.
- Modified `bitcast_glsl_op` to prevent bitcasting to/from boolean types, ensuring compliance with Metal's restrictions.
- Added a new test shader `spec-constant-bool-mixed.asm.frag` to validate the behavior of mixed specialization constants with the same SpecId for boolean and uint types.