### PR TITLE
MSL: BlockIO in vertex is captured as thread storage.

### DIFF
--- a/reference/opt/shaders-msl/vert/vertex-to-tess-block-io-leaf.for-tess.vert
+++ b/reference/opt/shaders-msl/vert/vertex-to-tess-block-io-leaf.for-tess.vert
@@ -1,0 +1,25 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct BlockIO
+{
+    float v;
+};
+
+struct main0_out
+{
+    float outBlock_v;
+};
+
+kernel void main0(uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 spvStageInputSize [[grid_size]], device main0_out* spvOut [[buffer(28)]])
+{
+    BlockIO outBlock = {};
+    device main0_out& out = spvOut[gl_GlobalInvocationID.y * spvStageInputSize.x + gl_GlobalInvocationID.x];
+    if (any(gl_GlobalInvocationID >= spvStageInputSize))
+        return;
+    outBlock.v = 1.0;
+    out.outBlock_v = outBlock.v;
+}
+

--- a/reference/shaders-msl/vert/vertex-to-tess-block-io-leaf.for-tess.vert
+++ b/reference/shaders-msl/vert/vertex-to-tess-block-io-leaf.for-tess.vert
@@ -1,0 +1,33 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct BlockIO
+{
+    float v;
+};
+
+struct main0_out
+{
+    float outBlock_v;
+};
+
+static inline __attribute__((always_inline))
+void func(thread BlockIO& outBlock)
+{
+    outBlock.v = 1.0;
+}
+
+kernel void main0(uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 spvStageInputSize [[grid_size]], device main0_out* spvOut [[buffer(28)]])
+{
+    BlockIO outBlock = {};
+    device main0_out& out = spvOut[gl_GlobalInvocationID.y * spvStageInputSize.x + gl_GlobalInvocationID.x];
+    if (any(gl_GlobalInvocationID >= spvStageInputSize))
+        return;
+    func(outBlock);
+    out.outBlock_v = outBlock.v;
+}
+

--- a/shaders-msl/vert/vertex-to-tess-block-io-leaf.for-tess.vert
+++ b/shaders-msl/vert/vertex-to-tess-block-io-leaf.for-tess.vert
@@ -1,0 +1,16 @@
+#version 450
+
+layout(location = 5) out BlockIO
+{
+	float v;
+} outBlock;
+
+void func()
+{
+	outBlock.v = 1.0;
+}
+
+void main(void)
+{
+	func();
+}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -14270,6 +14270,10 @@ string CompilerMSL::get_type_address_space(const SPIRType &type, uint32_t id, bo
 					addr_space = "threadgroup";
 			}
 
+			// BlockIO is passed as thread and lowered on return from main.
+			if (get_execution_model() == ExecutionModelVertex && has_decoration(type.self, DecorationBlock))
+				addr_space = "thread";
+
 			if (!addr_space)
 				addr_space = "device";
 		}


### PR DESCRIPTION
Fix #2588.