### PR TITLE
Avoid compiler warning when -Wconvert enabled

### DIFF
--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -1355,7 +1355,7 @@ struct SPIRConstant : IVariant
 
 	inline float scalar_bf8(uint32_t col = 0, uint32_t row = 0) const
 	{
-		return f16_to_f32(static_cast<uint16_t>(scalar_u8(col, row) << 8));
+		return f16_to_f32(uint16_t(scalar_u8(col, row) << 8));
 	}
 
 	inline float scalar_f32(uint32_t col = 0, uint32_t row = 0) const


### PR DESCRIPTION
Fixes clients that enable -Wconvert and treat warnings as errors when including public headers.