### PR TITLE
MSL: Fix mesh shader with no vertex outputs.

### DIFF
--- a/reference/opt/shaders-msl/asm/mesh/mesh-shader-no-vertices.asm.msl3.spv14.vk.mesh
+++ b/reference/opt/shaders-msl/asm/mesh/mesh-shader-no-vertices.asm.msl3.spv14.vk.mesh
@@ -1,0 +1,100 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wmissing-braces"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+template<typename T, size_t Num>
+struct spvUnsafeArray
+{
+    T elements[Num ? Num : 1];
+    
+    thread T& operator [] (size_t pos) thread
+    {
+        return elements[pos];
+    }
+    constexpr const thread T& operator [] (size_t pos) const thread
+    {
+        return elements[pos];
+    }
+    
+    device T& operator [] (size_t pos) device
+    {
+        return elements[pos];
+    }
+    constexpr const device T& operator [] (size_t pos) const device
+    {
+        return elements[pos];
+    }
+    
+    constexpr const constant T& operator [] (size_t pos) const constant
+    {
+        return elements[pos];
+    }
+    
+    threadgroup T& operator [] (size_t pos) threadgroup
+    {
+        return elements[pos];
+    }
+    constexpr const threadgroup T& operator [] (size_t pos) const threadgroup
+    {
+        return elements[pos];
+    }
+    
+    object_data T& operator [] (size_t pos) object_data
+    {
+        return elements[pos];
+    }
+    constexpr const object_data T& operator [] (size_t pos) const object_data
+    {
+        return elements[pos];
+    }
+};
+
+void spvSetMeshOutputsEXT(uint gl_LocalInvocationIndex, threadgroup uint2& spvMeshSizes, uint vertexCount, uint primitiveCount)
+{
+    if (gl_LocalInvocationIndex == 0)
+    {
+        spvMeshSizes.x = vertexCount;
+        spvMeshSizes.y = primitiveCount;
+    }
+}
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(128u, 1u, 1u);
+
+struct spvPerPrimitive
+{
+    float4 m_17 [[user(locn0)]];
+};
+
+using spvMesh_t = mesh<float4, spvPerPrimitive, 256, 256, topology::triangle>;
+
+static inline __attribute__((always_inline))
+void _4(thread uint& gl_LocalInvocationIndex, threadgroup uint2& spvMeshSizes)
+{
+    spvSetMeshOutputsEXT(gl_LocalInvocationIndex, spvMeshSizes, 0u, 0u);
+}
+
+[[mesh]] void main0(uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]], spvMesh_t spvMesh)
+{
+    threadgroup uint2 spvMeshSizes;
+    threadgroup spvUnsafeArray<float4, 256> _17;
+    if (gl_LocalInvocationIndex == 0) spvMeshSizes.y = 0u;
+    _4(gl_LocalInvocationIndex, spvMeshSizes);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (spvMeshSizes.y == 0)
+    {
+        return;
+    }
+    spvMesh.set_primitive_count(spvMeshSizes.y);
+    const uint spvThreadCount [[maybe_unused]] = (gl_WorkGroupSize.x * gl_WorkGroupSize.y * gl_WorkGroupSize.z);
+    for (uint spvPI = gl_LocalInvocationIndex; spvPI < spvMeshSizes.y; spvPI += spvThreadCount)
+    {
+        spvPerPrimitive spvP = {};
+        spvP.m_17 = _17[spvPI];
+        spvMesh.set_primitive(spvPI, spvP);
+    }
+}
+

--- a/reference/shaders-msl/asm/mesh/mesh-shader-no-vertices.asm.msl3.spv14.vk.mesh
+++ b/reference/shaders-msl/asm/mesh/mesh-shader-no-vertices.asm.msl3.spv14.vk.mesh
@@ -1,0 +1,100 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wmissing-braces"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+template<typename T, size_t Num>
+struct spvUnsafeArray
+{
+    T elements[Num ? Num : 1];
+    
+    thread T& operator [] (size_t pos) thread
+    {
+        return elements[pos];
+    }
+    constexpr const thread T& operator [] (size_t pos) const thread
+    {
+        return elements[pos];
+    }
+    
+    device T& operator [] (size_t pos) device
+    {
+        return elements[pos];
+    }
+    constexpr const device T& operator [] (size_t pos) const device
+    {
+        return elements[pos];
+    }
+    
+    constexpr const constant T& operator [] (size_t pos) const constant
+    {
+        return elements[pos];
+    }
+    
+    threadgroup T& operator [] (size_t pos) threadgroup
+    {
+        return elements[pos];
+    }
+    constexpr const threadgroup T& operator [] (size_t pos) const threadgroup
+    {
+        return elements[pos];
+    }
+    
+    object_data T& operator [] (size_t pos) object_data
+    {
+        return elements[pos];
+    }
+    constexpr const object_data T& operator [] (size_t pos) const object_data
+    {
+        return elements[pos];
+    }
+};
+
+void spvSetMeshOutputsEXT(uint gl_LocalInvocationIndex, threadgroup uint2& spvMeshSizes, uint vertexCount, uint primitiveCount)
+{
+    if (gl_LocalInvocationIndex == 0)
+    {
+        spvMeshSizes.x = vertexCount;
+        spvMeshSizes.y = primitiveCount;
+    }
+}
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(128u, 1u, 1u);
+
+struct spvPerPrimitive
+{
+    float4 m_17 [[user(locn0)]];
+};
+
+using spvMesh_t = mesh<float4, spvPerPrimitive, 256, 256, topology::triangle>;
+
+static inline __attribute__((always_inline))
+void _4(thread uint& gl_LocalInvocationIndex, threadgroup uint2& spvMeshSizes)
+{
+    spvSetMeshOutputsEXT(gl_LocalInvocationIndex, spvMeshSizes, 0u, 0u);
+}
+
+[[mesh]] void main0(uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]], spvMesh_t spvMesh)
+{
+    threadgroup uint2 spvMeshSizes;
+    threadgroup spvUnsafeArray<float4, 256> _17;
+    if (gl_LocalInvocationIndex == 0) spvMeshSizes.y = 0u;
+    _4(gl_LocalInvocationIndex, spvMeshSizes);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (spvMeshSizes.y == 0)
+    {
+        return;
+    }
+    spvMesh.set_primitive_count(spvMeshSizes.y);
+    const uint spvThreadCount [[maybe_unused]] = (gl_WorkGroupSize.x * gl_WorkGroupSize.y * gl_WorkGroupSize.z);
+    for (uint spvPI = gl_LocalInvocationIndex; spvPI < spvMeshSizes.y; spvPI += spvThreadCount)
+    {
+        spvPerPrimitive spvP = {};
+        spvP.m_17 = _17[spvPI];
+        spvMesh.set_primitive(spvPI, spvP);
+    }
+}
+

--- a/shaders-msl/asm/mesh/mesh-shader-no-vertices.asm.msl3.spv14.vk.mesh
+++ b/shaders-msl/asm/mesh/mesh-shader-no-vertices.asm.msl3.spv14.vk.mesh
@@ -1,0 +1,36 @@
+; SPIR-V
+; Version: 1.4
+; Generator: Khronos Glslang Reference Front End; 11
+; Bound: 18
+; Schema: 0
+               OpCapability MeshShadingEXT
+               OpExtension "SPV_EXT_mesh_shader"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint MeshEXT %4 "main" %17
+               OpExecutionMode %4 LocalSize 128 1 1
+               OpExecutionMode %4 OutputVertices 256
+               OpExecutionMode %4 OutputPrimitivesEXT 256
+               OpExecutionMode %4 OutputTrianglesEXT
+               OpDecorate %11 BuiltIn WorkgroupSize
+               OpDecorate %17 Location 0
+               OpDecorate %17 PerPrimitiveEXT
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 0
+          %7 = OpConstant %6 0
+          %8 = OpTypeVector %6 3
+          %9 = OpConstant %6 128
+         %10 = OpConstant %6 1
+         %11 = OpConstantComposite %8 %9 %10 %10
+         %12 = OpTypeFloat 32
+         %13 = OpTypeVector %12 4
+         %14 = OpConstant %6 256
+         %15 = OpTypeArray %13 %14
+         %16 = OpTypePointer Output %15
+         %17 = OpVariable %16 Output
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpSetMeshOutputsEXT %7 %7
+               OpReturn
+               OpFunctionEnd

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -8310,8 +8310,9 @@ void CompilerMSL::emit_resources()
 		else if (execution.flags.get(ExecutionModeOutputPoints))
 			topology = "topology::point";
 
+		const char *per_vertex = mesh_out_per_vertex ? "spvPerVertex" : "float4";
 		const char *per_primitive = mesh_out_per_primitive ? "spvPerPrimitive" : "void";
-		statement("using spvMesh_t = mesh<", "spvPerVertex, ", per_primitive, ", ", execution.output_vertices, ", ",
+		statement("using spvMesh_t = mesh<", per_vertex, ", ", per_primitive, ", ", execution.output_vertices, ", ",
 		          execution.output_primitives, ", ", topology, ">;");
 		statement("");
 	}


### PR DESCRIPTION
Found in `dEQP-VK.mesh_shader.ext.misc.no_triangles`.

When a mesh shader has no vertex outputs, the `spvPerVertex` struct is not defined, so the `mesh` type definition which references it fails to compile. It is also invalid to use an empty `spvPerVertex` struct, so just use `float4` which is the basic allowed per-vertex type for meshes as per the MSL spec.

Added the shader in question as a test as well.