### PR TITLE
feat(msl): add depth clip enable emulation

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -678,6 +678,7 @@ struct CLIArguments
 	bool msl_check_discarded_frag_stores = false;
 	bool msl_force_fragment_with_side_effects_execution = false;
 	bool msl_emulate_reversed_depth_viewport = false;
+	bool msl_emulate_depth_clip_enable = false;
 	bool msl_sample_dref_lod_array_as_grad = false;
 	bool msl_runtime_array_rich_descriptor = false;
 	bool msl_replace_recursive_inputs = false;
@@ -983,6 +984,7 @@ static void print_help_msl()
 	                "\t\tHowever, Vulkan expects fragment shader to be executed since it cannot be discarded until the discard\n"
 	                "\t\tpresent in the fragment execution, which would also execute the operations with side effects.\n"
 	                "\t[--msl-emulate-reversed-depth-viewport]:\n\t\tEmulate reversed-depth viewports by inverting clip-space Z.\n"
+	                "\t[--msl-emulate-depth-clip-enable]:\n\t\tEmulate Vulkan depth clip and clamp combinations unsupported by Metal.\n"
 	                "\t[--msl-sample-dref-lod-array-as-grad]:\n\t\tUse a gradient instead of a level argument.\n"
 	                "\t\tSome Metal devices have a bug where the level() argument to\n"
 	                "\t\tdepth2d_array<T>::sample_compare() in a fragment shader is biased by some\n"
@@ -1301,6 +1303,7 @@ static string compile_iteration(const CLIArguments &args, std::vector<uint32_t> 
 		msl_opts.check_discarded_frag_stores = args.msl_check_discarded_frag_stores;
 		msl_opts.force_fragment_with_side_effects_execution = args.msl_force_fragment_with_side_effects_execution;
 		msl_opts.emulate_reversed_depth_viewport = args.msl_emulate_reversed_depth_viewport;
+		msl_opts.emulate_depth_clip_enable = args.msl_emulate_depth_clip_enable;
 		msl_opts.sample_dref_lod_array_as_grad = args.msl_sample_dref_lod_array_as_grad;
 		msl_opts.ios_support_base_vertex_instance = true;
 		msl_opts.runtime_array_rich_descriptor = args.msl_runtime_array_rich_descriptor;
@@ -1905,6 +1908,7 @@ static int main_inner(int argc, char *argv[])
 	cbs.add("--msl-check-discarded-frag-stores", [&args](CLIParser &) { args.msl_check_discarded_frag_stores = true; });
 	cbs.add("--msl-force-frag-with-side-effects-execution", [&args](CLIParser &) { args.msl_force_fragment_with_side_effects_execution = true; });
 	cbs.add("--msl-emulate-reversed-depth-viewport", [&args](CLIParser &) { args.msl_emulate_reversed_depth_viewport = true; });
+	cbs.add("--msl-emulate-depth-clip-enable", [&args](CLIParser &) { args.msl_emulate_depth_clip_enable = true; });
 	cbs.add("--msl-sample-dref-lod-array-as-grad",
 	        [&args](CLIParser &) { args.msl_sample_dref_lod_array_as_grad = true; });
 	cbs.add("--msl-no-readwrite-texture-fences", [&args](CLIParser &) { args.msl_readwrite_texture_fences = false; });

--- a/reference/shaders-msl-no-opt/frag/depth-clip-enable-early-fragment-tests.emulate-depth-clip-enable.msl2.frag
+++ b/reference/shaders-msl-no-opt/frag/depth-clip-enable-early-fragment-tests.emulate-depth-clip-enable.msl2.frag
@@ -1,0 +1,19 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 color [[color(0)]];
+};
+
+[[ early_fragment_tests ]] fragment main0_out main0()
+{
+    float gl_FragDepth;
+    main0_out out = {};
+    out.color = float4(1.0);
+    gl_FragDepth = 1.25;
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/frag/depth-clip-enable-fallback.emulate-depth-clip-enable.frag
+++ b/reference/shaders-msl-no-opt/frag/depth-clip-enable-fallback.emulate-depth-clip-enable.frag
@@ -1,0 +1,31 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct spvDepthClipState
+{
+    uint emulateViewportZ;
+    uint emulateDepthClamp;
+    float2 viewportDepthRanges[16];
+};
+
+struct main0_out
+{
+    float4 color [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
+
+fragment main0_out main0(constant spvDepthClipState& spvDepthClipState [[buffer(17)]])
+{
+    main0_out out = {};
+    out.color = float4(1.0);
+    out.gl_FragDepth = 1.25;
+    if (spvDepthClipState.emulateDepthClamp != 0u)
+    {
+        float2 spvViewportDepthRange = spvDepthClipState.viewportDepthRanges[0];
+        out.gl_FragDepth = clamp(out.gl_FragDepth, spvViewportDepthRange.x, spvViewportDepthRange.y);
+    }
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/frag/depth-clip-enable-no-depth-write.emulate-depth-clip-enable.msl2.frag
+++ b/reference/shaders-msl-no-opt/frag/depth-clip-enable-no-depth-write.emulate-depth-clip-enable.msl2.frag
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct main0_out
+{
+    float4 color [[color(0)]];
+};
+
+fragment main0_out main0()
+{
+    main0_out out = {};
+    out.color = float4(1.0);
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/frag/depth-clip-enable-viewport-index.emulate-depth-clip-enable.msl2.frag
+++ b/reference/shaders-msl-no-opt/frag/depth-clip-enable-viewport-index.emulate-depth-clip-enable.msl2.frag
@@ -1,0 +1,31 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct spvDepthClipState
+{
+    uint emulateViewportZ;
+    uint emulateDepthClamp;
+    float2 viewportDepthRanges[16];
+};
+
+struct main0_out
+{
+    float4 color [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
+
+fragment main0_out main0(uint gl_ViewportIndex [[viewport_array_index]], constant spvDepthClipState& spvDepthClipState [[buffer(17)]])
+{
+    main0_out out = {};
+    out.color = float4(float(int(gl_ViewportIndex)));
+    out.gl_FragDepth = 1.25;
+    if (spvDepthClipState.emulateDepthClamp != 0u)
+    {
+        float2 spvViewportDepthRange = spvDepthClipState.viewportDepthRanges[gl_ViewportIndex];
+        out.gl_FragDepth = clamp(out.gl_FragDepth, spvViewportDepthRange.x, spvViewportDepthRange.y);
+    }
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/frag/depth-clip-enable.emulate-depth-clip-enable.msl2.frag
+++ b/reference/shaders-msl-no-opt/frag/depth-clip-enable.emulate-depth-clip-enable.msl2.frag
@@ -1,0 +1,31 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct spvDepthClipState
+{
+    uint emulateViewportZ;
+    uint emulateDepthClamp;
+    float2 viewportDepthRanges[16];
+};
+
+struct main0_out
+{
+    float4 color [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
+
+fragment main0_out main0(uint spvDepthClipViewportIndex [[viewport_array_index]], constant spvDepthClipState& spvDepthClipState [[buffer(17)]])
+{
+    main0_out out = {};
+    out.color = float4(1.0);
+    out.gl_FragDepth = 1.25;
+    if (spvDepthClipState.emulateDepthClamp != 0u)
+    {
+        float2 spvViewportDepthRange = spvDepthClipState.viewportDepthRanges[spvDepthClipViewportIndex];
+        out.gl_FragDepth = clamp(out.gl_FragDepth, spvViewportDepthRange.x, spvViewportDepthRange.y);
+    }
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/tese/depth-clip-enable-viewport-index.emulate-depth-clip-enable.msl2.tese
+++ b/reference/shaders-msl-no-opt/tese/depth-clip-enable-viewport-index.emulate-depth-clip-enable.msl2.tese
@@ -1,0 +1,41 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct spvDepthClipState
+{
+    uint emulateViewportZ;
+    uint emulateDepthClamp;
+    float2 viewportDepthRanges[16];
+};
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+    uint gl_ViewportIndex [[viewport_array_index]];
+};
+
+struct main0_in
+{
+    float4 gl_Position [[attribute(0)]];
+};
+
+struct main0_patchIn
+{
+    patch_control_point<main0_in> gl_in;
+};
+
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], constant spvDepthClipState& spvDepthClipState [[buffer(17)]])
+{
+    main0_out out = {};
+    out.gl_Position = patchIn.gl_in[0].gl_Position;
+    out.gl_ViewportIndex = uint(2);
+    if (spvDepthClipState.emulateViewportZ != 0u)
+    {
+        float2 spvViewportDepthRange = spvDepthClipState.viewportDepthRanges[uint(out.gl_ViewportIndex)];
+        out.gl_Position.z = out.gl_Position.z * (spvViewportDepthRange.y - spvViewportDepthRange.x) + out.gl_Position.w * spvViewportDepthRange.x;    // Emulate viewport Z transform
+    }
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/tese/depth-clip-enable.emulate-depth-clip-enable.tese
+++ b/reference/shaders-msl-no-opt/tese/depth-clip-enable.emulate-depth-clip-enable.tese
@@ -1,0 +1,39 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct spvDepthClipState
+{
+    uint emulateViewportZ;
+    uint emulateDepthClamp;
+    float2 viewportDepthRanges[16];
+};
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 gl_Position [[attribute(0)]];
+};
+
+struct main0_patchIn
+{
+    patch_control_point<main0_in> gl_in;
+};
+
+[[ patch(quad, 0) ]] vertex main0_out main0(main0_patchIn patchIn [[stage_in]], constant spvDepthClipState& spvDepthClipState [[buffer(17)]])
+{
+    main0_out out = {};
+    out.gl_Position = patchIn.gl_in[0].gl_Position;
+    if (spvDepthClipState.emulateViewportZ != 0u)
+    {
+        float2 spvViewportDepthRange = spvDepthClipState.viewportDepthRanges[0];
+        out.gl_Position.z = out.gl_Position.z * (spvViewportDepthRange.y - spvViewportDepthRange.x) + out.gl_Position.w * spvViewportDepthRange.x;    // Emulate viewport Z transform
+    }
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/vert/depth-clip-enable-viewport-index.emulate-depth-clip-enable.msl2.vert
+++ b/reference/shaders-msl-no-opt/vert/depth-clip-enable-viewport-index.emulate-depth-clip-enable.msl2.vert
@@ -1,0 +1,31 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct spvDepthClipState
+{
+    uint emulateViewportZ;
+    uint emulateDepthClamp;
+    float2 viewportDepthRanges[16];
+};
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+    uint gl_ViewportIndex [[viewport_array_index]];
+};
+
+vertex main0_out main0(constant spvDepthClipState& spvDepthClipState [[buffer(17)]])
+{
+    main0_out out = {};
+    out.gl_Position = float4(0.0, 0.0, 0.25, 1.0);
+    out.gl_ViewportIndex = uint(2);
+    if (spvDepthClipState.emulateViewportZ != 0u)
+    {
+        float2 spvViewportDepthRange = spvDepthClipState.viewportDepthRanges[uint(out.gl_ViewportIndex)];
+        out.gl_Position.z = out.gl_Position.z * (spvViewportDepthRange.y - spvViewportDepthRange.x) + out.gl_Position.w * spvViewportDepthRange.x;    // Emulate viewport Z transform
+    }
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/vert/depth-clip-enable.emulate-depth-clip-enable.emulate-reversed-depth-viewport.fixup-clipspace.vert
+++ b/reference/shaders-msl-no-opt/vert/depth-clip-enable.emulate-depth-clip-enable.emulate-reversed-depth-viewport.fixup-clipspace.vert
@@ -1,0 +1,34 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct spvDepthClipState
+{
+    uint emulateViewportZ;
+    uint emulateDepthClamp;
+    float2 viewportDepthRanges[16];
+};
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+vertex main0_out main0(constant spvDepthClipState& spvDepthClipState [[buffer(17)]], constant uint& spvEmulatedReversedDepthViewportMask [[buffer(18)]])
+{
+    main0_out out = {};
+    out.gl_Position = float4(0.0, 0.0, 0.25, 1.0);
+    out.gl_Position.z = (out.gl_Position.z + out.gl_Position.w) * 0.5;       // Adjust clip-space for Metal
+    if (spvDepthClipState.emulateViewportZ != 0u)
+    {
+        float2 spvViewportDepthRange = spvDepthClipState.viewportDepthRanges[0];
+        out.gl_Position.z = out.gl_Position.z * (spvViewportDepthRange.y - spvViewportDepthRange.x) + out.gl_Position.w * spvViewportDepthRange.x;    // Emulate viewport Z transform
+    }
+    if ((spvEmulatedReversedDepthViewportMask & 1u) != 0u)
+    {
+        out.gl_Position.z = out.gl_Position.w - out.gl_Position.z;    // Emulate reversed-depth viewport
+    }
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/vert/depth-clip-enable.emulate-depth-clip-enable.fixup-clipspace.vert
+++ b/reference/shaders-msl-no-opt/vert/depth-clip-enable.emulate-depth-clip-enable.fixup-clipspace.vert
@@ -1,0 +1,30 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct spvDepthClipState
+{
+    uint emulateViewportZ;
+    uint emulateDepthClamp;
+    float2 viewportDepthRanges[16];
+};
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+vertex main0_out main0(constant spvDepthClipState& spvDepthClipState [[buffer(17)]])
+{
+    main0_out out = {};
+    out.gl_Position = float4(0.0, 0.0, 0.25, 1.0);
+    out.gl_Position.z = (out.gl_Position.z + out.gl_Position.w) * 0.5;       // Adjust clip-space for Metal
+    if (spvDepthClipState.emulateViewportZ != 0u)
+    {
+        float2 spvViewportDepthRange = spvDepthClipState.viewportDepthRanges[0];
+        out.gl_Position.z = out.gl_Position.z * (spvViewportDepthRange.y - spvViewportDepthRange.x) + out.gl_Position.w * spvViewportDepthRange.x;    // Emulate viewport Z transform
+    }
+    return out;
+}
+

--- a/reference/shaders-msl-no-opt/vert/depth-clip-enable.emulate-depth-clip-enable.vert
+++ b/reference/shaders-msl-no-opt/vert/depth-clip-enable.emulate-depth-clip-enable.vert
@@ -1,0 +1,29 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct spvDepthClipState
+{
+    uint emulateViewportZ;
+    uint emulateDepthClamp;
+    float2 viewportDepthRanges[16];
+};
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+vertex main0_out main0(constant spvDepthClipState& spvDepthClipState [[buffer(17)]])
+{
+    main0_out out = {};
+    out.gl_Position = float4(0.0, 0.0, 0.25, 1.0);
+    if (spvDepthClipState.emulateViewportZ != 0u)
+    {
+        float2 spvViewportDepthRange = spvDepthClipState.viewportDepthRanges[0];
+        out.gl_Position.z = out.gl_Position.z * (spvViewportDepthRange.y - spvViewportDepthRange.x) + out.gl_Position.w * spvViewportDepthRange.x;    // Emulate viewport Z transform
+    }
+    return out;
+}
+

--- a/shaders-msl-no-opt/frag/depth-clip-enable-early-fragment-tests.emulate-depth-clip-enable.msl2.frag
+++ b/shaders-msl-no-opt/frag/depth-clip-enable-early-fragment-tests.emulate-depth-clip-enable.msl2.frag
@@ -1,0 +1,10 @@
+#version 450
+
+layout(early_fragment_tests) in;
+layout(location = 0) out vec4 color;
+
+void main()
+{
+	color = vec4(1.0);
+	gl_FragDepth = 1.25;
+}

--- a/shaders-msl-no-opt/frag/depth-clip-enable-fallback.emulate-depth-clip-enable.frag
+++ b/shaders-msl-no-opt/frag/depth-clip-enable-fallback.emulate-depth-clip-enable.frag
@@ -1,0 +1,9 @@
+#version 450
+
+layout(location = 0) out vec4 color;
+
+void main()
+{
+	color = vec4(1.0);
+	gl_FragDepth = 1.25;
+}

--- a/shaders-msl-no-opt/frag/depth-clip-enable-no-depth-write.emulate-depth-clip-enable.msl2.frag
+++ b/shaders-msl-no-opt/frag/depth-clip-enable-no-depth-write.emulate-depth-clip-enable.msl2.frag
@@ -1,0 +1,8 @@
+#version 450
+
+layout(location = 0) out vec4 color;
+
+void main()
+{
+	color = vec4(1.0);
+}

--- a/shaders-msl-no-opt/frag/depth-clip-enable-viewport-index.emulate-depth-clip-enable.msl2.frag
+++ b/shaders-msl-no-opt/frag/depth-clip-enable-viewport-index.emulate-depth-clip-enable.msl2.frag
@@ -1,0 +1,10 @@
+#version 450
+#extension GL_ARB_shader_viewport_layer_array : require
+
+layout(location = 0) out vec4 color;
+
+void main()
+{
+	color = vec4(gl_ViewportIndex);
+	gl_FragDepth = 1.25;
+}

--- a/shaders-msl-no-opt/frag/depth-clip-enable.emulate-depth-clip-enable.msl2.frag
+++ b/shaders-msl-no-opt/frag/depth-clip-enable.emulate-depth-clip-enable.msl2.frag
@@ -1,0 +1,9 @@
+#version 450
+
+layout(location = 0) out vec4 color;
+
+void main()
+{
+	color = vec4(1.0);
+	gl_FragDepth = 1.25;
+}

--- a/shaders-msl-no-opt/tese/depth-clip-enable-viewport-index.emulate-depth-clip-enable.msl2.tese
+++ b/shaders-msl-no-opt/tese/depth-clip-enable-viewport-index.emulate-depth-clip-enable.msl2.tese
@@ -1,0 +1,9 @@
+#version 450
+#extension GL_ARB_shader_viewport_layer_array : require
+layout(quads) in;
+
+void main()
+{
+	gl_Position = gl_in[0].gl_Position;
+	gl_ViewportIndex = 2;
+}

--- a/shaders-msl-no-opt/tese/depth-clip-enable.emulate-depth-clip-enable.tese
+++ b/shaders-msl-no-opt/tese/depth-clip-enable.emulate-depth-clip-enable.tese
@@ -1,0 +1,7 @@
+#version 450
+layout(quads) in;
+
+void main()
+{
+	gl_Position = gl_in[0].gl_Position;
+}

--- a/shaders-msl-no-opt/vert/depth-clip-enable-viewport-index.emulate-depth-clip-enable.msl2.vert
+++ b/shaders-msl-no-opt/vert/depth-clip-enable-viewport-index.emulate-depth-clip-enable.msl2.vert
@@ -1,0 +1,8 @@
+#version 450
+#extension GL_ARB_shader_viewport_layer_array : require
+
+void main()
+{
+	gl_Position = vec4(0.0, 0.0, 0.25, 1.0);
+	gl_ViewportIndex = 2;
+}

--- a/shaders-msl-no-opt/vert/depth-clip-enable.emulate-depth-clip-enable.emulate-reversed-depth-viewport.fixup-clipspace.vert
+++ b/shaders-msl-no-opt/vert/depth-clip-enable.emulate-depth-clip-enable.emulate-reversed-depth-viewport.fixup-clipspace.vert
@@ -1,0 +1,6 @@
+#version 450
+
+void main()
+{
+	gl_Position = vec4(0.0, 0.0, 0.25, 1.0);
+}

--- a/shaders-msl-no-opt/vert/depth-clip-enable.emulate-depth-clip-enable.fixup-clipspace.vert
+++ b/shaders-msl-no-opt/vert/depth-clip-enable.emulate-depth-clip-enable.fixup-clipspace.vert
@@ -1,0 +1,6 @@
+#version 450
+
+void main()
+{
+	gl_Position = vec4(0.0, 0.0, 0.25, 1.0);
+}

--- a/shaders-msl-no-opt/vert/depth-clip-enable.emulate-depth-clip-enable.vert
+++ b/shaders-msl-no-opt/vert/depth-clip-enable.emulate-depth-clip-enable.vert
@@ -1,0 +1,6 @@
+#version 450
+
+void main()
+{
+	gl_Position = vec4(0.0, 0.0, 0.25, 1.0);
+}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1793,6 +1793,7 @@ string CompilerMSL::compile()
 	// Do output first to ensure out. is declared at top of entry function.
 	qual_pos_var_name = "";
 	qual_viewport_idx_var_name = "";
+	qual_frag_depth_var_name = "";
 	if (is_mesh_shader())
 	{
 		fixup_implicit_builtin_block_names(get_execution_model());
@@ -2989,6 +2990,8 @@ void CompilerMSL::add_plain_variable_to_interface_block(StorageClass storage, co
 			qual_pos_var_name = qual_var_name;
 		if (builtin == BuiltInViewportIndex && storage == StorageClassOutput)
 			qual_viewport_idx_var_name = qual_var_name;
+		if (builtin == BuiltInFragDepth && storage == StorageClassOutput)
+			qual_frag_depth_var_name = qual_var_name;
 	}
 
 	// Copy interpolation decorations if needed
@@ -3619,6 +3622,8 @@ void CompilerMSL::add_plain_member_variable_to_interface_block(StorageClass stor
 			qual_pos_var_name = qual_var_name;
 		if (builtin == BuiltInViewportIndex && storage == StorageClassOutput)
 			qual_viewport_idx_var_name = qual_var_name;
+		if (builtin == BuiltInFragDepth && storage == StorageClassOutput)
+			qual_frag_depth_var_name = qual_var_name;
 	}
 
 	const SPIRConstant *c = nullptr;
@@ -8441,6 +8446,17 @@ void CompilerMSL::emit_resources()
 // Emit declarations for the specialization Metal function constants
 void CompilerMSL::emit_specialization_constants_and_structs()
 {
+	if (needs_depth_clip_state_buffer())
+	{
+		statement("struct spvDepthClipState");
+		begin_scope();
+		statement("uint emulateViewportZ;");
+		statement("uint emulateDepthClamp;");
+		statement("float2 viewportDepthRanges[16];");
+		end_scope_decl();
+		statement("");
+	}
+
 	SpecializationConstant wg_x, wg_y, wg_z;
 	ID workgroup_size_id = get_work_group_size_specialization_constants(wg_x, wg_y, wg_z);
 	if (workgroup_size_id == 0 && is_mesh_shader())
@@ -13549,6 +13565,23 @@ void CompilerMSL::emit_fixup()
 
 		if (is_vertex_like_shader() && !qual_pos_var_name.empty())
 		{
+			if (options.vertex.fixup_clipspace)
+				statement(qual_pos_var_name, ".z = (", qual_pos_var_name, ".z + ", qual_pos_var_name,
+				          ".w) * 0.5;       // Adjust clip-space for Metal");
+
+			if (msl_options.emulate_depth_clip_enable)
+			{
+				string viewport_idx =
+				    qual_viewport_idx_var_name.empty() ? "0" : join("uint(", qual_viewport_idx_var_name, ")");
+				statement("if (spvDepthClipState.emulateViewportZ != 0u)");
+				begin_scope();
+				statement("float2 spvViewportDepthRange = spvDepthClipState.viewportDepthRanges[", viewport_idx, "];");
+				statement(qual_pos_var_name, ".z = ", qual_pos_var_name,
+				          ".z * (spvViewportDepthRange.y - spvViewportDepthRange.x) + ", qual_pos_var_name,
+				          ".w * spvViewportDepthRange.x;    // Emulate viewport Z transform");
+				end_scope();
+			}
+
 			if (msl_options.emulate_reversed_depth_viewport)
 			{
 				if (qual_viewport_idx_var_name.empty())
@@ -13563,12 +13596,19 @@ void CompilerMSL::emit_fixup()
 				end_scope();
 			}
 
-			if (options.vertex.fixup_clipspace)
-				statement(qual_pos_var_name, ".z = (", qual_pos_var_name, ".z + ", qual_pos_var_name,
-						  ".w) * 0.5;       // Adjust clip-space for Metal");
-
 			if (options.vertex.flip_vert_y)
 				statement(qual_pos_var_name, ".y = -(", qual_pos_var_name, ".y);", "    // Invert Y-axis for Metal");
+		}
+		else if (get_execution_model() == ExecutionModelFragment && !qual_frag_depth_var_name.empty() &&
+		         msl_options.emulate_depth_clip_enable)
+		{
+			string viewport_idx = depth_clip_viewport_idx_var_name.empty() ? "0" : depth_clip_viewport_idx_var_name;
+			statement("if (spvDepthClipState.emulateDepthClamp != 0u)");
+			begin_scope();
+			statement("float2 spvViewportDepthRange = spvDepthClipState.viewportDepthRanges[", viewport_idx, "];");
+			statement(qual_frag_depth_var_name, " = clamp(", qual_frag_depth_var_name,
+			          ", spvViewportDepthRange.x, spvViewportDepthRange.y);");
+			end_scope();
 		}
 	}
 }
@@ -14727,6 +14767,8 @@ bool CompilerMSL::is_intersection_query() const
 
 void CompilerMSL::entry_point_args_builtin(string &ep_args)
 {
+	depth_clip_viewport_idx_var_name = "";
+
 	// Builtin variables
 	SmallVector<pair<SPIRVariable *, BuiltIn>, 8> active_builtins;
 	ir.for_each_typed_id<SPIRVariable>([&](uint32_t var_id, SPIRVariable &var) {
@@ -14751,6 +14793,9 @@ void CompilerMSL::entry_point_args_builtin(string &ep_args)
 
 			if (is_direct_input_builtin(bi_type))
 			{
+				if (bi_type == BuiltInViewportIndex)
+					depth_clip_viewport_idx_var_name = to_expression(var_id);
+
 				if (!ep_args.empty())
 					ep_args += ", ";
 
@@ -14814,6 +14859,23 @@ void CompilerMSL::entry_point_args_builtin(string &ep_args)
 
 	if (needs_base_instance_arg == TriState::Yes)
 		ep_args += built_in_func_arg(BuiltInBaseInstance, !ep_args.empty());
+
+	if (needs_depth_clip_state_buffer())
+	{
+		if (get_execution_model() == ExecutionModelFragment && msl_options.supports_msl_version(2, 0) &&
+		    depth_clip_viewport_idx_var_name.empty())
+		{
+			if (!ep_args.empty())
+				ep_args += ", ";
+			depth_clip_viewport_idx_var_name = "spvDepthClipViewportIndex";
+			ep_args += "uint spvDepthClipViewportIndex [[viewport_array_index]]";
+		}
+
+		if (!ep_args.empty())
+			ep_args += ", ";
+		ep_args += join("constant spvDepthClipState& spvDepthClipState [[buffer(",
+		                msl_options.depth_clip_state_buffer_index, ")]]");
+	}
 
 	if (msl_options.emulate_reversed_depth_viewport && stage_out_var_id && !capture_output_to_buffer &&
 	    is_vertex_like_shader() && !qual_pos_var_name.empty())

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -319,6 +319,7 @@ public:
 		uint32_t shader_patch_input_buffer_index = 20;
         uint32_t draw_id_buffer_index = 19;
 		uint32_t reversed_depth_viewport_buffer_index = 18;
+		uint32_t depth_clip_state_buffer_index = 17;
 		uint32_t shader_input_wg_index = 0;
 		uint32_t device_index = 0;
 		uint32_t enable_frag_output_mask = 0xffffffff;
@@ -341,6 +342,7 @@ public:
 		bool dispatch_base = false;
 		bool texture_1D_as_2D = false;
 		bool emulate_reversed_depth_viewport = false;
+		bool emulate_depth_clip_enable = false;
 
 		// Enable use of Metal argument buffers.
 		// MSL 2.0 must also be enabled.
@@ -632,6 +634,17 @@ public:
 	bool needs_view_mask_buffer() const
 	{
 		return msl_options.multiview && !msl_options.view_index_from_device_index;
+	}
+
+	// Provide feedback to calling API to allow it to pass depth clip
+	// emulation state.
+	bool needs_depth_clip_state_buffer() const
+	{
+		if (!msl_options.emulate_depth_clip_enable || !stage_out_var_id || capture_output_to_buffer)
+			return false;
+
+		return (is_vertex_like_shader() && !qual_pos_var_name.empty()) ||
+		       (get_execution_model() == ExecutionModelFragment && !qual_frag_depth_var_name.empty());
 	}
 
 	// Provide feedback to calling API to allow it to pass a buffer
@@ -1299,6 +1312,8 @@ protected:
 	bool writes_to_point_size = false;
 	std::string qual_pos_var_name;
 	std::string qual_viewport_idx_var_name;
+	std::string qual_frag_depth_var_name;
+	std::string depth_clip_viewport_idx_var_name;
 	std::string stage_in_var_name = "in";
 	std::string stage_out_var_name = "out";
 	std::string patch_stage_in_var_name = "patchIn";

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -381,6 +381,10 @@ def cross_compile_msl(shader, spirv, opt, iterations, paths):
         msl_args.append('--msl-force-frag-with-side-effects-execution')
     if '.emulate-reversed-depth-viewport.' in shader:
         msl_args.append('--msl-emulate-reversed-depth-viewport')
+    if '.emulate-depth-clip-enable.' in shader:
+        msl_args.append('--msl-emulate-depth-clip-enable')
+    if '.fixup-clipspace.' in shader:
+        msl_args.append('--fixup-clipspace')
     if '.lod-as-grad.' in shader:
         msl_args.append('--msl-sample-dref-lod-array-as-grad')
     if '.agx-cube-grad.' in shader:


### PR DESCRIPTION
Adds opt-in MSL support for Vulkan depth clip and clamp combinations that Metal cannot represent natively.

When enabled, SPIRV-Cross can:

- transform vertex or tessellation depth when clipping and clamping are both disabled;
- clamp fragment depth when clipping and clamping are both enabled;
- select per-viewport depth ranges through `ViewportIndex`;
- provide runtime state so dynamic changes do not require shader recompilation;
- preserve correct ordering with clip-space fixup, reversed viewports, and Metal OpenGL mode.

The depth-clip state buffer is emitted only when the shader stage needs. Existing output is unchanged.

This PR takes heavy inspiration from Mesa's KosmicKrisp implementation.

## Testing

- Warnings-as-errors and miscellaneous-warnings build: pass
- Shared build, install, and CTest: 23/23 pass
- MSL regression suite: 319/319 references match
- Apple Metal compilation: 286/286 eligible shaders compile
- New depth-clip fixtures: 12/12 match and compile

Not an expert so all advice/requested changes is appreciated!