### PR TITLE
Use last rather than first dimension to check for runtime array

### DIFF
--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -2068,7 +2068,7 @@ size_t Compiler::get_declared_struct_size_runtime_array(const SPIRType &type, si
 
 	size_t size = get_declared_struct_size(type);
 	auto &last_type = get<SPIRType>(type.member_types.back());
-	if (!last_type.array.empty() && last_type.array_size_literal[0] && last_type.array[0] == 0) // Runtime array
+	if (!last_type.array.empty() && last_type.array_size_literal.back() && last_type.array.back() == 0) // Runtime array
 		size += array_size * type_struct_member_array_stride(type, uint32_t(type.member_types.size() - 1));
 
 	return size;


### PR DESCRIPTION
This fixes handling of multi-dimensional arrays with the last dimension being unspecified, as in this code:

```
layout(location = 0, binding = 0) buffer MyBuffer {
    float data[16][];
};
```