### PR TITLE
Add support for GL_EXT_ray_tracing_position_fetch

### DIFF
--- a/reference/opt/shaders/vulkan/frag/rq-position-fetch.vk.spv14.nocompat.frag.vk
+++ b/reference/opt/shaders/vulkan/frag/rq-position-fetch.vk.spv14.nocompat.frag.vk
@@ -1,0 +1,22 @@
+#version 460
+#extension GL_EXT_ray_query : require
+#extension GL_EXT_ray_tracing_position_fetch : require
+
+layout(set = 0, binding = 0) uniform accelerationStructureEXT uAS;
+
+layout(location = 0) out vec3 o_color;
+rayQueryEXT query;
+
+void main()
+{
+    rayQueryInitializeEXT(query, uAS, 4u, 255u, vec3(0.0), 0.00999999977648258209228515625, vec3(1.0, 0.0, 0.0), 1.0);
+    bool _32 = rayQueryProceedEXT(query);
+    uint _36 = rayQueryGetIntersectionTypeEXT(query, bool(1));
+    if (_36 != 0u)
+    {
+        vec3 _45[3];
+        rayQueryGetIntersectionTriangleVertexPositionsEXT(query, bool(1), _45);
+        o_color = (_45[0] + _45[1]) + _45[2];
+    }
+}
+

--- a/reference/opt/shaders/vulkan/rchit/position_fetch.spv14.nocompat.vk.rchit.vk
+++ b/reference/opt/shaders/vulkan/rchit/position_fetch.spv14.nocompat.vk.rchit.vk
@@ -1,0 +1,12 @@
+#version 460
+#extension GL_EXT_ray_tracing : require
+#extension GL_EXT_ray_tracing_position_fetch : require
+
+hitAttributeEXT vec2 attribs;
+layout(location = 0) rayPayloadInEXT vec3 hitValue;
+
+void main()
+{
+    hitValue = ((gl_HitTriangleVertexPositionsEXT[0] * ((1.0 - attribs.x) - attribs.y)) + (gl_HitTriangleVertexPositionsEXT[1] * attribs.x)) + (gl_HitTriangleVertexPositionsEXT[2] * attribs.y);
+}
+

--- a/reference/shaders/vulkan/frag/rq-position-fetch.vk.spv14.nocompat.frag.vk
+++ b/reference/shaders/vulkan/frag/rq-position-fetch.vk.spv14.nocompat.frag.vk
@@ -1,0 +1,26 @@
+#version 460
+#extension GL_EXT_ray_query : require
+#extension GL_EXT_ray_tracing_position_fetch : require
+
+layout(set = 0, binding = 0) uniform accelerationStructureEXT uAS;
+
+layout(location = 0) out vec3 o_color;
+rayQueryEXT query;
+
+void main()
+{
+    float tmin = 0.00999999977648258209228515625;
+    float tmax = 1000.0;
+    vec3 dir = vec3(1.0, 0.0, 0.0);
+    rayQueryInitializeEXT(query, uAS, 4u, 255u, vec3(0.0), tmin, dir, 1.0);
+    bool _32 = rayQueryProceedEXT(query);
+    uint _36 = rayQueryGetIntersectionTypeEXT(query, bool(1));
+    if (_36 != 0u)
+    {
+        vec3 _45[3];
+        rayQueryGetIntersectionTriangleVertexPositionsEXT(query, bool(1), _45);
+        vec3 vs[3] = _45;
+        o_color = (vs[0] + vs[1]) + vs[2];
+    }
+}
+

--- a/reference/shaders/vulkan/rchit/position_fetch.spv14.nocompat.vk.rchit.vk
+++ b/reference/shaders/vulkan/rchit/position_fetch.spv14.nocompat.vk.rchit.vk
@@ -1,0 +1,16 @@
+#version 460
+#extension GL_EXT_ray_tracing : require
+#extension GL_EXT_ray_tracing_position_fetch : require
+
+hitAttributeEXT vec2 attribs;
+layout(location = 0) rayPayloadInEXT vec3 hitValue;
+
+void main()
+{
+    vec3 barycentricCoords = vec3((1.0 - attribs.x) - attribs.y, attribs.x, attribs.y);
+    vec3 pos0 = gl_HitTriangleVertexPositionsEXT[0];
+    vec3 pos1 = gl_HitTriangleVertexPositionsEXT[1];
+    vec3 pos2 = gl_HitTriangleVertexPositionsEXT[2];
+    hitValue = ((pos0 * barycentricCoords.x) + (pos1 * barycentricCoords.y)) + (pos2 * barycentricCoords.z);
+}
+

--- a/shaders/vulkan/frag/rq-position-fetch.vk.spv14.nocompat.frag
+++ b/shaders/vulkan/frag/rq-position-fetch.vk.spv14.nocompat.frag
@@ -1,0 +1,25 @@
+#version 460
+#extension GL_EXT_ray_query : enable
+#extension GL_EXT_ray_tracing_position_fetch : require
+
+layout(location = 0) out vec3 o_color;
+layout(set = 0, binding = 0) uniform accelerationStructureEXT uAS;
+
+void main(void)
+{
+	float tmin = 0.01;
+	float tmax = 1000.0;
+	vec3 dir = vec3(1.0, 0.0, 0.0);
+
+	rayQueryEXT query;
+	rayQueryInitializeEXT(query, uAS, gl_RayFlagsTerminateOnFirstHitEXT, 0xFF, vec3(0.0), tmin, dir, 1.0);
+
+	rayQueryProceedEXT(query);
+
+	if (rayQueryGetIntersectionTypeEXT(query, true) != gl_RayQueryCommittedIntersectionNoneEXT)
+	{
+		vec3 vs[3];
+		rayQueryGetIntersectionTriangleVertexPositionsEXT(query, true, vs);
+		o_color = vs[0] + vs[1] + vs[2];
+	}
+}

--- a/shaders/vulkan/rchit/position_fetch.spv14.nocompat.vk.rchit
+++ b/shaders/vulkan/rchit/position_fetch.spv14.nocompat.vk.rchit
@@ -1,0 +1,17 @@
+#version 460
+#extension GL_EXT_ray_tracing : require
+#extension GL_EXT_ray_tracing_position_fetch : require
+
+layout(location = 0) rayPayloadInEXT vec3 hitValue;
+hitAttributeEXT vec2 attribs;
+
+void main()
+{
+	const vec3 barycentricCoords = vec3(1.0 - attribs.x - attribs.y, attribs.x, attribs.y);
+
+	vec3 pos0 = gl_HitTriangleVertexPositionsEXT[0];
+	vec3 pos1 = gl_HitTriangleVertexPositionsEXT[1];
+	vec3 pos2 = gl_HitTriangleVertexPositionsEXT[2];
+
+	hitValue = pos0 * barycentricCoords.x + pos1 * barycentricCoords.y + pos2 * barycentricCoords.z;
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -654,6 +654,20 @@ void CompilerGLSL::find_static_extensions()
 			ray_tracing_is_khr = true;
 			break;
 
+		case CapabilityRayQueryPositionFetchKHR:
+			if (options.es || options.version < 460 || !options.vulkan_semantics)
+				SPIRV_CROSS_THROW("RayQuery Position Fetch requires Vulkan GLSL 460.");
+			require_extension_internal("GL_EXT_ray_tracing_position_fetch");
+			ray_tracing_is_khr = true;
+			break;
+
+		case CapabilityRayTracingPositionFetchKHR:
+			if (options.es || options.version < 460 || !options.vulkan_semantics)
+				SPIRV_CROSS_THROW("Ray Tracing Position Fetch requires Vulkan GLSL 460.");
+			require_extension_internal("GL_EXT_ray_tracing_position_fetch");
+			ray_tracing_is_khr = true;
+			break;
+
 		case CapabilityRayTraversalPrimitiveCullingKHR:
 			if (options.es || options.version < 460 || !options.vulkan_semantics)
 				SPIRV_CROSS_THROW("RayQuery requires Vulkan GLSL 460.");
@@ -10399,6 +10413,14 @@ string CompilerGLSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 	case BuiltInCullPrimitiveEXT:
 		return "gl_CullPrimitiveEXT";
 
+	case BuiltInHitTriangleVertexPositionsKHR:
+	{
+		if (!options.vulkan_semantics)
+			SPIRV_CROSS_THROW("Need Vulkan semantics for EXT_ray_tracing_position_fetch.");
+		require_extension_internal("GL_EXT_ray_tracing_position_fetch");
+		return "gl_HitTriangleVertexPositionsEXT";
+	}
+
 	case BuiltInClusterIDNV:
 	{
 		if (!options.vulkan_semantics)
@@ -15529,6 +15551,11 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 	case OpRayQueryConfirmIntersectionKHR:
 		flush_variable_declaration(ops[0]);
 		statement("rayQueryConfirmIntersectionEXT(", to_expression(ops[0]), ");");
+		break;
+	case OpRayQueryGetIntersectionTriangleVertexPositionsKHR:
+		flush_variable_declaration(ops[1]);
+		emit_uninitialized_temporary_expression(ops[0], ops[1]);
+		statement("rayQueryGetIntersectionTriangleVertexPositionsEXT(", to_expression(ops[2]), ", bool(", to_expression(ops[3]), "), ", to_expression(ops[1]), ");");
 		break;
 #define GLSL_RAY_QUERY_GET_OP(op) \
 	case OpRayQueryGet##op##KHR: \


### PR DESCRIPTION
Trying to convert SPIR-V using `SPV_KHR_ray_tracing_position_fetch` to GLSL currently fails with:
```
SPIRV-Cross threw an exception: Cannot resolve expression type.
```

This commit adds support for  `GL_EXT_ray_tracing_position_fetch` to improve this.