### PR TITLE
HLSL: Zero-init OpUndef Phi incomings to avoid uninitialized reads

### DIFF
--- a/reference/shaders-hlsl-no-opt/asm/comp/phi-undef-loop.asm.comp
+++ b/reference/shaders-hlsl-no-opt/asm/comp/phi-undef-loop.asm.comp
@@ -1,0 +1,18 @@
+static uint _16;
+
+RWByteAddressBuffer _4 : register(u0);
+
+void comp_main()
+{
+    uint _19 = 0u;
+    for (uint _22 = 0u; _22 < 10u; _19++, _22++)
+    {
+        _4.Store(0, _19);
+    }
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    comp_main();
+}

--- a/shaders-hlsl-no-opt/asm/comp/phi-undef-loop.asm.comp
+++ b/shaders-hlsl-no-opt/asm/comp/phi-undef-loop.asm.comp
@@ -1,0 +1,55 @@
+; Tests an OpPhi at a loop header where one incoming value is OpUndef
+; (the other is the loop back-edge). This pattern is produced by
+; --merge-return + --inline-entry-points-exhaustive when an inlined function
+; with an early `return` inside a loop is folded back. Reading the variable
+; on the first iteration would be undefined; we materialize the OpUndef
+; incoming as a zero so HLSL/FXC do not reject the generated code with X4555/X4000.
+;
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 1
+; Bound: 30
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpDecorate %SSBO BufferBlock
+               OpDecorate %ssbo DescriptorSet 0
+               OpDecorate %ssbo Binding 0
+       %void = OpTypeVoid
+   %fn_type  = OpTypeFunction %void
+       %bool = OpTypeBool
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+    %uint_10 = OpConstant %uint 10
+       %SSBO = OpTypeStruct %uint
+   %ptr_SSBO = OpTypePointer Uniform %SSBO
+   %ptr_uint = OpTypePointer Uniform %uint
+       %ssbo = OpVariable %ptr_SSBO Uniform
+       %int  = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+ %undef_uint = OpUndef %uint
+       %main = OpFunction %void None %fn_type
+      %entry = OpLabel
+                                 OpBranch %header
+     %header = OpLabel
+        %phi = OpPhi %uint %undef_uint %entry %back %continue
+          %i = OpPhi %uint %uint_0     %entry %inext %continue
+       %cond = OpULessThan %bool %i %uint_10
+                                 OpLoopMerge %merge %continue None
+                                 OpBranchConditional %cond %body %merge
+       %body = OpLabel
+        %dst = OpAccessChain %ptr_uint %ssbo %int_0
+                                 OpStore %dst %phi
+                                 OpBranch %continue
+   %continue = OpLabel
+       %back = OpIAdd %uint %phi %uint_1
+      %inext = OpIAdd %uint %i   %uint_1
+                                 OpBranch %header
+      %merge = OpLabel
+                                 OpReturn
+                                 OpFunctionEnd

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -17690,7 +17690,11 @@ void CompilerGLSL::flush_phi(BlockID from, BlockID to)
 				auto lhs = to_expression(phi.function_variable);
 
 				string rhs;
-				if (temporary_phi_variables.count(phi.local_variable))
+				// OpUndef sources: emit 0 instead of an uninitialized read (FXC X4555/X4000).
+				if (ir.ids[phi.local_variable].get_type() == TypeUndef &&
+				    type_can_zero_initialize(get<SPIRType>(var.basetype)))
+					rhs = to_zero_initialized_expression(var.basetype);
+				else if (temporary_phi_variables.count(phi.local_variable))
 					rhs = join("_", phi.local_variable, "_copy");
 				else
 					rhs = to_pointer_expression(phi.local_variable);
@@ -17943,13 +17947,27 @@ string CompilerGLSL::emit_continue_block(uint32_t continue_block, bool follow_tr
 	return merge(statements);
 }
 
+// Loop variable with OpUndef init: zero-init instead of leaving uninitialized (FXC X4555/X4000).
+std::string CompilerGLSL::undef_loop_variable_initializer_suffix(const SPIRVariable &var)
+{
+	uint32_t expr = var.static_expression;
+	if (expr == 0 || ir.ids[expr].get_type() != TypeUndef)
+		return "";
+
+	auto &type = get<SPIRType>(var.basetype);
+	if (!type_can_zero_initialize(type))
+		return "";
+
+	return join(" = ", to_zero_initialized_expression(var.basetype));
+}
+
 void CompilerGLSL::emit_while_loop_initializers(const SPIRBlock &block)
 {
 	// While loops do not take initializers, so declare all of them outside.
 	for (auto &loop_var : block.loop_variables)
 	{
 		auto &var = get<SPIRVariable>(loop_var);
-		statement(variable_decl(var), ";");
+		statement(variable_decl(var), undef_loop_variable_initializer_suffix(var), ";");
 	}
 }
 
@@ -17981,7 +17999,10 @@ string CompilerGLSL::emit_for_loop_initializers(const SPIRBlock &block)
 	else if (!same_types || missing_initializers == uint32_t(block.loop_variables.size()))
 	{
 		for (auto &loop_var : block.loop_variables)
-			statement(variable_decl(get<SPIRVariable>(loop_var)), ";");
+		{
+			auto &var = get<SPIRVariable>(loop_var);
+			statement(variable_decl(var), undef_loop_variable_initializer_suffix(var), ";");
+		}
 		return "";
 	}
 	else
@@ -17992,10 +18013,11 @@ string CompilerGLSL::emit_for_loop_initializers(const SPIRBlock &block)
 
 		for (auto &loop_var : block.loop_variables)
 		{
-			uint32_t static_expr = get<SPIRVariable>(loop_var).static_expression;
+			auto &var_for_undef = get<SPIRVariable>(loop_var);
+			uint32_t static_expr = var_for_undef.static_expression;
 			if (static_expr == 0 || ir.ids[static_expr].get_type() == TypeUndef)
 			{
-				statement(variable_decl(get<SPIRVariable>(loop_var)), ";");
+				statement(variable_decl(var_for_undef), undef_loop_variable_initializer_suffix(var_for_undef), ";");
 			}
 			else
 			{

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -1023,6 +1023,7 @@ protected:
 
 	std::string emit_for_loop_initializers(const SPIRBlock &block);
 	void emit_while_loop_initializers(const SPIRBlock &block);
+	std::string undef_loop_variable_initializer_suffix(const SPIRVariable &var);
 	bool for_loop_initializers_are_same_type(const SPIRBlock &block);
 	bool optimize_read_modify_write(const SPIRType &type, const std::string &lhs, const std::string &rhs);
 	void fixup_image_load_store_access();


### PR DESCRIPTION
When an `OpPhi` has `OpUndef` on an incoming edge, SPIRV-Cross emitted a read of the source variable. If that source was uninitialized too, FXC rejects the HLSL with `X4555` or `X4000`.

`OpUndef` allows any value per spec, so we substitute zero:

- `flush_phi`: emit `lhs = 0` when the Phi source is `OpUndef`.
- Loop variable declarations: add `= 0` when `static_expression` is `OpUndef`, via a new `undef_loop_variable_initializer_suffix` helper.

### Test

Added `shaders-hlsl-no-opt/asm/comp/phi-undef-loop.asm.comp` — a minimal SPIR-V loop with `OpUndef` as the preheader Phi incoming.

Without the patch, the generated HLSL is:

```hlsl
uint _19; // not set
for (uint _22 = 0u; _22 < 10u; _19++, _22++) // error X4555: cannot use casts on l-values (due to _19++ which is not set)
{
    _4.Store(0, _19);
}
```

With the patch, `_19` is declared as `uint _19 = 0u;` and FXC accepts it.