### PR TITLE
MSL: Don't emit const device for readonly SSBO.

### DIFF
--- a/reference/opt/shaders-msl/asm/tesc/tess-level-overrun.asm.tesc
+++ b/reference/opt/shaders-msl/asm/tesc/tess-level-overrun.asm.tesc
@@ -13,7 +13,7 @@ struct TessLevels
     float outer3;
 };
 
-kernel void main0(const device TessLevels& sb_levels [[buffer(0)]], uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], constant uint* spvIndirectParams [[buffer(29)]], device MTLTriangleTessellationFactorsHalf* spvTessLevel [[buffer(26)]])
+kernel void main0(device TessLevels& sb_levels [[buffer(0)]], uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], constant uint* spvIndirectParams [[buffer(29)]], device MTLTriangleTessellationFactorsHalf* spvTessLevel [[buffer(26)]])
 {
     spvTessLevel[gl_PrimitiveID].insideTessellationFactor = half(sb_levels.inner0);
     spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(sb_levels.outer0);

--- a/reference/opt/shaders-msl/asm/tesc/tess-level-overrun.multi-patch.asm.tesc
+++ b/reference/opt/shaders-msl/asm/tesc/tess-level-overrun.multi-patch.asm.tesc
@@ -13,7 +13,7 @@ struct TessLevels
     float outer3;
 };
 
-kernel void main0(const device TessLevels& sb_levels [[buffer(0)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], constant uint* spvIndirectParams [[buffer(29)]], device MTLTriangleTessellationFactorsHalf* spvTessLevel [[buffer(26)]])
+kernel void main0(device TessLevels& sb_levels [[buffer(0)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], constant uint* spvIndirectParams [[buffer(29)]], device MTLTriangleTessellationFactorsHalf* spvTessLevel [[buffer(26)]])
 {
     uint gl_PrimitiveID = min(gl_GlobalInvocationID.x / 1, spvIndirectParams[1] - 1);
     spvTessLevel[gl_PrimitiveID].insideTessellationFactor = half(sb_levels.inner0);

--- a/reference/opt/shaders-msl/comp/argument-buffers-discrete.msl2.argument.discrete.comp
+++ b/reference/opt/shaders-msl/comp/argument-buffers-discrete.msl2.argument.discrete.comp
@@ -27,15 +27,15 @@ constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 struct spvDescriptorSetBuffer0
 {
-    const device SSBO0* ssbo0 [[id(0)]];
+    device SSBO0* ssbo0 [[id(0)]];
 };
 
 struct spvDescriptorSetBuffer1
 {
-    const device SSBO1* ssbo1 [[id(0)]];
+    device SSBO1* ssbo1 [[id(0)]];
 };
 
-kernel void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], constant spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], device SSBO3& ssbo3 [[buffer(2)]], const device SSBO2& ssbo2 [[buffer(3)]])
+kernel void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], constant spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], device SSBO3& ssbo3 [[buffer(2)]], device SSBO2& ssbo2 [[buffer(3)]])
 {
     ssbo3.v = ((*spvDescriptorSet0.ssbo0).v + (*spvDescriptorSet1.ssbo1).v) + ssbo2.v;
 }

--- a/reference/opt/shaders-msl/comp/argument-buffers-runtime-array-buffer.argument.device-argument-buffer.argument-tier-1.msl2.comp
+++ b/reference/opt/shaders-msl/comp/argument-buffers-runtime-array-buffer.argument.device-argument-buffer.argument-tier-1.msl2.comp
@@ -64,7 +64,7 @@ struct spvDescriptorSetBuffer1
     spvDescriptor<device SSBOIns *> ws [[id(1)]][1] /* unsized array hack */;
 };
 
-kernel void main0(const device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], const device spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
+kernel void main0(device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], device spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
 {
     spvDescriptorArray<constant UBOs*> vs {spvDescriptorSet0.vs};
     spvDescriptorArray<device SSBOIns*> ws {spvDescriptorSet1.ws};

--- a/reference/opt/shaders-msl/comp/argument-buffers-runtime-array-buffer.rich-descriptor.argument.device-argument-buffer.argument-tier-1.msl2.comp
+++ b/reference/opt/shaders-msl/comp/argument-buffers-runtime-array-buffer.rich-descriptor.argument.device-argument-buffer.argument-tier-1.msl2.comp
@@ -96,7 +96,7 @@ struct spvDescriptorSetBuffer1
     spvBufferDescriptor<device SSBOIns *> ws [[id(1)]][1] /* unsized array hack */;
 };
 
-kernel void main0(const device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], const device spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
+kernel void main0(device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], device spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
 {
     spvDescriptorArray<constant UBOs*> vs {spvDescriptorSet0.vs};
     spvDescriptorArray<device SSBOIns*> ws {spvDescriptorSet1.ws};

--- a/reference/opt/shaders-msl/comp/argument-buffers-runtime-array.argument.device-argument-buffer.argument-tier-1.msl2.comp
+++ b/reference/opt/shaders-msl/comp/argument-buffers-runtime-array.argument.device-argument-buffer.argument-tier-1.msl2.comp
@@ -44,7 +44,7 @@ struct spvDescriptorSetBuffer1
     spvDescriptor<sampler> Ss [[id(1)]][1] /* unsized array hack */;
 };
 
-kernel void main0(const device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], const device spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
+kernel void main0(device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], device spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
 {
     spvDescriptorArray<texture2d<float>> Ts {spvDescriptorSet0.Ts};
     spvDescriptorArray<sampler> Ss {spvDescriptorSet1.Ss};

--- a/reference/opt/shaders-msl/comp/basic.comp
+++ b/reference/opt/shaders-msl/comp/basic.comp
@@ -23,7 +23,7 @@ struct SSBO3
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(const device SSBO& _23 [[buffer(0)]], device SSBO2& _45 [[buffer(1)]], device SSBO3& _48 [[buffer(2)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(device SSBO& _23 [[buffer(0)]], device SSBO2& _45 [[buffer(1)]], device SSBO3& _48 [[buffer(2)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
     float4 _29 = _23.in_data[gl_GlobalInvocationID.x];
     if (dot(_29, float4(1.0, 5.0, 6.0, 2.0)) > 8.19999980926513671875)

--- a/reference/opt/shaders-msl/comp/basic.dispatchbase.comp
+++ b/reference/opt/shaders-msl/comp/basic.dispatchbase.comp
@@ -25,7 +25,7 @@ constant uint _59_tmp [[function_constant(10)]];
 constant uint _59 = is_function_constant_defined(_59_tmp) ? _59_tmp : 1u;
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(_59, 1u, 1u);
 
-kernel void main0(const device SSBO& _27 [[buffer(0)]], device SSBO2& _49 [[buffer(1)]], device SSBO3& _52 [[buffer(2)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 spvDispatchBase [[grid_origin]])
+kernel void main0(device SSBO& _27 [[buffer(0)]], device SSBO2& _49 [[buffer(1)]], device SSBO3& _52 [[buffer(2)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 spvDispatchBase [[grid_origin]])
 {
     gl_GlobalInvocationID += spvDispatchBase * gl_WorkGroupSize;
     float4 _33 = _27.in_data[gl_GlobalInvocationID.x];

--- a/reference/opt/shaders-msl/comp/basic.dispatchbase.msl11.comp
+++ b/reference/opt/shaders-msl/comp/basic.dispatchbase.msl11.comp
@@ -23,7 +23,7 @@ struct SSBO3
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(constant uint3& spvDispatchBase [[buffer(29)]], const device SSBO& _27 [[buffer(0)]], device SSBO2& _49 [[buffer(1)]], device SSBO3& _52 [[buffer(2)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(constant uint3& spvDispatchBase [[buffer(29)]], device SSBO& _27 [[buffer(0)]], device SSBO2& _49 [[buffer(1)]], device SSBO3& _52 [[buffer(2)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
     gl_GlobalInvocationID += spvDispatchBase * gl_WorkGroupSize;
     float4 _33 = _27.in_data[gl_GlobalInvocationID.x];

--- a/reference/opt/shaders-msl/comp/culling.comp
+++ b/reference/opt/shaders-msl/comp/culling.comp
@@ -23,7 +23,7 @@ struct SSBO3
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(4u, 1u, 1u);
 
-kernel void main0(const device SSBO& _22 [[buffer(0)]], device SSBO2& _38 [[buffer(1)]], device SSBO3& _41 [[buffer(2)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(device SSBO& _22 [[buffer(0)]], device SSBO2& _38 [[buffer(1)]], device SSBO3& _41 [[buffer(2)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
     float _28 = _22.in_data[gl_GlobalInvocationID.x];
     if (_28 > 12.0)

--- a/reference/opt/shaders-msl/comp/dowhile.comp
+++ b/reference/opt/shaders-msl/comp/dowhile.comp
@@ -16,7 +16,7 @@ struct SSBO2
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(const device SSBO& _28 [[buffer(0)]], device SSBO2& _52 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(device SSBO& _28 [[buffer(0)]], device SSBO2& _52 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
     float4 _59;
     int _60;

--- a/reference/opt/shaders-msl/comp/inverse.comp
+++ b/reference/opt/shaders-msl/comp/inverse.comp
@@ -121,7 +121,7 @@ struct MatrixIn
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(device MatrixOut& _15 [[buffer(0)]], const device MatrixIn& _20 [[buffer(1)]])
+kernel void main0(device MatrixOut& _15 [[buffer(0)]], device MatrixIn& _20 [[buffer(1)]])
 {
     _15.m2out = spvInverse2x2(_20.m2in);
     _15.m3out = spvInverse3x3(_20.m3in);

--- a/reference/opt/shaders-msl/comp/mod.comp
+++ b/reference/opt/shaders-msl/comp/mod.comp
@@ -32,7 +32,7 @@ struct SSBO2
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(const device SSBO& _23 [[buffer(0)]], device SSBO2& _33 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(device SSBO& _23 [[buffer(0)]], device SSBO2& _33 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
     float4 _29 = _23.in_data[gl_GlobalInvocationID.x];
     _33.out_data[gl_GlobalInvocationID.x] = mod(_29, _33.out_data[gl_GlobalInvocationID.x]);

--- a/reference/opt/shaders-msl/comp/modf.comp
+++ b/reference/opt/shaders-msl/comp/modf.comp
@@ -21,7 +21,7 @@ struct SSBO2
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(const device SSBO& _23 [[buffer(0)]], device SSBO2& _38 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(device SSBO& _23 [[buffer(0)]], device SSBO2& _38 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
     ResType _32;
     _32._m0 = modf(_23.in_data[gl_GlobalInvocationID.x], _32._m1);

--- a/reference/opt/shaders-msl/comp/outer-product.comp
+++ b/reference/opt/shaders-msl/comp/outer-product.comp
@@ -25,7 +25,7 @@ struct ReadSSBO
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(device SSBO& _21 [[buffer(0)]], const device ReadSSBO& _26 [[buffer(1)]])
+kernel void main0(device SSBO& _21 [[buffer(0)]], device ReadSSBO& _26 [[buffer(1)]])
 {
     float2 _29 = _26.v2;
     _21.m22 = float2x2(_29 * _29.x, _29 * _29.y);

--- a/reference/opt/shaders-msl/comp/overlapping-bindings.msl31.argument.argument-tier-1.decoration-binding.device-argument-buffer.texture-buffer-native.comp
+++ b/reference/opt/shaders-msl/comp/overlapping-bindings.msl31.argument.argument-tier-1.decoration-binding.device-argument-buffer.texture-buffer-native.comp
@@ -114,7 +114,7 @@ struct spvDescriptorSetBuffer4
     // Overlapping binding: texture_buffer<uint, access::read_write> u4 [[id(0)]];
 };
 
-kernel void main0(const device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], const device spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], constant spvDescriptorSetBuffer2& spvDescriptorSet2 [[buffer(2)]], constant spvDescriptorSetBuffer3& spvDescriptorSet3 [[buffer(3)]], constant spvDescriptorSetBuffer4& spvDescriptorSet4 [[buffer(4)]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
+kernel void main0(device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], device spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], constant spvDescriptorSetBuffer2& spvDescriptorSet2 [[buffer(2)]], constant spvDescriptorSetBuffer3& spvDescriptorSet3 [[buffer(3)]], constant spvDescriptorSetBuffer4& spvDescriptorSet4 [[buffer(4)]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
 {
     spvDescriptorArray<device B30*> b30 {spvDescriptorSet1.b30};
     spvDescriptorArray<texture2d<uint>> t31 {reinterpret_cast<const device spvDescriptor<texture2d<uint>>*>(&spvDescriptorSet1.b30)};

--- a/reference/opt/shaders-msl/comp/raw-buffer-descriptor-aliasing.argument.discrete.device-argument-buffer.msl2.decoration-binding.comp
+++ b/reference/opt/shaders-msl/comp/raw-buffer-descriptor-aliasing.argument.discrete.device-argument-buffer.msl2.decoration-binding.comp
@@ -93,27 +93,27 @@ struct spvDescriptorSetBuffer0
     // Overlapping binding: constant UBO_D* ubo_d [[id(1)]];
     device SSBO_As* ssbo_as [[id(2)]][4];
     // Overlapping binding: device SSBO_Bs* ssbo_bs [[id(2)]][4];
-    // Overlapping binding: const device SSBO_BsRO* ssbo_bs_readonly [[id(2)]][4];
+    // Overlapping binding: device SSBO_BsRO* ssbo_bs_readonly [[id(2)]][4];
     constant UBO_Cs* ubo_cs [[id(6)]][4];
     // Overlapping binding: constant UBO_Ds* ubo_ds [[id(6)]][4];
     device SSBO_A* ssbo_a [[id(10)]];
     // Overlapping binding: device SSBO_B* ssbo_b [[id(10)]];
-    // Overlapping binding: const device SSBO_BRO* ssbo_b_readonly [[id(10)]];
+    // Overlapping binding: device SSBO_BRO* ssbo_b_readonly [[id(10)]];
 };
 
-kernel void main0(const device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], constant Registers& _42 [[buffer(1)]], device void* spvBufferAliasSet2Binding11 [[buffer(11)]], constant void* spvBufferAliasSet2Binding12 [[buffer(12)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
+kernel void main0(device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], constant Registers& _42 [[buffer(1)]], device void* spvBufferAliasSet2Binding11 [[buffer(11)]], constant void* spvBufferAliasSet2Binding12 [[buffer(12)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
 {
     device auto& ssbo_e = *(device SSBO_E*)spvBufferAliasSet2Binding11;
     constant auto& ubo_g = *(constant UBO_G*)spvBufferAliasSet2Binding12;
     device auto& ssbo_f = *(device SSBO_F*)spvBufferAliasSet2Binding11;
     constant auto& ubo_h = *(constant UBO_H*)spvBufferAliasSet2Binding12;
-    const device auto& ssbo_i = *(const device SSBO_I*)spvBufferAliasSet2Binding11;
+    device auto& ssbo_i = *(device SSBO_I*)spvBufferAliasSet2Binding11;
     constant auto &ubo_d = *reinterpret_cast<constant UBO_D* const device &>(spvDescriptorSet0.ubo_c);
     const device auto &ssbo_bs = reinterpret_cast<device SSBO_Bs* const device (&)[4]>(spvDescriptorSet0.ssbo_as);
-    const device auto &ssbo_bs_readonly = reinterpret_cast<const device SSBO_BsRO* const device (&)[4]>(spvDescriptorSet0.ssbo_as);
+    const device auto &ssbo_bs_readonly = reinterpret_cast<device SSBO_BsRO* const device (&)[4]>(spvDescriptorSet0.ssbo_as);
     const device auto &ubo_ds = reinterpret_cast<constant UBO_Ds* const device (&)[4]>(spvDescriptorSet0.ubo_cs);
     device auto &ssbo_b = *reinterpret_cast<device SSBO_B* const device &>(spvDescriptorSet0.ssbo_a);
-    const device auto &ssbo_b_readonly = *reinterpret_cast<const device SSBO_BRO* const device &>(spvDescriptorSet0.ssbo_a);
+    device auto &ssbo_b_readonly = *reinterpret_cast<device SSBO_BRO* const device &>(spvDescriptorSet0.ssbo_a);
     (*spvDescriptorSet0.ssbo_a).data[gl_GlobalInvocationID.x] = (*spvDescriptorSet0.ubo_c).data[gl_WorkGroupID.x].x + _42.reg;
     ssbo_b.data[gl_GlobalInvocationID.x] = ubo_d.data[gl_WorkGroupID.y].xy + ssbo_b_readonly.data[gl_GlobalInvocationID.x];
     spvDescriptorSet0.ssbo_as[gl_WorkGroupID.x]->data[gl_GlobalInvocationID.x] = spvDescriptorSet0.ubo_cs[gl_WorkGroupID.x]->data[0].x;

--- a/reference/opt/shaders-msl/comp/raw-buffer-descriptor-aliasing.argument.discrete.msl2.descriptor-binding.comp
+++ b/reference/opt/shaders-msl/comp/raw-buffer-descriptor-aliasing.argument.discrete.msl2.descriptor-binding.comp
@@ -91,12 +91,12 @@ struct spvDescriptorSetBuffer0
     constant UBO_C* ubo_c [[id(1)]];
     device SSBO_B* ssbo_b [[id(2)]];
     constant UBO_D* ubo_d [[id(3)]];
-    const device SSBO_BRO* ssbo_b_readonly [[id(4)]];
+    device SSBO_BRO* ssbo_b_readonly [[id(4)]];
     device SSBO_As* ssbo_as [[id(5)]][4];
     constant UBO_Cs* ubo_cs [[id(9)]][4];
     device SSBO_Bs* ssbo_bs [[id(13)]][4];
     constant UBO_Ds* ubo_ds [[id(17)]][4];
-    const device SSBO_BsRO* ssbo_bs_readonly [[id(21)]][4];
+    device SSBO_BsRO* ssbo_bs_readonly [[id(21)]][4];
 };
 
 kernel void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], constant Registers& _42 [[buffer(1)]], device void* spvBufferAliasSet2Binding0 [[buffer(2)]], constant void* spvBufferAliasSet2Binding1 [[buffer(3)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
@@ -105,7 +105,7 @@ kernel void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0
     constant auto& ubo_g = *(constant UBO_G*)spvBufferAliasSet2Binding1;
     device auto& ssbo_f = *(device SSBO_F*)spvBufferAliasSet2Binding0;
     constant auto& ubo_h = *(constant UBO_H*)spvBufferAliasSet2Binding1;
-    const device auto& ssbo_i = *(const device SSBO_I*)spvBufferAliasSet2Binding0;
+    device auto& ssbo_i = *(device SSBO_I*)spvBufferAliasSet2Binding0;
     (*spvDescriptorSet0.ssbo_a).data[gl_GlobalInvocationID.x] = (*spvDescriptorSet0.ubo_c).data[gl_WorkGroupID.x].x + _42.reg;
     (*spvDescriptorSet0.ssbo_b).data[gl_GlobalInvocationID.x] = (*spvDescriptorSet0.ubo_d).data[gl_WorkGroupID.y].xy + (*spvDescriptorSet0.ssbo_b_readonly).data[gl_GlobalInvocationID.x];
     spvDescriptorSet0.ssbo_as[gl_WorkGroupID.x]->data[gl_GlobalInvocationID.x] = spvDescriptorSet0.ubo_cs[gl_WorkGroupID.x]->data[0].x;

--- a/reference/opt/shaders-msl/comp/read-write-only.comp
+++ b/reference/opt/shaders-msl/comp/read-write-only.comp
@@ -23,7 +23,7 @@ struct SSBO1
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(device SSBO2& __restrict _10 [[buffer(0)]], const device SSBO0& _15 [[buffer(1)]], device SSBO1& __restrict _21 [[buffer(2)]])
+kernel void main0(device SSBO2& __restrict _10 [[buffer(0)]], device SSBO0& _15 [[buffer(1)]], device SSBO1& __restrict _21 [[buffer(2)]])
 {
     _10.data4 = _15.data0 + _21.data2;
     _10.data5 = _15.data1 + _21.data3;

--- a/reference/opt/shaders-msl/comp/shared-zero-init-simple.comp
+++ b/reference/opt/shaders-msl/comp/shared-zero-init-simple.comp
@@ -17,7 +17,7 @@ struct SSBO2
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(4u, 1u, 1u);
 
-kernel void main0(const device SSBO& _22 [[buffer(0)]], device SSBO2& _32 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]])
+kernel void main0(device SSBO& _22 [[buffer(0)]], device SSBO2& _32 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]])
 {
     threadgroup float sShared;
     {

--- a/reference/opt/shaders-msl/comp/shared-zero-init.comp
+++ b/reference/opt/shaders-msl/comp/shared-zero-init.comp
@@ -58,7 +58,7 @@ constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(4u, 1u, 1u);
 
 constant spvUnsafeArray<float, 4> _31 = spvUnsafeArray<float, 4>({ 0.0, 0.0, 0.0, 0.0 });
 
-kernel void main0(const device SSBO& _22 [[buffer(0)]], device SSBO2& _48 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]])
+kernel void main0(device SSBO& _22 [[buffer(0)]], device SSBO2& _48 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]])
 {
     threadgroup spvUnsafeArray<float, 4> sShared;
     {

--- a/reference/opt/shaders-msl/comp/shared.comp
+++ b/reference/opt/shaders-msl/comp/shared.comp
@@ -56,7 +56,7 @@ struct SSBO2
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(4u, 1u, 1u);
 
-kernel void main0(const device SSBO& _22 [[buffer(0)]], device SSBO2& _44 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]])
+kernel void main0(device SSBO& _22 [[buffer(0)]], device SSBO2& _44 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]])
 {
     threadgroup spvUnsafeArray<float, 4> sShared;
     sShared[gl_LocalInvocationIndex] = _22.in_data[gl_GlobalInvocationID.x];

--- a/reference/opt/shaders-msl/comp/struct-layout.comp
+++ b/reference/opt/shaders-msl/comp/struct-layout.comp
@@ -20,7 +20,7 @@ struct SSBO
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(device SSBO2& _23 [[buffer(0)]], const device SSBO& _30 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(device SSBO2& _23 [[buffer(0)]], device SSBO& _30 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
     _23.out_data[gl_GlobalInvocationID.x].m = _30.in_data[gl_GlobalInvocationID.x].m * _30.in_data[gl_GlobalInvocationID.x].m;
 }

--- a/reference/opt/shaders-msl/comp/torture-loop.comp
+++ b/reference/opt/shaders-msl/comp/torture-loop.comp
@@ -16,7 +16,7 @@ struct SSBO2
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(const device SSBO& _24 [[buffer(0)]], device SSBO2& _89 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(device SSBO& _24 [[buffer(0)]], device SSBO2& _89 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
     float4 _101;
     _101 = _24.in_data[gl_GlobalInvocationID.x];

--- a/reference/opt/shaders-msl/frag/argument-buffers.msl2.argument.frag
+++ b/reference/opt/shaders-msl/frag/argument-buffers.msl2.argument.frag
@@ -41,7 +41,7 @@ struct spvDescriptorSetBuffer1
 {
     array<texture2d<float>, 4> uTexture2 [[id(0)]];
     array<sampler, 2> uSampler [[id(4)]];
-    device SSBO* m_60 [[id(6)]];
+    const device SSBO* m_60 [[id(6)]];
     const device SSBOs* ssbos [[id(7)]][2];
 };
 

--- a/reference/opt/shaders-msl/frag/complex-expression-in-access-chain.frag
+++ b/reference/opt/shaders-msl/frag/complex-expression-in-access-chain.frag
@@ -29,7 +29,7 @@ struct main0_in
     int vIn2 [[user(locn1)]];
 };
 
-fragment main0_out main0(main0_in in [[stage_in]], device UBO& _34 [[buffer(0)]], texture2d<int> Buf [[texture(0)]], sampler BufSmplr [[sampler(0)]], float4 gl_FragCoord [[position]])
+fragment main0_out main0(main0_in in [[stage_in]], const device UBO& _34 [[buffer(0)]], texture2d<int> Buf [[texture(0)]], sampler BufSmplr [[sampler(0)]], float4 gl_FragCoord [[position]])
 {
     main0_out out = {};
     int _40 = spvSMod(Buf.read(uint2(int2(gl_FragCoord.xy)), 0).x, 16);

--- a/reference/opt/shaders-ue4/asm/frag/texture-atomics.asm.argument.msl2.frag
+++ b/reference/opt/shaders-ue4/asm/frag/texture-atomics.asm.argument.msl2.frag
@@ -20,7 +20,7 @@ constant float3 _70 = {};
 
 struct spvDescriptorSetBuffer0
 {
-    const device type_StructuredBuffer_v4float* CulledObjectBoxBounds [[id(0)]];
+    device type_StructuredBuffer_v4float* CulledObjectBoxBounds [[id(0)]];
     constant type_Globals* _Globals [[id(1)]];
     texture2d<uint> RWShadowTileNumCulledObjects [[id(2)]];
     device atomic_uint* RWShadowTileNumCulledObjects_atomic [[id(3)]];

--- a/reference/opt/shaders-ue4/asm/frag/texture-atomics.asm.frag
+++ b/reference/opt/shaders-ue4/asm/frag/texture-atomics.asm.frag
@@ -28,7 +28,7 @@ struct main0_in
     uint in_var_TEXCOORD0 [[user(locn0)]];
 };
 
-fragment main0_out main0(main0_in in [[stage_in]], const device type_StructuredBuffer_v4float& CulledObjectBoxBounds [[buffer(0)]], constant type_Globals& _Globals [[buffer(1)]], texture2d<uint> RWShadowTileNumCulledObjects [[texture(0)]], device atomic_uint* RWShadowTileNumCulledObjects_atomic [[buffer(2)]], float4 gl_FragCoord [[position]])
+fragment main0_out main0(main0_in in [[stage_in]], device type_StructuredBuffer_v4float& CulledObjectBoxBounds [[buffer(0)]], constant type_Globals& _Globals [[buffer(1)]], texture2d<uint> RWShadowTileNumCulledObjects [[texture(0)]], device atomic_uint* RWShadowTileNumCulledObjects_atomic [[buffer(2)]], float4 gl_FragCoord [[position]])
 {
     main0_out out = {};
     uint2 _77 = uint2(gl_FragCoord.xy);

--- a/reference/opt/shaders-ue4/asm/frag/texture-atomics.asm.graphics-robust-access.frag
+++ b/reference/opt/shaders-ue4/asm/frag/texture-atomics.asm.graphics-robust-access.frag
@@ -28,7 +28,7 @@ struct main0_in
     uint in_var_TEXCOORD0 [[user(locn0)]];
 };
 
-fragment main0_out main0(main0_in in [[stage_in]], constant uint* spvBufferSizeConstants [[buffer(25)]], const device type_StructuredBuffer_v4float& CulledObjectBoxBounds [[buffer(0)]], constant type_Globals& _Globals [[buffer(1)]], texture2d<uint> RWShadowTileNumCulledObjects [[texture(0)]], device atomic_uint* RWShadowTileNumCulledObjects_atomic [[buffer(2)]], float4 gl_FragCoord [[position]])
+fragment main0_out main0(main0_in in [[stage_in]], constant uint* spvBufferSizeConstants [[buffer(25)]], device type_StructuredBuffer_v4float& CulledObjectBoxBounds [[buffer(0)]], constant type_Globals& _Globals [[buffer(1)]], texture2d<uint> RWShadowTileNumCulledObjects [[texture(0)]], device atomic_uint* RWShadowTileNumCulledObjects_atomic [[buffer(2)]], float4 gl_FragCoord [[position]])
 {
     main0_out out = {};
     constant uint& CulledObjectBoxBoundsBufferSize = spvBufferSizeConstants[0];

--- a/reference/opt/shaders-ue4/asm/tesc/hs-incorrect-base-type.invalid.asm.tesc
+++ b/reference/opt/shaders-ue4/asm/tesc/hs-incorrect-base-type.invalid.asm.tesc
@@ -298,7 +298,7 @@ struct main0_in
     float4 in_var_VS_To_DS_Position [[attribute(7)]];
 };
 
-kernel void main0(main0_in in [[stage_in]], constant type_View& View [[buffer(0)]], const device type_StructuredBuffer_v4float& View_PrimitiveSceneData [[buffer(1)]], uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], device main0_out* spvOut [[buffer(28)]], constant uint* spvIndirectParams [[buffer(29)]], device main0_patchOut* spvPatchOut [[buffer(27)]], device MTLTriangleTessellationFactorsHalf* spvTessLevel [[buffer(26)]], threadgroup main0_in* gl_in [[threadgroup(0)]])
+kernel void main0(main0_in in [[stage_in]], constant type_View& View [[buffer(0)]], device type_StructuredBuffer_v4float& View_PrimitiveSceneData [[buffer(1)]], uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], device main0_out* spvOut [[buffer(28)]], constant uint* spvIndirectParams [[buffer(29)]], device main0_patchOut* spvPatchOut [[buffer(27)]], device MTLTriangleTessellationFactorsHalf* spvTessLevel [[buffer(26)]], threadgroup main0_in* gl_in [[threadgroup(0)]])
 {
     threadgroup spvUnsafeArray<FPNTessellationHSToDS, 3> temp_var_hullMainRetVal;
     device main0_out* gl_out = &spvOut[gl_PrimitiveID * 3];

--- a/reference/shaders-msl-no-opt/asm/comp/modf-storage-class.asm.comp
+++ b/reference/shaders-msl-no-opt/asm/comp/modf-storage-class.asm.comp
@@ -24,7 +24,7 @@ struct _13
     float2 _m0[648];
 };
 
-kernel void main0(const device _6& _7 [[buffer(0)]], device _9& _11 [[buffer(1)]], device _13& _14 [[buffer(2)]])
+kernel void main0(device _6& _7 [[buffer(0)]], device _9& _11 [[buffer(1)]], device _13& _14 [[buffer(2)]])
 {
     for (uint _46 = 0u; _46 < 648u; _46 += 2u)
     {

--- a/reference/shaders-msl-no-opt/asm/comp/storage-buffer-pointer-argument.asm.comp
+++ b/reference/shaders-msl-no-opt/asm/comp/storage-buffer-pointer-argument.asm.comp
@@ -21,7 +21,7 @@ void copy_out(device float& A, device const float& B)
     A = B;
 }
 
-kernel void main0(device SSBO& _10 [[buffer(0)]], const device SSBORead& _14 [[buffer(1)]])
+kernel void main0(device SSBO& _10 [[buffer(0)]], device SSBORead& _14 [[buffer(1)]])
 {
     copy_out(_10.a, _14.b);
 }

--- a/reference/shaders-msl-no-opt/comp/argument-buffer-readonly-writeonly-alias.msl2.argument.argument-tier-1.device-argument-buffer.comp
+++ b/reference/shaders-msl-no-opt/comp/argument-buffer-readonly-writeonly-alias.msl2.argument.argument-tier-1.device-argument-buffer.comp
@@ -1,4 +1,5 @@
 #pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wincompatible-pointer-types-discards-qualifiers"
 
 #include <metal_stdlib>
 #include <simd/simd.h>
@@ -24,22 +25,27 @@ struct spvDescriptorArray
     const device T* ptr;
 };
 
-struct SSBO
+struct D
 {
-    float4 a;
+    float data_d[1];
 };
 
-constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
+struct A
+{
+    float data_a[1];
+};
 
 struct spvDescriptorSetBuffer0
 {
-    spvDescriptor<device SSBO *> ssbos [[id(0)]][1] /* unsized array hack */;
+    spvDescriptor<device D *> d [[id(0)]][1] /* unsized array hack */;
+    // Overlapping binding: spvDescriptor<device A *> a [[id(0)]][1] /* unsized array hack */;
 };
 
 kernel void main0(device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
 {
-    spvDescriptorArray<device SSBO*> ssbos {spvDescriptorSet0.ssbos};
+    spvDescriptorArray<device D*> d {spvDescriptorSet0.d};
+    spvDescriptorArray<device A*> a {reinterpret_cast<spvDescriptor<device A *> const device *>(&spvDescriptorSet0.d)};
 
-    ssbos[gl_WorkGroupID.x]->a += float4(2.0);
+    d[gl_WorkGroupID.x]->data_d[0] = a[gl_WorkGroupID.x]->data_a[0];
 }
 

--- a/reference/shaders-msl-no-opt/comp/bda-atomics.msl23.comp
+++ b/reference/shaders-msl-no-opt/comp/bda-atomics.msl23.comp
@@ -31,7 +31,7 @@ struct SSBO
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(constant Registers& _12 [[buffer(0)]], constant UBO& _26 [[buffer(1)]], const device SSBO& _35 [[buffer(2)]])
+kernel void main0(constant Registers& _12 [[buffer(0)]], constant UBO& _26 [[buffer(1)]], device SSBO& _35 [[buffer(2)]])
 {
     uint _23 = atomic_fetch_add_explicit((device atomic_uint*)&_12.ptr->i, 10u, memory_order_relaxed);
     uint _32 = atomic_fetch_add_explicit((device atomic_uint*)&_26.ptr_ubo->i, 11u, memory_order_relaxed);

--- a/reference/shaders-msl-no-opt/comp/loop.comp
+++ b/reference/shaders-msl-no-opt/comp/loop.comp
@@ -16,7 +16,7 @@ struct SSBO2
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(const device SSBO& _24 [[buffer(0)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(device SSBO& _24 [[buffer(0)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
     uint ident = gl_GlobalInvocationID.x;
     float4 idat = _24.in_data[ident];

--- a/reference/shaders-msl/asm/comp/global-parameter-name-alias.asm.comp
+++ b/reference/shaders-msl/asm/comp/global-parameter-name-alias.asm.comp
@@ -11,20 +11,20 @@ struct ssbo
 };
 
 static inline __attribute__((always_inline))
-void Load(thread const uint& size, const device ssbo& ssbo_1)
+void Load(thread const uint& size, device ssbo& ssbo_1)
 {
     int byteAddrTemp = int(size >> uint(2));
     uint4 data = uint4(ssbo_1._data[byteAddrTemp], ssbo_1._data[byteAddrTemp + 1], ssbo_1._data[byteAddrTemp + 2], ssbo_1._data[byteAddrTemp + 3]);
 }
 
 static inline __attribute__((always_inline))
-void _main(thread const uint3& id, const device ssbo& ssbo_1)
+void _main(thread const uint3& id, device ssbo& ssbo_1)
 {
     uint param = 4u;
     Load(param, ssbo_1);
 }
 
-kernel void main0(const device ssbo& ssbo_1 [[buffer(0)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(device ssbo& ssbo_1 [[buffer(0)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
     uint3 id = gl_GlobalInvocationID;
     uint3 param = id;

--- a/reference/shaders-msl/asm/tesc/tess-level-overrun.asm.tesc
+++ b/reference/shaders-msl/asm/tesc/tess-level-overrun.asm.tesc
@@ -13,7 +13,7 @@ struct TessLevels
     float outer3;
 };
 
-kernel void main0(const device TessLevels& sb_levels [[buffer(0)]], uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], constant uint* spvIndirectParams [[buffer(29)]], device MTLTriangleTessellationFactorsHalf* spvTessLevel [[buffer(26)]])
+kernel void main0(device TessLevels& sb_levels [[buffer(0)]], uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], constant uint* spvIndirectParams [[buffer(29)]], device MTLTriangleTessellationFactorsHalf* spvTessLevel [[buffer(26)]])
 {
     spvTessLevel[gl_PrimitiveID].insideTessellationFactor = half(sb_levels.inner0);
     spvTessLevel[gl_PrimitiveID].edgeTessellationFactor[0] = half(sb_levels.outer0);

--- a/reference/shaders-msl/asm/tesc/tess-level-overrun.multi-patch.asm.tesc
+++ b/reference/shaders-msl/asm/tesc/tess-level-overrun.multi-patch.asm.tesc
@@ -13,7 +13,7 @@ struct TessLevels
     float outer3;
 };
 
-kernel void main0(const device TessLevels& sb_levels [[buffer(0)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], constant uint* spvIndirectParams [[buffer(29)]], device MTLTriangleTessellationFactorsHalf* spvTessLevel [[buffer(26)]])
+kernel void main0(device TessLevels& sb_levels [[buffer(0)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], constant uint* spvIndirectParams [[buffer(29)]], device MTLTriangleTessellationFactorsHalf* spvTessLevel [[buffer(26)]])
 {
     uint gl_PrimitiveID = min(gl_GlobalInvocationID.x / 1, spvIndirectParams[1] - 1);
     spvTessLevel[gl_PrimitiveID].insideTessellationFactor = half(sb_levels.inner0);

--- a/reference/shaders-msl/comp/argument-buffers-discrete.msl2.argument.discrete.comp
+++ b/reference/shaders-msl/comp/argument-buffers-discrete.msl2.argument.discrete.comp
@@ -27,15 +27,15 @@ constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
 struct spvDescriptorSetBuffer0
 {
-    const device SSBO0* ssbo0 [[id(0)]];
+    device SSBO0* ssbo0 [[id(0)]];
 };
 
 struct spvDescriptorSetBuffer1
 {
-    const device SSBO1* ssbo1 [[id(0)]];
+    device SSBO1* ssbo1 [[id(0)]];
 };
 
-kernel void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], constant spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], device SSBO3& ssbo3 [[buffer(2)]], const device SSBO2& ssbo2 [[buffer(3)]])
+kernel void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], constant spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], device SSBO3& ssbo3 [[buffer(2)]], device SSBO2& ssbo2 [[buffer(3)]])
 {
     ssbo3.v = ((*spvDescriptorSet0.ssbo0).v + (*spvDescriptorSet1.ssbo1).v) + ssbo2.v;
 }

--- a/reference/shaders-msl/comp/argument-buffers-runtime-array-buffer.argument.device-argument-buffer.argument-tier-1.msl2.comp
+++ b/reference/shaders-msl/comp/argument-buffers-runtime-array-buffer.argument.device-argument-buffer.argument-tier-1.msl2.comp
@@ -73,7 +73,7 @@ void in_func(device SSBO& o, thread uint3& gl_GlobalInvocationID, constant UBO& 
     o.v[gl_GlobalInvocationID.x] = ws[gl_WorkGroupID.x]->v;
 }
 
-kernel void main0(const device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], const device spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
+kernel void main0(device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], device spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
 {
     spvDescriptorArray<constant UBOs*> vs {spvDescriptorSet0.vs};
     spvDescriptorArray<device SSBOIns*> ws {spvDescriptorSet1.ws};

--- a/reference/shaders-msl/comp/argument-buffers-runtime-array-buffer.rich-descriptor.argument.device-argument-buffer.argument-tier-1.msl2.comp
+++ b/reference/shaders-msl/comp/argument-buffers-runtime-array-buffer.rich-descriptor.argument.device-argument-buffer.argument-tier-1.msl2.comp
@@ -105,7 +105,7 @@ void in_func(device SSBO& o, thread uint3& gl_GlobalInvocationID, constant UBO& 
     o.v[gl_GlobalInvocationID.x] = ws[gl_WorkGroupID.x]->v;
 }
 
-kernel void main0(const device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], const device spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
+kernel void main0(device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], device spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
 {
     spvDescriptorArray<constant UBOs*> vs {spvDescriptorSet0.vs};
     spvDescriptorArray<device SSBOIns*> ws {spvDescriptorSet1.ws};

--- a/reference/shaders-msl/comp/argument-buffers-runtime-array.argument.device-argument-buffer.argument-tier-1.msl2.comp
+++ b/reference/shaders-msl/comp/argument-buffers-runtime-array.argument.device-argument-buffer.argument-tier-1.msl2.comp
@@ -51,7 +51,7 @@ void in_func(device SSBO& _13, thread uint3& gl_GlobalInvocationID, texture2d<fl
     _13.v[gl_GlobalInvocationID.x] = Ts[gl_WorkGroupID.x].sample(Ss[gl_WorkGroupID.x], float2(0.5), level(0.0));
 }
 
-kernel void main0(const device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], const device spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
+kernel void main0(device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], device spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
 {
     spvDescriptorArray<texture2d<float>> Ts {spvDescriptorSet0.Ts};
     spvDescriptorArray<sampler> Ss {spvDescriptorSet1.Ss};

--- a/reference/shaders-msl/comp/basic.comp
+++ b/reference/shaders-msl/comp/basic.comp
@@ -23,7 +23,7 @@ struct SSBO3
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(const device SSBO& _23 [[buffer(0)]], device SSBO2& _45 [[buffer(1)]], device SSBO3& _48 [[buffer(2)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(device SSBO& _23 [[buffer(0)]], device SSBO2& _45 [[buffer(1)]], device SSBO3& _48 [[buffer(2)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
     uint ident = gl_GlobalInvocationID.x;
     float4 idata = _23.in_data[ident];

--- a/reference/shaders-msl/comp/basic.dispatchbase.comp
+++ b/reference/shaders-msl/comp/basic.dispatchbase.comp
@@ -25,7 +25,7 @@ constant uint _59_tmp [[function_constant(10)]];
 constant uint _59 = is_function_constant_defined(_59_tmp) ? _59_tmp : 1u;
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(_59, 1u, 1u);
 
-kernel void main0(const device SSBO& _27 [[buffer(0)]], device SSBO2& _49 [[buffer(1)]], device SSBO3& _52 [[buffer(2)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]], uint3 spvDispatchBase [[grid_origin]])
+kernel void main0(device SSBO& _27 [[buffer(0)]], device SSBO2& _49 [[buffer(1)]], device SSBO3& _52 [[buffer(2)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]], uint3 spvDispatchBase [[grid_origin]])
 {
     gl_GlobalInvocationID += spvDispatchBase * gl_WorkGroupSize;
     gl_WorkGroupID += spvDispatchBase;

--- a/reference/shaders-msl/comp/basic.dispatchbase.msl11.comp
+++ b/reference/shaders-msl/comp/basic.dispatchbase.msl11.comp
@@ -23,7 +23,7 @@ struct SSBO3
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(constant uint3& spvDispatchBase [[buffer(29)]], const device SSBO& _27 [[buffer(0)]], device SSBO2& _49 [[buffer(1)]], device SSBO3& _52 [[buffer(2)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
+kernel void main0(constant uint3& spvDispatchBase [[buffer(29)]], device SSBO& _27 [[buffer(0)]], device SSBO2& _49 [[buffer(1)]], device SSBO3& _52 [[buffer(2)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
 {
     gl_GlobalInvocationID += spvDispatchBase * gl_WorkGroupSize;
     gl_WorkGroupID += spvDispatchBase;

--- a/reference/shaders-msl/comp/culling.comp
+++ b/reference/shaders-msl/comp/culling.comp
@@ -23,7 +23,7 @@ struct SSBO3
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(4u, 1u, 1u);
 
-kernel void main0(const device SSBO& _22 [[buffer(0)]], device SSBO2& _38 [[buffer(1)]], device SSBO3& _41 [[buffer(2)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(device SSBO& _22 [[buffer(0)]], device SSBO2& _38 [[buffer(1)]], device SSBO3& _41 [[buffer(2)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
     uint ident = gl_GlobalInvocationID.x;
     float idata = _22.in_data[ident];

--- a/reference/shaders-msl/comp/dowhile.comp
+++ b/reference/shaders-msl/comp/dowhile.comp
@@ -16,7 +16,7 @@ struct SSBO2
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(const device SSBO& _28 [[buffer(0)]], device SSBO2& _52 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(device SSBO& _28 [[buffer(0)]], device SSBO2& _52 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
     uint ident = gl_GlobalInvocationID.x;
     int i = 0;

--- a/reference/shaders-msl/comp/inverse.comp
+++ b/reference/shaders-msl/comp/inverse.comp
@@ -121,7 +121,7 @@ struct MatrixIn
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(device MatrixOut& _15 [[buffer(0)]], const device MatrixIn& _20 [[buffer(1)]])
+kernel void main0(device MatrixOut& _15 [[buffer(0)]], device MatrixIn& _20 [[buffer(1)]])
 {
     _15.m2out = spvInverse2x2(_20.m2in);
     _15.m3out = spvInverse3x3(_20.m3in);

--- a/reference/shaders-msl/comp/mod.comp
+++ b/reference/shaders-msl/comp/mod.comp
@@ -32,7 +32,7 @@ struct SSBO2
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(const device SSBO& _23 [[buffer(0)]], device SSBO2& _33 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(device SSBO& _23 [[buffer(0)]], device SSBO2& _33 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
     uint ident = gl_GlobalInvocationID.x;
     float4 v = mod(_23.in_data[ident], _33.out_data[ident]);

--- a/reference/shaders-msl/comp/modf.comp
+++ b/reference/shaders-msl/comp/modf.comp
@@ -21,7 +21,7 @@ struct SSBO2
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(const device SSBO& _23 [[buffer(0)]], device SSBO2& _38 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(device SSBO& _23 [[buffer(0)]], device SSBO2& _38 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
     uint ident = gl_GlobalInvocationID.x;
     ResType _32;

--- a/reference/shaders-msl/comp/outer-product.comp
+++ b/reference/shaders-msl/comp/outer-product.comp
@@ -25,7 +25,7 @@ struct ReadSSBO
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(device SSBO& _21 [[buffer(0)]], const device ReadSSBO& _26 [[buffer(1)]])
+kernel void main0(device SSBO& _21 [[buffer(0)]], device ReadSSBO& _26 [[buffer(1)]])
 {
     _21.m22 = float2x2(_26.v2 * _26.v2.x, _26.v2 * _26.v2.y);
     _21.m23 = float2x3(_26.v3 * _26.v2.x, _26.v3 * _26.v2.y);

--- a/reference/shaders-msl/comp/overlapping-bindings.msl31.argument.argument-tier-1.decoration-binding.device-argument-buffer.texture-buffer-native.comp
+++ b/reference/shaders-msl/comp/overlapping-bindings.msl31.argument.argument-tier-1.decoration-binding.device-argument-buffer.texture-buffer-native.comp
@@ -158,7 +158,7 @@ void in_function(thread float4& r0, const device array<texture2d<float>, 8>& t00
     u4.write(as_type<uint4>(r4), uint(0));
 }
 
-kernel void main0(const device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], const device spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], constant spvDescriptorSetBuffer2& spvDescriptorSet2 [[buffer(2)]], constant spvDescriptorSetBuffer3& spvDescriptorSet3 [[buffer(3)]], constant spvDescriptorSetBuffer4& spvDescriptorSet4 [[buffer(4)]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
+kernel void main0(device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], device spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(1)]], constant spvDescriptorSetBuffer2& spvDescriptorSet2 [[buffer(2)]], constant spvDescriptorSetBuffer3& spvDescriptorSet3 [[buffer(3)]], constant spvDescriptorSetBuffer4& spvDescriptorSet4 [[buffer(4)]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
 {
     spvDescriptorArray<device B30*> b30 {spvDescriptorSet1.b30};
     spvDescriptorArray<texture2d<float>> t30 {reinterpret_cast<const device spvDescriptor<texture2d<float>>*>(&spvDescriptorSet1.b30)};

--- a/reference/shaders-msl/comp/raw-buffer-descriptor-aliasing.argument.discrete.device-argument-buffer.msl2.decoration-binding.comp
+++ b/reference/shaders-msl/comp/raw-buffer-descriptor-aliasing.argument.discrete.device-argument-buffer.msl2.decoration-binding.comp
@@ -94,16 +94,16 @@ struct spvDescriptorSetBuffer0
     // Overlapping binding: constant UBO_D* ubo_d [[id(1)]];
     device SSBO_As* ssbo_as [[id(2)]][4];
     // Overlapping binding: device SSBO_Bs* ssbo_bs [[id(2)]][4];
-    // Overlapping binding: const device SSBO_BsRO* ssbo_bs_readonly [[id(2)]][4];
+    // Overlapping binding: device SSBO_BsRO* ssbo_bs_readonly [[id(2)]][4];
     constant UBO_Cs* ubo_cs [[id(6)]][4];
     // Overlapping binding: constant UBO_Ds* ubo_ds [[id(6)]][4];
     device SSBO_A* ssbo_a [[id(10)]];
     // Overlapping binding: device SSBO_B* ssbo_b [[id(10)]];
-    // Overlapping binding: const device SSBO_BRO* ssbo_b_readonly [[id(10)]];
+    // Overlapping binding: device SSBO_BRO* ssbo_b_readonly [[id(10)]];
 };
 
 static inline __attribute__((always_inline))
-void func0(device SSBO_A& ssbo_a, thread uint3& gl_GlobalInvocationID, constant UBO_C& ubo_c, thread uint3& gl_WorkGroupID, constant Registers& _42, device SSBO_B& ssbo_b, constant UBO_D& ubo_d, const device SSBO_BRO& ssbo_b_readonly)
+void func0(device SSBO_A& ssbo_a, thread uint3& gl_GlobalInvocationID, constant UBO_C& ubo_c, thread uint3& gl_WorkGroupID, constant Registers& _42, device SSBO_B& ssbo_b, constant UBO_D& ubo_d, device SSBO_BRO& ssbo_b_readonly)
 {
     ssbo_a.data[gl_GlobalInvocationID.x] = ubo_c.data[gl_WorkGroupID.x].x + _42.reg;
     ssbo_b.data[gl_GlobalInvocationID.x] = ubo_d.data[gl_WorkGroupID.y].xy + ssbo_b_readonly.data[gl_GlobalInvocationID.x];
@@ -116,31 +116,31 @@ void func1(thread uint3& gl_GlobalInvocationID, thread uint3& gl_WorkGroupID, de
 }
 
 static inline __attribute__((always_inline))
-void func2(thread uint3& gl_GlobalInvocationID, thread uint3& gl_WorkGroupID, device SSBO_Bs* const device (&ssbo_bs)[4], constant UBO_Ds* const device (&ubo_ds)[4], const device SSBO_BsRO* const device (&ssbo_bs_readonly)[4])
+void func2(thread uint3& gl_GlobalInvocationID, thread uint3& gl_WorkGroupID, device SSBO_Bs* const device (&ssbo_bs)[4], constant UBO_Ds* const device (&ubo_ds)[4], device SSBO_BsRO* const device (&ssbo_bs_readonly)[4])
 {
     ssbo_bs[gl_WorkGroupID.x]->data[gl_GlobalInvocationID.x] = ubo_ds[gl_WorkGroupID.x]->data[0].xy + ssbo_bs_readonly[gl_WorkGroupID.x]->data[gl_GlobalInvocationID.x];
 }
 
 static inline __attribute__((always_inline))
-void func3(thread uint3& gl_GlobalInvocationID, thread uint3& gl_WorkGroupID, device SSBO_E& ssbo_e, constant UBO_G& ubo_g, device SSBO_F& ssbo_f, constant UBO_H& ubo_h, const device SSBO_I& ssbo_i)
+void func3(thread uint3& gl_GlobalInvocationID, thread uint3& gl_WorkGroupID, device SSBO_E& ssbo_e, constant UBO_G& ubo_g, device SSBO_F& ssbo_f, constant UBO_H& ubo_h, device SSBO_I& ssbo_i)
 {
     ssbo_e.data[gl_GlobalInvocationID.x] = ubo_g.data[gl_WorkGroupID.x].x;
     ssbo_f.data[gl_GlobalInvocationID.x] = ubo_h.data[gl_WorkGroupID.y].xy + ssbo_i.data[gl_GlobalInvocationID.x];
 }
 
-kernel void main0(const device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], constant Registers& _42 [[buffer(1)]], device void* spvBufferAliasSet2Binding11 [[buffer(11)]], constant void* spvBufferAliasSet2Binding12 [[buffer(12)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
+kernel void main0(device spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0)]], constant Registers& _42 [[buffer(1)]], device void* spvBufferAliasSet2Binding11 [[buffer(11)]], constant void* spvBufferAliasSet2Binding12 [[buffer(12)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]])
 {
     device auto& ssbo_e = *(device SSBO_E*)spvBufferAliasSet2Binding11;
     constant auto& ubo_g = *(constant UBO_G*)spvBufferAliasSet2Binding12;
     device auto& ssbo_f = *(device SSBO_F*)spvBufferAliasSet2Binding11;
     constant auto& ubo_h = *(constant UBO_H*)spvBufferAliasSet2Binding12;
-    const device auto& ssbo_i = *(const device SSBO_I*)spvBufferAliasSet2Binding11;
+    device auto& ssbo_i = *(device SSBO_I*)spvBufferAliasSet2Binding11;
     constant auto &ubo_d = *reinterpret_cast<constant UBO_D* const device &>(spvDescriptorSet0.ubo_c);
     const device auto &ssbo_bs = reinterpret_cast<device SSBO_Bs* const device (&)[4]>(spvDescriptorSet0.ssbo_as);
-    const device auto &ssbo_bs_readonly = reinterpret_cast<const device SSBO_BsRO* const device (&)[4]>(spvDescriptorSet0.ssbo_as);
+    const device auto &ssbo_bs_readonly = reinterpret_cast<device SSBO_BsRO* const device (&)[4]>(spvDescriptorSet0.ssbo_as);
     const device auto &ubo_ds = reinterpret_cast<constant UBO_Ds* const device (&)[4]>(spvDescriptorSet0.ubo_cs);
     device auto &ssbo_b = *reinterpret_cast<device SSBO_B* const device &>(spvDescriptorSet0.ssbo_a);
-    const device auto &ssbo_b_readonly = *reinterpret_cast<const device SSBO_BRO* const device &>(spvDescriptorSet0.ssbo_a);
+    device auto &ssbo_b_readonly = *reinterpret_cast<device SSBO_BRO* const device &>(spvDescriptorSet0.ssbo_a);
     func0((*spvDescriptorSet0.ssbo_a), gl_GlobalInvocationID, (*spvDescriptorSet0.ubo_c), gl_WorkGroupID, _42, ssbo_b, ubo_d, ssbo_b_readonly);
     func1(gl_GlobalInvocationID, gl_WorkGroupID, spvDescriptorSet0.ssbo_as, spvDescriptorSet0.ubo_cs);
     func2(gl_GlobalInvocationID, gl_WorkGroupID, ssbo_bs, ubo_ds, ssbo_bs_readonly);

--- a/reference/shaders-msl/comp/raw-buffer-descriptor-aliasing.argument.discrete.msl2.descriptor-binding.comp
+++ b/reference/shaders-msl/comp/raw-buffer-descriptor-aliasing.argument.discrete.msl2.descriptor-binding.comp
@@ -93,16 +93,16 @@ struct spvDescriptorSetBuffer0
     constant UBO_C* ubo_c [[id(1)]];
     device SSBO_B* ssbo_b [[id(2)]];
     constant UBO_D* ubo_d [[id(3)]];
-    const device SSBO_BRO* ssbo_b_readonly [[id(4)]];
+    device SSBO_BRO* ssbo_b_readonly [[id(4)]];
     device SSBO_As* ssbo_as [[id(5)]][4];
     constant UBO_Cs* ubo_cs [[id(9)]][4];
     device SSBO_Bs* ssbo_bs [[id(13)]][4];
     constant UBO_Ds* ubo_ds [[id(17)]][4];
-    const device SSBO_BsRO* ssbo_bs_readonly [[id(21)]][4];
+    device SSBO_BsRO* ssbo_bs_readonly [[id(21)]][4];
 };
 
 static inline __attribute__((always_inline))
-void func0(device SSBO_A& ssbo_a, thread uint3& gl_GlobalInvocationID, constant UBO_C& ubo_c, thread uint3& gl_WorkGroupID, constant Registers& _42, device SSBO_B& ssbo_b, constant UBO_D& ubo_d, const device SSBO_BRO& ssbo_b_readonly)
+void func0(device SSBO_A& ssbo_a, thread uint3& gl_GlobalInvocationID, constant UBO_C& ubo_c, thread uint3& gl_WorkGroupID, constant Registers& _42, device SSBO_B& ssbo_b, constant UBO_D& ubo_d, device SSBO_BRO& ssbo_b_readonly)
 {
     ssbo_a.data[gl_GlobalInvocationID.x] = ubo_c.data[gl_WorkGroupID.x].x + _42.reg;
     ssbo_b.data[gl_GlobalInvocationID.x] = ubo_d.data[gl_WorkGroupID.y].xy + ssbo_b_readonly.data[gl_GlobalInvocationID.x];
@@ -115,13 +115,13 @@ void func1(thread uint3& gl_GlobalInvocationID, thread uint3& gl_WorkGroupID, de
 }
 
 static inline __attribute__((always_inline))
-void func2(thread uint3& gl_GlobalInvocationID, thread uint3& gl_WorkGroupID, device SSBO_Bs* constant (&ssbo_bs)[4], constant UBO_Ds* constant (&ubo_ds)[4], const device SSBO_BsRO* constant (&ssbo_bs_readonly)[4])
+void func2(thread uint3& gl_GlobalInvocationID, thread uint3& gl_WorkGroupID, device SSBO_Bs* constant (&ssbo_bs)[4], constant UBO_Ds* constant (&ubo_ds)[4], device SSBO_BsRO* constant (&ssbo_bs_readonly)[4])
 {
     ssbo_bs[gl_WorkGroupID.x]->data[gl_GlobalInvocationID.x] = ubo_ds[gl_WorkGroupID.x]->data[0].xy + ssbo_bs_readonly[gl_WorkGroupID.x]->data[gl_GlobalInvocationID.x];
 }
 
 static inline __attribute__((always_inline))
-void func3(thread uint3& gl_GlobalInvocationID, thread uint3& gl_WorkGroupID, device SSBO_E& ssbo_e, constant UBO_G& ubo_g, device SSBO_F& ssbo_f, constant UBO_H& ubo_h, const device SSBO_I& ssbo_i)
+void func3(thread uint3& gl_GlobalInvocationID, thread uint3& gl_WorkGroupID, device SSBO_E& ssbo_e, constant UBO_G& ubo_g, device SSBO_F& ssbo_f, constant UBO_H& ubo_h, device SSBO_I& ssbo_i)
 {
     ssbo_e.data[gl_GlobalInvocationID.x] = ubo_g.data[gl_WorkGroupID.x].x;
     ssbo_f.data[gl_GlobalInvocationID.x] = ubo_h.data[gl_WorkGroupID.y].xy + ssbo_i.data[gl_GlobalInvocationID.x];
@@ -133,7 +133,7 @@ kernel void main0(constant spvDescriptorSetBuffer0& spvDescriptorSet0 [[buffer(0
     constant auto& ubo_g = *(constant UBO_G*)spvBufferAliasSet2Binding1;
     device auto& ssbo_f = *(device SSBO_F*)spvBufferAliasSet2Binding0;
     constant auto& ubo_h = *(constant UBO_H*)spvBufferAliasSet2Binding1;
-    const device auto& ssbo_i = *(const device SSBO_I*)spvBufferAliasSet2Binding0;
+    device auto& ssbo_i = *(device SSBO_I*)spvBufferAliasSet2Binding0;
     func0((*spvDescriptorSet0.ssbo_a), gl_GlobalInvocationID, (*spvDescriptorSet0.ubo_c), gl_WorkGroupID, _42, (*spvDescriptorSet0.ssbo_b), (*spvDescriptorSet0.ubo_d), (*spvDescriptorSet0.ssbo_b_readonly));
     func1(gl_GlobalInvocationID, gl_WorkGroupID, spvDescriptorSet0.ssbo_as, spvDescriptorSet0.ubo_cs);
     func2(gl_GlobalInvocationID, gl_WorkGroupID, spvDescriptorSet0.ssbo_bs, spvDescriptorSet0.ubo_ds, spvDescriptorSet0.ssbo_bs_readonly);

--- a/reference/shaders-msl/comp/read-write-only.comp
+++ b/reference/shaders-msl/comp/read-write-only.comp
@@ -23,7 +23,7 @@ struct SSBO1
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(device SSBO2& __restrict _10 [[buffer(0)]], const device SSBO0& _15 [[buffer(1)]], device SSBO1& __restrict _21 [[buffer(2)]])
+kernel void main0(device SSBO2& __restrict _10 [[buffer(0)]], device SSBO0& _15 [[buffer(1)]], device SSBO1& __restrict _21 [[buffer(2)]])
 {
     _10.data4 = _15.data0 + _21.data2;
     _10.data5 = _15.data1 + _21.data3;

--- a/reference/shaders-msl/comp/shared-zero-init-simple.comp
+++ b/reference/shaders-msl/comp/shared-zero-init-simple.comp
@@ -17,7 +17,7 @@ struct SSBO2
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(4u, 1u, 1u);
 
-kernel void main0(const device SSBO& _22 [[buffer(0)]], device SSBO2& _32 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]])
+kernel void main0(device SSBO& _22 [[buffer(0)]], device SSBO2& _32 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]])
 {
     threadgroup float sShared;
     {

--- a/reference/shaders-msl/comp/shared-zero-init.comp
+++ b/reference/shaders-msl/comp/shared-zero-init.comp
@@ -58,7 +58,7 @@ constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(4u, 1u, 1u);
 
 constant spvUnsafeArray<float, 4> _31 = spvUnsafeArray<float, 4>({ 0.0, 0.0, 0.0, 0.0 });
 
-kernel void main0(const device SSBO& _22 [[buffer(0)]], device SSBO2& _48 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]])
+kernel void main0(device SSBO& _22 [[buffer(0)]], device SSBO2& _48 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]])
 {
     threadgroup spvUnsafeArray<float, 4> sShared;
     {

--- a/reference/shaders-msl/comp/shared.comp
+++ b/reference/shaders-msl/comp/shared.comp
@@ -56,7 +56,7 @@ struct SSBO2
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(4u, 1u, 1u);
 
-kernel void main0(const device SSBO& _22 [[buffer(0)]], device SSBO2& _44 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]])
+kernel void main0(device SSBO& _22 [[buffer(0)]], device SSBO2& _44 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]])
 {
     threadgroup spvUnsafeArray<float, 4> sShared;
     uint ident = gl_GlobalInvocationID.x;

--- a/reference/shaders-msl/comp/struct-layout.comp
+++ b/reference/shaders-msl/comp/struct-layout.comp
@@ -20,7 +20,7 @@ struct SSBO
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(device SSBO2& _23 [[buffer(0)]], const device SSBO& _30 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(device SSBO2& _23 [[buffer(0)]], device SSBO& _30 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
     uint ident = gl_GlobalInvocationID.x;
     _23.out_data[ident].m = _30.in_data[ident].m * _30.in_data[ident].m;

--- a/reference/shaders-msl/comp/torture-loop.comp
+++ b/reference/shaders-msl/comp/torture-loop.comp
@@ -16,7 +16,7 @@ struct SSBO2
 
 constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(1u);
 
-kernel void main0(const device SSBO& _24 [[buffer(0)]], device SSBO2& _89 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(device SSBO& _24 [[buffer(0)]], device SSBO2& _89 [[buffer(1)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
     uint ident = gl_GlobalInvocationID.x;
     float4 idat = _24.in_data[ident];

--- a/reference/shaders-msl/frag/argument-buffers.msl2.argument.frag
+++ b/reference/shaders-msl/frag/argument-buffers.msl2.argument.frag
@@ -43,7 +43,7 @@ struct spvDescriptorSetBuffer1
 {
     array<texture2d<float>, 4> uTexture2 [[id(0)]];
     array<sampler, 2> uSampler [[id(4)]];
-    device SSBO* m_60 [[id(6)]];
+    const device SSBO* m_60 [[id(6)]];
     const device SSBOs* ssbos [[id(7)]][2];
 };
 
@@ -63,7 +63,7 @@ struct main0_in
 };
 
 static inline __attribute__((always_inline))
-float4 sample_in_function2(texture2d<float> uTexture, sampler uTextureSmplr, thread float2& vUV, constant array<texture2d<float>, 4>& uTexture2, constant array<sampler, 2>& uSampler, constant array<texture2d<float>, 2>& uTextures, constant array<sampler, 2>& uTexturesSmplr, device SSBO& _60, const device SSBOs* constant (&ssbos)[2], constant Push& registers)
+float4 sample_in_function2(texture2d<float> uTexture, sampler uTextureSmplr, thread float2& vUV, constant array<texture2d<float>, 4>& uTexture2, constant array<sampler, 2>& uSampler, constant array<texture2d<float>, 2>& uTextures, constant array<sampler, 2>& uTexturesSmplr, const device SSBO& _60, const device SSBOs* constant (&ssbos)[2], constant Push& registers)
 {
     float4 ret = uTexture.sample(uTextureSmplr, vUV);
     ret += uTexture2[2].sample(uSampler[1], vUV);
@@ -75,7 +75,7 @@ float4 sample_in_function2(texture2d<float> uTexture, sampler uTextureSmplr, thr
 }
 
 static inline __attribute__((always_inline))
-float4 sample_in_function(texture2d<float> uTexture, sampler uTextureSmplr, thread float2& vUV, constant array<texture2d<float>, 4>& uTexture2, constant array<sampler, 2>& uSampler, constant array<texture2d<float>, 2>& uTextures, constant array<sampler, 2>& uTexturesSmplr, device SSBO& _60, const device SSBOs* constant (&ssbos)[2], constant Push& registers, constant UBO& _90, constant UBOs* constant (&ubos)[4])
+float4 sample_in_function(texture2d<float> uTexture, sampler uTextureSmplr, thread float2& vUV, constant array<texture2d<float>, 4>& uTexture2, constant array<sampler, 2>& uSampler, constant array<texture2d<float>, 2>& uTextures, constant array<sampler, 2>& uTexturesSmplr, const device SSBO& _60, const device SSBOs* constant (&ssbos)[2], constant Push& registers, constant UBO& _90, constant UBOs* constant (&ubos)[4])
 {
     float4 ret = sample_in_function2(uTexture, uTextureSmplr, vUV, uTexture2, uSampler, uTextures, uTexturesSmplr, _60, ssbos, registers);
     ret += _90.ubo;

--- a/reference/shaders-msl/frag/complex-expression-in-access-chain.frag
+++ b/reference/shaders-msl/frag/complex-expression-in-access-chain.frag
@@ -29,7 +29,7 @@ struct main0_in
     int vIn2 [[user(locn1)]];
 };
 
-fragment main0_out main0(main0_in in [[stage_in]], device UBO& _34 [[buffer(0)]], texture2d<int> Buf [[texture(0)]], sampler BufSmplr [[sampler(0)]], float4 gl_FragCoord [[position]])
+fragment main0_out main0(main0_in in [[stage_in]], const device UBO& _34 [[buffer(0)]], texture2d<int> Buf [[texture(0)]], sampler BufSmplr [[sampler(0)]], float4 gl_FragCoord [[position]])
 {
     main0_out out = {};
     int4 coords = Buf.read(uint2(int2(gl_FragCoord.xy)), 0);

--- a/reference/shaders-ue4/asm/frag/texture-atomics.asm.argument.msl2.frag
+++ b/reference/shaders-ue4/asm/frag/texture-atomics.asm.argument.msl2.frag
@@ -60,7 +60,7 @@ constant float3 _70 = {};
 
 struct spvDescriptorSetBuffer0
 {
-    const device type_StructuredBuffer_v4float* CulledObjectBoxBounds [[id(0)]];
+    device type_StructuredBuffer_v4float* CulledObjectBoxBounds [[id(0)]];
     constant type_Globals* _Globals [[id(1)]];
     texture2d<uint> RWShadowTileNumCulledObjects [[id(2)]];
     device atomic_uint* RWShadowTileNumCulledObjects_atomic [[id(3)]];

--- a/reference/shaders-ue4/asm/frag/texture-atomics.asm.frag
+++ b/reference/shaders-ue4/asm/frag/texture-atomics.asm.frag
@@ -68,7 +68,7 @@ struct main0_in
     uint in_var_TEXCOORD0 [[user(locn0)]];
 };
 
-fragment main0_out main0(main0_in in [[stage_in]], const device type_StructuredBuffer_v4float& CulledObjectBoxBounds [[buffer(0)]], constant type_Globals& _Globals [[buffer(1)]], texture2d<uint> RWShadowTileNumCulledObjects [[texture(0)]], device atomic_uint* RWShadowTileNumCulledObjects_atomic [[buffer(2)]], float4 gl_FragCoord [[position]])
+fragment main0_out main0(main0_in in [[stage_in]], device type_StructuredBuffer_v4float& CulledObjectBoxBounds [[buffer(0)]], constant type_Globals& _Globals [[buffer(1)]], texture2d<uint> RWShadowTileNumCulledObjects [[texture(0)]], device atomic_uint* RWShadowTileNumCulledObjects_atomic [[buffer(2)]], float4 gl_FragCoord [[position]])
 {
     main0_out out = {};
     uint2 _77 = uint2(gl_FragCoord.xy);

--- a/reference/shaders-ue4/asm/frag/texture-atomics.asm.graphics-robust-access.frag
+++ b/reference/shaders-ue4/asm/frag/texture-atomics.asm.graphics-robust-access.frag
@@ -68,7 +68,7 @@ struct main0_in
     uint in_var_TEXCOORD0 [[user(locn0)]];
 };
 
-fragment main0_out main0(main0_in in [[stage_in]], const device type_StructuredBuffer_v4float& CulledObjectBoxBounds [[buffer(0)]], constant type_Globals& _Globals [[buffer(1)]], texture2d<uint> RWShadowTileNumCulledObjects [[texture(0)]], device atomic_uint* RWShadowTileNumCulledObjects_atomic [[buffer(2)]], float4 gl_FragCoord [[position]])
+fragment main0_out main0(main0_in in [[stage_in]], device type_StructuredBuffer_v4float& CulledObjectBoxBounds [[buffer(0)]], constant type_Globals& _Globals [[buffer(1)]], texture2d<uint> RWShadowTileNumCulledObjects [[texture(0)]], device atomic_uint* RWShadowTileNumCulledObjects_atomic [[buffer(2)]], float4 gl_FragCoord [[position]])
 {
     main0_out out = {};
     uint2 _77 = uint2(gl_FragCoord.xy);

--- a/reference/shaders-ue4/asm/tesc/hs-incorrect-base-type.invalid.asm.tesc
+++ b/reference/shaders-ue4/asm/tesc/hs-incorrect-base-type.invalid.asm.tesc
@@ -298,7 +298,7 @@ struct main0_in
     float4 in_var_VS_To_DS_Position [[attribute(7)]];
 };
 
-kernel void main0(main0_in in [[stage_in]], constant type_View& View [[buffer(0)]], const device type_StructuredBuffer_v4float& View_PrimitiveSceneData [[buffer(1)]], uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], device main0_out* spvOut [[buffer(28)]], constant uint* spvIndirectParams [[buffer(29)]], device main0_patchOut* spvPatchOut [[buffer(27)]], device MTLTriangleTessellationFactorsHalf* spvTessLevel [[buffer(26)]], threadgroup main0_in* gl_in [[threadgroup(0)]])
+kernel void main0(main0_in in [[stage_in]], constant type_View& View [[buffer(0)]], device type_StructuredBuffer_v4float& View_PrimitiveSceneData [[buffer(1)]], uint gl_InvocationID [[thread_index_in_threadgroup]], uint gl_PrimitiveID [[threadgroup_position_in_grid]], device main0_out* spvOut [[buffer(28)]], constant uint* spvIndirectParams [[buffer(29)]], device main0_patchOut* spvPatchOut [[buffer(27)]], device MTLTriangleTessellationFactorsHalf* spvTessLevel [[buffer(26)]], threadgroup main0_in* gl_in [[threadgroup(0)]])
 {
     threadgroup spvUnsafeArray<FPNTessellationHSToDS, 3> temp_var_hullMainRetVal;
     device main0_out* gl_out = &spvOut[gl_PrimitiveID * 3];

--- a/shaders-msl-no-opt/comp/argument-buffer-readonly-writeonly-alias.msl2.argument.argument-tier-1.device-argument-buffer.comp
+++ b/shaders-msl-no-opt/comp/argument-buffer-readonly-writeonly-alias.msl2.argument.argument-tier-1.device-argument-buffer.comp
@@ -1,0 +1,9 @@
+#version 450
+#extension GL_EXT_nonuniform_qualifier : require
+
+layout (binding = 0) readonly buffer A {float data_a[];} a[];
+layout (binding = 0) writeonly buffer D {float data_d[];} d[];
+
+void main() {
+	d[gl_WorkGroupID.x].data_d[0] = a[gl_WorkGroupID.x].data_a[0];
+}

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -1059,6 +1059,8 @@ protected:
 
 	void fix_up_shader_inputs_outputs();
 
+	bool entry_point_returns_stage_output() const;
+	bool entry_point_requires_const_device_buffers() const;
 	std::string func_type_decl(SPIRType &type);
 	std::string entry_point_args_classic(bool append_comma);
 	std::string entry_point_args_argument_buffer(bool append_comma);
@@ -1264,6 +1266,7 @@ protected:
 	bool using_builtin_array() const;
 
 	bool is_rasterization_disabled = false;
+	bool has_descriptor_side_effects = false;
 	bool capture_output_to_buffer = false;
 	bool needs_swizzle_buffer_def = false;
 	bool used_swizzle_buffer = false;


### PR DESCRIPTION
Any attempt to alias these creates pain and suffering. const pointers don't carry much meaning in C++ anyway unlike readonly in SPIR-V which gives stronger guarantees about the memory itself being non-writable, where C++ only blocks writing via that reference.

Fix #2537.