### PR TITLE
MSL: Fix array copy to array inside stage IO Blocks.

### DIFF
--- a/reference/shaders-msl-no-opt/vert/block-io-array-copy.vert
+++ b/reference/shaders-msl-no-opt/vert/block-io-array-copy.vert
@@ -1,0 +1,92 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wmissing-braces"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+template<typename T, size_t Num>
+struct spvUnsafeArray
+{
+    T elements[Num ? Num : 1];
+    
+    thread T& operator [] (size_t pos) thread
+    {
+        return elements[pos];
+    }
+    constexpr const thread T& operator [] (size_t pos) const thread
+    {
+        return elements[pos];
+    }
+    
+    device T& operator [] (size_t pos) device
+    {
+        return elements[pos];
+    }
+    constexpr const device T& operator [] (size_t pos) const device
+    {
+        return elements[pos];
+    }
+    
+    constexpr const constant T& operator [] (size_t pos) const constant
+    {
+        return elements[pos];
+    }
+    
+    threadgroup T& operator [] (size_t pos) threadgroup
+    {
+        return elements[pos];
+    }
+    constexpr const threadgroup T& operator [] (size_t pos) const threadgroup
+    {
+        return elements[pos];
+    }
+};
+
+struct Vertex
+{
+    float2 umbrage;
+    spvUnsafeArray<float4, 3> offset;
+};
+
+struct main0_out
+{
+    float2 aa_umbrage [[user(locn1)]];
+    float4 aa_offset_0 [[user(locn2)]];
+    float4 aa_offset_1 [[user(locn3)]];
+    float4 aa_offset_2 [[user(locn4)]];
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float3 dd_0 [[attribute(3)]];
+};
+
+static inline __attribute__((always_inline))
+void Wobble(thread const float2& uu, thread spvUnsafeArray<float4, 3>& offset)
+{
+    offset[0] = float4(uu.xyxy);
+    offset[1] = float4(uu.xyxy);
+    offset[2] = float4(uu.xyxy);
+}
+
+vertex main0_out main0(main0_in in [[stage_in]])
+{
+    main0_out out = {};
+    Vertex aa = {};
+    spvUnsafeArray<float3, 1> dd = {};
+    dd[0] = in.dd_0;
+    float2 param = dd[0].xy;
+    spvUnsafeArray<float4, 3> param_1;
+    Wobble(param, param_1);
+    aa.offset = param_1;
+    out.gl_Position = float4(1.0, 1.0, 0.0, 1.0);
+    out.aa_umbrage = aa.umbrage;
+    out.aa_offset_0 = aa.offset[0];
+    out.aa_offset_1 = aa.offset[1];
+    out.aa_offset_2 = aa.offset[2];
+    return out;
+}
+

--- a/shaders-msl-no-opt/vert/block-io-array-copy.vert
+++ b/shaders-msl-no-opt/vert/block-io-array-copy.vert
@@ -1,0 +1,21 @@
+#version 450
+
+void Wobble(vec2 uu, out vec4 offset[3])
+{
+	offset[0] = vec4(uu, uu);
+	offset[1] = vec4(uu, uu);
+	offset[2] = vec4(uu, uu);
+}
+
+layout(location = 3) in vec3 dd[1];
+
+layout(location = 1) out Vertex {
+	vec2 umbrage;
+	vec4 offset[3];
+} aa;
+
+void main()
+{
+	Wobble(dd[0].st, aa.offset);
+	gl_Position = vec4(1.0, 1.0, 0.0, 1.0);
+}

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -1178,11 +1178,8 @@ bool Compiler::type_is_top_level_block(const SPIRType &type) const
 	return has_decoration(type.self, DecorationBlock) || has_decoration(type.self, DecorationBufferBlock);
 }
 
-bool Compiler::type_is_block_like(const SPIRType &type) const
+bool Compiler::type_is_explicit_layout(const SPIRType &type) const
 {
-	if (type_is_top_level_block(type))
-		return true;
-
 	if (type.basetype == SPIRType::Struct)
 	{
 		// Block-like types may have Offset decorations.
@@ -1192,6 +1189,14 @@ bool Compiler::type_is_block_like(const SPIRType &type) const
 	}
 
 	return false;
+}
+
+bool Compiler::type_is_block_like(const SPIRType &type) const
+{
+	if (type_is_top_level_block(type))
+		return true;
+	else
+		return type_is_explicit_layout(type);
 }
 
 void Compiler::parse_fixup()

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -1172,6 +1172,7 @@ protected:
 	bool type_contains_recursion(const SPIRType &type);
 	bool type_is_array_of_pointers(const SPIRType &type) const;
 	bool type_is_block_like(const SPIRType &type) const;
+	bool type_is_explicit_layout(const SPIRType &type) const;
 	bool type_is_top_level_block(const SPIRType &type) const;
 	bool type_is_opaque_value(const SPIRType &type) const;
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -10801,13 +10801,13 @@ bool CompilerMSL::emit_array_copy(const char *expr, uint32_t lhs_id, uint32_t rh
 	auto *lhs_var = maybe_get_backing_variable(lhs_id);
 	if (lhs_var && lhs_storage == StorageClassStorageBuffer && storage_class_array_is_thread(lhs_var->storage))
 		lhs_is_array_template = true;
-	else if (lhs_var && lhs_storage != StorageClassGeneric && type_is_block_like(get<SPIRType>(lhs_var->basetype)))
+	else if (lhs_var && lhs_storage != StorageClassGeneric && type_is_explicit_layout(get<SPIRType>(lhs_var->basetype)))
 		lhs_is_array_template = false;
 
 	auto *rhs_var = maybe_get_backing_variable(rhs_id);
 	if (rhs_var && rhs_storage == StorageClassStorageBuffer && storage_class_array_is_thread(rhs_var->storage))
 		rhs_is_array_template = true;
-	else if (rhs_var && rhs_storage != StorageClassGeneric && type_is_block_like(get<SPIRType>(rhs_var->basetype)))
+	else if (rhs_var && rhs_storage != StorageClassGeneric && type_is_explicit_layout(get<SPIRType>(rhs_var->basetype)))
 		rhs_is_array_template = false;
 
 	// If threadgroup storage qualifiers are *not* used:


### PR DESCRIPTION
Need to consider if the type is actually using explicit layout (in which case we drop array wrapper), not if it's just block-like, which also covers stage IO.

Fix #2527.