### PR TITLE
GLSL: Fix row_major matrix order for push_constant to struct translation

### DIFF
--- a/reference/opt/shaders/asm/vert/push-constant-row-major-matrix.asm.vk.vert
+++ b/reference/opt/shaders/asm/vert/push-constant-row-major-matrix.asm.vk.vert
@@ -1,0 +1,16 @@
+#version 450
+
+struct type_PushConstant_Matrix
+{
+    mat4 transform;
+};
+
+uniform type_PushConstant_Matrix matrix_constants;
+
+layout(location = 0) in vec4 in_var_POSITION;
+
+void main()
+{
+    gl_Position = matrix_constants.transform * in_var_POSITION;
+}
+

--- a/reference/opt/shaders/asm/vert/push-constant-row-major-matrix.asm.vk.vert.vk
+++ b/reference/opt/shaders/asm/vert/push-constant-row-major-matrix.asm.vk.vert.vk
@@ -1,0 +1,14 @@
+#version 450
+
+layout(push_constant, std430) uniform type_PushConstant_Matrix
+{
+    layout(row_major) mat4 transform;
+} matrix_constants;
+
+layout(location = 0) in vec4 in_var_POSITION;
+
+void main()
+{
+    gl_Position = in_var_POSITION * matrix_constants.transform;
+}
+

--- a/reference/shaders-hlsl-no-opt/asm/vert/push-constant-row-major-matrix.asm.vk.vert
+++ b/reference/shaders-hlsl-no-opt/asm/vert/push-constant-row-major-matrix.asm.vk.vert
@@ -1,0 +1,32 @@
+cbuffer type_PushConstant_Matrix
+{
+    column_major float4x4 matrix_constants_transform : packoffset(c0);
+};
+
+
+static float4 gl_Position;
+static float4 in_var_POSITION;
+
+struct SPIRV_Cross_Input
+{
+    float4 in_var_POSITION : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 gl_Position : SV_Position;
+};
+
+void vert_main()
+{
+    gl_Position = mul(matrix_constants_transform, in_var_POSITION);
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    in_var_POSITION = stage_input.in_var_POSITION;
+    vert_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    return stage_output;
+}

--- a/reference/shaders-hlsl-no-opt/asm/vert/push-constant-row-major-matrix.sm30.asm.vk.vert
+++ b/reference/shaders-hlsl-no-opt/asm/vert/push-constant-row-major-matrix.sm30.asm.vk.vert
@@ -1,0 +1,35 @@
+cbuffer type_PushConstant_Matrix
+{
+    column_major float4x4 matrix_constants_transform : packoffset(c0);
+};
+
+uniform float4 gl_HalfPixel;
+
+static float4 gl_Position;
+static float4 in_var_POSITION;
+
+struct SPIRV_Cross_Input
+{
+    float4 in_var_POSITION : TEXCOORD0;
+};
+
+struct SPIRV_Cross_Output
+{
+    float4 gl_Position : POSITION;
+};
+
+void vert_main()
+{
+    gl_Position = mul(matrix_constants_transform, in_var_POSITION);
+    gl_Position.x = gl_Position.x - gl_HalfPixel.x * gl_Position.w;
+    gl_Position.y = gl_Position.y + gl_HalfPixel.y * gl_Position.w;
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+    in_var_POSITION = stage_input.in_var_POSITION;
+    vert_main();
+    SPIRV_Cross_Output stage_output;
+    stage_output.gl_Position = gl_Position;
+    return stage_output;
+}

--- a/reference/shaders-msl-no-opt/asm/vert/push-constant-row-major-matrix.asm.vk.vert
+++ b/reference/shaders-msl-no-opt/asm/vert/push-constant-row-major-matrix.asm.vk.vert
@@ -1,0 +1,27 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct type_PushConstant_Matrix
+{
+    float4x4 transform;
+};
+
+struct main0_out
+{
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float4 in_var_POSITION [[attribute(0)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant type_PushConstant_Matrix& matrix_constants [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = matrix_constants.transform * in.in_var_POSITION;
+    return out;
+}
+

--- a/reference/shaders/asm/vert/push-constant-row-major-matrix.asm.vk.vert
+++ b/reference/shaders/asm/vert/push-constant-row-major-matrix.asm.vk.vert
@@ -1,0 +1,16 @@
+#version 450
+
+struct type_PushConstant_Matrix
+{
+    mat4 transform;
+};
+
+uniform type_PushConstant_Matrix matrix_constants;
+
+layout(location = 0) in vec4 in_var_POSITION;
+
+void main()
+{
+    gl_Position = matrix_constants.transform * in_var_POSITION;
+}
+

--- a/reference/shaders/asm/vert/push-constant-row-major-matrix.asm.vk.vert.vk
+++ b/reference/shaders/asm/vert/push-constant-row-major-matrix.asm.vk.vert.vk
@@ -1,0 +1,14 @@
+#version 450
+
+layout(push_constant, std430) uniform type_PushConstant_Matrix
+{
+    layout(row_major) mat4 transform;
+} matrix_constants;
+
+layout(location = 0) in vec4 in_var_POSITION;
+
+void main()
+{
+    gl_Position = in_var_POSITION * matrix_constants.transform;
+}
+

--- a/shaders-hlsl-no-opt/asm/vert/push-constant-row-major-matrix.asm.vk.vert
+++ b/shaders-hlsl-no-opt/asm/vert/push-constant-row-major-matrix.asm.vk.vert
@@ -1,0 +1,66 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google spiregg; 0
+; Bound: 23
+; Schema: 0
+               OpCapability Shader
+               OpExtension "SPV_GOOGLE_hlsl_functionality1"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main" %in_var_POSITION %gl_Position
+          %4 = OpString ".\\push-constant-row-major-matrix.hlsl"
+               OpSource HLSL 600 %4 "
+struct Matrix {
+    float4x4 transform;
+};
+
+[[vk::push_constant]] Matrix matrix_constants;
+
+float4 main(float4 in_position : POSITION) : SV_Position {
+    return mul(matrix_constants.transform, in_position);
+}
+"
+               OpName %type_PushConstant_Matrix "type.PushConstant.Matrix"
+               OpMemberName %type_PushConstant_Matrix 0 "transform"
+               OpName %matrix_constants "matrix_constants"
+               OpName %in_var_POSITION "in.var.POSITION"
+               OpName %main "main"
+               OpDecorateString %in_var_POSITION UserSemantic "POSITION"
+               OpDecorate %gl_Position BuiltIn Position
+               OpDecorateString %gl_Position UserSemantic "SV_Position"
+               OpDecorate %in_var_POSITION Location 0
+               OpMemberDecorate %type_PushConstant_Matrix 0 Offset 0
+               OpMemberDecorate %type_PushConstant_Matrix 0 MatrixStride 16
+               OpMemberDecorate %type_PushConstant_Matrix 0 RowMajor
+               OpDecorate %type_PushConstant_Matrix Block
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%mat4v4float = OpTypeMatrix %v4float 4
+%type_PushConstant_Matrix = OpTypeStruct %mat4v4float
+%_ptr_PushConstant_type_PushConstant_Matrix = OpTypePointer PushConstant %type_PushConstant_Matrix
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+       %void = OpTypeVoid
+         %16 = OpTypeFunction %void
+%_ptr_PushConstant_mat4v4float = OpTypePointer PushConstant %mat4v4float
+%matrix_constants = OpVariable %_ptr_PushConstant_type_PushConstant_Matrix PushConstant
+%in_var_POSITION = OpVariable %_ptr_Input_v4float Input
+%gl_Position = OpVariable %_ptr_Output_v4float Output
+               OpLine %4 8 1
+       %main = OpFunction %void None %16
+               OpNoLine
+         %18 = OpLabel
+               OpLine %4 8 1
+         %19 = OpLoad %v4float %in_var_POSITION
+               OpLine %4 9 16
+         %20 = OpAccessChain %_ptr_PushConstant_mat4v4float %matrix_constants %int_0
+               OpLine %4 9 33
+         %21 = OpLoad %mat4v4float %20
+               OpLine %4 9 12
+         %22 = OpVectorTimesMatrix %v4float %19 %21
+               OpLine %4 8 1
+               OpStore %gl_Position %22
+               OpLine %4 10 1
+               OpReturn
+               OpFunctionEnd

--- a/shaders-hlsl-no-opt/asm/vert/push-constant-row-major-matrix.sm30.asm.vk.vert
+++ b/shaders-hlsl-no-opt/asm/vert/push-constant-row-major-matrix.sm30.asm.vk.vert
@@ -1,0 +1,66 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google spiregg; 0
+; Bound: 23
+; Schema: 0
+               OpCapability Shader
+               OpExtension "SPV_GOOGLE_hlsl_functionality1"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main" %in_var_POSITION %gl_Position
+          %4 = OpString ".\\push-constant-row-major-matrix.hlsl"
+               OpSource HLSL 600 %4 "
+struct Matrix {
+    float4x4 transform;
+};
+
+[[vk::push_constant]] Matrix matrix_constants;
+
+float4 main(float4 in_position : POSITION) : SV_Position {
+    return mul(matrix_constants.transform, in_position);
+}
+"
+               OpName %type_PushConstant_Matrix "type.PushConstant.Matrix"
+               OpMemberName %type_PushConstant_Matrix 0 "transform"
+               OpName %matrix_constants "matrix_constants"
+               OpName %in_var_POSITION "in.var.POSITION"
+               OpName %main "main"
+               OpDecorateString %in_var_POSITION UserSemantic "POSITION"
+               OpDecorate %gl_Position BuiltIn Position
+               OpDecorateString %gl_Position UserSemantic "SV_Position"
+               OpDecorate %in_var_POSITION Location 0
+               OpMemberDecorate %type_PushConstant_Matrix 0 Offset 0
+               OpMemberDecorate %type_PushConstant_Matrix 0 MatrixStride 16
+               OpMemberDecorate %type_PushConstant_Matrix 0 RowMajor
+               OpDecorate %type_PushConstant_Matrix Block
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%mat4v4float = OpTypeMatrix %v4float 4
+%type_PushConstant_Matrix = OpTypeStruct %mat4v4float
+%_ptr_PushConstant_type_PushConstant_Matrix = OpTypePointer PushConstant %type_PushConstant_Matrix
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+       %void = OpTypeVoid
+         %16 = OpTypeFunction %void
+%_ptr_PushConstant_mat4v4float = OpTypePointer PushConstant %mat4v4float
+%matrix_constants = OpVariable %_ptr_PushConstant_type_PushConstant_Matrix PushConstant
+%in_var_POSITION = OpVariable %_ptr_Input_v4float Input
+%gl_Position = OpVariable %_ptr_Output_v4float Output
+               OpLine %4 8 1
+       %main = OpFunction %void None %16
+               OpNoLine
+         %18 = OpLabel
+               OpLine %4 8 1
+         %19 = OpLoad %v4float %in_var_POSITION
+               OpLine %4 9 16
+         %20 = OpAccessChain %_ptr_PushConstant_mat4v4float %matrix_constants %int_0
+               OpLine %4 9 33
+         %21 = OpLoad %mat4v4float %20
+               OpLine %4 9 12
+         %22 = OpVectorTimesMatrix %v4float %19 %21
+               OpLine %4 8 1
+               OpStore %gl_Position %22
+               OpLine %4 10 1
+               OpReturn
+               OpFunctionEnd

--- a/shaders-msl-no-opt/asm/vert/push-constant-row-major-matrix.asm.vk.vert
+++ b/shaders-msl-no-opt/asm/vert/push-constant-row-major-matrix.asm.vk.vert
@@ -1,0 +1,66 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google spiregg; 0
+; Bound: 23
+; Schema: 0
+               OpCapability Shader
+               OpExtension "SPV_GOOGLE_hlsl_functionality1"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main" %in_var_POSITION %gl_Position
+          %4 = OpString ".\\push-constant-row-major-matrix.hlsl"
+               OpSource HLSL 600 %4 "
+struct Matrix {
+    float4x4 transform;
+};
+
+[[vk::push_constant]] Matrix matrix_constants;
+
+float4 main(float4 in_position : POSITION) : SV_Position {
+    return mul(matrix_constants.transform, in_position);
+}
+"
+               OpName %type_PushConstant_Matrix "type.PushConstant.Matrix"
+               OpMemberName %type_PushConstant_Matrix 0 "transform"
+               OpName %matrix_constants "matrix_constants"
+               OpName %in_var_POSITION "in.var.POSITION"
+               OpName %main "main"
+               OpDecorateString %in_var_POSITION UserSemantic "POSITION"
+               OpDecorate %gl_Position BuiltIn Position
+               OpDecorateString %gl_Position UserSemantic "SV_Position"
+               OpDecorate %in_var_POSITION Location 0
+               OpMemberDecorate %type_PushConstant_Matrix 0 Offset 0
+               OpMemberDecorate %type_PushConstant_Matrix 0 MatrixStride 16
+               OpMemberDecorate %type_PushConstant_Matrix 0 RowMajor
+               OpDecorate %type_PushConstant_Matrix Block
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%mat4v4float = OpTypeMatrix %v4float 4
+%type_PushConstant_Matrix = OpTypeStruct %mat4v4float
+%_ptr_PushConstant_type_PushConstant_Matrix = OpTypePointer PushConstant %type_PushConstant_Matrix
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+       %void = OpTypeVoid
+         %16 = OpTypeFunction %void
+%_ptr_PushConstant_mat4v4float = OpTypePointer PushConstant %mat4v4float
+%matrix_constants = OpVariable %_ptr_PushConstant_type_PushConstant_Matrix PushConstant
+%in_var_POSITION = OpVariable %_ptr_Input_v4float Input
+%gl_Position = OpVariable %_ptr_Output_v4float Output
+               OpLine %4 8 1
+       %main = OpFunction %void None %16
+               OpNoLine
+         %18 = OpLabel
+               OpLine %4 8 1
+         %19 = OpLoad %v4float %in_var_POSITION
+               OpLine %4 9 16
+         %20 = OpAccessChain %_ptr_PushConstant_mat4v4float %matrix_constants %int_0
+               OpLine %4 9 33
+         %21 = OpLoad %mat4v4float %20
+               OpLine %4 9 12
+         %22 = OpVectorTimesMatrix %v4float %19 %21
+               OpLine %4 8 1
+               OpStore %gl_Position %22
+               OpLine %4 10 1
+               OpReturn
+               OpFunctionEnd

--- a/shaders/asm/vert/push-constant-row-major-matrix.asm.vk.vert
+++ b/shaders/asm/vert/push-constant-row-major-matrix.asm.vk.vert
@@ -1,0 +1,66 @@
+; SPIR-V
+; Version: 1.0
+; Generator: Google spiregg; 0
+; Bound: 23
+; Schema: 0
+               OpCapability Shader
+               OpExtension "SPV_GOOGLE_hlsl_functionality1"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main" %in_var_POSITION %gl_Position
+          %4 = OpString ".\\push-constant-row-major-matrix.hlsl"
+               OpSource HLSL 600 %4 "
+struct Matrix {
+    float4x4 transform;
+};
+
+[[vk::push_constant]] Matrix matrix_constants;
+
+float4 main(float4 in_position : POSITION) : SV_Position {
+    return mul(matrix_constants.transform, in_position);
+}
+"
+               OpName %type_PushConstant_Matrix "type.PushConstant.Matrix"
+               OpMemberName %type_PushConstant_Matrix 0 "transform"
+               OpName %matrix_constants "matrix_constants"
+               OpName %in_var_POSITION "in.var.POSITION"
+               OpName %main "main"
+               OpDecorateString %in_var_POSITION UserSemantic "POSITION"
+               OpDecorate %gl_Position BuiltIn Position
+               OpDecorateString %gl_Position UserSemantic "SV_Position"
+               OpDecorate %in_var_POSITION Location 0
+               OpMemberDecorate %type_PushConstant_Matrix 0 Offset 0
+               OpMemberDecorate %type_PushConstant_Matrix 0 MatrixStride 16
+               OpMemberDecorate %type_PushConstant_Matrix 0 RowMajor
+               OpDecorate %type_PushConstant_Matrix Block
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%mat4v4float = OpTypeMatrix %v4float 4
+%type_PushConstant_Matrix = OpTypeStruct %mat4v4float
+%_ptr_PushConstant_type_PushConstant_Matrix = OpTypePointer PushConstant %type_PushConstant_Matrix
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+       %void = OpTypeVoid
+         %16 = OpTypeFunction %void
+%_ptr_PushConstant_mat4v4float = OpTypePointer PushConstant %mat4v4float
+%matrix_constants = OpVariable %_ptr_PushConstant_type_PushConstant_Matrix PushConstant
+%in_var_POSITION = OpVariable %_ptr_Input_v4float Input
+%gl_Position = OpVariable %_ptr_Output_v4float Output
+               OpLine %4 8 1
+       %main = OpFunction %void None %16
+               OpNoLine
+         %18 = OpLabel
+               OpLine %4 8 1
+         %19 = OpLoad %v4float %in_var_POSITION
+               OpLine %4 9 16
+         %20 = OpAccessChain %_ptr_PushConstant_mat4v4float %matrix_constants %int_0
+               OpLine %4 9 33
+         %21 = OpLoad %mat4v4float %20
+               OpLine %4 9 12
+         %22 = OpVectorTimesMatrix %v4float %19 %21
+               OpLine %4 8 1
+               OpStore %gl_Position %22
+               OpLine %4 10 1
+               OpReturn
+               OpFunctionEnd

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -11307,7 +11307,13 @@ string CompilerGLSL::access_chain_internal(uint32_t base, const uint32_t *indice
 			else
 				physical_type = 0;
 
-			row_major_matrix_needs_conversion = member_is_non_native_row_major_matrix(*type, index);
+			// GLSL does not allow `layout(row_major)` qualifier inside bare struct declarations.
+			// Structs used as members of UBO/SSBO blocks can have layout qualifiers applied at the block level.
+			// Push constant blocks in OpenGL are also emitted as bare structs (without Block decoration in output).
+			auto *var = maybe_get_backing_variable(base);
+			const bool is_push_constant_emulated = !options.vulkan_semantics && var != nullptr && var->storage == StorageClassPushConstant;
+
+			row_major_matrix_needs_conversion = member_is_non_native_row_major_matrix(*type, index, is_push_constant_emulated);
 			type_id = type->member_types[index];
 			type = &get<SPIRType>(type->member_types[index]);
 		}
@@ -16783,10 +16789,11 @@ bool CompilerGLSL::is_non_native_row_major_matrix(uint32_t id)
 }
 
 // Checks whether the member is a row_major matrix that requires conversion before use
-bool CompilerGLSL::member_is_non_native_row_major_matrix(const SPIRType &type, uint32_t index)
+bool CompilerGLSL::member_is_non_native_row_major_matrix(const SPIRType &type, uint32_t index, bool is_layout_disabled)
 {
-	// Natively supported row-major matrices do not need to be converted.
-	if (backend.native_row_major_matrix && !is_legacy())
+	// Natively supported row-major matrices do not need to be converted,
+	// unless layout qualifiers are disabled, which is the case for Vulkan push_constant to OpenGL struct translation.
+	if (backend.native_row_major_matrix && !is_legacy() && !is_layout_disabled)
 		return false;
 
 	// Non-matrix or column-major matrix types do not need to be converted.

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -604,7 +604,7 @@ protected:
 	void add_function_overload(const SPIRFunction &func);
 
 	virtual bool is_non_native_row_major_matrix(uint32_t id);
-	virtual bool member_is_non_native_row_major_matrix(const SPIRType &type, uint32_t index);
+	virtual bool member_is_non_native_row_major_matrix(const SPIRType &type, uint32_t index, bool is_layout_disabled = false);
 	bool member_is_remapped_physical_type(const SPIRType &type, uint32_t index) const;
 	bool member_is_packed_physical_type(const SPIRType &type, uint32_t index) const;
 	virtual std::string convert_row_major_matrix(std::string exp_str, const SPIRType &exp_type,

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -13573,7 +13573,7 @@ bool CompilerMSL::is_non_native_row_major_matrix(uint32_t id)
 }
 
 // Checks whether the member is a row_major matrix that requires conversion before use
-bool CompilerMSL::member_is_non_native_row_major_matrix(const SPIRType &type, uint32_t index)
+bool CompilerMSL::member_is_non_native_row_major_matrix(const SPIRType &type, uint32_t index, bool /*is_layout_disabled*/)
 {
 	return has_member_decoration(type.self, index, DecorationRowMajor);
 }

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -986,7 +986,7 @@ protected:
 
 	bool is_patch_block(const SPIRType &type);
 	bool is_non_native_row_major_matrix(uint32_t id) override;
-	bool member_is_non_native_row_major_matrix(const SPIRType &type, uint32_t index) override;
+	bool member_is_non_native_row_major_matrix(const SPIRType &type, uint32_t index, bool is_layout_disabled = false) override;
 	std::string convert_row_major_matrix(std::string exp_str, const SPIRType &exp_type, uint32_t physical_type_id,
 	                                     bool is_packed, bool relaxed) override;
 


### PR DESCRIPTION
I stumbled across this issue when I started compiling some of my LLGL examples to all backends, including GLSL140 which translates `push_constant` blocks to struct uniforms.
This is the input source for the new test I added as part of this PR:
```hlsl
struct Matrix {
    float4x4 transform;
};

[[vk::push_constant]] Matrix matrix_constants;

float4 main(float4 in_position : POSITION) : SV_Position {
    return mul(matrix_constants.transform, in_position);
}
```

HLSL shaders with the `[[vk::push_constant]]` attribute that are compiled to SPIR-V, their matrix layout uses row_major by default but these push constants are translated to bare structs in GLSL for OpenGL semantics, which do not support `layout(row_major)` qualifiers. In this case, allow the respective expression in `member_is_non_native_row_major_matrix()` to be marked with the `need_transpose` bit.

The expected behavior is presented in the new test 'push-constant-row-major-matrix.asm.vert':
```glsl
#version 450
struct type_PushConstant_Matrix {
    mat4 transform;
};
uniform type_PushConstant_Matrix matrix_constants;
layout(location = 0) in vec4 in_var_POSITION;
void main() {
    gl_Position = matrix_constants.transform * in_var_POSITION;
}
```

Without this change, SPIRV-Cross compiles this to the wrong expression:
```glsl
#version 450
struct type_PushConstant_Matrix {
    mat4 transform;
};
uniform type_PushConstant_Matrix matrix_constants;
layout(location = 0) in vec4 in_var_POSITION;
void main() {
    gl_Position = in_var_POSITION * matrix_constants.transform; // <- Wrong without 'layout(row_major)'
}
```