### PR TITLE
HLSL: Don't declare undef block types.

### DIFF
--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1610,7 +1610,9 @@ void CompilerHLSL::emit_specialization_constants_and_structs()
 			auto &undef = id.get<SPIRUndef>();
 			auto &type = this->get<SPIRType>(undef.basetype);
 			// OpUndef can be void for some reason ...
-			if (type.basetype == SPIRType::Void)
+			// Apparently also block types, but we don't declare those as normal types,
+			// so skip those. It's only used in some esoteric debug instructions in DXC.
+			if (type.basetype == SPIRType::Void || type_is_top_level_block(type))
 				return;
 
 			string initializer;


### PR DESCRIPTION
Other backends deal with this in other ways.

Fix #2653.