### PR TITLE
MSL: Fix layout of struct arrays whose ArrayStride exceeds the packed struct size

### DIFF
--- a/reference/opt/shaders-msl/frag/struct-array-stride-padded-element.frag
+++ b/reference/opt/shaders-msl/frag/struct-array-stride-padded-element.frag
@@ -1,0 +1,52 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+template <typename T, int stride>
+struct spvPaddedArrayElement { T data; char padding[stride - sizeof(T)]; };
+
+struct SpotLight
+{
+    packed_float3 position;
+    float range;
+    packed_float3 direction;
+    float angle;
+    packed_float3 color;
+    float intensity;
+    float penumbra;
+};
+
+struct UBO
+{
+    spvPaddedArrayElement<SpotLight, 64> spot_lights[4];
+    int spot_light_count;
+    char _m2_pad[12];
+    packed_float3 albedo;
+    float roughness;
+    float alpha;
+};
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(constant UBO& ubo [[buffer(0)]])
+{
+    main0_out out = {};
+    int _27 = min(ubo.spot_light_count, 4);
+    float3 _79;
+    _79 = float3(0.0);
+    for (int _78 = 0; _78 < _27; )
+    {
+        _79 += ((float3(ubo.spot_lights[_78].data.color) * ubo.spot_lights[_78].data.intensity) * ubo.spot_lights[_78].data.penumbra);
+        _78++;
+        continue;
+    }
+    out.FragColor = float4(ubo.albedo[0u], ubo.roughness, ubo.alpha * _79.z, 1.0);
+    return out;
+}
+

--- a/reference/shaders-msl/frag/struct-array-stride-padded-element.frag
+++ b/reference/shaders-msl/frag/struct-array-stride-padded-element.frag
@@ -1,0 +1,49 @@
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+template <typename T, int stride>
+struct spvPaddedArrayElement { T data; char padding[stride - sizeof(T)]; };
+
+struct SpotLight
+{
+    packed_float3 position;
+    float range;
+    packed_float3 direction;
+    float angle;
+    packed_float3 color;
+    float intensity;
+    float penumbra;
+};
+
+struct UBO
+{
+    spvPaddedArrayElement<SpotLight, 64> spot_lights[4];
+    int spot_light_count;
+    char _m2_pad[12];
+    packed_float3 albedo;
+    float roughness;
+    float alpha;
+};
+
+struct main0_out
+{
+    float4 FragColor [[color(0)]];
+};
+
+fragment main0_out main0(constant UBO& ubo [[buffer(0)]])
+{
+    main0_out out = {};
+    float3 acc = float3(0.0);
+    int n = min(ubo.spot_light_count, 4);
+    for (int i = 0; i < n; i++)
+    {
+        acc += ((float3(ubo.spot_lights[i].data.color) * ubo.spot_lights[i].data.intensity) * ubo.spot_lights[i].data.penumbra);
+    }
+    out.FragColor = float4(ubo.albedo[0u], ubo.roughness, ubo.alpha * acc.z, 1.0);
+    return out;
+}
+

--- a/shaders-msl/frag/struct-array-stride-padded-element.frag
+++ b/shaders-msl/frag/struct-array-stride-padded-element.frag
@@ -1,0 +1,35 @@
+#version 450
+
+// std140 gives SpotLight an ArrayStride of 64 while its packed MSL size is 52.
+// The array must be indexed dynamically so the padded array element path is taken;
+// every member following the array must keep its SPIR-V offset.
+struct SpotLight
+{
+	vec3 position;
+	float range;
+	vec3 direction;
+	float angle;
+	vec3 color;
+	float intensity;
+	float penumbra;
+};
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+	SpotLight spot_lights[4];
+	int spot_light_count;
+	vec3 albedo;
+	float roughness;
+	float alpha;
+} ubo;
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	vec3 acc = vec3(0.0);
+	int n = min(ubo.spot_light_count, 4);
+	for (int i = 0; i < n; i++)
+		acc += ubo.spot_lights[i].color * ubo.spot_lights[i].intensity * ubo.spot_lights[i].penumbra;
+	FragColor = vec4(ubo.albedo.r, ubo.roughness, ubo.alpha * acc.b, 1.0);
+}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -5127,6 +5127,36 @@ void CompilerMSL::align_struct(SPIRType &ib_type, unordered_set<uint32_t> &align
 		// offsets, array strides and matrix strides.
 		ensure_member_packing_rules_msl(ib_type, mbr_idx);
 
+		// Arrays of structs: the element struct may just have been packed (by its own align_struct pass above)
+		// to a size smaller than the declared ArrayStride. mark_scalar_layout_structs() runs before that packing
+		// and only sees the unpacked size, so it can miss this case. MSL cannot express an array stride larger
+		// than sizeof(T); route such arrays through spvPaddedArrayElement exactly like that pass does.
+		{
+			auto &mbr_type = get<SPIRType>(ib_type.member_types[mbr_idx]);
+			if (mbr_type.basetype == SPIRType::Struct && !mbr_type.array.empty() &&
+			    !(mbr_type.pointer && mbr_type.storage == StorageClassPhysicalStorageBuffer))
+			{
+				auto *struct_type = &mbr_type;
+				while (!struct_type->array.empty())
+					struct_type = &get<SPIRType>(struct_type->parent_type);
+
+				if (!has_decoration(struct_type->self, DecorationArrayStride))
+				{
+					uint32_t array_stride = type_struct_member_array_stride(ib_type, mbr_idx);
+					uint32_t dimensions = uint32_t(mbr_type.array.size() - 1);
+					for (uint32_t dim = 0; dim < dimensions; dim++)
+						array_stride /= max<uint32_t>(to_array_size_literal(mbr_type, dim), 1u);
+
+					uint32_t msl_size = get_declared_struct_size_msl(*struct_type);
+					if (array_stride > msl_size)
+					{
+						set_decoration(struct_type->self, DecorationArrayStride, msl_size);
+						add_spv_func_and_recompile(SPVFuncImplPaddedArrayElement);
+					}
+				}
+			}
+		}
+
 		// Align current offset to the current member's default alignment. If the member was packed, it will observe
 		// the updated alignment here.
 		uint32_t msl_align_mask = get_declared_struct_member_alignment_msl(ib_type, mbr_idx) - 1;
@@ -5134,6 +5164,12 @@ void CompilerMSL::align_struct(SPIRType &ib_type, unordered_set<uint32_t> &align
 
 		// Fetch the member offset as declared in the SPIRV.
 		uint32_t spirv_mbr_offset = get_member_decoration(ib_type_id, mbr_idx, DecorationOffset);
+
+		// A previous compilation pass may have recorded a padding target that no longer applies
+		// (e.g. a struct array that is now emitted with spvPaddedArrayElement and therefore
+		// already spans its full ArrayStride). Recompute it from scratch on every pass.
+		unset_extended_member_decoration(ib_type_id, mbr_idx, SPIRVCrossDecorationPaddingTarget);
+
 		if (spirv_mbr_offset > aligned_msl_offset)
 		{
 			// Since MSL and SPIR-V have slightly different struct member alignment and


### PR DESCRIPTION
## Problem

A std140 struct array such as

```glsl
struct SpotLight { vec3 position; float range; vec3 direction; float angle; vec3 color; float intensity; float penumbra; };
layout(std140, binding = 0) uniform UBO { SpotLight spot_lights[4]; int spot_light_count; vec3 albedo; float roughness; } ubo;
```

has `ArrayStride 64` but packs to 52 bytes in MSL. When the array is indexed dynamically and followed by further members, the emitted MSL is laid out wrong in one of two ways:

1. `SpotLight spot_lights[4]; char _m1_pad[48];` — native stride 52, so `spot_lights[1..3]` read from the wrong offsets. Cause: `mark_scalar_layout_structs()` runs before the element struct is packed by its own `align_struct()` pass, compares the ArrayStride against the *unpacked* size (64 == 64) and never marks the struct for `spvPaddedArrayElement`.
2. `spvPaddedArrayElement<SpotLight, 64> spot_lights[4]; char _m7_pad[48];` — happens when a later compilation pass does switch to the padded element (observed with a larger shader that triggers another recompile). The `SPIRVCrossDecorationPaddingTarget` recorded for the following member in the first pass (48 bytes from the 4×52 layout) is never cleared, so every member after the array is shifted by 48 bytes.

Both were found through a GLSL→SPIR-V→MSL pipeline where uniforms written at their SPIR-V offsets (`albedo`, `roughness`, …) were read back from the wrong location on Metal.

## Fix

* `align_struct()` re-checks the packed struct size after `ensure_member_packing_rules_msl()` and, when the declared ArrayStride is larger, sets `DecorationArrayStride` on the struct and requests `SPVFuncImplPaddedArrayElement` — the same mechanism `mark_scalar_layout_structs()` uses, just at a point where the packed size is known.
* `align_struct()` unsets `SPIRVCrossDecorationPaddingTarget` before recomputing it, so a stale value from an earlier pass cannot survive a recompile.

## Test

`shaders-msl/frag/struct-array-stride-padded-element.frag` (dynamically indexed struct array followed by int/vec3/float members) plus references. The full `--msl` and `--msl --opt` reference suites pass with no other reference changing.
