### PR TITLE
Fix spvFMulMatrixMatrix type mismatch for non-square matrix multiply

### DIFF
--- a/reference/opt/shaders-msl/vert/float-math.invariant-float-math.vert
+++ b/reference/opt/shaders-msl/vert/float-math.invariant-float-math.vert
@@ -80,13 +80,14 @@ template<typename T, int Cols, int Rows>
 template<typename T, int LCols, int LRows, int RCols, int RRows>
 [[clang::optnone]] matrix<T, RCols, LRows> spvFMulMatrixMatrix(matrix<T, LCols, LRows> l, matrix<T, RCols, RRows> r)
 {
+    static_assert(LCols == RRows, "column-row configuration mismatch");
     matrix<T, RCols, LRows> res;
     for (uint i = 0; i < RCols; i++)
     {
-        vec<T, RCols> tmp(0);
+        vec<T, LRows> tmp(0);
         for (uint j = 0; j < LCols; j++)
         {
-            tmp = fma(vec<T, RCols>(r[i][j]), l[j], tmp);
+            tmp = fma(vec<T, LRows>(r[i][j]), l[j], tmp);
         }
         res[i] = tmp;
     }

--- a/reference/opt/shaders-msl/vert/no-contraction.vert
+++ b/reference/opt/shaders-msl/vert/no-contraction.vert
@@ -41,13 +41,14 @@ template<typename T, int Cols, int Rows>
 template<typename T, int LCols, int LRows, int RCols, int RRows>
 [[clang::optnone]] matrix<T, RCols, LRows> spvFMulMatrixMatrix(matrix<T, LCols, LRows> l, matrix<T, RCols, RRows> r)
 {
+    static_assert(LCols == RRows, "column-row configuration mismatch");
     matrix<T, RCols, LRows> res;
     for (uint i = 0; i < RCols; i++)
     {
-        vec<T, RCols> tmp(0);
+        vec<T, LRows> tmp(0);
         for (uint j = 0; j < LCols; j++)
         {
-            tmp = fma(vec<T, RCols>(r[i][j]), l[j], tmp);
+            tmp = fma(vec<T, LRows>(r[i][j]), l[j], tmp);
         }
         res[i] = tmp;
     }

--- a/reference/shaders-msl-no-opt/comp/precise-non-square-matrix.comp
+++ b/reference/shaders-msl-no-opt/comp/precise-non-square-matrix.comp
@@ -55,39 +55,20 @@ template<typename T, int LCols, int LRows, int RCols, int RRows>
     return res;
 }
 
-template<typename T>
-[[clang::optnone]] T spvFAdd(T l, T r)
+struct SSBO
 {
-    return fma(T(1), l, r);
-}
-
-template<typename T>
-[[clang::optnone]] T spvFSub(T l, T r)
-{
-    return fma(T(-1), r, l);
-}
-
-struct main0_out
-{
-    float4 gl_Position [[position]];
+    float3x4 A;
+    float4x3 B;
+    float3x3 C;
+    float4x4 D;
 };
 
-struct main0_in
+kernel void main0(const device SSBO& _17 [[buffer(0)]])
 {
-    float4 vA [[attribute(0)]];
-    float4 vB [[attribute(1)]];
-    float4 vC [[attribute(2)]];
-};
-
-vertex main0_out main0(main0_in in [[stage_in]])
-{
-    main0_out out = {};
-    float4 mul = spvFMul(in.vA, in.vB);
-    float4 add = spvFAdd(in.vA, in.vB);
-    float4 sub = spvFSub(in.vA, in.vB);
-    float4 mad = spvFAdd(spvFMul(in.vA, in.vB), in.vC);
-    float4 summed = spvFAdd(spvFAdd(spvFAdd(mul, add), sub), mad);
-    out.gl_Position = summed;
-    return out;
+    float4x4 tmp0 = spvFMulMatrixMatrix(_17.A, _17.B);
+    float3x3 tmp1 = spvFMulMatrixMatrix(_17.B, _17.A);
+    float3x4 tmp2 = spvFMulMatrixMatrix(_17.A, _17.C);
+    float3x4 tmp3 = spvFMulMatrixMatrix(_17.D, _17.A);
+    float4x3 tmp4 = spvFMulMatrixMatrix(_17.B, _17.D);
 }
 

--- a/reference/shaders-msl/vert/float-math.invariant-float-math.vert
+++ b/reference/shaders-msl/vert/float-math.invariant-float-math.vert
@@ -80,13 +80,14 @@ template<typename T, int Cols, int Rows>
 template<typename T, int LCols, int LRows, int RCols, int RRows>
 [[clang::optnone]] matrix<T, RCols, LRows> spvFMulMatrixMatrix(matrix<T, LCols, LRows> l, matrix<T, RCols, RRows> r)
 {
+    static_assert(LCols == RRows, "column-row configuration mismatch");
     matrix<T, RCols, LRows> res;
     for (uint i = 0; i < RCols; i++)
     {
-        vec<T, RCols> tmp(0);
+        vec<T, LRows> tmp(0);
         for (uint j = 0; j < LCols; j++)
         {
-            tmp = fma(vec<T, RCols>(r[i][j]), l[j], tmp);
+            tmp = fma(vec<T, LRows>(r[i][j]), l[j], tmp);
         }
         res[i] = tmp;
     }

--- a/shaders-msl-no-opt/comp/precise-non-square-matrix.comp
+++ b/shaders-msl-no-opt/comp/precise-non-square-matrix.comp
@@ -1,0 +1,18 @@
+#version 450
+
+layout(binding = 0) buffer SSBO
+{
+	mat3x4 A;
+	mat4x3 B;
+	mat3x3 C;
+	mat4 D;
+};
+
+void main()
+{
+	precise mat4 tmp0 = A * B;
+	precise mat3 tmp1 = B * A;
+	precise mat3x4 tmp2 = A * C;
+	precise mat3x4 tmp3 = D * A;
+	precise mat4x3 tmp4 = B * D;
+}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -6441,6 +6441,7 @@ void CompilerMSL::emit_custom_functions()
 			statement("template<typename T, int LCols, int LRows, int RCols, int RRows>");
 			statement("[[clang::optnone]] matrix<T, RCols, LRows> spvFMulMatrixMatrix(matrix<T, LCols, LRows> l, matrix<T, RCols, RRows> r)");
 			begin_scope();
+			statement("static_assert(LCols == RRows, \"column-row configuration mismatch\");");
 			statement("matrix<T, RCols, LRows> res;");
 			statement("for (uint i = 0; i < RCols; i++)");
 			begin_scope();

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -6444,10 +6444,10 @@ void CompilerMSL::emit_custom_functions()
 			statement("matrix<T, RCols, LRows> res;");
 			statement("for (uint i = 0; i < RCols; i++)");
 			begin_scope();
-			statement("vec<T, RCols> tmp(0);");
+			statement("vec<T, LRows> tmp(0);");
 			statement("for (uint j = 0; j < LCols; j++)");
 			begin_scope();
-			statement("tmp = fma(vec<T, RCols>(r[i][j]), l[j], tmp);");
+			statement("tmp = fma(vec<T, LRows>(r[i][j]), l[j], tmp);");
 			end_scope();
 			statement("res[i] = tmp;");
 			end_scope();


### PR DESCRIPTION
The accumulator and fma splat vector used `vec<T, RCols>` (right matrix column count) instead of `vec<T, LRows>` (left matrix row count). These are equal for **square matrices**, masking the bug, but differ for **rectangular multiplications** like `float4x3 * float4x4` - generating `fma(float4, float3, float4)` which fails to compile on Metal.