### PR TITLE
HLSL: emit library exports as free functions

### DIFF
--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -4840,6 +4840,20 @@ void Compiler::build_function_control_flow_graphs_and_analyze()
 	CFGBuilder handler(*this);
 	handler.function_cfgs[ir.default_entry_point].reset(new CFG(*this, get<SPIRFunction>(ir.default_entry_point)));
 	traverse_all_reachable_opcodes(get<SPIRFunction>(ir.default_entry_point), handler);
+	if (ir.is_library_module)
+	{
+		// In library mode, default_entry_point is just the first exported
+		// function. Build a CFG for every other exported function (and its
+		// callees) so per-function analyses below cover all of them.
+		for (auto export_id : ir.library_exported_functions)
+		{
+			if (export_id == ir.default_entry_point)
+				continue;
+			auto &func = get<SPIRFunction>(export_id);
+			handler.function_cfgs[export_id].reset(new CFG(*this, func));
+			traverse_all_reachable_opcodes(func, handler);
+		}
+	}
 	function_cfgs = std::move(handler.function_cfgs);
 	bool single_function = function_cfgs.size() <= 1;
 

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -4847,11 +4847,9 @@ void Compiler::build_function_control_flow_graphs_and_analyze()
 		// callees) so per-function analyses below cover all of them.
 		for (auto export_id : ir.library_exported_functions)
 		{
-			if (export_id == ir.default_entry_point)
-				continue;
 			auto &func = get<SPIRFunction>(export_id);
-			handler.function_cfgs[export_id].reset(new CFG(*this, func));
-			traverse_all_reachable_opcodes(func, handler);
+			if (handler.follow_function_call(func))
+				traverse_all_reachable_opcodes(func, handler);
 		}
 	}
 	function_cfgs = std::move(handler.function_cfgs);

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -3117,7 +3117,12 @@ uint32_t CompilerHLSL::input_vertices_from_execution_mode(SPIREntryPoint &execut
 
 void CompilerHLSL::emit_function_prototype(SPIRFunction &func, const Bitset &return_flags)
 {
-	if (func.self != ir.default_entry_point)
+	// In library mode default_entry_point points at the first exported
+	// function; treat every export as a normal function rather than as the
+	// shader's entry point.
+	const bool is_entry_point = !ir.is_library_module && func.self == ir.default_entry_point;
+
+	if (!is_entry_point)
 		add_function_overload(func);
 
 	// Avoid shadow declarations.
@@ -3138,7 +3143,7 @@ void CompilerHLSL::emit_function_prototype(SPIRFunction &func, const Bitset &ret
 		decl = "void ";
 	}
 
-	if (func.self == ir.default_entry_point)
+	if (is_entry_point)
 	{
 		decl += get_inner_entry_point_name();
 		processing_entry_point = true;
@@ -7148,14 +7153,27 @@ string CompilerHLSL::compile()
 		emit_header();
 		emit_resources();
 
-		emit_function(get<SPIRFunction>(ir.default_entry_point), Bitset());
-		emit_hlsl_entry_point();
+		if (ir.is_library_module)
+		{
+			// Emit each exported function as a normal free function.
+			// emit_function recursively emits callees, so internal helpers
+			// are picked up too.
+			for (auto export_id : ir.library_exported_functions)
+				emit_function(get<SPIRFunction>(export_id), Bitset());
+		}
+		else
+		{
+			emit_function(get<SPIRFunction>(ir.default_entry_point), Bitset());
+			emit_hlsl_entry_point();
+		}
 
 		pass_count++;
 	} while (is_forcing_recompilation());
 
 	// Entry point in HLSL is always main() for the time being.
-	get_entry_point().name = "main";
+	// Skip the rename for library modules; their exports keep their declared names.
+	if (!ir.is_library_module)
+		get_entry_point().name = "main";
 
 	return buffer.str();
 }


### PR DESCRIPTION
PR #2623 and PR #2624 updated the parser to accept SPIR-V library modules and ensure per-function CFG analysis covers every exported function. This PR updates the HLSL backend to emit library exports as normal free functions instead of as the shader's entry point.

Stacked on #2624. This is step number 3 of the changes necessary to address issue https://github.com/KhronosGroup/SPIRV-Cross/issues/2622.