### PR TITLE
MSL: Deal with std140 layouts when copying arrays between storage class.

### DIFF
--- a/reference/shaders-msl-no-opt/asm/comp/array-copy-physical-layout-mismatch.asm.comp
+++ b/reference/shaders-msl-no-opt/asm/comp/array-copy-physical-layout-mismatch.asm.comp
@@ -1,0 +1,271 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wmissing-braces"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+template<typename T, size_t Num>
+struct spvUnsafeArray
+{
+    T elements[Num ? Num : 1];
+    
+    thread T& operator [] (size_t pos) thread
+    {
+        return elements[pos];
+    }
+    constexpr const thread T& operator [] (size_t pos) const thread
+    {
+        return elements[pos];
+    }
+    
+    device T& operator [] (size_t pos) device
+    {
+        return elements[pos];
+    }
+    constexpr const device T& operator [] (size_t pos) const device
+    {
+        return elements[pos];
+    }
+    
+    constexpr const constant T& operator [] (size_t pos) const constant
+    {
+        return elements[pos];
+    }
+    
+    threadgroup T& operator [] (size_t pos) threadgroup
+    {
+        return elements[pos];
+    }
+    constexpr const threadgroup T& operator [] (size_t pos) const threadgroup
+    {
+        return elements[pos];
+    }
+};
+
+template<typename T, uint N>
+inline void spvArrayCopyFromConstantToStack(thread T (&dst)[N], constant T (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        dst[i] = src[i];
+    }
+}
+template<typename T, uint V, uint N>
+inline void spvArrayCopyFromConstantToStack(thread T (&dst)[N], constant vec<T, V> (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        dst[i] = reinterpret_cast<constant T &>(src[i]);
+    }
+}
+
+template<typename T, uint Vdst, uint Vsrc, uint N>
+inline enable_if_t<Vdst != Vsrc> spvArrayCopyFromConstantToStack(thread vec<T, Vdst> (&dst)[N], constant vec<T, Vsrc> (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        dst[i] = reinterpret_cast<constant vec<T, Vdst> &>(src[i]);
+    }
+}
+
+template<typename T, uint N>
+inline void spvArrayCopyFromConstantToThreadGroup(threadgroup T (&dst)[N], constant T (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        dst[i] = src[i];
+    }
+}
+template<typename T, uint V, uint N>
+inline void spvArrayCopyFromConstantToThreadGroup(threadgroup T (&dst)[N], constant vec<T, V> (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        dst[i] = reinterpret_cast<constant T &>(src[i]);
+    }
+}
+
+template<typename T, uint Vdst, uint Vsrc, uint N>
+inline enable_if_t<Vdst != Vsrc> spvArrayCopyFromConstantToThreadGroup(threadgroup vec<T, Vdst> (&dst)[N], constant vec<T, Vsrc> (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        dst[i] = reinterpret_cast<constant vec<T, Vdst> &>(src[i]);
+    }
+}
+
+template<typename T, uint N>
+inline void spvArrayCopyFromStackToStack(thread T (&dst)[N], thread const T (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        dst[i] = src[i];
+    }
+}
+
+template<typename T, uint N>
+inline void spvArrayCopyFromStackToThreadGroup(threadgroup T (&dst)[N], thread const T (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        dst[i] = src[i];
+    }
+}
+
+template<typename T, uint N>
+inline void spvArrayCopyFromThreadGroupToStack(thread T (&dst)[N], threadgroup const T (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        dst[i] = src[i];
+    }
+}
+
+template<typename T, uint N>
+inline void spvArrayCopyFromThreadGroupToThreadGroup(threadgroup T (&dst)[N], threadgroup const T (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        dst[i] = src[i];
+    }
+}
+
+template<typename T, uint N>
+inline void spvArrayCopyFromDeviceToDevice(device T (&dst)[N], device const T (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        dst[i] = src[i];
+    }
+}
+
+template<typename T, uint N>
+inline void spvArrayCopyFromConstantToDevice(device T (&dst)[N], constant T (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        dst[i] = src[i];
+    }
+}
+
+template<typename T, uint N>
+inline void spvArrayCopyFromStackToDevice(device T (&dst)[N], thread const T (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        dst[i] = src[i];
+    }
+}
+template<typename T, uint V, uint N>
+inline void spvArrayCopyFromStackToDevice(device vec<T, V> (&dst)[N], thread const T (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        reinterpret_cast<device T &>(dst[i]) = src[i];
+    }
+}
+
+template<typename T, uint Vdst, uint Vsrc, uint N>
+inline enable_if_t<Vdst != Vsrc> spvArrayCopyFromStackToDevice(device vec<T, Vdst> (&dst)[N], thread const vec<T, Vsrc> (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        reinterpret_cast<device vec<T, Vsrc> &>(dst[i]) = src[i];
+    }
+}
+
+template<typename T, uint N>
+inline void spvArrayCopyFromThreadGroupToDevice(device T (&dst)[N], threadgroup const T (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        dst[i] = src[i];
+    }
+}
+template<typename T, uint V, uint N>
+inline void spvArrayCopyFromThreadGroupToDevice(device vec<T, V> (&dst)[N], threadgroup const T (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        reinterpret_cast<device T &>(dst[i]) = src[i];
+    }
+}
+
+template<typename T, uint Vdst, uint Vsrc, uint N>
+inline enable_if_t<Vdst != Vsrc> spvArrayCopyFromThreadGroupToDevice(device vec<T, Vdst> (&dst)[N], threadgroup const vec<T, Vsrc> (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        reinterpret_cast<device vec<T, Vsrc> &>(dst[i]) = src[i];
+    }
+}
+
+template<typename T, uint N>
+inline void spvArrayCopyFromDeviceToStack(thread T (&dst)[N], device const T (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        dst[i] = src[i];
+    }
+}
+template<typename T, uint V, uint N>
+inline void spvArrayCopyFromDeviceToStack(thread T (&dst)[N], device const vec<T, V> (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        dst[i] = reinterpret_cast<device const T &>(src[i]);
+    }
+}
+
+template<typename T, uint Vdst, uint Vsrc, uint N>
+inline enable_if_t<Vdst != Vsrc> spvArrayCopyFromDeviceToStack(thread vec<T, Vdst> (&dst)[N], device const vec<T, Vsrc> (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        dst[i] = reinterpret_cast<device const vec<T, Vdst> &>(src[i]);
+    }
+}
+
+template<typename T, uint N>
+inline void spvArrayCopyFromDeviceToThreadGroup(threadgroup T (&dst)[N], device const T (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        dst[i] = src[i];
+    }
+}
+template<typename T, uint V, uint N>
+inline void spvArrayCopyFromDeviceToThreadGroup(threadgroup T (&dst)[N], device const vec<T, V> (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        dst[i] = reinterpret_cast<device const T &>(src[i]);
+    }
+}
+
+template<typename T, uint Vdst, uint Vsrc, uint N>
+inline enable_if_t<Vdst != Vsrc> spvArrayCopyFromDeviceToThreadGroup(threadgroup vec<T, Vdst> (&dst)[N], device const vec<T, Vsrc> (&src)[N])
+{
+    for (uint i = 0; i < N; i++)
+    {
+        dst[i] = reinterpret_cast<device const vec<T, Vdst> &>(src[i]);
+    }
+}
+
+struct SSBO
+{
+    float4 b[5];
+    float4 c[5];
+};
+
+kernel void main0(device SSBO& _7 [[buffer(0)]])
+{
+    spvUnsafeArray<float, 5> a;
+    spvArrayCopyFromDeviceToStack(a.elements, _7.b);
+    spvArrayCopyFromDeviceToStack(a.elements, _7.b);
+    spvArrayCopyFromStackToDevice(_7.b, a.elements);
+    spvArrayCopyFromStackToDevice(_7.c, a.elements);
+}
+

--- a/reference/shaders-no-opt/asm/comp/array-copy-physical-layout-mismatch-ubo.asm.comp
+++ b/reference/shaders-no-opt/asm/comp/array-copy-physical-layout-mismatch-ubo.asm.comp
@@ -1,0 +1,15 @@
+#version 450
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0, std140) uniform UBO
+{
+    vec2 b[5];
+    vec2 c[5];
+} _7;
+
+void main()
+{
+    vec2 a[5] = _7.b;
+    a = _7.c;
+}
+

--- a/shaders-msl-no-opt/asm/comp/array-copy-physical-layout-mismatch.asm.comp
+++ b/shaders-msl-no-opt/asm/comp/array-copy-physical-layout-mismatch.asm.comp
@@ -1,0 +1,47 @@
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %a "a"
+               OpName %SSBO "SSBO"
+               OpMemberName %SSBO 0 "b"
+               OpMemberName %SSBO 1 "c"
+               OpName %_ ""
+               OpDecorate %_arr_float_uint_5 ArrayStride 16
+               OpDecorate %SSBO BufferBlock
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpMemberDecorate %SSBO 1 Offset 80
+               OpDecorate %_ Binding 0
+               OpDecorate %_ DescriptorSet 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+       %uint = OpTypeInt 32 0
+     %uint_5 = OpConstant %uint 5
+%_arr_float_uint_5 = OpTypeArray %float %uint_5
+%_ptr_Function__arr_float_uint_5 = OpTypePointer Function %_arr_float_uint_5
+%_ptr_Uniform__arr_float_uint_5 = OpTypePointer Uniform %_arr_float_uint_5
+%_ptr_Function_float = OpTypePointer Function %float
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+       %SSBO = OpTypeStruct %_arr_float_uint_5 %_arr_float_uint_5
+%_ptr_Uniform_SSBO = OpTypePointer Uniform %SSBO
+          %_ = OpVariable %_ptr_Uniform_SSBO Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %a = OpVariable %_ptr_Function__arr_float_uint_5 Function
+         %ptr_b = OpAccessChain %_ptr_Uniform__arr_float_uint_5 %_ %int_0
+         %ptr_c = OpAccessChain %_ptr_Uniform__arr_float_uint_5 %_ %int_1
+		 %loaded_b = OpLoad %_arr_float_uint_5 %ptr_b
+		 OpStore %a %loaded_b
+		 OpCopyMemory %a %ptr_b
+		 %loaded_a = OpLoad %_arr_float_uint_5 %a
+		 OpStore %ptr_b %loaded_a
+		 OpCopyMemory %ptr_c %a
+               OpReturn
+               OpFunctionEnd

--- a/shaders-no-opt/asm/comp/array-copy-physical-layout-mismatch-ubo.asm.comp
+++ b/shaders-no-opt/asm/comp/array-copy-physical-layout-mismatch-ubo.asm.comp
@@ -1,0 +1,50 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 11
+; Bound: 51
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %a "a"
+               OpName %UBO "UBO"
+               OpMemberName %UBO 0 "b"
+               OpMemberName %UBO 1 "c"
+               OpName %_ ""
+               OpDecorate %_arr_vec2_uint_5 ArrayStride 16
+               OpDecorate %UBO Block
+               OpMemberDecorate %UBO 0 Offset 0
+               OpMemberDecorate %UBO 1 Offset 80
+               OpDecorate %_ Binding 0
+               OpDecorate %_ DescriptorSet 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+	  %vec2  = OpTypeVector %float 2
+       %uint = OpTypeInt 32 0
+     %uint_5 = OpConstant %uint 5
+%_arr_vec2_uint_5 = OpTypeArray %vec2 %uint_5
+%_ptr_Function__arr_vec2_uint_5 = OpTypePointer Function %_arr_vec2_uint_5
+%_ptr_Uniform__arr_vec2_uint_5 = OpTypePointer Uniform %_arr_vec2_uint_5
+%_ptr_Function_float = OpTypePointer Function %float
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+       %UBO = OpTypeStruct %_arr_vec2_uint_5 %_arr_vec2_uint_5
+%_ptr_Uniform_UBO = OpTypePointer Uniform %UBO
+          %_ = OpVariable %_ptr_Uniform_UBO Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %a = OpVariable %_ptr_Function__arr_vec2_uint_5 Function
+         %ptr_b = OpAccessChain %_ptr_Uniform__arr_vec2_uint_5 %_ %int_0
+         %ptr_c = OpAccessChain %_ptr_Uniform__arr_vec2_uint_5 %_ %int_1
+		 %loaded_b = OpLoad %_arr_vec2_uint_5 %ptr_b
+		 OpStore %a %loaded_b
+		 OpCopyMemory %a %ptr_c
+               OpReturn
+               OpFunctionEnd

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -6170,14 +6170,31 @@ void CompilerMSL::emit_custom_functions()
 				"device", "device",      "device", "device",      "thread", "threadgroup",
 			};
 
+			static const bool src_is_physical_with_mismatch[] = {
+				true, true, false,
+				false, false, false,
+				false, false, false,
+				false, true, true,
+			};
+
+			static const bool dst_is_physical_with_mismatch[] = {
+				false, false, false,
+				false, false, false,
+				false, false, true,
+				true, false, false,
+			};
+
 			for (uint32_t variant = 0; variant < 12; variant++)
 			{
+				assert(!src_is_physical_with_mismatch[variant] || !dst_is_physical_with_mismatch[variant]);
 				bool is_multidim = spv_func == SPVFuncImplArrayCopyMultidim;
-				const char* dim = is_multidim ? "[N][M]" : "[N]";
+				const char *dim = is_multidim ? "[N][M]" : "[N]";
+
+				// Simple base case.
 				statement("template<typename T, uint N", is_multidim ? ", uint M>" : ">");
 				statement("inline void spvArrayCopy", function_name_tags[variant], "(",
-				          dst_address_space[variant], " T (&dst)", dim, ", ",
-				          src_address_space[variant], " T (&src)", dim, ")");
+						  dst_address_space[variant], " T (&dst)", dim, ", ",
+						  src_address_space[variant], " T (&src)", dim, ")");
 				begin_scope();
 				statement("for (uint i = 0; i < N; i++)");
 				begin_scope();
@@ -6187,6 +6204,81 @@ void CompilerMSL::emit_custom_functions()
 					statement("dst[i] = src[i];");
 				end_scope();
 				end_scope();
+
+				if (spv_function_implementations.count(SPVFuncImplArrayCopyExtendedSrc) &&
+					src_is_physical_with_mismatch[variant])
+				{
+					// 1st overload, src can be magic vector where dst is a scalar.
+					// Need reinterpret casts to be memory model correct. LLVM vectors are broken otherwise.
+					statement("template<typename T, uint V, uint N", is_multidim ? ", uint M>" : ">");
+					statement("inline void spvArrayCopy", function_name_tags[variant], "(",
+							  dst_address_space[variant], " T (&dst)", dim, ", ",
+							  src_address_space[variant], " vec<T, V> (&src)", dim, ")");
+					begin_scope();
+					statement("for (uint i = 0; i < N; i++)");
+					begin_scope();
+					if (is_multidim)
+						statement("spvArrayCopy", function_name_tags[variant], "(dst[i], src[i]);");
+					else
+						statement("dst[i] = reinterpret_cast<", src_address_space[variant], " T &>(src[i]);");
+					end_scope();
+					end_scope();
+
+					statement("");
+
+					// 2nd overload, both are vectors, but need SFINAE magic to avoid ambiguous case.
+					statement("template<typename T, uint Vdst, uint Vsrc, uint N", is_multidim ? ", uint M>" : ">");
+					statement("inline enable_if_t<Vdst != Vsrc> spvArrayCopy", function_name_tags[variant], "(",
+							  dst_address_space[variant], " vec<T, Vdst> (&dst)", dim, ", ",
+							  src_address_space[variant], " vec<T, Vsrc> (&src)", dim, ")");
+					begin_scope();
+					statement("for (uint i = 0; i < N; i++)");
+					begin_scope();
+					if (is_multidim)
+						statement("spvArrayCopy", function_name_tags[variant], "(dst[i], src[i]);");
+					else
+						statement("dst[i] = reinterpret_cast<", src_address_space[variant], " vec<T, Vdst> &>(src[i]);");
+					end_scope();
+					end_scope();
+				}
+
+				if (spv_function_implementations.count(SPVFuncImplArrayCopyExtendedDst) &&
+					dst_is_physical_with_mismatch[variant])
+				{
+					// 1st overload, src can be magic vector where dst is a scalar.
+					// Need reinterpret casts to be memory model correct. LLVM vectors are broken otherwise.
+					statement("template<typename T, uint V, uint N", is_multidim ? ", uint M>" : ">");
+					statement("inline void spvArrayCopy", function_name_tags[variant], "(",
+							  dst_address_space[variant], " vec<T, V> (&dst)", dim, ", ",
+							  src_address_space[variant], " T (&src)", dim, ")");
+					begin_scope();
+					statement("for (uint i = 0; i < N; i++)");
+					begin_scope();
+					if (is_multidim)
+						statement("spvArrayCopy", function_name_tags[variant], "(dst[i], src[i]);");
+					else
+						statement("reinterpret_cast<", dst_address_space[variant], " T &>(dst[i]) = src[i];");
+					end_scope();
+					end_scope();
+
+					statement("");
+
+					// 2nd overload, both are vectors, but need SFINAE magic to avoid ambiguous case.
+					statement("template<typename T, uint Vdst, uint Vsrc, uint N", is_multidim ? ", uint M>" : ">");
+					statement("inline enable_if_t<Vdst != Vsrc> spvArrayCopy", function_name_tags[variant], "(",
+							  dst_address_space[variant], " vec<T, Vdst> (&dst)", dim, ", ",
+							  src_address_space[variant], " vec<T, Vsrc> (&src)", dim, ")");
+					begin_scope();
+					statement("for (uint i = 0; i < N; i++)");
+					begin_scope();
+					if (is_multidim)
+						statement("spvArrayCopy", function_name_tags[variant], "(dst[i], src[i]);");
+					else
+						statement("reinterpret_cast<", dst_address_space[variant], " vec<T, Vsrc> &>(dst[i]) = src[i];");
+					end_scope();
+					end_scope();
+				}
+
 				statement("");
 			}
 			break;
@@ -10904,6 +10996,12 @@ bool CompilerMSL::emit_array_copy(const char *expr, uint32_t lhs_id, uint32_t rh
 			tag = "FromDeviceToStack";
 		else
 			SPIRV_CROSS_THROW("Unknown storage class used for copying arrays.");
+
+		// Should be very rare, but mark if we need extra magic template overloads.
+		if (has_extended_decoration(lhs_id, SPIRVCrossDecorationPhysicalTypeID))
+			add_spv_func_and_recompile(SPVFuncImplArrayCopyExtendedDst);
+		if (has_extended_decoration(rhs_id, SPIRVCrossDecorationPhysicalTypeID))
+			add_spv_func_and_recompile(SPVFuncImplArrayCopyExtendedSrc);
 
 		// Pass internal array of spvUnsafeArray<> into wrapper functions
 		if (lhs_is_array_template && rhs_is_array_template && !msl_options.force_native_arrays)

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -796,6 +796,8 @@ protected:
 		SPVFuncImplSSign,
 		SPVFuncImplArrayCopy,
 		SPVFuncImplArrayCopyMultidim,
+		SPVFuncImplArrayCopyExtendedSrc,
+		SPVFuncImplArrayCopyExtendedDst,
 		SPVFuncImplTexelBufferCoords,
 		SPVFuncImplImage2DAtomicCoords, // Emulate texture2D atomic operations
 		SPVFuncImplGradientCube,


### PR DESCRIPTION
Fix #2582.