### PR TITLE
GLSL: Add option to emit custom entry point name

### DIFF
--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -807,7 +807,10 @@ string CompilerGLSL::compile()
 	// The body was implemented in lieu of main().
 	if (interlocked_is_complex)
 	{
-		statement("void main()");
+		if (options.use_entry_point_name)
+			statement("void ", get_entry_point().name, "()");
+		else
+			statement("void main()");
 		begin_scope();
 		statement("// Interlocks were used in a way not compatible with GLSL, this is very slow.");
 		statement("SPIRV_Cross_beginInvocationInterlock();");
@@ -817,7 +820,8 @@ string CompilerGLSL::compile()
 	}
 
 	// Entry point in GLSL is always main().
-	get_entry_point().name = "main";
+	if (!options.use_entry_point_name)
+		get_entry_point().name = "main";
 
 	return buffer.str();
 }
@@ -17383,6 +17387,8 @@ void CompilerGLSL::emit_function_prototype(SPIRFunction &func, const Bitset &ret
 		// and interlock the entire shader ...
 		if (interlocked_is_complex)
 			decl += "spvMainInterlockedBody";
+		else if (options.use_entry_point_name)
+			decl += get_entry_point().name;
 		else
 			decl += "main";
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -159,6 +159,9 @@ public:
 		// If non-zero, controls layout(num_views = N) in; in GL_OVR_multiview2.
 		uint32_t ovr_multiview_view_count = 0;
 
+		// Emit the entry point name in SPIR-V rather than "main".
+		bool use_entry_point_name = false;
+
 		enum Precision
 		{
 			DontCare,


### PR DESCRIPTION
As discussed in #2412, this adds `use_entry_point_name` to GLSL (just as it exists in HLSL) to use the entry point name specified in the SPIR-V (optionally as modified by `rename_entry_point`) in the GLSL output instead of "main".

The use case is appending a custom `main()` wrapper to do things like alpha testing.