### PR TITLE
GLSL: Do not propagate RelaxedPrecision decoration through OpCopyObject.

### DIFF
--- a/reference/shaders/asm/frag/op-copy-object-relaxed-precision.asm.frag
+++ b/reference/shaders/asm/frag/op-copy-object-relaxed-precision.asm.frag
@@ -1,0 +1,16 @@
+#version 310 es
+precision mediump float;
+precision highp int;
+
+layout(location = 0) flat in mediump uint src;
+layout(location = 0) out mediump uint dst_mp;
+layout(location = 1) out uint dst_hp;
+
+void main()
+{
+    mediump uint copy_mp = src;
+    uint copy_hp = src;
+    dst_mp = copy_mp;
+    dst_hp = copy_hp << 16u;
+}
+

--- a/shaders/asm/frag/op-copy-object-relaxed-precision.asm.frag
+++ b/shaders/asm/frag/op-copy-object-relaxed-precision.asm.frag
@@ -1,0 +1,74 @@
+; Verifies that OpCopyObject's result precision is determined by its OWN
+; RelaxedPrecision decoration, not by the operand's. The SPIR-V spec defines
+; OpCopyObject as: "Make a copy of Operand. There are no pointer dereferences
+; involved." Result decorations are independent of the operand's, which makes
+; OpCopyObject a natural way to express explicit precision conversion (e.g.
+; inserting a non-RP shadow of an RP value, or vice versa). SPIR-V-Cross's
+; forward_relaxed_precision() incorrectly propagates the operand's RP onto
+; the result, which silently changes the consumer's evaluation precision.
+;
+; Test layout:
+;   %src is mediump (RelaxedPrecision-decorated input)
+;   %copy_mp = OpCopyObject %src        decorated RelaxedPrecision -> mediump
+;   %copy_hp = OpCopyObject %src        NOT RelaxedPrecision         -> highp
+;
+;   dst_mp gets copy_mp directly.
+;   dst_hp gets `copy_hp << 16` — the shift must be evaluated at highp
+;   precision; mediump uint is only guaranteed 16-bit, so a shift by 16
+;   is implementation-defined and produces 0 (or otherwise wrong) on
+;   conforming drivers.
+;
+; Expected GLSL output:
+;   mediump uint copy_mp = src;
+;   uint copy_hp = src;                  (not mediump — operates as highp)
+;   dst_hp = copy_hp << 16u;
+;
+; Without the fix, spirv-cross propagates %src's RelaxedPrecision through
+; OpCopyObject onto %copy_hp, emitting it as `mediump uint`. The shift
+; then operates at mediump precision and produces wrong device output:
+; with mediump uint at 16-bit, `value << 16` is undefined/zero, instead
+; of the intended `src << 16` highp value.
+;
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 11
+; Bound: 22
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %src %dst_mp %dst_hp
+               OpExecutionMode %main OriginUpperLeft
+               OpSource ESSL 310
+               OpName %main "main"
+               OpName %src "src"
+               OpName %dst_mp "dst_mp"
+               OpName %dst_hp "dst_hp"
+               OpName %copy_mp "copy_mp"
+               OpName %copy_hp "copy_hp"
+               OpDecorate %src Flat
+               OpDecorate %src Location 0
+               OpDecorate %src RelaxedPrecision
+               OpDecorate %dst_mp Location 0
+               OpDecorate %dst_mp RelaxedPrecision
+               OpDecorate %dst_hp Location 1
+               OpDecorate %copy_mp RelaxedPrecision
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%_ptr_Input_uint = OpTypePointer Input %uint
+%_ptr_Output_uint = OpTypePointer Output %uint
+        %src = OpVariable %_ptr_Input_uint Input
+     %dst_mp = OpVariable %_ptr_Output_uint Output
+     %dst_hp = OpVariable %_ptr_Output_uint Output
+    %uint_16 = OpConstant %uint 16
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %10 = OpLoad %uint %src
+    %copy_mp = OpCopyObject %uint %10
+    %copy_hp = OpCopyObject %uint %10
+      %shift = OpShiftLeftLogical %uint %copy_hp %uint_16
+               OpStore %dst_mp %copy_mp
+               OpStore %dst_hp %shift
+               OpReturn
+               OpFunctionEnd

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -12747,6 +12747,9 @@ static bool opcode_is_precision_sensitive_operation(Op op)
 // Instructions which just load data but don't do any arithmetic operation should just inherit the decoration.
 // SPIR-V doesn't require this, but it's somewhat implied it has to work this way, relaxed precision is only
 // relevant when operating on the IDs, not when shuffling things around.
+// Note, this is not generally safe to do. If the resulting instruction participates in an operation in which 
+// it's the only precision-qualified operand, then that determines the precision of the operation and 
+// that alters the result. See op-copy-object-relaxed-precision for an example.
 static bool opcode_is_precision_forwarding_instruction(Op op, uint32_t &arg_count)
 {
 	switch (op)
@@ -12758,7 +12761,7 @@ static bool opcode_is_precision_forwarding_instruction(Op op, uint32_t &arg_coun
 	case OpVectorExtractDynamic:
 	case OpSampledImage:
 	case OpImage:
-	case OpCopyObject:
+	// OpCopyObject intentionally excluded.
 
 	case OpImageRead:
 	case OpImageFetch:


### PR DESCRIPTION
This is the proposed bugfix for issue https://github.com/KhronosGroup/SPIRV-Cross/issues/2630

The fix is just a one line change (remove `OpCopyObject` from `opcode_is_precision_forwarding_instruction`). I've also added a test to validate the expected behavior and prevent regressions.