### PR TITLE
MSL: Fix handling of forced temporary row-major matrices.

### DIFF
--- a/reference/shaders-msl-no-opt/comp/transposed-temporary-expression-2.comp
+++ b/reference/shaders-msl-no-opt/comp/transposed-temporary-expression-2.comp
@@ -1,0 +1,29 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct SSBO
+{
+    float3x4 A;
+    float3x4 B;
+    float3x4 C;
+    float4 D;
+    float w0;
+    float w1;
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(64u, 1u, 1u);
+
+kernel void main0(device SSBO& _18 [[buffer(0)]])
+{
+    float4x3 Anew;
+    float4x3 Bnew;
+    do
+    {
+        Anew = transpose(_18.A * _18.w0);
+        Bnew = transpose(_18.B * _18.w1);
+    } while (false);
+    _18.D = float4(float4x3(Anew[0] + Bnew[0], Anew[1] + Bnew[1], Anew[2] + Bnew[2], Anew[3] + Bnew[3]) * _18.D, 1.0);
+}
+

--- a/reference/shaders-msl-no-opt/comp/transposed-temporary-expression.comp
+++ b/reference/shaders-msl-no-opt/comp/transposed-temporary-expression.comp
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct SSBO
+{
+    float3x4 A;
+    float3x4 B;
+    float3x4 C;
+    float4 D;
+    float w0;
+    float w1;
+};
+
+constant uint3 gl_WorkGroupSize [[maybe_unused]] = uint3(64u, 1u, 1u);
+
+kernel void main0(device SSBO& _12 [[buffer(0)]])
+{
+    float3x4 _23 = _12.A * _12.w0;
+    float3x4 _30 = _12.B * _12.w1;
+    _12.D = float4(float4x3(float3(_23[0][0], _23[1][0], _23[2][0]) + float3(_30[0][0], _30[1][0], _30[2][0]), float3(_23[0][1], _23[1][1], _23[2][1]) + float3(_30[0][1], _30[1][1], _30[2][1]), float3(_23[0][2], _23[1][2], _23[2][2]) + float3(_30[0][2], _30[1][2], _30[2][2]), float3(_23[0][3], _23[1][3], _23[2][3]) + float3(_30[0][3], _30[1][3], _30[2][3])) * _12.D, 1.0);
+}
+

--- a/shaders-msl-no-opt/comp/transposed-temporary-expression-2.comp
+++ b/shaders-msl-no-opt/comp/transposed-temporary-expression-2.comp
@@ -1,0 +1,24 @@
+#version 450
+layout(local_size_x = 64) in;
+
+layout(set = 0, binding = 0) buffer SSBO
+{
+	layout(row_major) mat4x3 A;
+	layout(row_major) mat4x3 B;
+	layout(row_major) mat4x3 C;
+	vec4 D;
+	float w0;
+	float w1;
+};
+
+void main()
+{
+	mat4x3 Anew;
+	mat4x3 Bnew;
+	do
+	{
+		Anew = A * w0;
+		Bnew = B * w1;
+	} while(false);
+	D = vec4((Anew + Bnew) * D, 1.0);
+}

--- a/shaders-msl-no-opt/comp/transposed-temporary-expression.comp
+++ b/shaders-msl-no-opt/comp/transposed-temporary-expression.comp
@@ -1,0 +1,17 @@
+#version 450
+layout(local_size_x = 64) in;
+
+layout(set = 0, binding = 0) buffer SSBO
+{
+	layout(row_major) mat4x3 A;
+	layout(row_major) mat4x3 B;
+	layout(row_major) mat4x3 C;
+	vec4 D;
+	float w0;
+	float w1;
+};
+
+void main()
+{
+	D = vec4((A * w0 + B * w1) * D, 1.0);
+}

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -6896,6 +6896,16 @@ void CompilerGLSL::emit_uninitialized_temporary(uint32_t result_type, uint32_t r
 	}
 }
 
+bool CompilerGLSL::can_declare_inline_temporary(uint32_t id) const
+{
+	if (!block_temporary_hoisting && current_continue_block && !hoisted_temporaries.count(id))
+		return false;
+	if (hoisted_temporaries.count(id))
+		return false;
+
+	return true;
+}
+
 string CompilerGLSL::declare_temporary(uint32_t result_type, uint32_t result_id)
 {
 	auto &type = get<SPIRType>(result_type);
@@ -6970,6 +6980,42 @@ SPIRExpression &CompilerGLSL::emit_op(uint32_t result_type, uint32_t result_id, 
 		// If expression isn't immutable, bind it to a temporary and make the new temporary immutable (they always are).
 		statement(declare_temporary(result_type, result_id), rhs, ";");
 		return set<SPIRExpression>(result_id, to_name(result_id), result_type, true);
+	}
+}
+
+void CompilerGLSL::emit_transposed_op(uint32_t result_type, uint32_t result_id, const string &rhs, bool forwarding)
+{
+	if (forwarding && (forced_temporaries.find(result_id) == end(forced_temporaries)))
+	{
+		// Just forward it without temporary.
+		// If the forward is trivial, we do not force flushing to temporary for this expression.
+		forwarded_temporaries.insert(result_id);
+		auto &e = set<SPIRExpression>(result_id, rhs, result_type, true);
+		e.need_transpose = true;
+	}
+	else if (can_declare_inline_temporary(result_id))
+	{
+		// If expression isn't immutable, bind it to a temporary and make the new temporary immutable (they always are).
+		// Since the expression is transposed, we have to ensure the temporary is the transposed type.
+
+		auto &transposed_type_id = extra_sub_expressions[result_id];
+		if (!transposed_type_id)
+		{
+			auto dummy_type = get<SPIRType>(result_type);
+			std::swap(dummy_type.columns, dummy_type.vecsize);
+			transposed_type_id = ir.increase_bound_by(1);
+			set<SPIRType>(transposed_type_id, dummy_type);
+		}
+
+		statement(declare_temporary(transposed_type_id, result_id), rhs, ";");
+		auto &e = set<SPIRExpression>(result_id, to_name(result_id), result_type, true);
+		e.need_transpose = true;
+	}
+	else
+	{
+		// If we cannot declare the temporary because it's already been hoisted, we don't have the
+		// chance to override the temporary type ourselves. Just transpose() the expression.
+		emit_op(result_type, result_id, join("transpose(", rhs, ")"), forwarding);
 	}
 }
 
@@ -13507,8 +13553,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 			auto expr = join(enclose_expression(to_unpacked_row_major_matrix_expression(ops[3])), " * ",
 			                 enclose_expression(to_unpacked_row_major_matrix_expression(ops[2])));
 			bool forward = should_forward(ops[2]) && should_forward(ops[3]);
-			auto &e = emit_op(ops[0], ops[1], expr, forward);
-			e.need_transpose = true;
+			emit_transposed_op(ops[0], ops[1], expr, forward);
 			a->need_transpose = true;
 			b->need_transpose = true;
 			inherit_expression_dependencies(ops[1], ops[2]);
@@ -13531,8 +13576,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 			auto expr = join(enclose_expression(to_unpacked_row_major_matrix_expression(ops[2])), " * ",
 			                 to_enclosed_unpacked_expression(ops[3]));
 			bool forward = should_forward(ops[2]) && should_forward(ops[3]);
-			auto &e = emit_op(ops[0], ops[1], expr, forward);
-			e.need_transpose = true;
+			emit_transposed_op(ops[0], ops[1], expr, forward);
 			a->need_transpose = true;
 			inherit_expression_dependencies(ops[1], ops[2]);
 			inherit_expression_dependencies(ops[1], ops[3]);

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -763,6 +763,7 @@ protected:
 	bool expression_read_implies_multiple_reads(uint32_t id) const;
 	SPIRExpression &emit_op(uint32_t result_type, uint32_t result_id, const std::string &rhs, bool forward_rhs,
 	                        bool suppress_usage_tracking = false);
+	void emit_transposed_op(uint32_t result_type, uint32_t result_id, const std::string &rhs, bool forward_rhs);
 
 	void access_chain_internal_append_index(std::string &expr, uint32_t base, const SPIRType *type,
 	                                        AccessChainFlags flags, bool &access_chain_is_arrayed, uint32_t index);
@@ -805,6 +806,7 @@ protected:
 	const char *index_to_swizzle(uint32_t index);
 	std::string remap_swizzle(const SPIRType &result_type, uint32_t input_components, const std::string &expr);
 	std::string declare_temporary(uint32_t type, uint32_t id);
+	bool can_declare_inline_temporary(uint32_t id) const;
 	void emit_uninitialized_temporary(uint32_t type, uint32_t id);
 	SPIRExpression &emit_uninitialized_temporary_expression(uint32_t type, uint32_t id);
 	virtual void append_global_func_args(const SPIRFunction &func, uint32_t index, SmallVector<std::string> &arglist);

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -10158,8 +10158,7 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 			         enclose_expression(to_unpacked_row_major_matrix_expression(ops[2])), ")");
 
 			bool forward = should_forward(ops[2]) && should_forward(ops[3]);
-			auto &e = emit_op(ops[0], ops[1], expr, forward);
-			e.need_transpose = true;
+			emit_transposed_op(ops[0], ops[1], expr, forward);
 			a->need_transpose = true;
 			b->need_transpose = true;
 			inherit_expression_dependencies(ops[1], ops[2]);


### PR DESCRIPTION
If we lower to temporary, we must fixup the type.
Puzzling that this hasn't come up before now ...

Fix #2566.