### PR TITLE
MSL: add gl_DrawID (DrawIndex) support for MacOS

### DIFF
--- a/reference/opt/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.for-tess.vert
+++ b/reference/opt/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.for-tess.vert
@@ -8,13 +8,13 @@ struct main0_out
     float4 gl_Position;
 };
 
-kernel void main0(uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 spvStageInputSize [[grid_size]], uint3 spvDispatchBase [[grid_origin]], device main0_out* spvOut [[buffer(28)]])
+kernel void main0(constant uint *gl_DrawID [[buffer(19)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 spvStageInputSize [[grid_size]], uint3 spvDispatchBase [[grid_origin]], device main0_out* spvOut [[buffer(28)]])
 {
     device main0_out& out = spvOut[gl_GlobalInvocationID.y * spvStageInputSize.x + gl_GlobalInvocationID.x];
     if (any(gl_GlobalInvocationID >= spvStageInputSize))
         return;
     uint gl_BaseVertex = spvDispatchBase.x;
     uint gl_BaseInstance = spvDispatchBase.y;
-    out.gl_Position = float4(float(int(gl_BaseVertex)), float(int(gl_BaseInstance)), 0.0, 1.0);
+    out.gl_Position = float4(float(int(gl_BaseVertex)), float(int(gl_BaseInstance)), float(*gl_DrawID), 1.0);
 }
 

--- a/reference/opt/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.for-tess.vert
+++ b/reference/opt/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.for-tess.vert
@@ -8,13 +8,14 @@ struct main0_out
     float4 gl_Position;
 };
 
-kernel void main0(constant uint *gl_DrawID [[buffer(19)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 spvStageInputSize [[grid_size]], uint3 spvDispatchBase [[grid_origin]], device main0_out* spvOut [[buffer(28)]])
+kernel void main0(constant uint* spvDrawIndex [[buffer(19)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 spvStageInputSize [[grid_size]], uint3 spvDispatchBase [[grid_origin]], device main0_out* spvOut [[buffer(28)]])
 {
     device main0_out& out = spvOut[gl_GlobalInvocationID.y * spvStageInputSize.x + gl_GlobalInvocationID.x];
     if (any(gl_GlobalInvocationID >= spvStageInputSize))
         return;
     uint gl_BaseVertex = spvDispatchBase.x;
     uint gl_BaseInstance = spvDispatchBase.y;
-    out.gl_Position = float4(float(int(gl_BaseVertex)), float(int(gl_BaseInstance)), float(*gl_DrawID), 1.0);
+    uint gl_DrawID = *spvDrawIndex;
+    out.gl_Position = float4(float(int(gl_BaseVertex)), float(int(gl_BaseInstance)), float(int(gl_DrawID)), 1.0);
 }
 

--- a/reference/opt/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
+++ b/reference/opt/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
@@ -8,10 +8,11 @@ struct main0_out
     float4 gl_Position [[position]];
 };
 
-vertex main0_out main0(uint gl_BaseVertex [[base_vertex]], uint gl_BaseInstance [[base_instance]], constant uint *gl_DrawID [[buffer(19)]])
+vertex main0_out main0(constant uint* spvDrawIndex [[buffer(19)]], uint gl_BaseVertex [[base_vertex]], uint gl_BaseInstance [[base_instance]])
 {
     main0_out out = {};
-    out.gl_Position = float4(float(int(gl_BaseVertex)), float(int(gl_BaseInstance)), float(*gl_DrawID), 1.0);
+    uint gl_DrawID = *spvDrawIndex;
+    out.gl_Position = float4(float(int(gl_BaseVertex)), float(int(gl_BaseInstance)), float(int(gl_DrawID)), 1.0);
     return out;
 }
 

--- a/reference/opt/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
+++ b/reference/opt/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
@@ -8,10 +8,10 @@ struct main0_out
     float4 gl_Position [[position]];
 };
 
-vertex main0_out main0(uint gl_BaseVertex [[base_vertex]], uint gl_BaseInstance [[base_instance]])
+vertex main0_out main0(uint gl_BaseVertex [[base_vertex]], uint gl_BaseInstance [[base_instance]], constant uint *gl_DrawID [[buffer(19)]])
 {
     main0_out out = {};
-    out.gl_Position = float4(float(int(gl_BaseVertex)), float(int(gl_BaseInstance)), 0.0, 1.0);
+    out.gl_Position = float4(float(int(gl_BaseVertex)), float(int(gl_BaseInstance)), float(*gl_DrawID), 1.0);
     return out;
 }
 

--- a/reference/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.for-tess.vert
+++ b/reference/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.for-tess.vert
@@ -8,13 +8,13 @@ struct main0_out
     float4 gl_Position;
 };
 
-kernel void main0(uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 spvStageInputSize [[grid_size]], uint3 spvDispatchBase [[grid_origin]], device main0_out* spvOut [[buffer(28)]])
+kernel void main0(constant uint *gl_DrawID [[buffer(19)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 spvStageInputSize [[grid_size]], uint3 spvDispatchBase [[grid_origin]], device main0_out* spvOut [[buffer(28)]])
 {
     device main0_out& out = spvOut[gl_GlobalInvocationID.y * spvStageInputSize.x + gl_GlobalInvocationID.x];
     if (any(gl_GlobalInvocationID >= spvStageInputSize))
         return;
     uint gl_BaseVertex = spvDispatchBase.x;
     uint gl_BaseInstance = spvDispatchBase.y;
-    out.gl_Position = float4(float(int(gl_BaseVertex)), float(int(gl_BaseInstance)), 0.0, 1.0);
+    out.gl_Position = float4(float(int(gl_BaseVertex)), float(int(gl_BaseInstance)), float(*gl_DrawID), 1.0);
 }
 

--- a/reference/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.for-tess.vert
+++ b/reference/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.for-tess.vert
@@ -8,13 +8,14 @@ struct main0_out
     float4 gl_Position;
 };
 
-kernel void main0(constant uint *gl_DrawID [[buffer(19)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 spvStageInputSize [[grid_size]], uint3 spvDispatchBase [[grid_origin]], device main0_out* spvOut [[buffer(28)]])
+kernel void main0(constant uint* spvDrawIndex [[buffer(19)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]], uint3 spvStageInputSize [[grid_size]], uint3 spvDispatchBase [[grid_origin]], device main0_out* spvOut [[buffer(28)]])
 {
     device main0_out& out = spvOut[gl_GlobalInvocationID.y * spvStageInputSize.x + gl_GlobalInvocationID.x];
     if (any(gl_GlobalInvocationID >= spvStageInputSize))
         return;
     uint gl_BaseVertex = spvDispatchBase.x;
     uint gl_BaseInstance = spvDispatchBase.y;
-    out.gl_Position = float4(float(int(gl_BaseVertex)), float(int(gl_BaseInstance)), float(*gl_DrawID), 1.0);
+    uint gl_DrawID = *spvDrawIndex;
+    out.gl_Position = float4(float(int(gl_BaseVertex)), float(int(gl_BaseInstance)), float(int(gl_DrawID)), 1.0);
 }
 

--- a/reference/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
+++ b/reference/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
@@ -8,10 +8,11 @@ struct main0_out
     float4 gl_Position [[position]];
 };
 
-vertex main0_out main0(uint gl_BaseVertex [[base_vertex]], uint gl_BaseInstance [[base_instance]], constant uint *gl_DrawID [[buffer(19)]])
+vertex main0_out main0(constant uint* spvDrawIndex [[buffer(19)]], uint gl_BaseVertex [[base_vertex]], uint gl_BaseInstance [[base_instance]])
 {
     main0_out out = {};
-    out.gl_Position = float4(float(int(gl_BaseVertex)), float(int(gl_BaseInstance)), float(*gl_DrawID), 1.0);
+    uint gl_DrawID = *spvDrawIndex;
+    out.gl_Position = float4(float(int(gl_BaseVertex)), float(int(gl_BaseInstance)), float(int(gl_DrawID)), 1.0);
     return out;
 }
 

--- a/reference/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
+++ b/reference/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
@@ -8,10 +8,10 @@ struct main0_out
     float4 gl_Position [[position]];
 };
 
-vertex main0_out main0(uint gl_BaseVertex [[base_vertex]], uint gl_BaseInstance [[base_instance]])
+vertex main0_out main0(uint gl_BaseVertex [[base_vertex]], uint gl_BaseInstance [[base_instance]], constant uint *gl_DrawID [[buffer(19)]])
 {
     main0_out out = {};
-    out.gl_Position = float4(float(int(gl_BaseVertex)), float(int(gl_BaseInstance)), 0.0, 1.0);
+    out.gl_Position = float4(float(int(gl_BaseVertex)), float(int(gl_BaseInstance)), float(*gl_DrawID), 1.0);
     return out;
 }
 

--- a/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.for-tess.vert
+++ b/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.for-tess.vert
@@ -7,5 +7,5 @@ out gl_PerVertex
 
 void main()
 {
-    gl_Position = vec4(gl_BaseVertex, gl_BaseInstance, 0, 1);
+    gl_Position = vec4(gl_BaseVertex, gl_BaseInstance, gl_DrawID, 1);
 }

--- a/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
+++ b/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
@@ -5,6 +5,11 @@ out gl_PerVertex
     vec4 gl_Position;
 };
 
+void in_func()
+{
+	gl_Position.w = float(gl_DrawID);
+}
+
 void main()
 {
     gl_Position = vec4(gl_BaseVertex, gl_BaseInstance, gl_DrawID, 1);

--- a/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
+++ b/shaders-msl/desktop-only/vert/shader-draw-parameters.desktop.vert
@@ -7,5 +7,5 @@ out gl_PerVertex
 
 void main()
 {
-    gl_Position = vec4(gl_BaseVertex, gl_BaseInstance, 0, 1);
+    gl_Position = vec4(gl_BaseVertex, gl_BaseInstance, gl_DrawID, 1);
 }

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -290,8 +290,8 @@ void CompilerMSL::build_implicit_builtins()
         if (!has_extended_decoration(var_id, SPIRVCrossDecorationResourceIndexPrimary))
             set_extended_decoration(var_id, SPIRVCrossDecorationResourceIndexPrimary, buffer_index);
 
-        set_decoration(var_id, spv::DecorationBinding, buffer_index);
-        set_decoration(var_id, spv::DecorationDescriptorSet, 0);
+        set_decoration(var_id, DecorationBinding, buffer_index);
+        set_decoration(var_id, DecorationDescriptorSet, 0);
 
         // Mark it so we know it's a buffer (not stage_in, not texture, etc.)
         add_resource_name(var_id);

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -282,20 +282,6 @@ void CompilerMSL::build_implicit_builtins()
 	needs_point_size_output =
 	    msl_options.enable_point_size_builtin && msl_options.enable_point_size_default &&
 	    entry_point_is_vertex();
-    
-    if (needs_draw_id_buffer_def) {
-        uint32_t buffer_index = msl_options.draw_id_buffer_index;
-        uint32_t var_id = build_constant_uint_array_pointer();
-
-        if (!has_extended_decoration(var_id, SPIRVCrossDecorationResourceIndexPrimary))
-            set_extended_decoration(var_id, SPIRVCrossDecorationResourceIndexPrimary, buffer_index);
-
-        set_decoration(var_id, DecorationBinding, buffer_index);
-        set_decoration(var_id, DecorationDescriptorSet, 0);
-
-        // Mark it so we know it's a buffer (not stage_in, not texture, etc.)
-        add_resource_name(var_id);
-    }
 
 	if (need_subpass_input || need_sample_pos || need_subgroup_mask || need_vertex_params || need_tesc_params ||
 	    need_tese_params || need_multiview || need_dispatch_base || need_vertex_base_params || need_grid_params ||
@@ -1101,6 +1087,18 @@ void CompilerMSL::build_implicit_builtins()
 		dynamic_offsets_buffer_id = var_id;
 	}
 
+	if (active_input_builtins.get(BuiltInDrawIndex))
+	{
+		// This is always emulated.
+		uint32_t var_id = build_constant_uint_array_pointer();
+		set_name(var_id, "spvDrawIndex");
+		// This should never match anything.
+		set_decoration(var_id, DecorationDescriptorSet, ~(6u));
+		set_decoration(var_id, DecorationBinding, msl_options.draw_id_buffer_index);
+		set_extended_decoration(var_id, SPIRVCrossDecorationResourceIndexPrimary, msl_options.draw_id_buffer_index);
+		draw_index_buffer_id = var_id;
+	}
+
 	// If we're returning a struct from a vertex-like entry point, we must return a position attribute.
 	bool need_position = (get_execution_model() == ExecutionModelVertex || is_tese_shader()) &&
 	                     !capture_output_to_buffer && !get_is_rasterization_disabled() &&
@@ -1780,6 +1778,8 @@ string CompilerMSL::compile()
 		add_active_interface_variable(view_mask_buffer_id);
 	if (dynamic_offsets_buffer_id)
 		add_active_interface_variable(dynamic_offsets_buffer_id);
+	if (draw_index_buffer_id)
+		add_active_interface_variable(draw_index_buffer_id);
 	if (builtin_layer_id)
 		add_active_interface_variable(builtin_layer_id);
 	if (builtin_dispatch_base_id && !msl_options.supports_msl_version(1, 2))
@@ -13834,9 +13834,6 @@ string CompilerMSL::member_attribute_qualifier(const SPIRType &type, uint32_t in
 					return "";
 				return string(" [[") + builtin_qualifier(builtin) + "]]";
 
-			case BuiltInDrawIndex:
-                return string(" [[") + builtin_qualifier(builtin) + "]]";
-
 			default:
 				return "";
 			}
@@ -14685,6 +14682,9 @@ bool CompilerMSL::is_direct_input_builtin(BuiltIn bi_type)
 		/* fallthrough */
 	case BuiltInSubgroupLocalInvocationId:
 		return !msl_options.emulate_subgroups;
+	case BuiltInDrawIndex:
+		// Emulated
+		return false;
 	default:
 		return true;
 	}
@@ -15981,6 +15981,12 @@ void CompilerMSL::fix_up_shader_inputs_outputs()
 				entry_func.fixup_hooks_in.push_back([=]() {
 					statement(builtin_type_decl(bi_type), " ", to_expression(var_id), " = ",
 					          to_expression(builtin_dispatch_base_id), ".y;");
+				});
+				break;
+			case BuiltInDrawIndex:
+				entry_func.fixup_hooks_in.push_back([=]() {
+					statement(builtin_type_decl(bi_type), " ", to_expression(var_id), " = *",
+					          to_expression(draw_index_buffer_id), ";");
 				});
 				break;
 			default:
@@ -18133,10 +18139,9 @@ string CompilerMSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 		{
 			SPIRV_CROSS_THROW("BaseInstance requires Metal 1.1 and Mac or Apple A9+ hardware.");
 		}
+
 	case BuiltInDrawIndex:
-            // since it's fully emulated, no need to do the checks
-            needs_draw_id_buffer_def = true;
-            return "*gl_DrawID";
+		return "gl_DrawID";
 
 	// When used in the entry function, output builtins are qualified with output struct name.
 	// Test storage class as NOT Input, as output builtins might be part of generic type.
@@ -18247,8 +18252,6 @@ string CompilerMSL::builtin_qualifier(BuiltIn builtin)
 		return "instance_id";
 	case BuiltInBaseInstance:
 		return "base_instance";
-	case BuiltInDrawIndex:
-        return string("buffer(") + std::to_string(msl_options.draw_id_buffer_index) + ")";
 
 	// Vertex function out
 	case BuiltInClipDistance:
@@ -18472,7 +18475,7 @@ string CompilerMSL::builtin_type_decl(BuiltIn builtin, uint32_t id)
 	case BuiltInBaseInstance:
 		return "uint";
 	case BuiltInDrawIndex:
-        return "constant uint";
+        return "uint";
 
 	// Vertex function out
 	case BuiltInClipDistance:
@@ -19686,6 +19689,7 @@ void CompilerMSL::cast_from_variable_load(uint32_t source_id, std::string &expr,
 	case BuiltInSubgroupSize:
 	case BuiltInSubgroupLocalInvocationId:
 	case BuiltInViewIndex:
+	case BuiltInDrawIndex:
 	case BuiltInVertexIndex:
 	case BuiltInInstanceIndex:
 	case BuiltInBaseInstance:

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -282,6 +282,20 @@ void CompilerMSL::build_implicit_builtins()
 	needs_point_size_output =
 	    msl_options.enable_point_size_builtin && msl_options.enable_point_size_default &&
 	    entry_point_is_vertex();
+    
+    if (needs_draw_id_buffer_def) {
+        uint32_t buffer_index = msl_options.draw_id_buffer_index;
+        uint32_t var_id = build_constant_uint_array_pointer();
+
+        if (!has_extended_decoration(var_id, SPIRVCrossDecorationResourceIndexPrimary))
+            set_extended_decoration(var_id, SPIRVCrossDecorationResourceIndexPrimary, buffer_index);
+
+        set_decoration(var_id, spv::DecorationBinding, buffer_index);
+        set_decoration(var_id, spv::DecorationDescriptorSet, 0);
+
+        // Mark it so we know it's a buffer (not stage_in, not texture, etc.)
+        add_resource_name(var_id);
+    }
 
 	if (need_subpass_input || need_sample_pos || need_subgroup_mask || need_vertex_params || need_tesc_params ||
 	    need_tese_params || need_multiview || need_dispatch_base || need_vertex_base_params || need_grid_params ||
@@ -13821,7 +13835,9 @@ string CompilerMSL::member_attribute_qualifier(const SPIRType &type, uint32_t in
 				return string(" [[") + builtin_qualifier(builtin) + "]]";
 
 			case BuiltInDrawIndex:
-				SPIRV_CROSS_THROW("DrawIndex is not supported in MSL.");
+                if (msl_options.vertex_for_tessellation)
+                    return "";
+                return string(" [[") + builtin_qualifier(builtin) + "]]";
 
 			default:
 				return "";
@@ -18120,7 +18136,18 @@ string CompilerMSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 			SPIRV_CROSS_THROW("BaseInstance requires Metal 1.1 and Mac or Apple A9+ hardware.");
 		}
 	case BuiltInDrawIndex:
-		SPIRV_CROSS_THROW("DrawIndex is not supported in MSL.");
+            // Not positive on the Metal version or if ios needs it
+            if (msl_options.supports_msl_version(1, 1) &&
+                // (msl_options.ios_support_base_vertex_instance || msl_options.is_macos()))
+                msl_options.is_macos())
+            {
+                needs_draw_id_buffer_def = true;
+                return "*gl_DrawID";
+            }
+            else
+            {
+                SPIRV_CROSS_THROW("DrawIndex requires Metal 1.1 and Mac or Apple A9+ hardware.");
+            }
 
 	// When used in the entry function, output builtins are qualified with output struct name.
 	// Test storage class as NOT Input, as output builtins might be part of generic type.
@@ -18232,7 +18259,7 @@ string CompilerMSL::builtin_qualifier(BuiltIn builtin)
 	case BuiltInBaseInstance:
 		return "base_instance";
 	case BuiltInDrawIndex:
-		SPIRV_CROSS_THROW("DrawIndex is not supported in MSL.");
+        return string("buffer(") + std::to_string(msl_options.draw_id_buffer_index) + ")";
 
 	// Vertex function out
 	case BuiltInClipDistance:
@@ -18456,7 +18483,7 @@ string CompilerMSL::builtin_type_decl(BuiltIn builtin, uint32_t id)
 	case BuiltInBaseInstance:
 		return "uint";
 	case BuiltInDrawIndex:
-		SPIRV_CROSS_THROW("DrawIndex is not supported in MSL.");
+        return "constant uint";
 
 	// Vertex function out
 	case BuiltInClipDistance:

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -13835,8 +13835,6 @@ string CompilerMSL::member_attribute_qualifier(const SPIRType &type, uint32_t in
 				return string(" [[") + builtin_qualifier(builtin) + "]]";
 
 			case BuiltInDrawIndex:
-                if (msl_options.vertex_for_tessellation)
-                    return "";
                 return string(" [[") + builtin_qualifier(builtin) + "]]";
 
 			default:
@@ -18136,18 +18134,9 @@ string CompilerMSL::builtin_to_glsl(BuiltIn builtin, StorageClass storage)
 			SPIRV_CROSS_THROW("BaseInstance requires Metal 1.1 and Mac or Apple A9+ hardware.");
 		}
 	case BuiltInDrawIndex:
-            // Not positive on the Metal version or if ios needs it
-            if (msl_options.supports_msl_version(1, 1) &&
-                // (msl_options.ios_support_base_vertex_instance || msl_options.is_macos()))
-                msl_options.is_macos())
-            {
-                needs_draw_id_buffer_def = true;
-                return "*gl_DrawID";
-            }
-            else
-            {
-                SPIRV_CROSS_THROW("DrawIndex requires Metal 1.1 and Mac or Apple A9+ hardware.");
-            }
+            // since it's fully emulated, no need to do the checks
+            needs_draw_id_buffer_def = true;
+            return "*gl_DrawID";
 
 	// When used in the entry function, output builtins are qualified with output struct name.
 	// Test storage class as NOT Input, as output builtins might be part of generic type.

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -1181,6 +1181,7 @@ protected:
 	uint32_t swizzle_buffer_id = 0;
 	uint32_t buffer_size_buffer_id = 0;
 	uint32_t view_mask_buffer_id = 0;
+	uint32_t draw_index_buffer_id = 0;
 	uint32_t dynamic_offsets_buffer_id = 0;
 	uint32_t uint_type_id = 0;
 	uint32_t shared_uint_type_id = 0;
@@ -1274,7 +1275,6 @@ protected:
 	bool is_rasterization_disabled = false;
 	bool has_descriptor_side_effects_buffer = false;
 	bool capture_output_to_buffer = false;
-    bool needs_draw_id_buffer_def = false;
 	bool needs_swizzle_buffer_def = false;
 	bool used_swizzle_buffer = false;
 	bool added_builtin_tess_level = false;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -317,6 +317,7 @@ public:
 		uint32_t shader_input_buffer_index = 22;
 		uint32_t shader_index_buffer_index = 21;
 		uint32_t shader_patch_input_buffer_index = 20;
+        uint32_t draw_id_buffer_index = 19;
 		uint32_t shader_input_wg_index = 0;
 		uint32_t device_index = 0;
 		uint32_t enable_frag_output_mask = 0xffffffff;
@@ -1273,6 +1274,7 @@ protected:
 	bool is_rasterization_disabled = false;
 	bool has_descriptor_side_effects_buffer = false;
 	bool capture_output_to_buffer = false;
+    bool needs_draw_id_buffer_def = false;
 	bool needs_swizzle_buffer_def = false;
 	bool used_swizzle_buffer = false;
 	bool added_builtin_tess_level = false;


### PR DESCRIPTION
Related to these reported issues:

SPIRV-Cross: #669 
MoltenVK: [1743](https://github.com/KhronosGroup/MoltenVK/issues/1743)
 
Corresponding MoltenVK change:
https://github.com/denisk-dev/MoltenVK/tree/add-gl-draw-id

Kitten Space Agency (KSA) is using Vulkan and gl_DrawID is used in the rocket parts shaders. 
