### PR TITLE
MSL: Fix writing default gl_PointSize in tessellation shaders.

### DIFF
--- a/reference/opt/shaders-msl/tese/no_pointsize.default-point-size.tese
+++ b/reference/opt/shaders-msl/tese/no_pointsize.default-point-size.tese
@@ -1,0 +1,19 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+    float gl_PointSize [[point_size]];
+};
+
+[[ patch(triangle, 0) ]] vertex main0_out main0()
+{
+    main0_out out = {};
+    out.gl_Position = float4(1.0);
+    out.gl_PointSize = 1.0;
+    return out;
+}
+

--- a/reference/shaders-msl/tese/no_pointsize.default-point-size.tese
+++ b/reference/shaders-msl/tese/no_pointsize.default-point-size.tese
@@ -1,0 +1,19 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+    float gl_PointSize [[point_size]];
+};
+
+[[ patch(triangle, 0) ]] vertex main0_out main0()
+{
+    main0_out out = {};
+    out.gl_Position = float4(1.0);
+    out.gl_PointSize = 1.0;
+    return out;
+}
+

--- a/shaders-msl/tese/no_pointsize.default-point-size.tese
+++ b/shaders-msl/tese/no_pointsize.default-point-size.tese
@@ -1,0 +1,10 @@
+#version 310 es
+#extension GL_EXT_tessellation_shader : require
+
+layout(cw, triangles, fractional_even_spacing, point_mode) in;
+
+void main()
+{
+   gl_Position = vec4(1.0);
+}
+

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -1060,6 +1060,7 @@ protected:
 
 	void fix_up_shader_inputs_outputs();
 
+	bool entry_point_is_vertex() const;
 	bool entry_point_returns_stage_output() const;
 	bool entry_point_requires_const_device_buffers() const;
 	std::string func_type_decl(SPIRType &type);
@@ -1278,6 +1279,7 @@ protected:
 	bool needs_sample_id = false;
 	bool needs_helper_invocation = false;
 	bool needs_workgroup_zero_init = false;
+	bool needs_point_size_output = false;
 	bool writes_to_depth = false;
 	bool writes_to_point_size = false;
 	std::string qual_pos_var_name;


### PR DESCRIPTION
Oversight from the original change to enable writing a default point size for MSL. The check to write the default is within a `is_vertex_like_shader()` block, but the check added to define the output if needed just uses `get_execution_model() == ExecutionModelVertex`. As a result, tessellation shaders with default point size enabled are failing to compile:
```
program_source:21:9: error: no member named 'gl_PointSize' in 'main0_out'
    out.gl_PointSize = 1.0;
    ~~~ ^
```

Fixed by setting up the correct condition for this to handle both vertex and tessellation evaluation stages, and reusing the result in a flag variable to maintain consistency.