### PR TITLE
Fix: change default namespace spirv_cross to configurable SPIRV_CROSS_NAMESPACE in spirv_hlsl.cpp

### DIFF
--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -3029,7 +3029,7 @@ string CompilerHLSL::get_inner_entry_point_name() const
 		SPIRV_CROSS_THROW("Unsupported execution model.");
 }
 
-uint32_t CompilerHLSL::input_vertices_from_execution_mode(SPIRV_CROSS_NAMESPACE::SPIREntryPoint &execution) const
+uint32_t CompilerHLSL::input_vertices_from_execution_mode(SPIREntryPoint &execution) const
 {
 	uint32_t input_vertices = 1;
 


### PR DESCRIPTION
I found up that in e.g. [Diligent Engine](https://github.com/DiligentGraphics/DiligentEngine) defines it's own namespace 'diligent_spirv_cross' instead of default 'spirv_cross' which brokes compilation at [spirv_hlsl.cpp:3032](https://github.com/KhronosGroup/SPIRV-Cross/blob/072444287f4e139c178d6d8fe32e04a0d2c34e8b/spirv_hlsl.cpp#L3032)