### PR TITLE
[fix] MSL: Additional MSL specific keywords(`signed`).

### DIFF
--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -16278,6 +16278,7 @@ const std::unordered_set<std::string> &CompilerMSL::get_reserved_keyword_set()
 		"quad_broadcast",
 		"thread",
 		"threadgroup",
+		"signed",
 	};
 
 	return keywords;
@@ -16421,6 +16422,7 @@ const std::unordered_set<std::string> &CompilerMSL::get_illegal_func_names()
 		"uint16",
 		"float8",
 		"float16",
+		"signed",
 	};
 
 	return illegal_func_names;


### PR DESCRIPTION
I'm very sorry, I have submitted two similar revisions in a row
After confirmation, 'signed' is also one of the keywords in Apple's MSL
I'm a bit unsure if glsl has the same issue here, should we also add glsl for insurance purposes?
