### PR TITLE
CFG: build per-function CFGs for all library exports

### DIFF
--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -4840,6 +4840,20 @@ void Compiler::build_function_control_flow_graphs_and_analyze()
 	CFGBuilder handler(*this);
 	handler.function_cfgs[ir.default_entry_point].reset(new CFG(*this, get<SPIRFunction>(ir.default_entry_point)));
 	traverse_all_reachable_opcodes(get<SPIRFunction>(ir.default_entry_point), handler);
+	if (ir.is_library_module)
+	{
+		// In library mode, default_entry_point is just the first exported
+		// function. Build a CFG for every other exported function (and its
+		// callees) so per-function analyses below cover all of them.
+		for (auto export_id : ir.library_exported_functions)
+		{
+			if (export_id == ir.default_entry_point)
+				continue;
+			auto &func = get<SPIRFunction>(export_id);
+			handler.function_cfgs[export_id].reset(new CFG(*this, func));
+			traverse_all_reachable_opcodes(func, handler);
+		}
+	}
 	function_cfgs = std::move(handler.function_cfgs);
 	bool single_function = function_cfgs.size() <= 1;
 

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -4847,11 +4847,9 @@ void Compiler::build_function_control_flow_graphs_and_analyze()
 		// callees) so per-function analyses below cover all of them.
 		for (auto export_id : ir.library_exported_functions)
 		{
-			if (export_id == ir.default_entry_point)
-				continue;
 			auto &func = get<SPIRFunction>(export_id);
-			handler.function_cfgs[export_id].reset(new CFG(*this, func));
-			traverse_all_reachable_opcodes(func, handler);
+			if (handler.follow_function_call(func))
+				traverse_all_reachable_opcodes(func, handler);
 		}
 	}
 	function_cfgs = std::move(handler.function_cfgs);


### PR DESCRIPTION
build_function_control_flow_graphs_and_analyze() builds a CFG starting from default_entry_point and walks reachable callees from there. In a library module, default_entry_point is just the first exported function (designated by the parser); every other exported function sits in its own disconnected sub-graph that the existing walk does not reach.

Iterate ir.library_exported_functions and build a CFG for each one not already covered by default_entry_point. Per-function analyses that follow in the same routine (analyze_variable_scope, find_function_local_luts, etc.) then operate over every exported function instead of just one.

The change is gated on ir.is_library_module, so non-library modules are unaffected.
  
Stacked on #2623. This is step number 2 of the changes necessary to address issue https://github.com/KhronosGroup/SPIRV-Cross/issues/2622