### PR TITLE
HLSL: better support for geometry shaders builtins

### DIFF
--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1295,10 +1295,10 @@ void CompilerHLSL::emit_builtin_variables()
 
 		// If we need to emit 2 separate variables (for both input & output), we'll update this value
 		bool has_separate_input_output = false;
-		for (int variableIndex = 0; variableIndex < (has_separate_input_output ? 2 : 1); ++variableIndex)
+		for (int variable_index = 0; variable_index < (has_separate_input_output ? 2 : 1); variable_index++)
 		{
 			uint32_t array_size = 0;
-			StorageClass storage = active_input_builtins.get(i) && variableIndex == 0
+			StorageClass storage = active_input_builtins.get(i) && variable_index == 0
 				? StorageClassInput
 				: StorageClassOutput;
 			const char *type = nullptr;


### PR DESCRIPTION
**SV_Position in geometry shaders (1ca6a7a0)**

Geometry shaders have both an input and output gl_Position, which requires two separate global variables.

A `has_separate_input_output` loop was introduced in emit_builtin_variables() to emit both gl_PositionIn (input, array-sized by vertex count) and gl_Position (output).
Note: this also applies to BuiltInSampleMask (which had different type as input and output) and is now handled automatically with the same system.

**SV_PrimitiveID / SV_GSInstanceID in geometry shaders (3b374aee)**

In HLSL, SV_PrimitiveID is passed as a direct function parameter to the geometry shader entry point rather than via the input struct. The input struct emission is suppressed for GS, the parameter is added to the entry point argument list, and the copy-in assigns gl_PrimitiveIDIn = gl_PrimitiveID. SV_GSInstanceID (mapping to BuiltInInvocationId) is handled similarly for instanced geometry shaders.

**Fix per-vertex array dimension stripping (707bc66c)**

SPIR-V stores array dimensions in reverse order (outermost dimension last in the array vector). The previous code removed the innermost dimension, which was wrong.