### PR TITLE
HLSL: Fix HLSL tests (FXC isn't running in CI anymore).

### DIFF
--- a/reference/opt/shaders-hlsl/asm/comp/replicated-composites.spv16.vk.asm.comp
+++ b/reference/opt/shaders-hlsl/asm/comp/replicated-composites.spv16.vk.asm.comp
@@ -2,7 +2,7 @@
 #define SPIRV_CROSS_CONSTANT_ID_0 0.0f
 #endif
 static const float spec_const = SPIRV_CROSS_CONSTANT_ID_0;
-static const float4 _20 = float4(spec_const);
+static const float4 _20 = (float4)spec_const;
 static float _42;
 
 static const float _26[8] = { 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f };
@@ -15,10 +15,10 @@ cbuffer UBO : register(b0)
 
 void comp_main()
 {
-    float4 a = float4(0.0f);
-    float4x4 b = float4x4(float4(1.0f), float4(1.0f), float4(1.0f), float4(1.0f));
+    float4 a = (float4)0.0f;
+    float4x4 b = float4x4((float4)1.0f, (float4)1.0f, (float4)1.0f, (float4)1.0f);
     float4 c = _20;
-    float4 _36 = float4(ubo_uniform_float);
+    float4 _36 = (float4)ubo_uniform_float;
     float4 d = _36;
     float4x4 e = float4x4(_36, _36, _36, _36);
 }

--- a/reference/opt/shaders-hlsl/comp/ssbo-store-array.comp
+++ b/reference/opt/shaders-hlsl/comp/ssbo-store-array.comp
@@ -1,5 +1,15 @@
+struct Data
+{
+    uint arr[3];
+};
+
+RWByteAddressBuffer _21 : register(u0);
+
 void comp_main()
 {
+    _21.Store(0, 1u);
+    _21.Store(4, 2u);
+    _21.Store(8, 3u);
 }
 
 [numthreads(1, 1, 1)]

--- a/reference/shaders-hlsl/asm/comp/replicated-composites.spv16.vk.asm.comp
+++ b/reference/shaders-hlsl/asm/comp/replicated-composites.spv16.vk.asm.comp
@@ -2,7 +2,7 @@
 #define SPIRV_CROSS_CONSTANT_ID_0 0.0f
 #endif
 static const float spec_const = SPIRV_CROSS_CONSTANT_ID_0;
-static const float4 _20 = float4(spec_const);
+static const float4 _20 = (float4)spec_const;
 
 static const float _26[8] = { 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f };
 
@@ -14,10 +14,10 @@ cbuffer UBO : register(b0)
 
 void comp_main()
 {
-    float4 a = float4(0.0f);
-    float4x4 b = float4x4(float4(1.0f), float4(1.0f), float4(1.0f), float4(1.0f));
+    float4 a = (float4)0.0f;
+    float4x4 b = float4x4((float4)1.0f, (float4)1.0f, (float4)1.0f, (float4)1.0f);
     float4 c = _20;
-    float4 d = float4(ubo_uniform_float);
+    float4 d = (float4)ubo_uniform_float;
     float4x4 e = float4x4(d, d, d, d);
     float f[8] = {ubo_uniform_float, ubo_uniform_float, ubo_uniform_float, ubo_uniform_float, ubo_uniform_float, ubo_uniform_float, ubo_uniform_float, ubo_uniform_float};
 }

--- a/reference/shaders-hlsl/comp/ssbo-store-array.comp
+++ b/reference/shaders-hlsl/comp/ssbo-store-array.comp
@@ -3,14 +3,17 @@ struct Data
     uint arr[3];
 };
 
-RWByteAddressBuffer _13 : register(u0);
+static const uint _14[3] = { 1u, 2u, 3u };
+static const Data _15 = { { 1u, 2u, 3u } };
+
+RWByteAddressBuffer _21 : register(u0);
 
 void comp_main()
 {
-    Data d1;
-    _13.Store(0, d1.arr[0]);
-    _13.Store(4, d1.arr[1]);
-    _13.Store(8, d1.arr[2]);
+    Data d1 = _15;
+    _21.Store(0, d1.arr[0]);
+    _21.Store(4, d1.arr[1]);
+    _21.Store(8, d1.arr[2]);
 }
 
 [numthreads(1, 1, 1)]

--- a/shaders-hlsl/comp/ssbo-store-array.comp
+++ b/shaders-hlsl/comp/ssbo-store-array.comp
@@ -12,7 +12,7 @@ layout(set = 0, binding = 0, std430) buffer B0
 
 void main()
 {
-    Data d1;
+    Data d1 = Data( uint[3](1, 2, 3) );
     d[0].arr = d1.arr;
 }
 

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -16636,12 +16636,11 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		else
 		{
 			// HLSL needs to emit scalar-to-vector constructors as C-style type casts, e.g. `(float4)1.0` vs. `vec4(1.0)`.
-			const std::string ops_expr = to_expression(ops[2]);
 			if (!backend.use_constructor_splatting &&
 				type.vecsize > 1 && type.columns == 1 && is_scalar(get<SPIRType>(expression_type_id(ops[2]))))
-				rhs = join("(", type_to_glsl(type), ")", ops_expr);
+				rhs = join("(", type_to_glsl(type), ")", to_enclosed_expression(ops[2]));
 			else
-				rhs = join(type_to_glsl(type), "(", ops_expr, ")");
+				rhs = join(type_to_glsl(type), "(", to_expression(ops[2]), ")");
 		}
 		emit_op(result_type, id, rhs, true);
 		break;

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -6391,7 +6391,13 @@ string CompilerGLSL::constant_expression(const SPIRConstant &c,
 		}
 		else
 		{
-			return join(type_to_glsl(type), "(", to_expression(c.subconstants[0]), ")");
+			// HLSL needs to emit scalar-to-vector constructors as C-style type casts, e.g. `(float4)1.0` vs. `vec4(1.0)`.
+			std::string subconst_expr = to_expression(c.subconstants[0]);
+			if (!backend.use_constructor_splatting &&
+				type.vecsize > 1 && type.columns == 1 && is_scalar(get<SPIRType>(expression_type_id(c.subconstants[0]))))
+				return join("(", type_to_glsl(type), ")", subconst_expr);
+			else
+				return join(type_to_glsl(type), "(", subconst_expr, ")");
 		}
 	}
 	else if (!c.subconstants.empty())
@@ -16629,7 +16635,13 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		}
 		else
 		{
-			rhs = join(type_to_glsl(type), "(", to_expression(ops[2]), ")");
+			// HLSL needs to emit scalar-to-vector constructors as C-style type casts, e.g. `(float4)1.0` vs. `vec4(1.0)`.
+			const std::string ops_expr = to_expression(ops[2]);
+			if (!backend.use_constructor_splatting &&
+				type.vecsize > 1 && type.columns == 1 && is_scalar(get<SPIRType>(expression_type_id(ops[2]))))
+				rhs = join("(", type_to_glsl(type), ")", ops_expr);
+			else
+				rhs = join(type_to_glsl(type), "(", ops_expr, ")");
 		}
 		emit_op(result_type, id, rhs, true);
 		break;

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -10070,7 +10070,7 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 		case Dim1D:
 			if (!msl_options.texture_1D_as_2D)
 				SPIRV_CROSS_THROW("ImageQueryLod is not supported on 1D textures.");
-			[[fallthrough]];
+			/* fallthrough */
 		case Dim2D:
 			if (coord_type.vecsize > 2)
 				coord_expr = enclose_expression(coord_expr) + ".xy";

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -485,12 +485,16 @@ def validate_shader_hlsl(shader, force_no_external_validation, paths):
     if test_glslang:
         subprocess.check_call(hlsl_args)
 
+    # FXC cannot compile shaders above shader model 5
+    shader_model = shader_model_hlsl(shader)
+    is_valid_fxc_shader_model = shader_model and len(shader_model) >= 3 and int(shader_model[-3]) <= 5
+
     is_no_fxc = '.nofxc.' in shader
     global ignore_fxc
-    if (not ignore_fxc) and (not force_no_external_validation) and (not is_no_fxc):
+    if (not ignore_fxc) and (not force_no_external_validation) and (not is_no_fxc) and is_valid_fxc_shader_model:
         try:
             win_path = shader_to_win_path(shader)
-            args = ['fxc', '-nologo', shader_model_hlsl(shader), win_path]
+            args = ['fxc', '-nologo', shader_model, win_path]
             if '.nonuniformresource.' in shader:
                 args.append('/enable_unbounded_descriptor_tables')
             subprocess.check_call(args)


### PR DESCRIPTION
This PR fixes the HLSL tests on Windows. I noticed that the CI runs ignore FXC (not sure since when): https://github.com/KhronosGroup/SPIRV-Cross/actions/runs/33520477162/job/99898143627#step:10:6824

- Update HLSL references for 'replicated-composites.spv16.vk.asm.comp'; Their scalar-to-vector constructors are not supported by FXC nor DXC, it needs to be a type cast, e.g. `(float4)(0.0f)` instead of `float4(0.0f)`.
- Don't run FXC in test_shaders.py script for shader models > 5; Mesh shaders for instance are not supported by FXC.
- Fix ssbo-store-array.comp test shader; `Data d1` variable was read uninitialized and that fails with FXC while glslang seems to ignore it.
- There's one single `[[fallthrough]]` statement in the entire code base; ~Compile it out if target language is not C++17 or newer~ Replace it with `/* fallthrough */` (as the other places do) to fix warning in MSVC17.