### PR TITLE
HLSL: regression test for module-scope arrays in library mode

### DIFF
--- a/reference/shaders-hlsl/asm/lib/global-array.asm.lib
+++ b/reference/shaders-hlsl/asm/lib/global-array.asm.lib
@@ -1,0 +1,7 @@
+static const uint _15[4] = { 10u, 20u, 30u, 40u };
+
+uint lookup(uint i)
+{
+    return _15[i];
+}
+

--- a/reference/shaders-hlsl/asm/lib/multi-export.asm.lib
+++ b/reference/shaders-hlsl/asm/lib/multi-export.asm.lib
@@ -1,0 +1,17 @@
+uint add_one(uint x)
+{
+    return x + 1u;
+}
+
+uint helper_add(uint a, uint b)
+{
+    return a + b;
+}
+
+uint add_two(uint y)
+{
+    uint _22 = y;
+    uint _23 = 2u;
+    return helper_add(_22, _23);
+}
+

--- a/shaders-hlsl/asm/lib/global-array.asm.lib
+++ b/shaders-hlsl/asm/lib/global-array.asm.lib
@@ -1,0 +1,35 @@
+; SPIR-V
+; Version: 1.5
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 30
+; Schema: 0
+               OpCapability Linkage
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpSource HLSL 630
+               OpName %lookup "lookup"
+               OpName %i "i"
+               OpName %table "table"
+               OpDecorate %lookup LinkageAttributes "lookup" Export
+       %uint = OpTypeInt 32 0
+    %uint_10 = OpConstant %uint 10
+    %uint_20 = OpConstant %uint 20
+    %uint_30 = OpConstant %uint 30
+    %uint_40 = OpConstant %uint 40
+     %uint_4 = OpConstant %uint 4
+%_arr_uint_uint_4 = OpTypeArray %uint %uint_4
+%_ptr_Private__arr_uint_uint_4 = OpTypePointer Private %_arr_uint_uint_4
+%_ptr_Private_uint = OpTypePointer Private %uint
+%_ptr_Function_uint = OpTypePointer Function %uint
+        %fn1 = OpTypeFunction %uint %_ptr_Function_uint
+%table_init = OpConstantComposite %_arr_uint_uint_4 %uint_10 %uint_20 %uint_30 %uint_40
+      %table = OpVariable %_ptr_Private__arr_uint_uint_4 Private %table_init
+
+     %lookup = OpFunction %uint None %fn1
+          %i = OpFunctionParameter %_ptr_Function_uint
+       %l_bb = OpLabel
+       %l_iv = OpLoad %uint %i
+       %l_ac = OpAccessChain %_ptr_Private_uint %table %l_iv
+       %l_v  = OpLoad %uint %l_ac
+               OpReturnValue %l_v
+               OpFunctionEnd

--- a/shaders-hlsl/asm/lib/multi-export.asm.lib
+++ b/shaders-hlsl/asm/lib/multi-export.asm.lib
@@ -1,0 +1,54 @@
+; SPIR-V
+; Version: 1.5
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 40
+; Schema: 0
+               OpCapability Linkage
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpSource HLSL 630
+               OpName %add_one "add_one"
+               OpName %x "x"
+               OpName %add_two "add_two"
+               OpName %y "y"
+               OpName %helper_add "helper_add"
+               OpName %a "a"
+               OpName %b "b"
+               OpDecorate %add_one LinkageAttributes "add_one" Export
+               OpDecorate %add_two LinkageAttributes "add_two" Export
+       %uint = OpTypeInt 32 0
+     %uint_1 = OpConstant %uint 1
+     %uint_2 = OpConstant %uint 2
+%_ptr_Function_uint = OpTypePointer Function %uint
+       %fn1 = OpTypeFunction %uint %_ptr_Function_uint
+       %fn2 = OpTypeFunction %uint %_ptr_Function_uint %_ptr_Function_uint
+
+ %helper_add = OpFunction %uint None %fn2
+          %a = OpFunctionParameter %_ptr_Function_uint
+          %b = OpFunctionParameter %_ptr_Function_uint
+       %h_bb = OpLabel
+       %h_av = OpLoad %uint %a
+       %h_bv = OpLoad %uint %b
+      %h_sum = OpIAdd %uint %h_av %h_bv
+               OpReturnValue %h_sum
+               OpFunctionEnd
+
+    %add_one = OpFunction %uint None %fn1
+          %x = OpFunctionParameter %_ptr_Function_uint
+       %o_bb = OpLabel
+       %o_xv = OpLoad %uint %x
+        %o_r = OpIAdd %uint %o_xv %uint_1
+               OpReturnValue %o_r
+               OpFunctionEnd
+
+    %add_two = OpFunction %uint None %fn1
+          %y = OpFunctionParameter %_ptr_Function_uint
+       %t_bb = OpLabel
+     %t_arg1 = OpVariable %_ptr_Function_uint Function
+     %t_arg2 = OpVariable %_ptr_Function_uint Function
+       %t_yv = OpLoad %uint %y
+               OpStore %t_arg1 %t_yv
+               OpStore %t_arg2 %uint_2
+        %t_r = OpFunctionCall %uint %helper_add %t_arg1 %t_arg2
+               OpReturnValue %t_r
+               OpFunctionEnd

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -4840,6 +4840,20 @@ void Compiler::build_function_control_flow_graphs_and_analyze()
 	CFGBuilder handler(*this);
 	handler.function_cfgs[ir.default_entry_point].reset(new CFG(*this, get<SPIRFunction>(ir.default_entry_point)));
 	traverse_all_reachable_opcodes(get<SPIRFunction>(ir.default_entry_point), handler);
+	if (ir.is_library_module)
+	{
+		// In library mode, default_entry_point is just the first exported
+		// function. Build a CFG for every other exported function (and its
+		// callees) so per-function analyses below cover all of them.
+		for (auto export_id : ir.library_exported_functions)
+		{
+			if (export_id == ir.default_entry_point)
+				continue;
+			auto &func = get<SPIRFunction>(export_id);
+			handler.function_cfgs[export_id].reset(new CFG(*this, func));
+			traverse_all_reachable_opcodes(func, handler);
+		}
+	}
 	function_cfgs = std::move(handler.function_cfgs);
 	bool single_function = function_cfgs.size() <= 1;
 

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -4847,11 +4847,9 @@ void Compiler::build_function_control_flow_graphs_and_analyze()
 		// callees) so per-function analyses below cover all of them.
 		for (auto export_id : ir.library_exported_functions)
 		{
-			if (export_id == ir.default_entry_point)
-				continue;
 			auto &func = get<SPIRFunction>(export_id);
-			handler.function_cfgs[export_id].reset(new CFG(*this, func));
-			traverse_all_reachable_opcodes(func, handler);
+			if (handler.follow_function_call(func))
+				traverse_all_reachable_opcodes(func, handler);
 		}
 	}
 	function_cfgs = std::move(handler.function_cfgs);

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -3117,7 +3117,12 @@ uint32_t CompilerHLSL::input_vertices_from_execution_mode(SPIREntryPoint &execut
 
 void CompilerHLSL::emit_function_prototype(SPIRFunction &func, const Bitset &return_flags)
 {
-	if (func.self != ir.default_entry_point)
+	// In library mode default_entry_point points at the first exported
+	// function; treat every export as a normal function rather than as the
+	// shader's entry point.
+	const bool is_entry_point = !ir.is_library_module && func.self == ir.default_entry_point;
+
+	if (!is_entry_point)
 		add_function_overload(func);
 
 	// Avoid shadow declarations.
@@ -3138,7 +3143,7 @@ void CompilerHLSL::emit_function_prototype(SPIRFunction &func, const Bitset &ret
 		decl = "void ";
 	}
 
-	if (func.self == ir.default_entry_point)
+	if (is_entry_point)
 	{
 		decl += get_inner_entry_point_name();
 		processing_entry_point = true;
@@ -7148,14 +7153,27 @@ string CompilerHLSL::compile()
 		emit_header();
 		emit_resources();
 
-		emit_function(get<SPIRFunction>(ir.default_entry_point), Bitset());
-		emit_hlsl_entry_point();
+		if (ir.is_library_module)
+		{
+			// Emit each exported function as a normal free function.
+			// emit_function recursively emits callees, so internal helpers
+			// are picked up too.
+			for (auto export_id : ir.library_exported_functions)
+				emit_function(get<SPIRFunction>(export_id), Bitset());
+		}
+		else
+		{
+			emit_function(get<SPIRFunction>(ir.default_entry_point), Bitset());
+			emit_hlsl_entry_point();
+		}
 
 		pass_count++;
 	} while (is_forcing_recompilation());
 
 	// Entry point in HLSL is always main() for the time being.
-	get_entry_point().name = "main";
+	// Skip the rename for library modules; their exports keep their declared names.
+	if (!ir.is_library_module)
+		get_entry_point().name = "main";
 
 	return buffer.str();
 }

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -470,6 +470,11 @@ def validate_shader_hlsl(shader, force_no_external_validation, paths):
         test_glslang = False
     if '.task' in shader or '.mesh' in shader:
         test_glslang = False
+    if shader_is_library(shader):
+        # Library HLSL output has no entry point; glslangValidator's -e main
+        # would fail. Skip the round-trip — the output is meant to be
+        # included by HLSL/GLSL source rather than compiled standalone.
+        test_glslang = False
 
     hlsl_args = [paths.glslang, '--amb', '-e', 'main', '-D', '--target-env', 'vulkan1.1', '-V', shader]
     if '.sm30.' in shader:
@@ -522,7 +527,12 @@ def cross_compile_hlsl(shader, spirv, opt, force_no_external_validation, iterati
     spirv_16 = '.spv16.' in shader
     spirv_14 = '.spv14.' in shader
 
-    if spirv_16:
+    if shader_is_library(shader):
+        # Library modules use the Linkage capability, which is rejected
+        # by Vulkan target envs. Use a universal/spv target instead.
+        spirv_env = 'spv1.5'
+        glslang_env = 'spirv1.5'
+    elif spirv_16:
         spirv_env = 'spv1.6'
         glslang_env = 'vulkan1.3'
     elif spirv_14:
@@ -551,7 +561,14 @@ def cross_compile_hlsl(shader, spirv, opt, force_no_external_validation, iterati
 
     sm = shader_to_sm(shader)
 
-    hlsl_args = [spirv_cross_path, '--entry', 'main', '--output', hlsl_path, spirv_path, '--hlsl-enable-compat', '--hlsl', '--shader-model', sm, '--iterations', str(iterations)]
+    # Library SPIR-V modules (e.g. dxc -T lib_6_*) have no OpEntryPoint;
+    # skip the --entry flag for those so spirv-cross does not try to
+    # select an entry point that does not exist.
+    is_library = shader_is_library(shader)
+    hlsl_args = [spirv_cross_path]
+    if not is_library:
+        hlsl_args += ['--entry', 'main']
+    hlsl_args += ['--output', hlsl_path, spirv_path, '--hlsl-enable-compat', '--hlsl', '--shader-model', sm, '--iterations', str(iterations)]
     if '.line.' in shader:
         hlsl_args.append('--emit-line-directives')
     if '.flatten.' in shader:
@@ -844,6 +861,12 @@ def shader_is_eliminate_dead_variables(shader):
 
 def shader_is_spirv(shader):
     return '.asm.' in shader
+
+def shader_is_library(shader):
+    # SPIR-V library module: no OpEntryPoint, exports declared via
+    # OpDecorate ... LinkageAttributes ... Export. Recognised by the
+    # `.lib` filename suffix (e.g. foo.asm.lib).
+    return shader.endswith('.lib')
 
 def shader_is_invalid_spirv(shader):
     return '.invalid.' in shader


### PR DESCRIPTION
This builds upon previous PRs: https://github.com/KhronosGroup/SPIRV-Cross/pull/2623, https://github.com/KhronosGroup/SPIRV-Cross/pull/2624, https://github.com/KhronosGroup/SPIRV-Cross/pull/2625, https://github.com/KhronosGroup/SPIRV-Cross/pull/2625, and adds an additional test to ensure local arrays survive into the HLSL output.

Stacked on https://github.com/KhronosGroup/SPIRV-Cross/pull/2626. Addresses issue https://github.com/KhronosGroup/SPIRV-Cross/issues/2622.