### PR TITLE
[fix] HLSL: Additional HLSL specific keywords(`signed`).

### DIFF
--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1595,6 +1595,7 @@ void CompilerHLSL::replace_illegal_names()
 		"Texture3D", "TextureCube", "TextureCubeArray", "true", "typedef", "triangle",
 		"triangleadj", "TriangleStream", "uint", "uniform", "unorm", "unsigned",
 		"vector", "vertexfragment", "VertexShader", "vertices", "void", "volatile", "while",
+		"signed",
 	};
 
 	CompilerGLSL::replace_illegal_names(keywords);


### PR DESCRIPTION
When I use signed as the variable name and generate HLSL runtime, I was told by the compiler that I used keywords as the variable name
`Signed 'is the keyword of HLSL, but it is not reflected in Microsoft's documents
My environment is windows 11
Device: Intel (R) UHD graphics 630
Drive: 31.0.101.2135
I am not sure if it is a specific driver problem However, after I added the keyword list, there was no error in the compilation