### PR TITLE
HLSL: Support baseline SM 6.4 idot.

### DIFF
--- a/reference/shaders-hlsl-no-opt/comp/integer-dot-product.sm64.fxconly.nofxc.comp
+++ b/reference/shaders-hlsl-no-opt/comp/integer-dot-product.sm64.fxconly.nofxc.comp
@@ -1,0 +1,19 @@
+static const uint3 gl_WorkGroupSize = uint3(1u, 1u, 1u);
+
+RWByteAddressBuffer comp2 : register(u1, space0);
+RWByteAddressBuffer comp : register(u0, space0);
+
+void comp_main()
+{
+    uint spdot32 = uint(dot4add_i8packed(comp2.Load<uint>(0), comp2.Load<uint>(4), 0));
+    int spdoti32 = dot4add_i8packed(comp2.Load<uint>(0), comp2.Load<uint>(4), 0);
+    uint updot32 = dot4add_u8packed(comp2.Load<uint>(0), comp2.Load<uint>(4), 0);
+    uint udotaddsat_pack = dot4add_u8packed(comp2.Load<uint>(0), comp2.Load<uint>(4), updot32 /* WARN: HLSL will not saturate */);
+    uint sdotaddsat_pack = uint(dot4add_i8packed(comp2.Load<uint>(0), comp2.Load<uint>(4), updot32 /* WARN: HLSL will not saturate */));
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    comp_main();
+}

--- a/shaders-hlsl-no-opt/comp/integer-dot-product.sm64.fxconly.nofxc.comp
+++ b/shaders-hlsl-no-opt/comp/integer-dot-product.sm64.fxconly.nofxc.comp
@@ -1,0 +1,42 @@
+#version 450
+#extension GL_EXT_shader_8bit_storage : require
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types : require
+#extension GL_EXT_spirv_intrinsics : require
+
+layout(local_size_x = 1) in;
+
+layout(std430, binding = 0) buffer InOut {
+    uvec4 x;
+    uvec4 y;
+    int result;
+} comp;
+
+layout(std430, binding = 1) buffer InOut2 {
+    uint x;
+    uint y;
+    uint result;
+} comp2;
+
+spirv_instruction (extensions = ["SPV_KHR_integer_dot_product"], capabilities = [6019, 6018], id = 4450)
+uint spdot_to_32(uint x, uint y, spirv_literal uint packedFormat);
+
+spirv_instruction (extensions = ["SPV_KHR_integer_dot_product"], capabilities = [6019, 6018], id = 4450)
+int spdot_to_i32(uint x, uint y, spirv_literal uint packedFormat);
+
+spirv_instruction (extensions = ["SPV_KHR_integer_dot_product"], capabilities = [6019, 6018], id = 4451)
+uint updot_to_32(uint x, uint y, spirv_literal uint packedFormat);
+
+spirv_instruction (extensions = ["SPV_KHR_integer_dot_product"], capabilities = [6019, 6018], id = 4454)
+uint udotaddsat_packed(uint x, uint y, uint acc, spirv_literal uint packedFormat);
+
+spirv_instruction (extensions = ["SPV_KHR_integer_dot_product"], capabilities = [6019, 6018], id = 4453)
+uint sdotaddsat_packed(uint x, uint y, uint acc, spirv_literal uint packedFormat);
+
+void main() {
+    uint spdot32 = spdot_to_32(comp2.x, comp2.y, 0x0); // PackedVectorFormat4x8Bit
+    int spdoti32 = spdot_to_i32(comp2.x, comp2.y, 0x0); // PackedVectorFormat4x8Bit
+    uint updot32 = updot_to_32(comp2.x, comp2.y, 0x0); // PackedVectorFormat4x8Bit
+    uint udotaddsat_pack = udotaddsat_packed(comp2.x, comp2.y, updot32, 0); // PackedVectorFormat4x8Bit
+    uint sdotaddsat_pack = sdotaddsat_packed(comp2.x, comp2.y, updot32, 0); // PackedVectorFormat4x8Bit
+}

--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -5923,6 +5923,7 @@ void CompilerHLSL::emit_instruction(const Instruction &instruction)
 {
 	auto ops = stream(instruction);
 	auto opcode = static_cast<Op>(instruction.op);
+	uint32_t length = instruction.length;
 
 #define HLSL_BOP(op) emit_binary_op(ops[0], ops[1], ops[2], ops[3], #op)
 #define HLSL_BOP_CAST(op, type) \
@@ -6907,6 +6908,69 @@ void CompilerHLSL::emit_instruction(const Instruction &instruction)
 		statement("geometry_stream.RestartStrip();");
 		break;
 	}
+
+	case OpSDot:
+	case OpUDot:
+	case OpSUDot:
+	case OpSDotAccSat:
+	case OpUDotAccSat:
+	case OpSUDotAccSat:
+	{
+		uint32_t result_type = ops[0];
+		uint32_t id = ops[1];
+		bool is_acc_sat = opcode == OpSDotAccSat || opcode == OpUDotAccSat || opcode == OpSUDotAccSat;
+
+		if (length == (is_acc_sat ? 6 : 5))
+		{
+			if (ops[length - 1] != PackedVectorFormatPackedVectorFormat4x8Bit)
+				SPIRV_CROSS_THROW("Only 4x8bit packing is supported.");
+		}
+
+		// Don't bother with polyfills. Integer dot products that aren't full speed are worthless.
+		if (hlsl_options.shader_model < 64)
+			SPIRV_CROSS_THROW("Integer dot product requires SM 6.4.");
+		if (opcode == OpSUDotAccSat || opcode == OpSUDot)
+			SPIRV_CROSS_THROW("Mixed signed dot product not supported.");
+		if (expression_type(ops[2]).vecsize != 1)
+			SPIRV_CROSS_THROW("HLSL dot products must be 4x8bit packed.");
+		if (integer_width != 32)
+			SPIRV_CROSS_THROW("HLSL dot products must be 32-bit accumulator.");
+
+		const char *intrinsic;
+		if (opcode == OpSDot || opcode == OpSDotAccSat)
+			intrinsic = "dot4add_i8packed";
+		else
+			intrinsic = "dot4add_u8packed";
+
+		auto expr = join(intrinsic, "(", to_expression(ops[2]), ", ", to_expression(ops[3]), ", ");
+
+		// HLSL only has the accumulating variant without saturation.
+		// We could implement saturation ourselves, but it negates the point of using it.
+		// Take the lazier approach and just implement it as-is.
+		// Saturation is extremely unlikely to come up for any reasonable i8 kernel.
+		if (is_acc_sat)
+			expr += to_expression(ops[4]) + " /* WARN: HLSL will not saturate */)";
+		else
+			expr += "0)";
+
+		if (((opcode == OpSDot || opcode == OpSDotAccSat) && get <SPIRType>(result_type).basetype != SPIRType::Int) ||
+		    ((opcode == OpUDot || opcode == OpUDotAccSat) && get <SPIRType>(result_type).basetype != SPIRType::UInt))
+		{
+			expr = join(type_to_glsl(get <SPIRType>(result_type)), "(", expr, ")");
+		}
+
+		bool forward = should_forward(ops[2]) && should_forward(ops[3]);
+		if (is_acc_sat && forward)
+			forward = should_forward(ops[4]);
+
+		emit_op(result_type, id, expr, forward);
+		inherit_expression_dependencies(id, ops[2]);
+		inherit_expression_dependencies(id, ops[3]);
+		if (is_acc_sat)
+			inherit_expression_dependencies(id, ops[4]);
+		break;
+	}
+
 	default:
 		CompilerGLSL::emit_instruction(instruction);
 		break;

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -515,6 +515,8 @@ def shader_to_sm(shader):
         return '60'
     elif '.sm68.' in shader:
         return '68'
+    elif '.sm64.' in shader:
+        return '64'
     elif '.sm51.' in shader:
         return '51'
     elif '.sm30.' in shader:


### PR DESCRIPTION
Baseline implementation only.

No polyfills for missing cases, or edge case handling of saturation. Either of these would slow it down to the point where using integer dot product would be useless in the first place.

Fix #2642.