### PR TITLE
Respect MemoryAccessVolatileMask on OpLoad to prevent forwarding

### DIFF
--- a/reference/shaders-msl-no-opt/asm/comp/volatile-phys-buf-load-no-forward.asm.msl24.comp
+++ b/reference/shaders-msl-no-opt/asm/comp/volatile-phys-buf-load-no-forward.asm.msl24.comp
@@ -1,0 +1,19 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct Registers
+{
+    ulong addr;
+    ulong addr2;
+};
+
+kernel void main0(constant Registers& registers [[buffer(0)]])
+{
+    device int* _21 = reinterpret_cast<device int*>(registers.addr2);
+    int _22 = *(reinterpret_cast<device int*>(registers.addr));
+    *_21 = _22;
+    *(reinterpret_cast<device int*>(reinterpret_cast<ulong>(_21) + 4ul)) = _22;
+}
+

--- a/reference/shaders-no-opt/asm/comp/volatile-phys-buf-load-no-forward.nocompat.vk.asm.comp.vk
+++ b/reference/shaders-no-opt/asm/comp/volatile-phys-buf-load-no-forward.nocompat.vk.asm.comp.vk
@@ -1,0 +1,30 @@
+#version 450
+#if defined(GL_ARB_gpu_shader_int64)
+#extension GL_ARB_gpu_shader_int64 : require
+#else
+#error No extension available for 64-bit integers.
+#endif
+#extension GL_EXT_buffer_reference2 : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(buffer_reference) buffer intPointer;
+
+layout(buffer_reference, buffer_reference_align = 4) buffer intPointer
+{
+    int value;
+};
+
+layout(push_constant, std430) uniform Registers
+{
+    uint64_t addr;
+    uint64_t addr2;
+} registers;
+
+void main()
+{
+    intPointer _21 = intPointer(registers.addr2);
+    int _22 = intPointer(registers.addr).value;
+    _21.value = _22;
+    intPointer(uint64_t(_21) + 4ul).value = _22;
+}
+

--- a/shaders-msl-no-opt/asm/comp/volatile-phys-buf-load-no-forward.asm.msl24.comp
+++ b/shaders-msl-no-opt/asm/comp/volatile-phys-buf-load-no-forward.asm.msl24.comp
@@ -1,0 +1,60 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 40
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int64
+               OpCapability PhysicalStorageBufferAddresses
+               OpExtension "SPV_KHR_physical_storage_buffer"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel PhysicalStorageBuffer64 GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpName %main "main"
+               OpName %Registers "Registers"
+               OpMemberName %Registers 0 "addr"
+               OpMemberName %Registers 1 "addr2"
+               OpName %registers "registers"
+               OpMemberDecorate %Registers 0 Offset 0
+               OpMemberDecorate %Registers 1 Offset 8
+               OpDecorate %Registers Block
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %ulong = OpTypeInt 64 0
+  %Registers = OpTypeStruct %ulong %ulong
+%_ptr_PushConstant_Registers = OpTypePointer PushConstant %Registers
+  %registers = OpVariable %_ptr_PushConstant_Registers PushConstant
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+    %ulong_4 = OpConstant %ulong 4
+%_ptr_PushConstant_ulong = OpTypePointer PushConstant %ulong
+%_ptr_PhysicalStorageBuffer_int = OpTypePointer PhysicalStorageBuffer %int
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+
+         %pc0 = OpAccessChain %_ptr_PushConstant_ulong %registers %int_0
+       %addr0 = OpLoad %ulong %pc0
+       %src_p = OpConvertUToPtr %_ptr_PhysicalStorageBuffer_int %addr0
+
+         %pc1 = OpAccessChain %_ptr_PushConstant_ulong %registers %int_1
+       %addr1 = OpLoad %ulong %pc1
+       %dst_p = OpConvertUToPtr %_ptr_PhysicalStorageBuffer_int %addr1
+
+               ; Volatile load from src — must NOT be forwarded
+          %ld = OpLoad %int %src_p Volatile|Aligned 4
+
+               ; Store the loaded value into dst (first use)
+               OpStore %dst_p %ld Aligned 4
+
+               ; Compute dst + 1 element via integer arithmetic
+     %dst_u64 = OpConvertPtrToU %ulong %dst_p
+   %dst_plus4 = OpIAdd %ulong %dst_u64 %ulong_4
+      %dst_p2 = OpConvertUToPtr %_ptr_PhysicalStorageBuffer_int %dst_plus4
+
+               ; Store the same loaded value again (second use)
+               OpStore %dst_p2 %ld Aligned 4
+
+               OpReturn
+               OpFunctionEnd

--- a/shaders-no-opt/asm/comp/volatile-phys-buf-load-no-forward.nocompat.vk.asm.comp
+++ b/shaders-no-opt/asm/comp/volatile-phys-buf-load-no-forward.nocompat.vk.asm.comp
@@ -1,0 +1,60 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 40
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int64
+               OpCapability PhysicalStorageBufferAddresses
+               OpExtension "SPV_KHR_physical_storage_buffer"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel PhysicalStorageBuffer64 GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpName %main "main"
+               OpName %Registers "Registers"
+               OpMemberName %Registers 0 "addr"
+               OpMemberName %Registers 1 "addr2"
+               OpName %registers "registers"
+               OpMemberDecorate %Registers 0 Offset 0
+               OpMemberDecorate %Registers 1 Offset 8
+               OpDecorate %Registers Block
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %ulong = OpTypeInt 64 0
+  %Registers = OpTypeStruct %ulong %ulong
+%_ptr_PushConstant_Registers = OpTypePointer PushConstant %Registers
+  %registers = OpVariable %_ptr_PushConstant_Registers PushConstant
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+    %ulong_4 = OpConstant %ulong 4
+%_ptr_PushConstant_ulong = OpTypePointer PushConstant %ulong
+%_ptr_PhysicalStorageBuffer_int = OpTypePointer PhysicalStorageBuffer %int
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+
+         %pc0 = OpAccessChain %_ptr_PushConstant_ulong %registers %int_0
+       %addr0 = OpLoad %ulong %pc0
+       %src_p = OpConvertUToPtr %_ptr_PhysicalStorageBuffer_int %addr0
+
+         %pc1 = OpAccessChain %_ptr_PushConstant_ulong %registers %int_1
+       %addr1 = OpLoad %ulong %pc1
+       %dst_p = OpConvertUToPtr %_ptr_PhysicalStorageBuffer_int %addr1
+
+               ; Volatile load from src — must NOT be forwarded
+          %ld = OpLoad %int %src_p Volatile|Aligned 4
+
+               ; Store the loaded value into dst (first use)
+               OpStore %dst_p %ld Aligned 4
+
+               ; Compute dst + 1 element via integer arithmetic
+     %dst_u64 = OpConvertPtrToU %ulong %dst_p
+   %dst_plus4 = OpIAdd %ulong %dst_u64 %ulong_4
+      %dst_p2 = OpConvertUToPtr %_ptr_PhysicalStorageBuffer_int %dst_plus4
+
+               ; Store the same loaded value again (second use)
+               OpStore %dst_p2 %ld Aligned 4
+
+               OpReturn
+               OpFunctionEnd

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -12432,6 +12432,8 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		// Volatile memory access requires the value be read exactly once from
 		// memory.  Do not forward the expression so that re-evaluation at each
 		// use site cannot re-read potentially modified memory.
+		// FIXME: To force implementations to actually respect the volatile nature of the load,
+		// the block itself must be marked volatile, or VulkanMM is used to do an explicit volatile load.
 		if (forward && length >= 4 && (ops[3] & MemoryAccessVolatileMask) != 0)
 			forward = false;
 

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -12429,6 +12429,12 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		// If an expression is mutable and forwardable, we speculate that it is immutable.
 		bool forward = should_forward(ptr) && forced_temporaries.find(id) == end(forced_temporaries);
 
+		// Volatile memory access requires the value be read exactly once from
+		// memory.  Do not forward the expression so that re-evaluation at each
+		// use site cannot re-read potentially modified memory.
+		if (forward && length >= 4 && (ops[3] & MemoryAccessVolatileMask) != 0)
+			forward = false;
+
 		// If loading a non-native row-major matrix, mark the expression as need_transpose.
 		bool need_transpose = false;
 		bool old_need_transpose = false;


### PR DESCRIPTION
### Problem

SPIRV-Cross has an expression forwarding optimization that inlines loaded values at each use site rather than materializing them into temporaries. For example, given:

```
%val = OpLoad %int %ptr
OpStore %dst1 %val
OpStore %dst2 %val
```

Forwarding produces:

```c
*dst1 = *ptr;
*dst2 = *ptr;
```

rather than:

```c
int val = *ptr;
*dst1 = val;
*dst2 = val;
```

This is done intentionally to produce cleaner, more readable generated code with fewer temporary variables. When a value is used only once, forwarding is always safe — it's the same single read, just without naming it. When a value is used multiple times, the duplicated dereferences look like extra memory I/O, but for normal storage buffer and uniform loads the downstream shader compiler (Metal, GLSL, etc.) can see that the pointer target hasn't been modified between uses and will CSE (common subexpression eliminate) them back into a single read. So in practice, forwarding doesn't cost extra I/O in the normal case.

However, for `PhysicalStorageBuffer` pointers (raw `device T*` in Metal, `buffer_reference` in GLSL), the downstream compiler cannot easily prove the pointer target is stable — especially when stores to the same address space happen between uses. If the `OpLoad` carries the `Volatile` memory access flag, the SPIR-V is explicitly stating that the memory location may change unpredictably. Duplicating the read by forwarding can then produce incorrect results: the two use sites may observe different values from what should be a single load.

### Fix

When processing an `OpLoad`, SPIRV-Cross already decides whether to forward the expression. This patch adds a check: if the load carries `MemoryAccessVolatileMask`, forwarding is disabled, forcing the value into a temporary. This ensures the memory is read exactly once, matching SPIR-V semantics.

### Test plan

- Added MSL regression test (`volatile-phys-buf-load-no-forward.asm.msl24.comp`): volatile load from a PhysicalStorageBuffer pointer used in two stores; reference output shows a temporary rather than duplicated dereferences
- Added Vulkan GLSL regression test (`volatile-phys-buf-load-no-forward.nocompat.vk.asm.comp`): same shader, verifying the GLSL backend also materializes a temporary
- Both tests fail (output differs from reference) without the fix and pass with it
- Ran full `shaders-msl-no-opt` and `shaders-no-opt` test suites; no regressions

### What the test does

The test is a minimal SPIR-V compute shader that:

1. Loads two raw GPU addresses (u64) from push constants — one for a source pointer, one for a destination pointer
2. Does a single `OpLoad` with `Volatile|Aligned` from the source pointer, producing one value
3. Stores that value to two locations: the destination pointer, and the destination pointer + 4 bytes

The reference output checks that SPIRV-Cross emits one read into a temporary and reuses it:

```c
int _22 = *(reinterpret_cast<device int*>(registers.addr));  // one read
*_21 = _22;                                                   // reuse
*(reinterpret_cast<device int*>(...)) = _22;                  // reuse
```

Without the fix, SPIRV-Cross forwards the load and emits two reads:

```c
*_21 = *_18;                                                  // read 1
*(reinterpret_cast<device int*>(...)) = *_18;                 // read 2
```

The test is a source-level regression test that verifies the shape of the generated code — it does not execute the shader at runtime.