### PR TITLE
CMake: enable C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,8 @@
 #  2. The MIT License, found at <http://opensource.org/licenses/MIT>.
 #
 
-cmake_minimum_required(VERSION 3.10)
-set(CMAKE_CXX_STANDARD 11)
+cmake_minimum_required(VERSION 3.19)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Avoid a warning if parent project sets VERSION in project().

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ It is also the only build system which has install commands and other useful bui
 
 However, you can just run `make` on the command line as a fallback if you only care about the CLI tool.
 
-A non-ancient GCC (4.8+) or Clang (3.x+) compiler is required as SPIRV-Cross uses C++11 extensively.
+A non-ancient GCC (4.8+) or Clang (3.x+) compiler is required as SPIRV-Cross uses C++11 extensively and C++17.
 
 ### Windows
 


### PR DESCRIPTION
`SPIRV-Cross` de facto already relies on `C++17` features like the `[[maybe_unused]]` attribute.

If we don't enable `C++17` during compilation, we see warnings such as:
```
C5051: attribute [[maybe_unused]] requires at least '/std:c++17'; ignored.
```

Enabling C++17 resolves these warnings.